### PR TITLE
fix minor data races in both server and client crypto setups

### DIFF
--- a/handshake/crypto_setup_client.go
+++ b/handshake/crypto_setup_client.go
@@ -323,6 +323,9 @@ func (h *cryptoSetupClient) GetSealer() (protocol.EncryptionLevel, Sealer) {
 }
 
 func (h *cryptoSetupClient) GetSealerWithEncryptionLevel(encLevel protocol.EncryptionLevel) (Sealer, error) {
+	h.mutex.RLock()
+	defer h.mutex.RUnlock()
+
 	switch encLevel {
 	case protocol.EncryptionUnencrypted:
 		return h.sealUnencrypted, nil

--- a/handshake/crypto_setup_server.go
+++ b/handshake/crypto_setup_server.go
@@ -208,6 +208,9 @@ func (h *cryptoSetupServer) GetSealer() (protocol.EncryptionLevel, Sealer) {
 }
 
 func (h *cryptoSetupServer) GetSealerWithEncryptionLevel(encLevel protocol.EncryptionLevel) (Sealer, error) {
+	h.mutex.RLock()
+	defer h.mutex.RUnlock()
+
 	switch encLevel {
 	case protocol.EncryptionUnencrypted:
 		return h.sealUnencrypted, nil


### PR DESCRIPTION
These races are almost certainly non-critical, because `GetSealerWithEncryptionLevel` is only called when a packet packed with a certain encryption level needs to be retransmitted, i.e. long after the corresponding AEAD was created (which is the thing the mutex protects here).