### PR TITLE
add a quic.Config option to request connection ID truncation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,4 +3,5 @@
 ## v0.6.0 (unreleased)
 
 - Add a `quic.Config` option for QUIC versions
+- Add a `quic.Config` option to request truncation of the connection ID from a server
 - Various bugfixes

--- a/client.go
+++ b/client.go
@@ -75,9 +75,10 @@ func populateClientConfig(config *Config) *Config {
 	}
 
 	return &Config{
-		TLSConfig: config.TLSConfig,
-		ConnState: config.ConnState,
-		Versions:  versions,
+		TLSConfig:                     config.TLSConfig,
+		ConnState:                     config.ConnState,
+		Versions:                      versions,
+		RequestConnectionIDTruncation: config.RequestConnectionIDTruncation,
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -257,8 +257,8 @@ func (c *client) createNewSession(negotiatedVersions []protocol.VersionNumber) e
 		c.hostname,
 		c.version,
 		c.connectionID,
-		c.config.TLSConfig,
 		c.cryptoChangeCallback,
+		c.config,
 		negotiatedVersions,
 	)
 	if err != nil {

--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -52,8 +52,9 @@ func NewClient(t *QuicRoundTripper, tlsConfig *tls.Config, hostname string) *Cli
 	}
 	c.cryptoChangedCond = sync.Cond{L: &c.mutex}
 	c.config = &quic.Config{
-		ConnState: c.connStateCallback,
-		TLSConfig: tlsConfig,
+		ConnState:                     c.connStateCallback,
+		TLSConfig:                     tlsConfig,
+		RequestConnectionIDTruncation: true,
 	}
 	return c
 }

--- a/handshake/interface.go
+++ b/handshake/interface.go
@@ -16,3 +16,8 @@ type CryptoSetup interface {
 	GetSealer() (protocol.EncryptionLevel, Sealer)
 	GetSealerWithEncryptionLevel(protocol.EncryptionLevel) (Sealer, error)
 }
+
+// TransportParameters are parameters sent to the peer during the handshake
+type TransportParameters struct {
+	RequestConnectionIDTruncation bool
+}

--- a/interface.go
+++ b/interface.go
@@ -67,6 +67,10 @@ type Config struct {
 	// If not set, it uses all versions available.
 	// Warning: This API should not be considered stable and will change soon.
 	Versions []protocol.VersionNumber
+	// Ask the server to truncate the connection ID sent in the Public Header.
+	// This saves 8 bytes in the Public Header in every packet. However, if the IP address of the server changes, the connection cannot be migrated.
+	// Currently only valid for the client.
+	RequestConnectionIDTruncation bool
 }
 
 // A Listener for incoming QUIC connections

--- a/server.go
+++ b/server.go
@@ -34,7 +34,7 @@ type server struct {
 	sessionsMutex             sync.RWMutex
 	deleteClosedSessionsAfter time.Duration
 
-	newSession func(conn connection, v protocol.VersionNumber, connectionID protocol.ConnectionID, sCfg *handshake.ServerConfig, cryptoChangeCallback cryptoChangeCallback, supportedVersions []protocol.VersionNumber) (packetHandler, error)
+	newSession func(conn connection, v protocol.VersionNumber, connectionID protocol.ConnectionID, sCfg *handshake.ServerConfig, cryptoChangeCallback cryptoChangeCallback, config *Config) (packetHandler, error)
 }
 
 var _ Listener = &server{}
@@ -197,7 +197,7 @@ func (s *server) handlePacket(pconn net.PacketConn, remoteAddr net.Addr, packet 
 			hdr.ConnectionID,
 			s.scfg,
 			s.cryptoChangeCallback,
-			s.config.Versions,
+			s.config,
 		)
 		if err != nil {
 			return err

--- a/server_test.go
+++ b/server_test.go
@@ -56,7 +56,7 @@ func (s *mockSession) RemoteAddr() net.Addr {
 
 var _ Session = &mockSession{}
 
-func newMockSession(_ connection, _ protocol.VersionNumber, connectionID protocol.ConnectionID, _ *handshake.ServerConfig, _ cryptoChangeCallback, _ []protocol.VersionNumber) (packetHandler, error) {
+func newMockSession(_ connection, _ protocol.VersionNumber, connectionID protocol.ConnectionID, _ *handshake.ServerConfig, _ cryptoChangeCallback, _ *Config) (packetHandler, error) {
 	return &mockSession{
 		connectionID: connectionID,
 		stopRunLoop:  make(chan struct{}),

--- a/session.go
+++ b/session.go
@@ -175,7 +175,17 @@ func newClientSession(
 	s.aeadChanged = aeadChanged
 	cryptoStream, _ := s.OpenStream()
 	var err error
-	s.cryptoSetup, err = handshake.NewCryptoSetupClient(hostname, connectionID, v, cryptoStream, config.TLSConfig, s.connectionParameters, aeadChanged, negotiatedVersions)
+	s.cryptoSetup, err = handshake.NewCryptoSetupClient(
+		hostname,
+		connectionID,
+		v,
+		cryptoStream,
+		config.TLSConfig,
+		s.connectionParameters,
+		aeadChanged,
+		&handshake.TransportParameters{RequestConnectionIDTruncation: config.RequestConnectionIDTruncation},
+		negotiatedVersions,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -749,6 +749,20 @@ var _ = Describe("Session", func() {
 			Expect(clientSess.Close(nil)).To(Succeed())
 		})
 
+		It("passes the transport parameters to the cryptoSetup, as a client", func() {
+			s, err := newClientSession(
+				nil,
+				"hostname",
+				protocol.Version35,
+				0,
+				func(Session, bool) {},
+				populateClientConfig(&Config{RequestConnectionIDTruncation: true}),
+				nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*(*bool)(unsafe.Pointer(reflect.ValueOf(s.cryptoSetup).Elem().FieldByName("params").Elem().FieldByName("RequestConnectionIDTruncation").UnsafeAddr()))).To(BeTrue())
+		})
+
 		Context("updating the remote address", func() {
 			It("sets the remote address", func() {
 				remoteIP := &net.IPAddr{IP: net.IPv4(192, 168, 0, 100)}

--- a/session_test.go
+++ b/session_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Session", func() {
 			0,
 			scfg,
 			func(Session, bool) {},
-			nil,
+			populateServerConfig(&Config{}),
 		)
 		Expect(err).NotTo(HaveOccurred())
 		sess = pSess.(*session)
@@ -167,8 +167,8 @@ var _ = Describe("Session", func() {
 			"hostname",
 			protocol.Version35,
 			0,
-			nil,
 			func(Session, bool) {},
+			populateClientConfig(&Config{}),
 			nil,
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -188,7 +188,7 @@ var _ = Describe("Session", func() {
 				0,
 				scfg,
 				func(Session, bool) {},
-				nil,
+				populateServerConfig(&Config{}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*(*[]byte)(unsafe.Pointer(reflect.ValueOf(sess.(*session).cryptoSetup).Elem().FieldByName("sourceAddr").UnsafeAddr()))).To(Equal([]byte{192, 168, 100, 200}))
@@ -204,7 +204,7 @@ var _ = Describe("Session", func() {
 				0,
 				scfg,
 				func(Session, bool) {},
-				nil,
+				populateServerConfig(&Config{}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*(*[]byte)(unsafe.Pointer(reflect.ValueOf(sess.(*session).cryptoSetup).Elem().FieldByName("sourceAddr").UnsafeAddr()))).To(Equal([]byte("192.168.100.200:1337")))


### PR DESCRIPTION
Fixes #524, fixes #434.

I don't really like the name of the `quic.Config` option though, maybe @lucas-clemente has a better idea (`RequestConnectionIDTruncation` or so, but that's too long).

I added a `handshake.TransportParameters` struct. The name comes from the QUIC WG draft (https://quicwg.github.io/base-drafts/draft-ietf-quic-transport.html#transport-parameter-definitions). Currently it only has one field, but it will need some more in the future. I hope this will make contributing to the other *want-help* issues easier.

The option is currently only valid for the client. In principle, we could also allow servers to allow connection ID truncation, but we'll need to add some logic to the `server` to assign packets to the right sessions then.