### PR TITLE
use random port numbers in integration tests

### DIFF
--- a/integrationtests/drop_test.go
+++ b/integrationtests/drop_test.go
@@ -3,6 +3,7 @@ package integrationtests
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"os/exec"
 	"strconv"
 	"time"
@@ -24,7 +25,7 @@ var _ = Describe("Drop Proxy", func() {
 	var dropproxy *proxy.UDPProxy
 
 	runDropTest := func(incomingPacketDropper, outgoingPacketDropper proxy.DropCallback, version protocol.VersionNumber) {
-		proxyPort := 12345
+		proxyPort := 50000 + int(rand.Int63n(10000))
 
 		iPort, _ := strconv.Atoi(port)
 		var err error

--- a/integrationtests/integrationtests_suite_test.go
+++ b/integrationtests/integrationtests_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -57,6 +58,9 @@ var _ = BeforeSuite(func() {
 	setupHTTPHandlers()
 	setupQuicServer()
 	setupSelenium()
+
+	// seed the random number generator used to generate random port numbers
+	rand.Seed(time.Now().UnixNano())
 })
 
 var _ = AfterSuite(func() {

--- a/integrationtests/random_rtt_test.go
+++ b/integrationtests/random_rtt_test.go
@@ -3,6 +3,7 @@ package integrationtests
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"os/exec"
 	"strconv"
 	"time"
@@ -24,7 +25,7 @@ var _ = Describe("Random RTT", func() {
 	var rttProxy *proxy.UDPProxy
 
 	runRTTTest := func(minRtt, maxRtt time.Duration, version protocol.VersionNumber) {
-		proxyPort := 12345
+		proxyPort := 50000 + int(rand.Int63n(10000))
 
 		iPort, _ := strconv.Atoi(port)
 		var err error

--- a/integrationtests/rtt_test.go
+++ b/integrationtests/rtt_test.go
@@ -3,6 +3,7 @@ package integrationtests
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"os/exec"
 	"strconv"
 	"time"
@@ -24,7 +25,7 @@ var _ = Describe("non-zero RTT", func() {
 	var rttProxy *proxy.UDPProxy
 
 	runRTTTest := func(rtt time.Duration, version protocol.VersionNumber) {
-		proxyPort := 12345
+		proxyPort := 50000 + int(rand.Int63n(10000))
 
 		iPort, _ := strconv.Atoi(port)
 		var err error

--- a/integrationtests/server_test.go
+++ b/integrationtests/server_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 var _ = Describe("Server tests", func() {
-	mrand.Seed(time.Now().UnixNano())
-
 	var (
 		serverPort string
 		tmpDir     string


### PR DESCRIPTION
This helps prevent “address already in use” errors that occur from time to time when running the tests with the untilItFails option.