### PR TITLE
fix parsing of STREAM frames that have the FinBit set

### DIFF
--- a/frames/stream_frame.go
+++ b/frames/stream_frame.go
@@ -64,7 +64,7 @@ func ParseStreamFrame(r *bytes.Reader) (*StreamFrame, error) {
 		return nil, qerr.Error(qerr.InvalidStreamData, "data len too large")
 	}
 
-	if dataLen == 0 {
+	if !frame.DataLenPresent {
 		// The rest of the packet is data
 		dataLen = uint16(r.Len())
 	}


### PR DESCRIPTION
Fixes #542.

Probably also fixes #535. I found this issue while running the benchmark tests in my Ubuntu VM. With this fix, I didn't see any flaky benchmark test there anymore.

This could also be the fix for some of the other flaky tests.