### PR TITLE
use OpenStreamSync to open the data stream in the h2quic client

### DIFF
--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -168,8 +168,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		c.cryptoChangedCond.Wait()
 	}
 	hdrChan := make(chan *http.Response)
-	// TODO: think about what to do with a TooManyOpenStreams error. Wait and retry?
-	dataStream, err := c.session.OpenStream()
+	dataStream, err := c.session.OpenStreamSync()
 	if err != nil {
 		c.Close(err)
 		return nil, err

--- a/h2quic/server_test.go
+++ b/h2quic/server_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+	"time"
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
@@ -23,12 +24,13 @@ import (
 )
 
 type mockSession struct {
-	closed          bool
-	closedWithError error
-	dataStream      quic.Stream
-	streamToAccept  quic.Stream
-	streamToOpen    quic.Stream
-	streamOpenErr   error
+	closed              bool
+	closedWithError     error
+	dataStream          quic.Stream
+	streamToAccept      quic.Stream
+	streamToOpen        quic.Stream
+	blockOpenStreamSync bool
+	streamOpenErr       error
 }
 
 func (s *mockSession) GetOrOpenStream(id protocol.StreamID) (quic.Stream, error) {
@@ -44,7 +46,10 @@ func (s *mockSession) OpenStream() (quic.Stream, error) {
 	return s.streamToOpen, nil
 }
 func (s *mockSession) OpenStreamSync() (quic.Stream, error) {
-	panic("not implemented")
+	if s.blockOpenStreamSync {
+		time.Sleep(time.Hour)
+	}
+	return s.OpenStream()
 }
 func (s *mockSession) Close(e error) error {
 	s.closed = true


### PR DESCRIPTION
That's exactly what `OpenStreamSync` is intended for. It wasn't used so far because the client was implemented before the redesign of our API.