### PR TITLE
Add support for version 36

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ quic-go is an implementation of the [QUIC](https://en.wikipedia.org/wiki/QUIC) p
 
 Done:
 
-- Basic protocol with support for QUIC version 34-35
+- Basic protocol with support for QUIC version 34-36
 - HTTP/2 support
 - Crypto (RSA / ECDSA certificates, Curve25519 for key exchange, AES-GCM or Chacha20-Poly1305 as stream cipher)
 - Loss detection and retransmission (currently fast retransmission & RTO)

--- a/h2quic/server_test.go
+++ b/h2quic/server_test.go
@@ -196,7 +196,7 @@ var _ = Describe("H2 server", func() {
 
 	Context("setting http headers", func() {
 		expected := http.Header{
-			"Alt-Svc":            {`quic=":443"; ma=2592000; v="35,34"`},
+			"Alt-Svc":            {`quic=":443"; ma=2592000; v="36,35,34"`},
 			"Alternate-Protocol": {`443:quic`},
 		}
 

--- a/integrationtests/integrationtests_suite_test.go
+++ b/integrationtests/integrationtests_suite_test.go
@@ -152,7 +152,7 @@ func setupQuicServer() {
 
 func setupSelenium() {
 	var err error
-	pullCmd := exec.Command("docker", "pull", "lclemente/standalone-chrome:beta")
+	pullCmd := exec.Command("docker", "pull", "lclemente/standalone-chrome:dev")
 	pull, err := gexec.Start(pullCmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	// Assuming a download at 10 Mbit/s
@@ -165,7 +165,7 @@ func setupSelenium() {
 		"--rm",
 		"-p=4444:4444",
 		"--name", "quic-test-selenium",
-		"lclemente/standalone-chrome:beta",
+		"lclemente/standalone-chrome:dev",
 	)
 	docker, err = gexec.Start(dockerCmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())

--- a/protocol/version.go
+++ b/protocol/version.go
@@ -13,12 +13,13 @@ type VersionNumber int
 const (
 	Version34 VersionNumber = 34 + iota
 	Version35
+	Version36
 	VersionWhatever = 0 // for when the version doesn't matter
 )
 
 // SupportedVersions lists the versions that the server supports
 var SupportedVersions = []VersionNumber{
-	Version34, Version35,
+	Version34, Version35, Version36,
 }
 
 // SupportedVersionsAsTags is needed for the SHLO crypto message

--- a/protocol/version_test.go
+++ b/protocol/version_test.go
@@ -17,11 +17,11 @@ var _ = Describe("Version", func() {
 	})
 
 	It("has proper tag list", func() {
-		Expect(SupportedVersionsAsTags).To(Equal([]byte("Q034Q035")))
+		Expect(SupportedVersionsAsTags).To(Equal([]byte("Q034Q035Q036")))
 	})
 
 	It("has proper version list", func() {
-		Expect(SupportedVersionsAsString).To(Equal("35,34"))
+		Expect(SupportedVersionsAsString).To(Equal("36,35,34"))
 	})
 
 	It("recognizes supported versions", func() {


### PR DESCRIPTION
Fixes #312. This PR is blocked until Chrome beta adds support for v36.