### PR TITLE
Don't rely on GOPATH to load the certificates or error codes

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -10,7 +10,8 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
-	"os"
+	"path"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -99,6 +100,15 @@ func init() {
 	})
 }
 
+func getBuildDir() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("Failed to get current frame")
+	}
+
+	return path.Dir(filename)
+}
+
 func main() {
 	// defer profile.Start().Stop()
 	go func() {
@@ -109,7 +119,7 @@ func main() {
 	verbose := flag.Bool("v", false, "verbose")
 	bs := binds{}
 	flag.Var(&bs, "bind", "bind to")
-	certPath := flag.String("certpath", os.Getenv("GOPATH")+"/src/github.com/lucas-clemente/quic-go/example/", "certificate directory")
+	certPath := flag.String("certpath", getBuildDir(), "certificate directory")
 	www := flag.String("www", "/var/www", "www data")
 	tcp := flag.Bool("tcp", false, "also listen on TCP")
 	flag.Parse()

--- a/h2quic/server_test.go
+++ b/h2quic/server_test.go
@@ -33,9 +33,6 @@ func (s *mockSession) RemoteAddr() *net.UDPAddr {
 }
 
 var _ = Describe("H2 server", func() {
-	certPath := os.Getenv("GOPATH")
-	certPath += "/src/github.com/lucas-clemente/quic-go/example/"
-
 	var (
 		s          *Server
 		session    *mockSession
@@ -243,7 +240,7 @@ var _ = Describe("H2 server", func() {
 	})
 
 	It("should error when ListenAndServeTLS is called with s.Server nil", func() {
-		err := (&Server{}).ListenAndServeTLS(certPath+"fullchain.pem", certPath+"privkey.pem")
+		err := (&Server{}).ListenAndServeTLS(testdata.GetCertificatePaths())
 		Expect(err).To(MatchError("use of h2quic.Server without http.Server"))
 	})
 
@@ -296,7 +293,7 @@ var _ = Describe("H2 server", func() {
 			for i := 0; i < 2; i++ {
 				go func() {
 					defer GinkgoRecover()
-					err := s.ListenAndServeTLS(certPath+"fullchain.pem", certPath+"privkey.pem")
+					err := s.ListenAndServeTLS(testdata.GetCertificatePaths())
 					if err != nil {
 						cErr <- err
 					}
@@ -325,7 +322,8 @@ var _ = Describe("H2 server", func() {
 		c, err := net.ListenUDP("udp", udpAddr)
 		Expect(err).NotTo(HaveOccurred())
 		defer c.Close()
-		err = ListenAndServeQUIC(addr, certPath+"fullchain.pem", certPath+"privkey.pem", nil)
+		fullpem, privkey := testdata.GetCertificatePaths()
+		err = ListenAndServeQUIC(addr, fullpem, privkey, nil)
 		// Check that it's an EADDRINUSE
 		Expect(err).ToNot(BeNil())
 		opErr, ok := err.(*net.OpError)

--- a/qerr/errorcodes_test.go
+++ b/qerr/errorcodes_test.go
@@ -4,7 +4,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
+	"path"
+	"runtime"
 	"strconv"
 
 	. "github.com/onsi/ginkgo"
@@ -16,7 +17,11 @@ var _ = Describe("error codes", func() {
 	It("has a string representation for every error code", func() {
 		// We parse the error code file, extract all constants, and verify that
 		// each of them has a string version. Go FTW!
-		filename := os.Getenv("GOPATH") + "/src/github.com/lucas-clemente/quic-go/qerr/error_codes.go"
+		_, thisfile, _, ok := runtime.Caller(0)
+		if !ok {
+			panic("Failed to get current frame")
+		}
+		filename := path.Join(path.Dir(thisfile), "error_codes.go")
 		fileAst, err := parser.ParseFile(token.NewFileSet(), filename, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 		constSpecs := fileAst.Decls[0].(*ast.GenDecl).Specs

--- a/testdata/cert.go
+++ b/testdata/cert.go
@@ -2,19 +2,30 @@ package testdata
 
 import (
 	"crypto/tls"
-	"os"
+	"path"
+	"runtime"
 )
 
 var certPath string
 
 func init() {
-	certPath = os.Getenv("GOPATH")
-	certPath += "/src/github.com/lucas-clemente/quic-go/example"
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("Failed to get current frame")
+	}
+
+	certPath = path.Join(path.Dir(path.Dir(filename)), "example")
+}
+
+// GetCertificatePaths returns the paths to 'fullchain.pem' and 'privkey.pem' for the
+// quic.clemente.io cert.
+func GetCertificatePaths() (string, string) {
+	return path.Join(certPath, "fullchain.pem"), path.Join(certPath, "privkey.pem")
 }
 
 // GetTLSConfig returns a tls config for quic.clemente.io
 func GetTLSConfig() *tls.Config {
-	cert, err := tls.LoadX509KeyPair(certPath+"/fullchain.pem", certPath+"/privkey.pem")
+	cert, err := tls.LoadX509KeyPair(GetCertificatePaths())
 	if err != nil {
 		panic(err)
 	}
@@ -25,7 +36,7 @@ func GetTLSConfig() *tls.Config {
 
 // GetCertificate returns a certificate for quic.clemente.io
 func GetCertificate() tls.Certificate {
-	cert, err := tls.LoadX509KeyPair(certPath+"/fullchain.pem", certPath+"/privkey.pem")
+	cert, err := tls.LoadX509KeyPair(GetCertificatePaths())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
GOPATH is a list of paths, similar to PATH. If someone does have a list
set, the tests will try to use the full list as a path prefix to load
the certificates, which won't work.

But even handling GOPATH as a list does not solve the issue of what
certificate or error_codes.go file to load, since the code might not be
under the first one it finds.

Instead, use the runtime functionality to get the filename of the path
of the project at compilation time and perform the lookups relative to
that, which guarantees that we're loading the files from the path of the
code that is running.