### PR TITLE
fix infinite loop in session test

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -103,7 +103,11 @@ type mockReceivedPacketHandler struct {
 	nextAckFrame *frames.AckFrame
 }
 
-func (m *mockReceivedPacketHandler) GetAckFrame() *frames.AckFrame { return m.nextAckFrame }
+func (m *mockReceivedPacketHandler) GetAckFrame() *frames.AckFrame {
+	f := m.nextAckFrame
+	m.nextAckFrame = nil
+	return f
+}
 func (m *mockReceivedPacketHandler) ReceivedPacket(packetNumber protocol.PacketNumber, shouldInstigateAck bool) error {
 	panic("not implemented")
 }


### PR DESCRIPTION
fixes #598.

The `mockReceivedPacketHandler` returned the same ACK frame over and over again, so that the loop in `session.sendPacket()` would send packets containing this packet indefinitely.

Note that while this fixes the flaky test, there's still a race condition. I'll create a separate issue for this.