### PR TITLE
Fix reading of tls.Config certificates

### DIFF
--- a/crypto/cert_chain.go
+++ b/crypto/cert_chain.go
@@ -55,30 +55,46 @@ func (c *certChain) GetLeafCert(sni string) ([]byte, error) {
 	return cert.Certificate[0], nil
 }
 
-func (c *certChain) getCertForSNI(sni string) (*tls.Certificate, error) {
-	if c.config.GetCertificate != nil {
-		cert, err := c.config.GetCertificate(&tls.ClientHelloInfo{ServerName: sni})
-		if err != nil {
-			return nil, err
+func (cc *certChain) getCertForSNI(sni string) (*tls.Certificate, error) {
+	c := cc.config
+	// The rest of this function is mostly copied from crypto/tls.getCertificate
+
+	if c.GetCertificate != nil {
+		cert, err := c.GetCertificate(&tls.ClientHelloInfo{ServerName: sni})
+		if cert != nil || err != nil {
+			return cert, err
 		}
-		if cert != nil {
+	}
+
+	if len(c.Certificates) == 0 {
+		return nil, errNoMatchingCertificate
+	}
+
+	if len(c.Certificates) == 1 || c.NameToCertificate == nil {
+		// There's only one choice, so no point doing any work.
+		return &c.Certificates[0], nil
+	}
+
+	name := strings.ToLower(sni)
+	for len(name) > 0 && name[len(name)-1] == '.' {
+		name = name[:len(name)-1]
+	}
+
+	if cert, ok := c.NameToCertificate[name]; ok {
+		return cert, nil
+	}
+
+	// try replacing labels in the name with wildcards until we get a
+	// match.
+	labels := strings.Split(name, ".")
+	for i := range labels {
+		labels[i] = "*"
+		candidate := strings.Join(labels, ".")
+		if cert, ok := c.NameToCertificate[candidate]; ok {
 			return cert, nil
 		}
 	}
 
-	if len(c.config.NameToCertificate) != 0 {
-		if cert, ok := c.config.NameToCertificate[sni]; ok {
-			return cert, nil
-		}
-		wildcardSNI := "*" + strings.TrimLeftFunc(sni, func(r rune) bool { return r != '.' })
-		if cert, ok := c.config.NameToCertificate[wildcardSNI]; ok {
-			return cert, nil
-		}
-	}
-
-	if len(c.config.Certificates) != 0 {
-		return &c.config.Certificates[0], nil
-	}
-
-	return nil, errNoMatchingCertificate
+	// If nothing matches, return the first certificate.
+	return &c.Certificates[0], nil
 }

--- a/crypto/cert_chain.go
+++ b/crypto/cert_chain.go
@@ -57,6 +57,15 @@ func (c *certChain) GetLeafCert(sni string) ([]byte, error) {
 
 func (cc *certChain) getCertForSNI(sni string) (*tls.Certificate, error) {
 	c := cc.config
+	if c.GetConfigForClient != nil {
+		var err error
+		c, err = c.GetConfigForClient(&tls.ClientHelloInfo{
+			ServerName: sni,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
 	// The rest of this function is mostly copied from crypto/tls.getCertificate
 
 	if c.GetCertificate != nil {

--- a/crypto/cert_chain.go
+++ b/crypto/cert_chain.go
@@ -57,14 +57,9 @@ func (c *certChain) GetLeafCert(sni string) ([]byte, error) {
 
 func (cc *certChain) getCertForSNI(sni string) (*tls.Certificate, error) {
 	c := cc.config
-	if c.GetConfigForClient != nil {
-		var err error
-		c, err = c.GetConfigForClient(&tls.ClientHelloInfo{
-			ServerName: sni,
-		})
-		if err != nil {
-			return nil, err
-		}
+	c, err := maybeGetConfigForClient(c, sni)
+	if err != nil {
+		return nil, err
 	}
 	// The rest of this function is mostly copied from crypto/tls.getCertificate
 

--- a/crypto/cert_chain_test.go
+++ b/crypto/cert_chain_test.go
@@ -127,5 +127,16 @@ var _ = Describe("Proof", func() {
 			_, err := cc.GetLeafCert("invalid domain")
 			Expect(err).To(MatchError(errNoMatchingCertificate))
 		})
+
+		It("respects GetConfigForClient", func() {
+			nestedConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+			config.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+				Expect(chi.ServerName).To(Equal("quic.clemente.io"))
+				return nestedConfig, nil
+			}
+			resultCert, err := cc.getCertForSNI("quic.clemente.io")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*resultCert).To(Equal(cert))
+		})
 	})
 })

--- a/crypto/cert_chain_test.go
+++ b/crypto/cert_chain_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Proof", func() {
 		})
 
 		It("uses NameToCertificate entries", func() {
+			config.Certificates = []tls.Certificate{cert, cert} // two entries so the long path is used
 			config.NameToCertificate = map[string]*tls.Certificate{
 				"quic.clemente.io": &cert,
 			}
@@ -94,6 +95,7 @@ var _ = Describe("Proof", func() {
 		})
 
 		It("uses NameToCertificate entries with wildcard", func() {
+			config.Certificates = []tls.Certificate{cert, cert} // two entries so the long path is used
 			config.NameToCertificate = map[string]*tls.Certificate{
 				"*.clemente.io": &cert,
 			}

--- a/crypto/config_for_client_1.8.go
+++ b/crypto/config_for_client_1.8.go
@@ -1,0 +1,14 @@
+// +build go1.8
+
+package crypto
+
+import "crypto/tls"
+
+func maybeGetConfigForClient(c *tls.Config, sni string) (*tls.Config, error) {
+	if c.GetConfigForClient == nil {
+		return c, nil
+	}
+	return c.GetConfigForClient(&tls.ClientHelloInfo{
+		ServerName: sni,
+	})
+}

--- a/crypto/config_for_client_pre1.8.go
+++ b/crypto/config_for_client_pre1.8.go
@@ -1,0 +1,9 @@
+// +build !go1.8
+
+package crypto
+
+import "crypto/tls"
+
+func maybeGetConfigForClient(c *tls.Config, sni string) (*tls.Config, error) {
+	return c, nil
+}


### PR DESCRIPTION
This commit mostly copies the getCertificate function from crypto/tls to
align our certificate reading with the standard library.

Should fix #458 and https://github.com/mholt/caddy/issues/1483.