### PR TITLE
properly implement handling of RST_STREAM frames

### DIFF
--- a/flowcontrol/flow_control_manager_test.go
+++ b/flowcontrol/flow_control_manager_test.go
@@ -131,17 +131,21 @@ var _ = Describe("Flow Control Manager", func() {
 			fcm.NewStream(1, false)
 			fcm.NewStream(4, true)
 			fcm.NewStream(6, true)
+			fcm.streamFlowController[1].bytesSent = 0x41
+			fcm.streamFlowController[4].bytesSent = 0x42
 		})
 
 		It("updates the connection level flow controller if the stream contributes", func() {
-			err := fcm.ResetStream(4, 0x100)
+			bytesSent, err := fcm.ResetStream(4, 0x100)
+			Expect(bytesSent).To(Equal(protocol.ByteCount(0x42)))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fcm.streamFlowController[0].highestReceived).To(Equal(protocol.ByteCount(0x100)))
 			Expect(fcm.streamFlowController[4].highestReceived).To(Equal(protocol.ByteCount(0x100)))
 		})
 
 		It("does not update the connection level flow controller if the stream does not contribute", func() {
-			err := fcm.ResetStream(1, 0x100)
+			bytesSent, err := fcm.ResetStream(1, 0x100)
+			Expect(bytesSent).To(Equal(protocol.ByteCount(0x41)))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fcm.streamFlowController[0].highestReceived).To(BeZero())
 			Expect(fcm.streamFlowController[1].highestReceived).To(Equal(protocol.ByteCount(0x100)))
@@ -150,24 +154,24 @@ var _ = Describe("Flow Control Manager", func() {
 		It("errors if the byteOffset is smaller than a byteOffset that set earlier", func() {
 			err := fcm.UpdateHighestReceived(4, 0x100)
 			Expect(err).ToNot(HaveOccurred())
-			err = fcm.ResetStream(4, 0x50)
+			_, err = fcm.ResetStream(4, 0x50)
 			Expect(err).To(MatchError(qerr.StreamDataAfterTermination))
 		})
 
 		It("returns an error when called with an unknown stream", func() {
-			err := fcm.ResetStream(1337, 0x1337)
+			_, err := fcm.ResetStream(1337, 0x1337)
 			Expect(err).To(MatchError(errMapAccess))
 		})
 
 		Context("flow control violations", func() {
 			It("errors when encountering a stream level flow control violation", func() {
-				err := fcm.ResetStream(4, 0x101)
+				_, err := fcm.ResetStream(4, 0x101)
 				Expect(err).To(MatchError(qerr.Error(qerr.FlowControlReceivedTooMuchData, "Received 257 bytes on stream 4, allowed 256 bytes"))) // 0x100 = 256, 0x101 = 257
 			})
 
 			It("errors when encountering a connection-level flow control violation", func() {
 				fcm.streamFlowController[4].receiveFlowControlWindow = 0x300
-				err := fcm.ResetStream(4, 0x201)
+				_, err := fcm.ResetStream(4, 0x201)
 				Expect(err).To(MatchError(qerr.Error(qerr.FlowControlReceivedTooMuchData, "Received 513 bytes for the connection, allowed 512 bytes"))) // 0x200 = 512, 0x201 = 513
 			})
 		})

--- a/flowcontrol/flow_control_manager_test.go
+++ b/flowcontrol/flow_control_manager_test.go
@@ -82,13 +82,13 @@ var _ = Describe("Flow Control Manager", func() {
 		Context("flow control violations", func() {
 			It("errors when encountering a stream level flow control violation", func() {
 				err := fcm.UpdateHighestReceived(4, 0x101)
-				Expect(err).To(MatchError(ErrStreamFlowControlViolation))
+				Expect(err).To(MatchError(qerr.Error(qerr.FlowControlReceivedTooMuchData, "Received 257 bytes on stream 4, allowed 256 bytes"))) // 0x100 = 256, 0x101 = 257
 			})
 
 			It("errors when encountering a connection-level flow control violation", func() {
 				fcm.streamFlowController[4].receiveFlowControlWindow = 0x300
 				err := fcm.UpdateHighestReceived(4, 0x201)
-				Expect(err).To(MatchError(ErrConnectionFlowControlViolation))
+				Expect(err).To(MatchError(qerr.Error(qerr.FlowControlReceivedTooMuchData, "Received 513 bytes for the connection, allowed 512 bytes"))) // 0x200 = 512, 0x201 = 513
 			})
 		})
 
@@ -162,13 +162,13 @@ var _ = Describe("Flow Control Manager", func() {
 		Context("flow control violations", func() {
 			It("errors when encountering a stream level flow control violation", func() {
 				err := fcm.ResetStream(4, 0x101)
-				Expect(err).To(MatchError(ErrStreamFlowControlViolation))
+				Expect(err).To(MatchError(qerr.Error(qerr.FlowControlReceivedTooMuchData, "Received 257 bytes on stream 4, allowed 256 bytes"))) // 0x100 = 256, 0x101 = 257
 			})
 
 			It("errors when encountering a connection-level flow control violation", func() {
 				fcm.streamFlowController[4].receiveFlowControlWindow = 0x300
 				err := fcm.ResetStream(4, 0x201)
-				Expect(err).To(MatchError(ErrConnectionFlowControlViolation))
+				Expect(err).To(MatchError(qerr.Error(qerr.FlowControlReceivedTooMuchData, "Received 513 bytes for the connection, allowed 512 bytes"))) // 0x200 = 512, 0x201 = 513
 			})
 		})
 	})

--- a/flowcontrol/flow_controller.go
+++ b/flowcontrol/flow_controller.go
@@ -1,6 +1,7 @@
 package flowcontrol
 
 import (
+	"errors"
 	"time"
 
 	"github.com/lucas-clemente/quic-go/congestion"
@@ -26,6 +27,9 @@ type flowController struct {
 	receiveFlowControlWindowIncrement    protocol.ByteCount
 	maxReceiveFlowControlWindowIncrement protocol.ByteCount
 }
+
+// ErrReceivedSmallerByteOffset occurs if the ByteOffset received is smaller than a ByteOffset that was set previously
+var ErrReceivedSmallerByteOffset = errors.New("Received a smaller byte offset")
 
 // newFlowController gets a new flow controller
 func newFlowController(streamID protocol.StreamID, connectionParameters handshake.ConnectionParametersManager, rttStats *congestion.RTTStats) *flowController {
@@ -87,13 +91,19 @@ func (c *flowController) SendWindowOffset() protocol.ByteCount {
 
 // UpdateHighestReceived updates the highestReceived value, if the byteOffset is higher
 // Should **only** be used for the stream-level FlowController
-func (c *flowController) UpdateHighestReceived(byteOffset protocol.ByteCount) protocol.ByteCount {
+// it returns an ErrReceivedSmallerByteOffset if the received byteOffset is smaller than any byteOffset received before
+// This error occurs every time StreamFrames get reordered and has to be ignored in that case
+// It should only be treated as an error when resetting a stream
+func (c *flowController) UpdateHighestReceived(byteOffset protocol.ByteCount) (protocol.ByteCount, error) {
+	if byteOffset == c.highestReceived {
+		return 0, nil
+	}
 	if byteOffset > c.highestReceived {
 		increment := byteOffset - c.highestReceived
 		c.highestReceived = byteOffset
-		return increment
+		return increment, nil
 	}
-	return 0
+	return 0, ErrReceivedSmallerByteOffset
 }
 
 // IncrementHighestReceived adds an increment to the highestReceived value

--- a/flowcontrol/flow_controller.go
+++ b/flowcontrol/flow_controller.go
@@ -66,6 +66,10 @@ func (c *flowController) AddBytesSent(n protocol.ByteCount) {
 	c.bytesSent += n
 }
 
+func (c *flowController) GetBytesSent() protocol.ByteCount {
+	return c.bytesSent
+}
+
 // UpdateSendWindow should be called after receiving a WindowUpdateFrame
 // it returns true if the window was actually updated
 func (c *flowController) UpdateSendWindow(newOffset protocol.ByteCount) bool {

--- a/flowcontrol/flow_controller_test.go
+++ b/flowcontrol/flow_controller_test.go
@@ -206,16 +206,25 @@ var _ = Describe("Flow controller", func() {
 
 		It("updates the highestReceived", func() {
 			controller.highestReceived = 1337
-			increment := controller.UpdateHighestReceived(1338)
+			increment, err := controller.UpdateHighestReceived(1338)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(increment).To(Equal(protocol.ByteCount(1338 - 1337)))
 			Expect(controller.highestReceived).To(Equal(protocol.ByteCount(1338)))
 		})
 
 		It("does not decrease the highestReceived", func() {
 			controller.highestReceived = 1337
-			increment := controller.UpdateHighestReceived(1000)
-			Expect(increment).To(Equal(protocol.ByteCount(0)))
+			increment, err := controller.UpdateHighestReceived(1000)
+			Expect(err).To(MatchError(ErrReceivedSmallerByteOffset))
+			Expect(increment).To(BeZero())
 			Expect(controller.highestReceived).To(Equal(protocol.ByteCount(1337)))
+		})
+
+		It("does not error when setting the same byte offset", func() {
+			controller.highestReceived = 1337
+			increment, err := controller.UpdateHighestReceived(1337)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(increment).To(BeZero())
 		})
 
 		It("increases the highestReceived by a given increment", func() {

--- a/flowcontrol/flow_controller_test.go
+++ b/flowcontrol/flow_controller_test.go
@@ -108,6 +108,11 @@ var _ = Describe("Flow controller", func() {
 			Expect(controller.bytesSent).To(Equal(protocol.ByteCount(5 + 6)))
 		})
 
+		It("gets the bytesSent", func() {
+			controller.bytesSent = 8
+			Expect(controller.GetBytesSent()).To(Equal(protocol.ByteCount(8)))
+		})
+
 		It("gets the size of the remaining flow control window", func() {
 			controller.bytesSent = 5
 			controller.sendFlowControlWindow = 12

--- a/flowcontrol/interface.go
+++ b/flowcontrol/interface.go
@@ -13,6 +13,7 @@ type FlowControlManager interface {
 	NewStream(streamID protocol.StreamID, contributesToConnectionFlow bool)
 	RemoveStream(streamID protocol.StreamID)
 	// methods needed for receiving data
+	ResetStream(streamID protocol.StreamID, byteOffset protocol.ByteCount) error
 	UpdateHighestReceived(streamID protocol.StreamID, byteOffset protocol.ByteCount) error
 	AddBytesRead(streamID protocol.StreamID, n protocol.ByteCount) error
 	GetWindowUpdates() []WindowUpdate

--- a/flowcontrol/interface.go
+++ b/flowcontrol/interface.go
@@ -13,7 +13,7 @@ type FlowControlManager interface {
 	NewStream(streamID protocol.StreamID, contributesToConnectionFlow bool)
 	RemoveStream(streamID protocol.StreamID)
 	// methods needed for receiving data
-	ResetStream(streamID protocol.StreamID, byteOffset protocol.ByteCount) error
+	ResetStream(streamID protocol.StreamID, byteOffset protocol.ByteCount) (protocol.ByteCount, error)
 	UpdateHighestReceived(streamID protocol.StreamID, byteOffset protocol.ByteCount) error
 	AddBytesRead(streamID protocol.StreamID, n protocol.ByteCount) error
 	GetWindowUpdates() []WindowUpdate

--- a/session.go
+++ b/session.go
@@ -393,7 +393,6 @@ func (s *Session) handleWindowUpdateFrame(frame *frames.WindowUpdateFrame) error
 	return err
 }
 
-// TODO: Handle frame.byteOffset
 func (s *Session) handleRstStreamFrame(frame *frames.RstStreamFrame) error {
 	str, err := s.streamsMap.GetOrOpenStream(frame.StreamID)
 	if err != nil {
@@ -401,6 +400,10 @@ func (s *Session) handleRstStreamFrame(frame *frames.RstStreamFrame) error {
 	}
 	if str == nil {
 		return errRstStreamOnInvalidStream
+	}
+	err = s.flowControlManager.ResetStream(frame.StreamID, frame.ByteOffset)
+	if err != nil {
+		return err
 	}
 	s.closeStreamWithError(str, fmt.Errorf("RST_STREAM received with code %d", frame.ErrorCode))
 	return nil

--- a/session.go
+++ b/session.go
@@ -401,11 +401,11 @@ func (s *Session) handleRstStreamFrame(frame *frames.RstStreamFrame) error {
 	if str == nil {
 		return errRstStreamOnInvalidStream
 	}
-	err = s.flowControlManager.ResetStream(frame.StreamID, frame.ByteOffset)
+	s.closeStreamWithError(str, fmt.Errorf("RST_STREAM received with code %d", frame.ErrorCode))
+	_, err = s.flowControlManager.ResetStream(frame.StreamID, frame.ByteOffset)
 	if err != nil {
 		return err
 	}
-	s.closeStreamWithError(str, fmt.Errorf("RST_STREAM received with code %d", frame.ErrorCode))
 	return nil
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -317,6 +317,33 @@ var _ = Describe("Session", func() {
 			Expect(err).To(MatchError("RST_STREAM received with code 42"))
 		})
 
+		It("queues a RST_STERAM frame with the correct offset", func() {
+			_, err := session.GetOrOpenStream(5)
+			Expect(err).ToNot(HaveOccurred())
+			session.flowControlManager = newMockFlowControlHandler()
+			session.flowControlManager.(*mockFlowControlHandler).bytesSent = 0x1337
+			err = session.handleRstStreamFrame(&frames.RstStreamFrame{
+				StreamID: 5,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session.packer.controlFrames).To(HaveLen(1))
+			Expect(session.packer.controlFrames[0].(*frames.RstStreamFrame)).To(Equal(&frames.RstStreamFrame{
+				StreamID:   5,
+				ByteOffset: 0x1337,
+			}))
+		})
+
+		It("doesn't queue a RST_STREAM for a stream that it already sent a FIN on", func() {
+			str, err := session.GetOrOpenStream(5)
+			str.(*stream).sentFin()
+			str.Close()
+			err = session.handleRstStreamFrame(&frames.RstStreamFrame{
+				StreamID: 5,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session.packer.controlFrames).To(BeEmpty())
+		})
+
 		It("passes the byte offset to the flow controller", func() {
 			session.streamsMap.GetOrOpenStream(5)
 			session.flowControlManager = newMockFlowControlHandler()

--- a/session_test.go
+++ b/session_test.go
@@ -317,6 +317,30 @@ var _ = Describe("Session", func() {
 			Expect(err).To(MatchError("RST_STREAM received with code 42"))
 		})
 
+		It("passes the byte offset to the flow controller", func() {
+			session.streamsMap.GetOrOpenStream(5)
+			session.flowControlManager = newMockFlowControlHandler()
+			err := session.handleRstStreamFrame(&frames.RstStreamFrame{
+				StreamID:   5,
+				ByteOffset: 0x1337,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(session.flowControlManager.(*mockFlowControlHandler).highestReceivedForStream).To(Equal(protocol.StreamID(5)))
+			Expect(session.flowControlManager.(*mockFlowControlHandler).highestReceived).To(Equal(protocol.ByteCount(0x1337)))
+		})
+
+		It("returns errors from the flow controller", func() {
+			session.streamsMap.GetOrOpenStream(5)
+			session.flowControlManager = newMockFlowControlHandler()
+			testErr := errors.New("flow control violation")
+			session.flowControlManager.(*mockFlowControlHandler).flowControlViolation = testErr
+			err := session.handleRstStreamFrame(&frames.RstStreamFrame{
+				StreamID:   5,
+				ByteOffset: 0x1337,
+			})
+			Expect(err).To(MatchError(testErr))
+		})
+
 		It("ignores the error when the stream is not known", func() {
 			err := session.handleFrames([]frames.Frame{&frames.RstStreamFrame{
 				StreamID:  5,

--- a/stream.go
+++ b/stream.go
@@ -9,7 +9,6 @@ import (
 	"github.com/lucas-clemente/quic-go/flowcontrol"
 	"github.com/lucas-clemente/quic-go/frames"
 	"github.com/lucas-clemente/quic-go/protocol"
-	"github.com/lucas-clemente/quic-go/qerr"
 	"github.com/lucas-clemente/quic-go/utils"
 )
 
@@ -209,12 +208,6 @@ func (s *stream) AddStreamFrame(frame *frames.StreamFrame) error {
 	maxOffset := frame.Offset + frame.DataLen()
 	err := s.flowControlManager.UpdateHighestReceived(s.streamID, maxOffset)
 
-	if err == flowcontrol.ErrStreamFlowControlViolation {
-		return qerr.FlowControlReceivedTooMuchData
-	}
-	if err == flowcontrol.ErrConnectionFlowControlViolation {
-		return qerr.FlowControlReceivedTooMuchData
-	}
 	if err != nil {
 		return err
 	}

--- a/stream_test.go
+++ b/stream_test.go
@@ -62,7 +62,7 @@ func (m *mockFlowControlHandler) AddBytesRead(streamID protocol.StreamID, n prot
 }
 
 func (m *mockFlowControlHandler) ResetStream(streamID protocol.StreamID, byteOffset protocol.ByteCount) (protocol.ByteCount, error) {
-	return 0, m.UpdateHighestReceived(streamID, byteOffset)
+	return m.bytesSent, m.UpdateHighestReceived(streamID, byteOffset)
 }
 
 func (m *mockFlowControlHandler) UpdateHighestReceived(streamID protocol.StreamID, byteOffset protocol.ByteCount) error {

--- a/stream_test.go
+++ b/stream_test.go
@@ -61,8 +61,8 @@ func (m *mockFlowControlHandler) AddBytesRead(streamID protocol.StreamID, n prot
 	return nil
 }
 
-func (m *mockFlowControlHandler) ResetStream(streamID protocol.StreamID, byteOffset protocol.ByteCount) error {
-	return m.UpdateHighestReceived(streamID, byteOffset)
+func (m *mockFlowControlHandler) ResetStream(streamID protocol.StreamID, byteOffset protocol.ByteCount) (protocol.ByteCount, error) {
+	return 0, m.UpdateHighestReceived(streamID, byteOffset)
 }
 
 func (m *mockFlowControlHandler) UpdateHighestReceived(streamID protocol.StreamID, byteOffset protocol.ByteCount) error {

--- a/stream_test.go
+++ b/stream_test.go
@@ -62,7 +62,7 @@ func (m *mockFlowControlHandler) AddBytesRead(streamID protocol.StreamID, n prot
 }
 
 func (m *mockFlowControlHandler) ResetStream(streamID protocol.StreamID, byteOffset protocol.ByteCount) error {
-	panic("not implemented")
+	return m.UpdateHighestReceived(streamID, byteOffset)
 }
 
 func (m *mockFlowControlHandler) UpdateHighestReceived(streamID protocol.StreamID, byteOffset protocol.ByteCount) error {

--- a/stream_test.go
+++ b/stream_test.go
@@ -60,6 +60,10 @@ func (m *mockFlowControlHandler) AddBytesRead(streamID protocol.StreamID, n prot
 	return nil
 }
 
+func (m *mockFlowControlHandler) ResetStream(streamID protocol.StreamID, byteOffset protocol.ByteCount) error {
+	panic("not implemented")
+}
+
 func (m *mockFlowControlHandler) UpdateHighestReceived(streamID protocol.StreamID, byteOffset protocol.ByteCount) error {
 	m.highestReceivedForStream = streamID
 	m.highestReceived = byteOffset

--- a/stream_test.go
+++ b/stream_test.go
@@ -548,6 +548,19 @@ var _ = Describe("Stream", func() {
 				Expect(n).To(BeZero())
 				Expect(err).To(MatchError(testErr))
 			})
+
+			It("doesn't get data for writing if an error occurred", func() {
+				go func() {
+					_, err := str.Write([]byte("foobar"))
+					Expect(err).To(MatchError(testErr))
+				}()
+				Eventually(func() []byte { return str.dataForWriting }).ShouldNot(BeNil())
+				Expect(str.lenOfDataForWriting()).ToNot(BeZero())
+				str.RegisterError(testErr)
+				data := str.getDataForWriting(6)
+				Expect(data).To(BeNil())
+				Expect(str.lenOfDataForWriting()).To(BeZero())
+			})
 		})
 
 		Context("when CloseRemote is called", func() {


### PR DESCRIPTION
When we receive a RST_STREAM from the peer, we need to make adjustments to our flow controller (#377) and reply with a RST_STREAM frame in order to inform the peer about our state of the flow controller regarding data we sent on this stream (#378), if we didn't send a FIN on that stream yet.

Note that there's still another issue related to RST_STREAMs. This PR is not concerned with streams that get canceled mid-stream on our side. There we also need to send a RST_STREAM. This can be dealt with in a separate issue (#380).