### PR TITLE
fix a race condition in the client crypto setup

### DIFF
--- a/handshake/crypto_setup_client.go
+++ b/handshake/crypto_setup_client.go
@@ -104,9 +104,7 @@ func (h *cryptoSetupClient) HandleCryptoStream() error {
 			}
 		}
 
-		var shloData bytes.Buffer
-
-		messageTag, cryptoData, err := ParseHandshakeMessage(io.TeeReader(h.cryptoStream, &shloData))
+		messageTag, cryptoData, err := ParseHandshakeMessage(h.cryptoStream)
 		if err != nil {
 			return qerr.HandshakeFailed
 		}

--- a/handshake/crypto_setup_server.go
+++ b/handshake/crypto_setup_server.go
@@ -435,7 +435,7 @@ func (h *cryptoSetupServer) DiversificationNonce() []byte {
 	return h.diversificationNonce
 }
 
-func (h *cryptoSetupServer) SetDiversificationNonce(data []byte) error {
+func (h *cryptoSetupServer) SetDiversificationNonce(data []byte) {
 	panic("not needed for cryptoSetupServer")
 }
 

--- a/handshake/crypto_setup_server_test.go
+++ b/handshake/crypto_setup_server_test.go
@@ -231,9 +231,12 @@ var _ = Describe("Server Crypto Setup", func() {
 		})
 
 		It("doesn't support Chrome's head-of-line blocking experiment", func() {
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, map[Tag][]byte{
-				TagFHL2: []byte("foobar"),
-			})
+			HandshakeMessage{
+				Tag: TagCHLO,
+				Data: map[Tag][]byte{
+					TagFHL2: []byte("foobar"),
+				},
+			}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(ErrHOLExperiment))
 		})
@@ -292,13 +295,16 @@ var _ = Describe("Server Crypto Setup", func() {
 		})
 
 		It("handles long handshake", func() {
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, map[Tag][]byte{
-				TagSNI: []byte("quic.clemente.io"),
-				TagSTK: validSTK,
-				TagPAD: bytes.Repeat([]byte{'a'}, protocol.ClientHelloMinimumSize),
-				TagVER: versionTag,
-			})
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{
+				Tag: TagCHLO,
+				Data: map[Tag][]byte{
+					TagSNI: []byte("quic.clemente.io"),
+					TagSTK: validSTK,
+					TagPAD: bytes.Repeat([]byte{'a'}, protocol.ClientHelloMinimumSize),
+					TagVER: versionTag,
+				},
+			}.Write(&stream.dataToRead)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stream.dataWritten.Bytes()).To(HavePrefix("REJ"))
@@ -311,14 +317,14 @@ var _ = Describe("Server Crypto Setup", func() {
 
 		It("rejects client nonces that have the wrong length", func() {
 			fullCHLO[TagNONC] = []byte("too short client nonce")
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.InvalidCryptoMessageParameter, "invalid client nonce length")))
 		})
 
 		It("rejects client nonces that have the wrong OBIT value", func() {
 			fullCHLO[TagNONC] = make([]byte, 32) // the OBIT value is nonce[4:12] and here just initialized to 0
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.InvalidCryptoMessageParameter, "OBIT not matching")))
 		})
@@ -326,13 +332,13 @@ var _ = Describe("Server Crypto Setup", func() {
 		It("errors if it can't calculate a shared key", func() {
 			testErr := errors.New("test error")
 			kex.sharedKeyError = testErr
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(testErr))
 		})
 
 		It("handles 0-RTT handshake", func() {
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stream.dataWritten.Bytes()).To(HavePrefix("SHLO"))
@@ -382,17 +388,20 @@ var _ = Describe("Server Crypto Setup", func() {
 		})
 
 		It("rejects CHLOs without the version tag", func() {
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, map[Tag][]byte{
-				TagSCID: scfg.ID,
-				TagSNI:  []byte("quic.clemente.io"),
-			})
+			HandshakeMessage{
+				Tag: TagCHLO,
+				Data: map[Tag][]byte{
+					TagSCID: scfg.ID,
+					TagSNI:  []byte("quic.clemente.io"),
+				},
+			}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.InvalidCryptoMessageParameter, "client hello missing version tag")))
 		})
 
 		It("rejects CHLOs with a version tag that has the wrong length", func() {
 			fullCHLO[TagVER] = []byte{0x13, 0x37} // should be 4 bytes
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.InvalidCryptoMessageParameter, "incorrect version tag")))
 		})
@@ -405,7 +414,7 @@ var _ = Describe("Server Crypto Setup", func() {
 			b := make([]byte, 4)
 			binary.LittleEndian.PutUint32(b, protocol.VersionNumberToTag(lowestSupportedVersion))
 			fullCHLO[TagVER] = b
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.VersionNegotiationMismatch, "Downgrade attack detected")))
 		})
@@ -418,53 +427,59 @@ var _ = Describe("Server Crypto Setup", func() {
 			b := make([]byte, 4)
 			binary.LittleEndian.PutUint32(b, protocol.VersionNumberToTag(unsupportedVersion))
 			fullCHLO[TagVER] = b
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("errors if the AEAD tag is missing", func() {
 			delete(fullCHLO, TagAEAD)
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.CryptoNoSupport, "Unsupported AEAD or KEXS")))
 		})
 
 		It("errors if the AEAD tag has the wrong value", func() {
 			fullCHLO[TagAEAD] = []byte("wrong")
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.CryptoNoSupport, "Unsupported AEAD or KEXS")))
 		})
 
 		It("errors if the KEXS tag is missing", func() {
 			delete(fullCHLO, TagKEXS)
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.CryptoNoSupport, "Unsupported AEAD or KEXS")))
 		})
 
 		It("errors if the KEXS tag has the wrong value", func() {
 			fullCHLO[TagKEXS] = []byte("wrong")
-			WriteHandshakeMessage(&stream.dataToRead, TagCHLO, fullCHLO)
+			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
 			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.CryptoNoSupport, "Unsupported AEAD or KEXS")))
 		})
 	})
 
 	It("errors without SNI", func() {
-		WriteHandshakeMessage(&stream.dataToRead, TagCHLO, map[Tag][]byte{
-			TagSTK: validSTK,
-		})
+		HandshakeMessage{
+			Tag: TagCHLO,
+			Data: map[Tag][]byte{
+				TagSTK: validSTK,
+			},
+		}.Write(&stream.dataToRead)
 		err := cs.HandleCryptoStream()
 		Expect(err).To(MatchError("CryptoMessageParameterNotFound: SNI required"))
 	})
 
 	It("errors with empty SNI", func() {
-		WriteHandshakeMessage(&stream.dataToRead, TagCHLO, map[Tag][]byte{
-			TagSTK: validSTK,
-			TagSNI: nil,
-		})
+		HandshakeMessage{
+			Tag: TagCHLO,
+			Data: map[Tag][]byte{
+				TagSTK: validSTK,
+				TagSNI: nil,
+			},
+		}.Write(&stream.dataToRead)
 		err := cs.HandleCryptoStream()
 		Expect(err).To(MatchError("CryptoMessageParameterNotFound: SNI required"))
 	})
@@ -475,7 +490,7 @@ var _ = Describe("Server Crypto Setup", func() {
 	})
 
 	It("errors with non-CHLO message", func() {
-		WriteHandshakeMessage(&stream.dataToRead, TagPAD, nil)
+		HandshakeMessage{Tag: TagPAD, Data: nil}.Write(&stream.dataToRead)
 		err := cs.HandleCryptoStream()
 		Expect(err).To(MatchError(qerr.InvalidCryptoMessageType))
 	})

--- a/handshake/interface.go
+++ b/handshake/interface.go
@@ -10,8 +10,8 @@ type CryptoSetup interface {
 	Open(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte) ([]byte, protocol.EncryptionLevel, error)
 	HandleCryptoStream() error
 	// TODO: clean up this interface
-	DiversificationNonce() []byte         // only needed for cryptoSetupServer
-	SetDiversificationNonce([]byte) error // only needed for cryptoSetupClient
+	DiversificationNonce() []byte   // only needed for cryptoSetupServer
+	SetDiversificationNonce([]byte) // only needed for cryptoSetupClient
 
 	GetSealer() (protocol.EncryptionLevel, Sealer)
 	GetSealerWithEncryptionLevel(protocol.EncryptionLevel) (Sealer, error)

--- a/handshake/server_config.go
+++ b/handshake/server_config.go
@@ -51,14 +51,18 @@ func NewServerConfig(kex crypto.KeyExchange, certChain crypto.CertChain) (*Serve
 // Get the server config binary representation
 func (s *ServerConfig) Get() []byte {
 	var serverConfig bytes.Buffer
-	WriteHandshakeMessage(&serverConfig, TagSCFG, map[Tag][]byte{
-		TagSCID: s.ID,
-		TagKEXS: []byte("C255"),
-		TagAEAD: []byte("AESG"),
-		TagPUBS: append([]byte{0x20, 0x00, 0x00}, s.kex.PublicKey()...),
-		TagOBIT: s.obit,
-		TagEXPY: {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
-	})
+	msg := HandshakeMessage{
+		Tag: TagSCFG,
+		Data: map[Tag][]byte{
+			TagSCID: s.ID,
+			TagKEXS: []byte("C255"),
+			TagAEAD: []byte("AESG"),
+			TagPUBS: append([]byte{0x20, 0x00, 0x00}, s.kex.PublicKey()...),
+			TagOBIT: s.obit,
+			TagEXPY: {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+	}
+	msg.Write(&serverConfig)
 	return serverConfig.Bytes()
 }
 

--- a/handshake/server_config_client.go
+++ b/handshake/server_config_client.go
@@ -28,16 +28,16 @@ var (
 
 // parseServerConfig parses a server config
 func parseServerConfig(data []byte) (*serverConfigClient, error) {
-	tag, tagMap, err := ParseHandshakeMessage(bytes.NewReader(data))
+	message, err := ParseHandshakeMessage(bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
-	if tag != TagSCFG {
+	if message.Tag != TagSCFG {
 		return nil, errMessageNotServerConfig
 	}
 
 	scfg := &serverConfigClient{raw: data}
-	err = scfg.parseValues(tagMap)
+	err = scfg.parseValues(message.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/handshake/server_config_client_test.go
+++ b/handshake/server_config_client_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Server Config", func() {
 	It("returns the parsed server config", func() {
 		tagMap[TagSCID] = []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
 		b := &bytes.Buffer{}
-		WriteHandshakeMessage(b, TagSCFG, tagMap)
+		HandshakeMessage{Tag: TagSCFG, Data: tagMap}.Write(b)
 		scfg, err := parseServerConfig(b.Bytes())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(scfg.ID).To(Equal(tagMap[TagSCID]))
@@ -39,7 +39,7 @@ var _ = Describe("Server Config", func() {
 
 	It("saves the raw server config", func() {
 		b := &bytes.Buffer{}
-		WriteHandshakeMessage(b, TagSCFG, tagMap)
+		HandshakeMessage{Tag: TagSCFG, Data: tagMap}.Write(b)
 		scfg, err := parseServerConfig(b.Bytes())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(scfg.raw).To(Equal(b.Bytes()))
@@ -56,28 +56,28 @@ var _ = Describe("Server Config", func() {
 	Context("parsing the server config", func() {
 		It("rejects a handshake message with the wrong message tag", func() {
 			var serverConfig bytes.Buffer
-			WriteHandshakeMessage(&serverConfig, TagCHLO, make(map[Tag][]byte))
+			HandshakeMessage{Tag: TagCHLO, Data: make(map[Tag][]byte)}.Write(&serverConfig)
 			_, err := parseServerConfig(serverConfig.Bytes())
 			Expect(err).To(MatchError(errMessageNotServerConfig))
 		})
 
 		It("errors on invalid handshake messages", func() {
 			var serverConfig bytes.Buffer
-			WriteHandshakeMessage(&serverConfig, TagSCFG, make(map[Tag][]byte))
+			HandshakeMessage{Tag: TagSCFG, Data: make(map[Tag][]byte)}.Write(&serverConfig)
 			_, err := parseServerConfig(serverConfig.Bytes()[:serverConfig.Len()-2])
 			Expect(err).To(MatchError("unexpected EOF"))
 		})
 
 		It("passes on errors encountered when reading the TagMap", func() {
 			var serverConfig bytes.Buffer
-			WriteHandshakeMessage(&serverConfig, TagSCFG, make(map[Tag][]byte))
+			HandshakeMessage{Tag: TagSCFG, Data: make(map[Tag][]byte)}.Write(&serverConfig)
 			_, err := parseServerConfig(serverConfig.Bytes())
 			Expect(err).To(MatchError("CryptoMessageParameterNotFound: SCID"))
 		})
 
 		It("reads an example Handshake Message", func() {
 			var serverConfig bytes.Buffer
-			WriteHandshakeMessage(&serverConfig, TagSCFG, tagMap)
+			HandshakeMessage{Tag: TagSCFG, Data: tagMap}.Write(&serverConfig)
 			scfg, err := parseServerConfig(serverConfig.Bytes())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(scfg.ID).To(Equal(tagMap[TagSCID]))

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -35,7 +35,7 @@ func (m *mockCryptoSetup) GetSealerWithEncryptionLevel(protocol.EncryptionLevel)
 func (m *mockCryptoSetup) DiversificationNonce() []byte {
 	return m.divNonce
 }
-func (m *mockCryptoSetup) SetDiversificationNonce([]byte) error { panic("not implemented") }
+func (m *mockCryptoSetup) SetDiversificationNonce([]byte) { panic("not implemented") }
 
 var _ handshake.CryptoSetup = &mockCryptoSetup{}
 

--- a/public_reset.go
+++ b/public_reset.go
@@ -32,15 +32,15 @@ func writePublicReset(connectionID protocol.ConnectionID, rejectedPacketNumber p
 
 func parsePublicReset(r *bytes.Reader) (*publicReset, error) {
 	pr := publicReset{}
-	tag, tagMap, err := handshake.ParseHandshakeMessage(r)
+	msg, err := handshake.ParseHandshakeMessage(r)
 	if err != nil {
 		return nil, err
 	}
-	if tag != handshake.TagPRST {
+	if msg.Tag != handshake.TagPRST {
 		return nil, errors.New("wrong public reset tag")
 	}
 
-	rseq, ok := tagMap[handshake.TagRSEQ]
+	rseq, ok := msg.Data[handshake.TagRSEQ]
 	if !ok {
 		return nil, errors.New("RSEQ missing")
 	}
@@ -49,7 +49,7 @@ func parsePublicReset(r *bytes.Reader) (*publicReset, error) {
 	}
 	pr.rejectedPacketNumber = protocol.PacketNumber(binary.LittleEndian.Uint64(rseq))
 
-	rnon, ok := tagMap[handshake.TagRNON]
+	rnon, ok := msg.Data[handshake.TagRNON]
 	if !ok {
 		return nil, errors.New("RNON missing")
 	}

--- a/public_reset_test.go
+++ b/public_reset_test.go
@@ -49,7 +49,7 @@ var _ = Describe("public reset", func() {
 		})
 
 		It("rejects packets with the wrong tag", func() {
-			handshake.WriteHandshakeMessage(b, handshake.TagREJ, nil)
+			handshake.HandshakeMessage{Tag: handshake.TagREJ, Data: nil}.Write(b)
 			_, err := parsePublicReset(bytes.NewReader(b.Bytes()))
 			Expect(err).To(MatchError("wrong public reset tag"))
 		})
@@ -58,7 +58,7 @@ var _ = Describe("public reset", func() {
 			data := map[handshake.Tag][]byte{
 				handshake.TagRSEQ: []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37},
 			}
-			handshake.WriteHandshakeMessage(b, handshake.TagPRST, data)
+			handshake.HandshakeMessage{Tag: handshake.TagPRST, Data: data}.Write(b)
 			_, err := parsePublicReset(bytes.NewReader(b.Bytes()))
 			Expect(err).To(MatchError("RNON missing"))
 		})
@@ -68,7 +68,7 @@ var _ = Describe("public reset", func() {
 				handshake.TagRSEQ: []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37},
 				handshake.TagRNON: []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13},
 			}
-			handshake.WriteHandshakeMessage(b, handshake.TagPRST, data)
+			handshake.HandshakeMessage{Tag: handshake.TagPRST, Data: data}.Write(b)
 			_, err := parsePublicReset(bytes.NewReader(b.Bytes()))
 			Expect(err).To(MatchError("invalid RNON tag"))
 		})
@@ -77,7 +77,7 @@ var _ = Describe("public reset", func() {
 			data := map[handshake.Tag][]byte{
 				handshake.TagRNON: []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37},
 			}
-			handshake.WriteHandshakeMessage(b, handshake.TagPRST, data)
+			handshake.HandshakeMessage{Tag: handshake.TagPRST, Data: data}.Write(b)
 			_, err := parsePublicReset(bytes.NewReader(b.Bytes()))
 			Expect(err).To(MatchError("RSEQ missing"))
 		})
@@ -87,7 +87,7 @@ var _ = Describe("public reset", func() {
 				handshake.TagRSEQ: []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13},
 				handshake.TagRNON: []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37},
 			}
-			handshake.WriteHandshakeMessage(b, handshake.TagPRST, data)
+			handshake.HandshakeMessage{Tag: handshake.TagPRST, Data: data}.Write(b)
 			_, err := parsePublicReset(bytes.NewReader(b.Bytes()))
 			Expect(err).To(MatchError("invalid RSEQ tag"))
 		})

--- a/session_test.go
+++ b/session_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Session", func() {
 		sess.connectionParameters = cpm
 
 		clientSess, err = newClientSession(
-			nil,
+			mconn,
 			"hostname",
 			protocol.Version35,
 			0,
@@ -738,11 +738,14 @@ var _ = Describe("Session", func() {
 		})
 
 		It("passes the diversification nonce to the cryptoSetup, if it is a client", func() {
+			go clientSess.run()
+			time.Sleep(50 * time.Millisecond)
 			hdr.PacketNumber = 5
 			hdr.DiversificationNonce = []byte("foobar")
 			err := clientSess.handlePacketImpl(&receivedPacket{publicHeader: hdr})
 			Expect(err).ToNot(HaveOccurred())
 			Expect((*[]byte)(unsafe.Pointer(reflect.ValueOf(clientSess.cryptoSetup).Elem().FieldByName("diversificationNonce").UnsafeAddr()))).To(Equal(&hdr.DiversificationNonce))
+			Expect(clientSess.Close(nil)).To(Succeed())
 		})
 
 		Context("updating the remote address", func() {

--- a/session_test.go
+++ b/session_test.go
@@ -739,12 +739,13 @@ var _ = Describe("Session", func() {
 
 		It("passes the diversification nonce to the cryptoSetup, if it is a client", func() {
 			go clientSess.run()
-			time.Sleep(50 * time.Millisecond)
 			hdr.PacketNumber = 5
 			hdr.DiversificationNonce = []byte("foobar")
 			err := clientSess.handlePacketImpl(&receivedPacket{publicHeader: hdr})
 			Expect(err).ToNot(HaveOccurred())
-			Expect((*[]byte)(unsafe.Pointer(reflect.ValueOf(clientSess.cryptoSetup).Elem().FieldByName("diversificationNonce").UnsafeAddr()))).To(Equal(&hdr.DiversificationNonce))
+			Eventually(func() []byte {
+				return *(*[]byte)(unsafe.Pointer(reflect.ValueOf(clientSess.cryptoSetup).Elem().FieldByName("diversificationNonce").UnsafeAddr()))
+			}).Should(Equal(hdr.DiversificationNonce))
 			Expect(clientSess.Close(nil)).To(Succeed())
 		})
 


### PR DESCRIPTION
This is a pretty large PR for fixing a simple race condition.

When doing the handshake for a the server, there's only one thing that can trigger an escalation of the crypto level: a new CHLO arriving on the crypto stream. That's why it's a good solution to just have one go routine block on reading the crypto stream (`HandleCryptoStream`).
For the client however, there are two things that can trigger an escalation of the crypto level: a new message (REJ or SHLO) on the crypto stream, and a diversification nonce (which is needed to create the `secureAEAD`). This PR introduces a `select` in `HandleCryptoStream`, which accepts the diversification nonce as well as handshake messages, which are passed there from a separate go routine parsing the crypto channel.