### PR TITLE
send a Public Reset when receiving a CHLO with the FHL2 tag

### DIFF
--- a/handshake/crypto_setup_server_test.go
+++ b/handshake/crypto_setup_server_test.go
@@ -222,6 +222,14 @@ var _ = Describe("Crypto setup", func() {
 			binary.LittleEndian.PutUint64(xlct, crypto.HashCert(cert))
 		})
 
+		It("doesn't support Chrome's head-of-line blocking experiment", func() {
+			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, map[Tag][]byte{
+				TagFHL2: []byte("foobar"),
+			})
+			err := cs.HandleCryptoStream()
+			Expect(err).To(MatchError(ErrHOLExperiment))
+		})
+
 		It("generates REJ messages", func() {
 			response, err := cs.handleInchoateCHLO("", bytes.Repeat([]byte{'a'}, protocol.ClientHelloMinimumSize), nil)
 			Expect(err).ToNot(HaveOccurred())

--- a/handshake/tags.go
+++ b/handshake/tags.go
@@ -50,6 +50,11 @@ const (
 	// TagSFCW is the initial stream flow control receive window.
 	TagSFCW Tag = 'S' + 'F'<<8 + 'C'<<16 + 'W'<<24
 
+	// TagFHL2 forces head of line blocking.
+	// Chrome experiment (see https://codereview.chromium.org/2115033002)
+	// unsupported by quic-go
+	TagFHL2 Tag = 'F' + 'H'<<8 + 'L'<<16 + '2'<<24
+
 	// TagSTK is the source-address token
 	TagSTK Tag = 'S' + 'T'<<8 + 'K'<<16
 	// TagSNO is the server nonce

--- a/session.go
+++ b/session.go
@@ -542,7 +542,7 @@ func (s *session) closeImpl(e error, remoteClose bool) error {
 		return nil
 	}
 
-	if quicErr.ErrorCode == qerr.DecryptionFailure {
+	if quicErr.ErrorCode == qerr.DecryptionFailure || quicErr == handshake.ErrHOLExperiment {
 		// If we send a public reset, don't send a CONNECTION_CLOSE
 		s.closeChan <- nil
 		return s.sendPublicReset(s.lastRcvdPacketNumber)


### PR DESCRIPTION
Fixes #411.

Chrome sends the FHL2 when it wants to perform a head-of-line blocking
experiment, introduced in QUIC version 36 (see
https://codereview.chromium.org/2115033002). We don’t support this
experiment. By sending a Public Reset when receiving this tag we force
Chrome to use the TCP fallback.