### PR TITLE
Fixing deadlock with runloop in session.go

### DIFF
--- a/handshake/crypto_setup_client.go
+++ b/handshake/crypto_setup_client.go
@@ -247,9 +247,11 @@ func (h *cryptoSetupClient) handleSHLOMessage(cryptoData map[Tag][]byte) error {
 	if err != nil {
 		return qerr.InvalidCryptoMessageParameter
 	}
-
+	
+	h.mutex.Unlock()
 	h.aeadChanged <- protocol.EncryptionForwardSecure
-
+	h.mutex.Lock()
+	
 	return nil
 }
 


### PR DESCRIPTION
If a client is in `handleSHLOMessage` in parallel to running the runloop (run) in session.go (this is usually the case) and being past the select statement there, other calls in the runloop can wait for the lock (e.g. idleTimeout()), while `h.aeadChanged <- ...` blocks until the select statement in the runloop is called, thus causing a potential deadlock.

This fix releases the lock to make progress. The channel itself acts like a lock in this situation causing the deadlock.