### PR TITLE
run benchmark tests with integration tests on travis

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -4,9 +4,10 @@ set -e
 
 go get -t ./...
 if [ ${TESTMODE} == "unit" ]; then
-  ginkgo -r --cover --randomizeAllSpecs --randomizeSuites --trace --progress --skipPackage integrationtests
+  ginkgo -r --cover --randomizeAllSpecs --randomizeSuites --trace --progress --skipPackage integrationtests --skipMeasurements
 fi
 
 if [ ${TESTMODE} == "integration" ]; then
+  ginkgo --randomizeAllSpecs --randomizeSuites --trace --progress -focus "Benchmark"
   ginkgo -r --randomizeAllSpecs --randomizeSuites --trace --progress integrationtests
 fi


### PR DESCRIPTION
Fixes #430 

Considering that the benchmark test is more like an integration test than a unit test, I think it makes sense to run it in the *integration* Travis job.