### PR TITLE
accept server config if one of the key exchange algorithms is Curve25519

### DIFF
--- a/handshake/server_config_client.go
+++ b/handshake/server_config_client.go
@@ -57,8 +57,6 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 	s.ID = scfgID
 
 	// KEXS
-	// TODO: allow for P256 in the list
-	// TODO: setup Key Exchange
 	kexs, ok := tagMap[TagKEXS]
 	if !ok {
 		return qerr.Error(qerr.CryptoMessageParameterNotFound, "KEXS")
@@ -66,7 +64,13 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 	if len(kexs)%4 != 0 {
 		return qerr.Error(qerr.CryptoInvalidValueLength, "KEXS")
 	}
-	if !bytes.Equal(kexs, []byte("C255")) {
+	var c255Found bool
+	for i := 0; i < len(kexs)/4; i++ {
+		if bytes.Equal(kexs[4*i:4*i+4], []byte("C255")) {
+			c255Found = true
+		}
+	}
+	if !c255Found {
 		return qerr.Error(qerr.CryptoNoSupport, "KEXS")
 	}
 

--- a/handshake/server_config_client_test.go
+++ b/handshake/server_config_client_test.go
@@ -127,6 +127,18 @@ var _ = Describe("Server Config", func() {
 				Expect(err).To(MatchError("CryptoNoSupport: KEXS"))
 			})
 
+			It("recognizes C255 in the list of KEXS, at the first position", func() {
+				tagMap[TagKEXS] = []byte("P256C255")
+				err := scfg.parseValues(tagMap)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("recognizes C255 in the list of KEXS, not at the first position", func() {
+				tagMap[TagKEXS] = []byte("C255P256")
+				err := scfg.parseValues(tagMap)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
 			It("errors if the KEXS is missing", func() {
 				delete(tagMap, TagKEXS)
 				err := scfg.parseValues(tagMap)


### PR DESCRIPTION
In the server config, the server lists all supported key exchange algorithms. The client should accept the config as long as the list contains C255 (Curve25519).