### PR TITLE
Fix quic_client integration tests

### DIFF
--- a/integrationtests/integration_test.go
+++ b/integrationtests/integration_test.go
@@ -38,7 +38,8 @@ var _ = Describe("Integration tests", func() {
 				Expect(err).NotTo(HaveOccurred())
 				defer session.Kill()
 				Eventually(session).Should(Exit(0))
-				Expect(session.Out).To(Say("Response:\nheaders: HTTP/1.1 200\nstatus: 200\n\nbody: Hello, World!\n"))
+				Expect(session.Out).To(Say(":status 200"))
+				Expect(session.Out).To(Say("body: Hello, World!\n"))
 			})
 
 			It("posts and reads a body", func() {
@@ -54,7 +55,8 @@ var _ = Describe("Integration tests", func() {
 				Expect(err).NotTo(HaveOccurred())
 				defer session.Kill()
 				Eventually(session).Should(Exit(0))
-				Expect(session.Out).To(Say("Response:\nheaders: HTTP/1.1 200\nstatus: 200\n\nbody: foo\n"))
+				Expect(session.Out).To(Say(":status 200"))
+				Expect(session.Out).To(Say("body: foo\n"))
 			})
 
 			It("gets a file", func() {


### PR DESCRIPTION
Apparently the output format of the quic_client changed.