### PR TITLE
Make responseWriter a CloseNotifier

### DIFF
--- a/h2quic/response_writer.go
+++ b/h2quic/response_writer.go
@@ -83,8 +83,14 @@ func (w *responseWriter) Write(p []byte) (int, error) {
 
 func (w *responseWriter) Flush() {}
 
+// TODO: Implement a functional CloseNotify method.
+func (w *responseWriter) CloseNotify() <-chan bool { return make(<-chan bool) }
+
 // test that we implement http.Flusher
 var _ http.Flusher = &responseWriter{}
+
+// test that we implement http.CloseNotifier
+var _ http.CloseNotifier = &responseWriter{}
 
 // copied from http2/http2.go
 // bodyAllowedForStatus reports whether a given response status code


### PR DESCRIPTION
This is a temporary no-op that returns a new channel; eventually it'd be nice if this worked for real. Closes #583.

You definitely don't want this to be a long-term solution; but then again I'm not sure the consequences are _so_ severe. I'm not even sure what they would be for a connection-less protocol like UDP/QUIC.