### PR TITLE
return an error when the network conn is closed in Listener.Serve()

### DIFF
--- a/server.go
+++ b/server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -88,9 +87,6 @@ func (s *server) Serve() error {
 		// If it does, we only read a truncated packet, which will then end up undecryptable
 		n, remoteAddr, err := s.conn.ReadFrom(data)
 		if err != nil {
-			if strings.HasSuffix(err.Error(), "use of closed network connection") {
-				return nil
-			}
 			return err
 		}
 		data = data[:n]

--- a/server_test.go
+++ b/server_test.go
@@ -219,7 +219,8 @@ var _ = Describe("Server", func() {
 			go func() {
 				defer GinkgoRecover()
 				err := ln.Serve()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("use of closed network connection"))
 				returned = true
 			}()
 			ln.Close()


### PR DESCRIPTION
fixes #483