### PR TITLE
don’t pass version negotiation packets to the session

### DIFF
--- a/client.go
+++ b/client.go
@@ -168,10 +168,8 @@ func (c *client) handlePacket(remoteAddr net.Addr, packet []byte) error {
 	}
 
 	if hdr.VersionFlag {
-		err = c.handlePacketWithVersionFlag(hdr)
-		if err != nil {
-			return err
-		}
+		// version negotiation packets have no payload
+		return c.handlePacketWithVersionFlag(hdr)
 	}
 
 	c.session.handlePacket(&receivedPacket{
@@ -215,7 +213,7 @@ func (c *client) handlePacketWithVersionFlag(hdr *PublicHeader) error {
 		go c.config.ConnState(c.session, ConnStateVersionNegotiated)
 	}
 
-	return nil // version negotiation packets have no payload
+	return nil
 }
 
 func (c *client) cryptoChangeCallback(_ Session, isForwardSecure bool) {

--- a/client_test.go
+++ b/client_test.go
@@ -242,8 +242,10 @@ var _ = Describe("Client", func() {
 			Expect(cl.session).ToNot(Equal(sess))
 			Expect(cl.connectionID).ToNot(Equal(0x1337)) // it generated a new connection ID
 			Expect(err).ToNot(HaveOccurred())
-			// it didn't pass the version negoation packet to the session (since it has no payload)
+			// it didn't pass the version negoation packet to the old session (since it has no payload)
 			Expect(sess.packetCount).To(BeZero())
+			// if the version negotiation packet was passed to the new session, it would end up as an undecryptable packet there
+			Expect(cl.session.(*session).undecryptablePackets).To(BeEmpty())
 			Expect(*(*[]protocol.VersionNumber)(unsafe.Pointer(reflect.ValueOf(cl.session.(*session).cryptoSetup).Elem().FieldByName("negotiatedVersions").UnsafeAddr()))).To(Equal([]protocol.VersionNumber{35}))
 		})
 


### PR DESCRIPTION
Version negotiation packets don’t have any payload. They must not be passed to the session, because they’ll end up there as undecryptable packets.