### PR TITLE
Fix some racetime conditions

### DIFF
--- a/client.go
+++ b/client.go
@@ -150,11 +150,14 @@ func (c *client) handlePacket(remoteAddr net.Addr, packet []byte) error {
 		return qerr.Error(qerr.InvalidPacketHeader, err.Error())
 	}
 	hdr.Raw = packet[:len(packet)-r.Len()]
-
+	
+	c.mutex.Lock()
 	// ignore delayed / duplicated version negotiation packets
 	if c.connState >= ConnStateVersionNegotiated && hdr.VersionFlag {
+		c.mutex.Unlock()
 		return nil
 	}
+	c.mutex.Unlock()
 
 	// this is the first packet after the client sent a packet with the VersionFlag set
 	// if the server doesn't send a version negotiation packet, it supports the suggested version

--- a/handshake/crypto_setup_client.go
+++ b/handshake/crypto_setup_client.go
@@ -303,6 +303,8 @@ func (h *cryptoSetupClient) Open(dst, src []byte, packetNumber protocol.PacketNu
 }
 
 func (h *cryptoSetupClient) Seal(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte) ([]byte, protocol.EncryptionLevel) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
 	if h.forwardSecureAEAD != nil {
 		return h.forwardSecureAEAD.Seal(dst, src, packetNumber, associatedData), protocol.EncryptionForwardSecure
 	}


### PR DESCRIPTION
Re-arranged mutex locks and unlocks to avoid some racetime conditions,
this potentially resolves issue #343, download stalling because
congestion limited