### PR TITLE
get the respone context into files

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"sync"
+  "strings"
+  "os"
 
 	"github.com/lucas-clemente/quic-go/h2quic"
 	"github.com/lucas-clemente/quic-go/utils"
@@ -42,8 +44,15 @@ func main() {
 			if err != nil {
 				panic(err)
 			}
-			utils.Infof("Request Body:")
-			utils.Infof("%s", body.Bytes())
+	//		utils.Infof("Request Body:")
+	//		utils.Infof("%s", body.Bytes())
+			fileName :=strings.Replace(rsp.Request.URL.Path, "/", "-", -1)
+      dst, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE, 0644)
+      if err != nil {
+        return
+      }
+      defer dst.Close()
+      io.Copy(dst,body)
 			wg.Done()
 		}(addr)
 	}

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -49,7 +49,7 @@ func main() {
 			fileName :=strings.Replace(rsp.Request.URL.Path, "/", "-", -1)
       dst, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE, 0644)
       if err != nil {
-        return
+        panic(err)
       }
       defer dst.Close()
       io.Copy(dst,body)


### PR DESCRIPTION
the origin example just print the response context in terminal. i think get the response context into files, will be more available when the content length is huge.