### PR TITLE
immediately switch to forward-secure crypto after sending the SHLO

### DIFF
--- a/ackhandler/packet.go
+++ b/ackhandler/packet.go
@@ -10,9 +10,10 @@ import (
 // A Packet is a packet
 // +gen linkedlist
 type Packet struct {
-	PacketNumber protocol.PacketNumber
-	Frames       []frames.Frame
-	Length       protocol.ByteCount
+	PacketNumber    protocol.PacketNumber
+	Frames          []frames.Frame
+	Length          protocol.ByteCount
+	EncryptionLevel protocol.EncryptionLevel
 
 	MissingReports uint8
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -68,6 +68,7 @@ func (c *linkedConnection) Close() error                         { return nil }
 
 func setAEAD(cs handshake.CryptoSetup, aead crypto.AEAD) {
 	*(*bool)(unsafe.Pointer(reflect.ValueOf(cs).Elem().FieldByName("receivedForwardSecurePacket").UnsafeAddr())) = true
+	*(*bool)(unsafe.Pointer(reflect.ValueOf(cs).Elem().FieldByName("sentSHLO").UnsafeAddr())) = true
 	*(*crypto.AEAD)(unsafe.Pointer(reflect.ValueOf(cs).Elem().FieldByName("forwardSecureAEAD").UnsafeAddr())) = aead
 }
 

--- a/handshake/crypto_setup_client.go
+++ b/handshake/crypto_setup_client.go
@@ -331,7 +331,7 @@ func (h *cryptoSetupClient) SealWith(dst, src []byte, packetNumber protocol.Pack
 	return nil, protocol.EncryptionUnspecified, errors.New("no encryption level specified")
 }
 
-func (h *cryptoSetupClient) DiversificationNonce() []byte {
+func (h *cryptoSetupClient) DiversificationNonce(bool) []byte {
 	panic("not needed for cryptoSetupClient")
 }
 

--- a/handshake/crypto_setup_client.go
+++ b/handshake/crypto_setup_client.go
@@ -312,6 +312,25 @@ func (h *cryptoSetupClient) Seal(dst, src []byte, packetNumber protocol.PacketNu
 	return (&crypto.NullAEAD{}).Seal(dst, src, packetNumber, associatedData), protocol.EncryptionUnencrypted
 }
 
+func (h *cryptoSetupClient) SealWith(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte, forceEncryptionLevel protocol.EncryptionLevel) ([]byte, protocol.EncryptionLevel, error) {
+	switch forceEncryptionLevel {
+	case protocol.EncryptionUnencrypted:
+		return (&crypto.NullAEAD{}).Seal(dst, src, packetNumber, associatedData), protocol.EncryptionUnencrypted, nil
+	case protocol.EncryptionSecure:
+		if h.secureAEAD == nil {
+			return nil, protocol.EncryptionUnspecified, errors.New("CryptoSetupClient: no secureAEAD")
+		}
+		return h.secureAEAD.Seal(dst, src, packetNumber, associatedData), protocol.EncryptionSecure, nil
+	case protocol.EncryptionForwardSecure:
+		if h.forwardSecureAEAD == nil {
+			return nil, protocol.EncryptionUnspecified, errors.New("CryptoSetupClient: no forwardSecureAEAD")
+		}
+		return h.forwardSecureAEAD.Seal(dst, src, packetNumber, associatedData), protocol.EncryptionForwardSecure, nil
+	}
+
+	return nil, protocol.EncryptionUnspecified, errors.New("no encryption level specified")
+}
+
 func (h *cryptoSetupClient) DiversificationNonce() []byte {
 	panic("not needed for cryptoSetupClient")
 }

--- a/handshake/crypto_setup_client_test.go
+++ b/handshake/crypto_setup_client_test.go
@@ -744,6 +744,48 @@ var _ = Describe("Crypto setup", func() {
 				Expect(enc).To(Equal(protocol.EncryptionForwardSecure))
 			})
 		})
+
+		Context("forcing encryption levels", func() {
+			It("forces null encryption", func() {
+				d, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionUnencrypted)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(d).To(Equal(foobarFNVSigned))
+				Expect(enc).To(Equal(protocol.EncryptionUnencrypted))
+			})
+
+			It("forces initial encryption", func() {
+				doCompleteREJ()
+				d, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionSecure)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(d).To(Equal([]byte("foobar  normal sec")))
+				Expect(enc).To(Equal(protocol.EncryptionSecure))
+			})
+
+			It("errors of no AEAD for initial encryption is available", func() {
+				_, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionSecure)
+				Expect(err).To(MatchError("CryptoSetupClient: no secureAEAD"))
+				Expect(enc).To(Equal(protocol.EncryptionUnspecified))
+			})
+
+			It("forces forward-secure encryption", func() {
+				doSHLO()
+				d, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionForwardSecure)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(d).To(Equal([]byte("foobar forward sec")))
+				Expect(enc).To(Equal(protocol.EncryptionForwardSecure))
+			})
+
+			It("errors of no AEAD for forward-secure encryption is available", func() {
+				_, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionForwardSecure)
+				Expect(err).To(MatchError("CryptoSetupClient: no forwardSecureAEAD"))
+				Expect(enc).To(Equal(protocol.EncryptionUnspecified))
+			})
+
+			It("errors if no encryption level is specified", func() {
+				_, _, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionUnspecified)
+				Expect(err).To(MatchError("no encryption level specified"))
+			})
+		})
 	})
 
 	Context("Diversification Nonces", func() {

--- a/handshake/crypto_setup_interface.go
+++ b/handshake/crypto_setup_interface.go
@@ -12,6 +12,6 @@ type CryptoSetup interface {
 	UnlockForSealing()
 	HandshakeComplete() bool
 	// TODO: clean up this interface
-	DiversificationNonce() []byte         // only needed for cryptoSetupServer
-	SetDiversificationNonce([]byte) error // only needed for cryptoSetupClient
+	DiversificationNonce(force bool) []byte // only needed for cryptoSetupServer
+	SetDiversificationNonce([]byte) error   // only needed for cryptoSetupClient
 }

--- a/handshake/crypto_setup_interface.go
+++ b/handshake/crypto_setup_interface.go
@@ -7,6 +7,7 @@ type CryptoSetup interface {
 	HandleCryptoStream() error
 	Open(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte) ([]byte, protocol.EncryptionLevel, error)
 	Seal(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte) ([]byte, protocol.EncryptionLevel)
+	SealWith(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte, forceEncryptionLevel protocol.EncryptionLevel) ([]byte, protocol.EncryptionLevel, error)
 	LockForSealing()
 	UnlockForSealing()
 	HandshakeComplete() bool

--- a/handshake/crypto_setup_server.go
+++ b/handshake/crypto_setup_server.go
@@ -390,11 +390,11 @@ func (h *cryptoSetupServer) handleCHLO(sni string, data []byte, cryptoData map[T
 }
 
 // DiversificationNonce returns a diversification nonce if required in the next packet to be Seal'ed. See LockForSealing()!
-func (h *cryptoSetupServer) DiversificationNonce() []byte {
-	if h.secureAEAD == nil || h.sentSHLO {
-		return nil
+func (h *cryptoSetupServer) DiversificationNonce(force bool) []byte {
+	if force || (h.secureAEAD != nil && !h.sentSHLO) {
+		return h.diversificationNonce
 	}
-	return h.diversificationNonce
+	return nil
 }
 
 func (h *cryptoSetupServer) SetDiversificationNonce(data []byte) error {

--- a/handshake/crypto_setup_server.go
+++ b/handshake/crypto_setup_server.go
@@ -334,6 +334,8 @@ func (h *cryptoSetupServer) handleCHLO(sni string, data []byte, cryptoData map[T
 		return nil, err
 	}
 
+	h.aeadChanged <- protocol.EncryptionSecure
+
 	// Generate a new curve instance to derive the forward secure key
 	var fsNonce bytes.Buffer
 	fsNonce.Write(clientNonce)

--- a/handshake/crypto_setup_server_test.go
+++ b/handshake/crypto_setup_server_test.go
@@ -185,23 +185,28 @@ var _ = Describe("Crypto setup", func() {
 			cs.secureAEAD = &mockAEAD{}
 			cs.receivedForwardSecurePacket = false
 
-			Expect(cs.DiversificationNonce()).To(BeEmpty())
+			Expect(cs.DiversificationNonce(false)).To(BeEmpty())
 			// Div nonce is created after CHLO
 			cs.handleCHLO("", nil, map[Tag][]byte{TagNONC: nonce32})
 		})
 
 		It("returns diversification nonces", func() {
-			Expect(cs.DiversificationNonce()).To(HaveLen(32))
+			Expect(cs.DiversificationNonce(false)).To(HaveLen(32))
 		})
 
 		It("does not return nonce after sending the SHLO", func() {
 			cs.sentSHLO = true
-			Expect(cs.DiversificationNonce()).To(BeEmpty())
+			Expect(cs.DiversificationNonce(false)).To(BeEmpty())
+		})
+
+		It("returns a nonce for a retransmission, even after sending the SHLO", func() {
+			cs.sentSHLO = true
+			Expect(cs.DiversificationNonce(true)).To(HaveLen(32))
 		})
 
 		It("does not return nonce for unencrypted packets", func() {
 			cs.secureAEAD = nil
-			Expect(cs.DiversificationNonce()).To(BeEmpty())
+			Expect(cs.DiversificationNonce(false)).To(BeEmpty())
 		})
 	})
 

--- a/handshake/crypto_setup_server_test.go
+++ b/handshake/crypto_setup_server_test.go
@@ -659,6 +659,48 @@ var _ = Describe("Crypto setup", func() {
 				Expect(enc).To(Equal(protocol.EncryptionForwardSecure))
 			})
 		})
+
+		Context("forcing encryption levels", func() {
+			It("forces null encryption", func() {
+				d, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionUnencrypted)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(d).To(Equal(foobarFNVSigned))
+				Expect(enc).To(Equal(protocol.EncryptionUnencrypted))
+			})
+
+			It("forces initial encryption", func() {
+				doCHLO()
+				d, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionSecure)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(d).To(Equal([]byte("foobar  normal sec")))
+				Expect(enc).To(Equal(protocol.EncryptionSecure))
+			})
+
+			It("errors of no AEAD for initial encryption is available", func() {
+				_, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionSecure)
+				Expect(err).To(MatchError("CryptoSetupServer: no secureAEAD"))
+				Expect(enc).To(Equal(protocol.EncryptionUnspecified))
+			})
+
+			It("forces forward-secure encryption", func() {
+				doCHLO()
+				d, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionForwardSecure)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(d).To(Equal([]byte("foobar forward sec")))
+				Expect(enc).To(Equal(protocol.EncryptionForwardSecure))
+			})
+
+			It("errors of no AEAD for forward-secure encryption is available", func() {
+				_, enc, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionForwardSecure)
+				Expect(err).To(MatchError("CryptoSetupServer: no forwardSecureAEAD"))
+				Expect(enc).To(Equal(protocol.EncryptionUnspecified))
+			})
+
+			It("errors if no encryption level is specified", func() {
+				_, _, err := cs.SealWith(nil, []byte("foobar"), 0, []byte{}, protocol.EncryptionUnspecified)
+				Expect(err).To(MatchError("no encryption level specified"))
+			})
+		})
 	})
 
 	Context("STK verification and creation", func() {

--- a/handshake/crypto_setup_server_test.go
+++ b/handshake/crypto_setup_server_test.go
@@ -336,7 +336,11 @@ var _ = Describe("Crypto setup", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stream.dataWritten.Bytes()).To(HavePrefix("SHLO"))
 			Expect(stream.dataWritten.Bytes()).ToNot(ContainSubstring("REJ"))
-			Expect(aeadChanged).To(Receive())
+			var encLevel protocol.EncryptionLevel
+			Expect(aeadChanged).To(Receive(&encLevel))
+			Expect(encLevel).To(Equal(protocol.EncryptionSecure))
+			Expect(aeadChanged).To(Receive(&encLevel))
+			Expect(encLevel).To(Equal(protocol.EncryptionForwardSecure))
 		})
 
 		It("recognizes inchoate CHLOs missing SCID", func() {

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -104,7 +104,8 @@ func (p *packetPacker) packPacket(stopWaitingFrame *frames.StopWaitingFrame, lea
 	if isConnectionClose {
 		payloadFrames = []frames.Frame{p.controlFrames[0]}
 	} else {
-		payloadFrames, err = p.composeNextPacket(stopWaitingFrame, publicHeaderLength)
+		maxSize := protocol.MaxFrameAndPublicHeaderSize - publicHeaderLength
+		payloadFrames, err = p.composeNextPacket(stopWaitingFrame, maxSize)
 		if err != nil {
 			return nil, err
 		}
@@ -164,11 +165,9 @@ func (p *packetPacker) packPacket(stopWaitingFrame *frames.StopWaitingFrame, lea
 	}, nil
 }
 
-func (p *packetPacker) composeNextPacket(stopWaitingFrame *frames.StopWaitingFrame, publicHeaderLength protocol.ByteCount) ([]frames.Frame, error) {
+func (p *packetPacker) composeNextPacket(stopWaitingFrame *frames.StopWaitingFrame, maxFrameSize protocol.ByteCount) ([]frames.Frame, error) {
 	var payloadLength protocol.ByteCount
 	var payloadFrames []frames.Frame
-
-	maxFrameSize := protocol.MaxFrameAndPublicHeaderSize - publicHeaderLength
 
 	if stopWaitingFrame != nil {
 		payloadFrames = append(payloadFrames, stopWaitingFrame)

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/lucas-clemente/quic-go/ackhandler"
 	"github.com/lucas-clemente/quic-go/frames"
 	"github.com/lucas-clemente/quic-go/handshake"
 	"github.com/lucas-clemente/quic-go/protocol"
@@ -51,7 +52,19 @@ func (p *packetPacker) PackConnectionClose(ccf *frames.ConnectionCloseFrame, lea
 	// in case the connection is closed, all queued control frames aren't of any use anymore
 	// discard them and queue the ConnectionCloseFrame
 	p.controlFrames = []frames.Frame{ccf}
-	return p.packPacket(nil, leastUnacked)
+	return p.packPacket(nil, leastUnacked, nil)
+}
+
+//  RetransmitNonForwardSecurePacket retransmits a handshake packet, that was sent with less than forward-secure encryption
+func (p *packetPacker) RetransmitNonForwardSecurePacket(stopWaitingFrame *frames.StopWaitingFrame, packet *ackhandler.Packet) (*packedPacket, error) {
+	if packet.EncryptionLevel == protocol.EncryptionForwardSecure {
+		return nil, errors.New("PacketPacker BUG: forward-secure encrypted handshake packets don't need special treatment")
+	}
+	if stopWaitingFrame == nil {
+		return nil, errors.New("PacketPacker BUG: Handshake retransmissions must contain a StopWaitingFrame")
+	}
+
+	return p.packPacket(stopWaitingFrame, 0, packet)
 }
 
 // PackPacket packs a new packet
@@ -59,10 +72,12 @@ func (p *packetPacker) PackConnectionClose(ccf *frames.ConnectionCloseFrame, lea
 // the other controlFrames are sent in the next packet, but might be queued and sent in the next packet if the packet would overflow MaxPacketSize otherwise
 func (p *packetPacker) PackPacket(stopWaitingFrame *frames.StopWaitingFrame, controlFrames []frames.Frame, leastUnacked protocol.PacketNumber) (*packedPacket, error) {
 	p.controlFrames = append(p.controlFrames, controlFrames...)
-	return p.packPacket(stopWaitingFrame, leastUnacked)
+	return p.packPacket(stopWaitingFrame, leastUnacked, nil)
 }
 
-func (p *packetPacker) packPacket(stopWaitingFrame *frames.StopWaitingFrame, leastUnacked protocol.PacketNumber) (*packedPacket, error) {
+func (p *packetPacker) packPacket(stopWaitingFrame *frames.StopWaitingFrame, leastUnacked protocol.PacketNumber, packetToRetransmit *ackhandler.Packet) (*packedPacket, error) {
+	// packetToRetransmit is only set for handshake retransmissions
+	isHandshakeRetransmission := (packetToRetransmit != nil)
 	// cryptoSetup needs to be locked here, so that the AEADs are not changed between
 	// calling DiversificationNonce() and Seal().
 	p.cryptoSetup.LockForSealing()
@@ -103,7 +118,19 @@ func (p *packetPacker) packPacket(stopWaitingFrame *frames.StopWaitingFrame, lea
 	}
 
 	var payloadFrames []frames.Frame
-	if isConnectionClose {
+	if isHandshakeRetransmission {
+		payloadFrames = append(payloadFrames, stopWaitingFrame)
+		// don't retransmit Acks and StopWaitings
+		for _, f := range packetToRetransmit.Frames {
+			switch f.(type) {
+			case *frames.AckFrame:
+				continue
+			case *frames.StopWaitingFrame:
+				continue
+			}
+			payloadFrames = append(payloadFrames, f)
+		}
+	} else if isConnectionClose {
 		payloadFrames = []frames.Frame{p.controlFrames[0]}
 	} else {
 		maxSize := protocol.MaxFrameAndPublicHeaderSize - publicHeaderLength
@@ -139,7 +166,7 @@ func (p *packetPacker) packPacket(stopWaitingFrame *frames.StopWaitingFrame, lea
 		if sf, ok := frame.(*frames.StreamFrame); ok && sf.StreamID != 1 {
 			hasNonCryptoStreamData = true
 		}
-		err := frame.Write(buffer, p.version)
+		err = frame.Write(buffer, p.version)
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +177,16 @@ func (p *packetPacker) packPacket(stopWaitingFrame *frames.StopWaitingFrame, lea
 	}
 
 	raw = raw[0:buffer.Len()]
-	_, encryptionLevel := p.cryptoSetup.Seal(raw[payloadStartIndex:payloadStartIndex], raw[payloadStartIndex:], currentPacketNumber, raw[:payloadStartIndex])
+	var encryptionLevel protocol.EncryptionLevel
+	if isHandshakeRetransmission {
+		var err error
+		_, encryptionLevel, err = p.cryptoSetup.SealWith(raw[payloadStartIndex:payloadStartIndex], raw[payloadStartIndex:], currentPacketNumber, raw[:payloadStartIndex], packetToRetransmit.EncryptionLevel)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		_, encryptionLevel = p.cryptoSetup.Seal(raw[payloadStartIndex:payloadStartIndex], raw[payloadStartIndex:], currentPacketNumber, raw[:payloadStartIndex])
+	}
 	raw = raw[0 : buffer.Len()+12]
 
 	if hasNonCryptoStreamData && encryptionLevel <= protocol.EncryptionUnencrypted {

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -93,7 +93,8 @@ func (p *packetPacker) packPacket(stopWaitingFrame *frames.StopWaitingFrame, lea
 	}
 
 	if p.perspective == protocol.PerspectiveServer {
-		responsePublicHeader.DiversificationNonce = p.cryptoSetup.DiversificationNonce()
+		force := isHandshakeRetransmission && (packetToRetransmit.EncryptionLevel == protocol.EncryptionSecure)
+		responsePublicHeader.DiversificationNonce = p.cryptoSetup.DiversificationNonce(force)
 	}
 
 	if p.perspective == protocol.PerspectiveClient && !p.cryptoSetup.HandshakeComplete() {

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -24,6 +24,9 @@ func (m *mockCryptoSetup) Open(dst, src []byte, packetNumber protocol.PacketNumb
 func (m *mockCryptoSetup) Seal(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte) ([]byte, protocol.EncryptionLevel) {
 	return append(src, bytes.Repeat([]byte{0}, 12)...), m.encLevelSeal
 }
+func (m *mockCryptoSetup) SealWith(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte, encLevel protocol.EncryptionLevel) ([]byte, protocol.EncryptionLevel, error) {
+	panic("not implemented")
+}
 func (m *mockCryptoSetup) LockForSealing()                      {}
 func (m *mockCryptoSetup) UnlockForSealing()                    {}
 func (m *mockCryptoSetup) HandshakeComplete() bool              { return m.handshakeComplete }

--- a/protocol/server_parameters.go
+++ b/protocol/server_parameters.go
@@ -2,6 +2,10 @@ package protocol
 
 import "time"
 
+// NonForwardSecurePacketSizeReduction is the number of bytes a non forward-secure packet has to be smaller than a forward-secure packet
+// This makes sure that those packets can always be retransmitted without splitting the contained StreamFrames
+const NonForwardSecurePacketSizeReduction = 50
+
 // DefaultMaxCongestionWindow is the default for the max congestion window
 const DefaultMaxCongestionWindow = 1000
 

--- a/session.go
+++ b/session.go
@@ -623,9 +623,10 @@ func (s *session) sendPacket() error {
 		}
 
 		err = s.sentPacketHandler.SentPacket(&ackhandler.Packet{
-			PacketNumber: packet.number,
-			Frames:       packet.frames,
-			Length:       protocol.ByteCount(len(packet.raw)),
+			PacketNumber:    packet.number,
+			Frames:          packet.frames,
+			Length:          protocol.ByteCount(len(packet.raw)),
+			EncryptionLevel: packet.encryptionLevel,
 		})
 		if err != nil {
 			return err

--- a/session.go
+++ b/session.go
@@ -236,6 +236,9 @@ runLoop:
 			// begins with the public header and we never copy it.
 			putPacketBuffer(p.publicHeader.Raw)
 		case l := <-s.aeadChanged:
+			if l == protocol.EncryptionForwardSecure {
+				s.packer.SetForwardSecure()
+			}
 			s.tryDecryptingQueuedPackets()
 			s.cryptoChangeCallback(s, l == protocol.EncryptionForwardSecure)
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -1083,6 +1083,14 @@ var _ = Describe("Session", func() {
 		})
 	})
 
+	It("tells the packetPacker when forward-secure encryption is used", func() {
+		go sess.run()
+		sess.aeadChanged <- protocol.EncryptionSecure
+		Consistently(func() bool { return sess.packer.isForwardSecure }).Should(BeFalse())
+		sess.aeadChanged <- protocol.EncryptionForwardSecure
+		Eventually(func() bool { return sess.packer.isForwardSecure }).Should(BeTrue())
+	})
+
 	It("closes when crypto stream errors", func() {
 		go sess.run()
 		s, err := sess.GetOrOpenStream(3)

--- a/session_test.go
+++ b/session_test.go
@@ -825,189 +825,236 @@ var _ = Describe("Session", func() {
 	})
 
 	Context("retransmissions", func() {
+		var sph *mockSentPacketHandler
 		BeforeEach(func() {
+			// a StopWaitingFrame is added, so make sure the packet number of the new package is higher than the packet number of the retransmitted packet
+			sess.packer.packetNumberGenerator.next = 0x1337 + 10
+			sph = newMockSentPacketHandler().(*mockSentPacketHandler)
+			sess.sentPacketHandler = sph
 			sess.packer.cryptoSetup = &mockCryptoSetup{encLevelSeal: protocol.EncryptionForwardSecure}
 		})
 
-		It("sends a StreamFrame from a packet queued for retransmission", func() {
-			// a StopWaitingFrame is added, so make sure the packet number of the new package is higher than the packet number of the retransmitted packet
-			sess.packer.packetNumberGenerator.next = 0x1337 + 9
+		Context("for handshake packets", func() {
+			It("retransmits an unencrypted packet", func() {
+				sf := &frames.StreamFrame{StreamID: 1, Data: []byte("foobar")}
+				sph.retransmissionQueue = []*ackhandler.Packet{{
+					Frames:          []frames.Frame{sf},
+					EncryptionLevel: protocol.EncryptionUnencrypted,
+				}}
+				err := sess.sendPacket()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mconn.written).To(HaveLen(1))
+				sentPackets := sph.sentPackets
+				Expect(sentPackets).To(HaveLen(1))
+				Expect(sentPackets[0].EncryptionLevel).To(Equal(protocol.EncryptionUnencrypted))
+				Expect(sentPackets[0].Frames).To(HaveLen(2))
+				Expect(sentPackets[0].Frames[1]).To(Equal(sf))
+				swf := sentPackets[0].Frames[0].(*frames.StopWaitingFrame)
+				Expect(swf.LeastUnacked).To(Equal(protocol.PacketNumber(0x1337)))
+			})
 
-			f := frames.StreamFrame{
-				StreamID: 0x5,
-				Data:     []byte("foobar1234567"),
-			}
-			p := ackhandler.Packet{
-				PacketNumber: 0x1337,
-				Frames:       []frames.Frame{&f},
-			}
-			sph := newMockSentPacketHandler()
-			sph.(*mockSentPacketHandler).retransmissionQueue = []*ackhandler.Packet{&p}
-			sess.sentPacketHandler = sph
+			It("doesn't retransmit non-retransmittable packets", func() {
+				sph.retransmissionQueue = []*ackhandler.Packet{{
+					Frames: []frames.Frame{
+						&frames.AckFrame{},
+						&frames.StopWaitingFrame{},
+					},
+					EncryptionLevel: protocol.EncryptionUnencrypted,
+				}}
+				err := sess.sendPacket()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mconn.written).To(BeEmpty())
+			})
 
-			err := sess.sendPacket()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(mconn.written).To(HaveLen(1))
-			Expect(sph.(*mockSentPacketHandler).requestedStopWaiting).To(BeTrue())
-			Expect(mconn.written[0]).To(ContainSubstring("foobar1234567"))
+			It("retransmit a packet encrypted with the initial encryption", func() {
+				sf := &frames.StreamFrame{StreamID: 1, Data: []byte("foobar")}
+				sph.retransmissionQueue = []*ackhandler.Packet{{
+					Frames:          []frames.Frame{sf},
+					EncryptionLevel: protocol.EncryptionSecure,
+				}}
+				err := sess.sendPacket()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mconn.written).To(HaveLen(1))
+				sentPackets := sph.sentPackets
+				Expect(sentPackets).To(HaveLen(1))
+				Expect(sentPackets[0].EncryptionLevel).To(Equal(protocol.EncryptionSecure))
+				Expect(sentPackets[0].Frames).To(HaveLen(2))
+				Expect(sentPackets[0].Frames).To(ContainElement(sf))
+			})
 		})
 
-		It("sends a StreamFrame from a packet queued for retransmission", func() {
-			// a StopWaitingFrame is added, so make sure the packet number of the new package is higher than the packet number of the retransmitted packet
-			sess.packer.packetNumberGenerator.next = 0x1337 + 9
+		Context("for packets after the handshake", func() {
+			BeforeEach(func() {
+				sess.packer.SetForwardSecure()
+			})
 
-			f1 := frames.StreamFrame{
-				StreamID: 0x5,
-				Data:     []byte("foobar"),
-			}
-			f2 := frames.StreamFrame{
-				StreamID: 0x7,
-				Data:     []byte("loremipsum"),
-			}
-			p1 := ackhandler.Packet{
-				PacketNumber: 0x1337,
-				Frames:       []frames.Frame{&f1},
-			}
-			p2 := ackhandler.Packet{
-				PacketNumber: 0x1338,
-				Frames:       []frames.Frame{&f2},
-			}
-			sph := newMockSentPacketHandler()
-			sph.(*mockSentPacketHandler).retransmissionQueue = []*ackhandler.Packet{&p1, &p2}
-			sess.sentPacketHandler = sph
+			It("sends a StreamFrame from a packet queued for retransmission", func() {
+				f := frames.StreamFrame{
+					StreamID: 0x5,
+					Data:     []byte("foobar1234567"),
+				}
+				p := ackhandler.Packet{
+					PacketNumber:    0x1337,
+					Frames:          []frames.Frame{&f},
+					EncryptionLevel: protocol.EncryptionForwardSecure,
+				}
+				sph.retransmissionQueue = []*ackhandler.Packet{&p}
 
-			err := sess.sendPacket()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(mconn.written).To(HaveLen(1))
-			Expect(mconn.written[0]).To(ContainSubstring("foobar"))
-			Expect(mconn.written[0]).To(ContainSubstring("loremipsum"))
-		})
+				err := sess.sendPacket()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mconn.written).To(HaveLen(1))
+				Expect(sph.requestedStopWaiting).To(BeTrue())
+				Expect(mconn.written[0]).To(ContainSubstring("foobar1234567"))
+			})
 
-		It("always attaches a StopWaiting to a packet that contains a retransmission", func() {
-			// make sure the packet number of the new package is higher than the packet number of the retransmitted packet
-			sess.packer.packetNumberGenerator.next = 0x1337 + 9
+			It("sends a StreamFrame from a packet queued for retransmission", func() {
+				f1 := frames.StreamFrame{
+					StreamID: 0x5,
+					Data:     []byte("foobar"),
+				}
+				f2 := frames.StreamFrame{
+					StreamID: 0x7,
+					Data:     []byte("loremipsum"),
+				}
+				p1 := ackhandler.Packet{
+					PacketNumber:    0x1337,
+					Frames:          []frames.Frame{&f1},
+					EncryptionLevel: protocol.EncryptionForwardSecure,
+				}
+				p2 := ackhandler.Packet{
+					PacketNumber:    0x1338,
+					Frames:          []frames.Frame{&f2},
+					EncryptionLevel: protocol.EncryptionForwardSecure,
+				}
+				sph.retransmissionQueue = []*ackhandler.Packet{&p1, &p2}
 
-			f := &frames.StreamFrame{
-				StreamID: 0x5,
-				Data:     bytes.Repeat([]byte{'f'}, int(1.5*float32(protocol.MaxPacketSize))),
-			}
-			sess.streamFramer.AddFrameForRetransmission(f)
+				err := sess.sendPacket()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mconn.written).To(HaveLen(1))
+				Expect(mconn.written[0]).To(ContainSubstring("foobar"))
+				Expect(mconn.written[0]).To(ContainSubstring("loremipsum"))
+			})
 
-			sph := newMockSentPacketHandler()
-			sess.sentPacketHandler = sph
+			It("always attaches a StopWaiting to a packet that contains a retransmission", func() {
+				f := &frames.StreamFrame{
+					StreamID: 0x5,
+					Data:     bytes.Repeat([]byte{'f'}, int(1.5*float32(protocol.MaxPacketSize))),
+				}
+				sess.streamFramer.AddFrameForRetransmission(f)
 
-			err := sess.sendPacket()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(mconn.written).To(HaveLen(2))
-			sentPackets := sph.(*mockSentPacketHandler).sentPackets
-			Expect(sentPackets).To(HaveLen(2))
-			_, ok := sentPackets[0].Frames[0].(*frames.StopWaitingFrame)
-			Expect(ok).To(BeTrue())
-			_, ok = sentPackets[1].Frames[0].(*frames.StopWaitingFrame)
-			Expect(ok).To(BeTrue())
-		})
+				err := sess.sendPacket()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mconn.written).To(HaveLen(2))
+				sentPackets := sph.sentPackets
+				Expect(sentPackets).To(HaveLen(2))
+				_, ok := sentPackets[0].Frames[0].(*frames.StopWaitingFrame)
+				Expect(ok).To(BeTrue())
+				_, ok = sentPackets[1].Frames[0].(*frames.StopWaitingFrame)
+				Expect(ok).To(BeTrue())
+			})
 
-		It("calls MaybeQueueRTOs even if congestion blocked, so that bytesInFlight is updated", func() {
-			sph := newMockSentPacketHandler()
-			sph.(*mockSentPacketHandler).congestionLimited = true
-			sess.sentPacketHandler = sph
-			err := sess.sendPacket()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(sph.(*mockSentPacketHandler).maybeQueueRTOsCalled).To(BeTrue())
-		})
+			It("calls MaybeQueueRTOs even if congestion blocked, so that bytesInFlight is updated", func() {
+				sph.congestionLimited = true
+				sess.sentPacketHandler = sph
+				err := sess.sendPacket()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sph.maybeQueueRTOsCalled).To(BeTrue())
+			})
 
-		It("retransmits a WindowUpdates if it hasn't already sent a WindowUpdate with a higher ByteOffset", func() {
-			_, err := sess.GetOrOpenStream(5)
-			Expect(err).ToNot(HaveOccurred())
-			fc := newMockFlowControlHandler()
-			fc.receiveWindow = 0x1000
-			sess.flowControlManager = fc
-			sph := newMockSentPacketHandler()
-			sess.sentPacketHandler = sph
-			wuf := &frames.WindowUpdateFrame{
-				StreamID:   5,
-				ByteOffset: 0x1000,
-			}
-			sph.(*mockSentPacketHandler).retransmissionQueue = []*ackhandler.Packet{{
-				Frames: []frames.Frame{wuf},
-			}}
-			err = sess.sendPacket()
-			Expect(err).ToNot(HaveOccurred())
-			sentPackets := sph.(*mockSentPacketHandler).sentPackets
-			Expect(sentPackets).To(HaveLen(1))
-			Expect(sentPackets[0].Frames).To(ContainElement(wuf))
-		})
-
-		It("doesn't retransmit WindowUpdates if it already sent a WindowUpdate with a higher ByteOffset", func() {
-			_, err := sess.GetOrOpenStream(5)
-			Expect(err).ToNot(HaveOccurred())
-			fc := newMockFlowControlHandler()
-			fc.receiveWindow = 0x2000
-			sess.flowControlManager = fc
-			sph := newMockSentPacketHandler()
-			sess.sentPacketHandler = sph
-			sph.(*mockSentPacketHandler).retransmissionQueue = []*ackhandler.Packet{{
-				Frames: []frames.Frame{&frames.WindowUpdateFrame{
+			It("retransmits a WindowUpdates if it hasn't already sent a WindowUpdate with a higher ByteOffset", func() {
+				_, err := sess.GetOrOpenStream(5)
+				Expect(err).ToNot(HaveOccurred())
+				fc := newMockFlowControlHandler()
+				fc.receiveWindow = 0x1000
+				sess.flowControlManager = fc
+				wuf := &frames.WindowUpdateFrame{
 					StreamID:   5,
 					ByteOffset: 0x1000,
-				}},
-			}}
-			err = sess.sendPacket()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sph.(*mockSentPacketHandler).sentPackets).To(BeEmpty())
-		})
+				}
+				sph.retransmissionQueue = []*ackhandler.Packet{{
+					Frames:          []frames.Frame{wuf},
+					EncryptionLevel: protocol.EncryptionForwardSecure,
+				}}
+				err = sess.sendPacket()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sph.sentPackets).To(HaveLen(1))
+				Expect(sph.sentPackets[0].Frames).To(ContainElement(wuf))
+			})
 
-		It("doesn't retransmit WindowUpdates for closed streams", func() {
-			str, err := sess.GetOrOpenStream(5)
-			Expect(err).ToNot(HaveOccurred())
-			// close the stream
-			str.(*stream).sentFin()
-			str.Close()
-			str.(*stream).RegisterRemoteError(nil)
-			sess.garbageCollectStreams()
-			_, err = sess.flowControlManager.SendWindowSize(5)
-			Expect(err).To(MatchError("Error accessing the flowController map."))
-			sph := newMockSentPacketHandler()
-			sess.sentPacketHandler = sph
-			sph.(*mockSentPacketHandler).retransmissionQueue = []*ackhandler.Packet{{
-				Frames: []frames.Frame{&frames.WindowUpdateFrame{
-					StreamID:   5,
-					ByteOffset: 0x1337,
-				}},
-			}}
-			err = sess.sendPacket()
-			Expect(err).ToNot(HaveOccurred())
-			sentPackets := sph.(*mockSentPacketHandler).sentPackets
-			Expect(sentPackets).To(BeEmpty())
-		})
+			It("doesn't retransmit WindowUpdates if it already sent a WindowUpdate with a higher ByteOffset", func() {
+				_, err := sess.GetOrOpenStream(5)
+				Expect(err).ToNot(HaveOccurred())
+				fc := newMockFlowControlHandler()
+				fc.receiveWindow = 0x2000
+				sess.flowControlManager = fc
+				sph.retransmissionQueue = []*ackhandler.Packet{{
+					Frames: []frames.Frame{&frames.WindowUpdateFrame{
+						StreamID:   5,
+						ByteOffset: 0x1000,
+					}},
+					EncryptionLevel: protocol.EncryptionForwardSecure,
+				}}
+				err = sess.sendPacket()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sph.sentPackets).To(BeEmpty())
+			})
 
-		It("retransmits RTO packets", func() {
-			// We simulate consistently low RTTs, so that the test works faster
-			n := protocol.PacketNumber(10)
-			for p := protocol.PacketNumber(1); p < n; p++ {
-				err := sess.sentPacketHandler.SentPacket(&ackhandler.Packet{PacketNumber: p, Length: 1})
-				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(time.Microsecond)
-				ack := &frames.AckFrame{}
-				ack.LargestAcked = p
-				err = sess.sentPacketHandler.ReceivedAck(ack, p, time.Now())
-				Expect(err).NotTo(HaveOccurred())
-			}
-			sess.packer.packetNumberGenerator.next = n + 1
-			// Now, we send a single packet, and expect that it was retransmitted later
+			It("doesn't retransmit WindowUpdates for closed streams", func() {
+				str, err := sess.GetOrOpenStream(5)
+				Expect(err).ToNot(HaveOccurred())
+				// close the stream
+				str.(*stream).sentFin()
+				str.Close()
+				str.(*stream).RegisterRemoteError(nil)
+				sess.garbageCollectStreams()
+				_, err = sess.flowControlManager.SendWindowSize(5)
+				Expect(err).To(MatchError("Error accessing the flowController map."))
+				sph.retransmissionQueue = []*ackhandler.Packet{{
+					Frames: []frames.Frame{&frames.WindowUpdateFrame{
+						StreamID:   5,
+						ByteOffset: 0x1337,
+					}},
+					EncryptionLevel: protocol.EncryptionForwardSecure,
+				}}
+				err = sess.sendPacket()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sph.sentPackets).To(BeEmpty())
+			})
+		})
+	})
+
+	It("retransmits RTO packets", func() {
+		sess.packer.cryptoSetup = &mockCryptoSetup{encLevelSeal: protocol.EncryptionForwardSecure}
+		// We simulate consistently low RTTs, so that the test works faster
+		n := protocol.PacketNumber(10)
+		for p := protocol.PacketNumber(1); p < n; p++ {
 			err := sess.sentPacketHandler.SentPacket(&ackhandler.Packet{
-				PacketNumber: n,
-				Length:       1,
-				Frames: []frames.Frame{&frames.StreamFrame{
-					Data: []byte("foobar"),
-				}},
+				PacketNumber:    p,
+				Length:          1,
+				EncryptionLevel: protocol.EncryptionForwardSecure,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			go sess.run()
-			sess.scheduleSending()
-			Eventually(func() [][]byte { return mconn.written }).ShouldNot(BeEmpty())
-			Expect(mconn.written[0]).To(ContainSubstring("foobar"))
+			time.Sleep(time.Microsecond)
+			ack := &frames.AckFrame{}
+			ack.LargestAcked = p
+			err = sess.sentPacketHandler.ReceivedAck(ack, p, time.Now())
+			Expect(err).NotTo(HaveOccurred())
+		}
+		sess.packer.packetNumberGenerator.next = n + 1
+		// Now, we send a single packet, and expect that it was retransmitted later
+		err := sess.sentPacketHandler.SentPacket(&ackhandler.Packet{
+			PacketNumber: n,
+			Length:       1,
+			Frames: []frames.Frame{&frames.StreamFrame{
+				Data: []byte("foobar"),
+			}},
+			EncryptionLevel: protocol.EncryptionForwardSecure,
 		})
+		Expect(err).NotTo(HaveOccurred())
+		go sess.run()
+		sess.scheduleSending()
+		Eventually(func() [][]byte { return mconn.written }).ShouldNot(BeEmpty())
+		Expect(mconn.written[0]).To(ContainSubstring("foobar"))
 	})
 
 	Context("scheduling sending", func() {


### PR DESCRIPTION
This requires us to pay more attention to the encryption level of retransmission. The SHLO (which is always sent with initial encryption) must be retransmitted with initial encryption level.

Fixes #391.