### PR TITLE
Added parsing of PUBS tag and filtering according to KEXS

### DIFF
--- a/handshake/server_config_client.go
+++ b/handshake/server_config_client.go
@@ -73,8 +73,8 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 			break
 		}
 	}
-	if (c255Foundat < 0) {
-		return qerr.Error(qerr.CryptoNoSupport, "KEXS")
+	if c255Foundat < 0 {
+		return qerr.Error(qerr.CryptoNoSupport, "KEXS: Could not find C255, other key exchanges are not supported")
 	}
 
 	// AEAD

--- a/handshake/server_config_client.go
+++ b/handshake/server_config_client.go
@@ -110,13 +110,21 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 
 		err := binary.Read(bytes.NewReader([]byte{pubs[i], pubs[i+1], pubs[i+2], 0x00}), binary.LittleEndian, &last_len);
 		if err != nil {
+			return qerr.Error(qerr.CryptoInvalidValueLength, "PUBS not decodable")
+		}
+		if last_len == 0 {
 			return qerr.Error(qerr.CryptoInvalidValueLength, "PUBS")
 		}
+
+		if i+3+int(last_len) > len(pubs) {
+			return qerr.Error(qerr.CryptoInvalidValueLength, "PUBS")
+		}
+
 		pubs_kexs = append(pubs_kexs, struct{Length uint32; Value []byte}{last_len, pubs[i+3:i+3+int(last_len)]})
 	}
 
 	if c255Foundat >= len(pubs_kexs) {
-		return qerr.Error(qerr.CryptoInvalidValueLength, "KEXS not in PUBS")
+		return qerr.Error(qerr.CryptoMessageParameterNotFound, "KEXS not in PUBS")
 	}
 
 	if pubs_kexs[c255Foundat].Length != 32 {

--- a/handshake/server_config_client.go
+++ b/handshake/server_config_client.go
@@ -57,7 +57,6 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 	s.ID = scfgID
 
 	// KEXS
-	// TODO: allow for P256 in the list
 	// TODO: setup Key Exchange
 	kexs, ok := tagMap[TagKEXS]
 	if !ok {
@@ -66,7 +65,15 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 	if len(kexs)%4 != 0 {
 		return qerr.Error(qerr.CryptoInvalidValueLength, "KEXS")
 	}
-	if !bytes.Equal(kexs, []byte("C255")) {
+	c255Foundat := -1
+
+	for i := 0; i < len(kexs)/4; i++ {
+		if bytes.Equal(kexs[4*i:4*i+4], []byte("C255")) {
+			c255Foundat = i
+			break
+		}
+	}
+	if (c255Foundat < 0) {
 		return qerr.Error(qerr.CryptoNoSupport, "KEXS")
 	}
 
@@ -90,12 +97,29 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 	}
 
 	// PUBS
-	// TODO: save this value
 	pubs, ok := tagMap[TagPUBS]
 	if !ok {
 		return qerr.Error(qerr.CryptoMessageParameterNotFound, "PUBS")
 	}
-	if len(pubs) != 35 {
+
+	var pubs_kexs []struct{Length uint32; Value []byte}
+	var last_len uint32
+
+	for i := 0; i < len(pubs)-3; i += int(last_len)+3 {
+		// the PUBS value is always prepended by 3 byte little endian length field
+
+		err := binary.Read(bytes.NewReader([]byte{pubs[i], pubs[i+1], pubs[i+2], 0x00}), binary.LittleEndian, &last_len);
+		if err != nil {
+			return qerr.Error(qerr.CryptoInvalidValueLength, "PUBS")
+		}
+		pubs_kexs = append(pubs_kexs, struct{Length uint32; Value []byte}{last_len, pubs[i+3:i+3+int(last_len)]})
+	}
+
+	if c255Foundat >= len(pubs_kexs) {
+		return qerr.Error(qerr.CryptoInvalidValueLength, "KEXS not in PUBS")
+	}
+
+	if pubs_kexs[c255Foundat].Length != 32 {
 		return qerr.Error(qerr.CryptoInvalidValueLength, "PUBS")
 	}
 
@@ -105,8 +129,8 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 		return err
 	}
 
-	// the PUBS value is always prepended by []byte{0x20, 0x00, 0x00}
-	s.sharedSecret, err = s.kex.CalculateSharedKey(pubs[3:])
+
+	s.sharedSecret, err = s.kex.CalculateSharedKey(pubs_kexs[c255Foundat].Value)
 	if err != nil {
 		return err
 	}

--- a/handshake/server_config_client_test.go
+++ b/handshake/server_config_client_test.go
@@ -15,7 +15,7 @@ func getDefaultServerConfigClient() map[Tag][]byte {
 		TagSCID: bytes.Repeat([]byte{'F'}, 16),
 		TagKEXS: []byte("C255"),
 		TagAEAD: []byte("AESG"),
-		TagPUBS: bytes.Repeat([]byte{0}, 35),
+		TagPUBS: append([]byte{0x20, 0x00, 0x00}, bytes.Repeat([]byte{0}, 32)...),
 		TagOBIT: bytes.Repeat([]byte{0}, 8),
 		TagEXPY: []byte{0x0, 0x6c, 0x57, 0x78, 0, 0, 0, 0}, // 2033-12-24
 	}
@@ -180,6 +180,12 @@ var _ = Describe("Server Config", func() {
 
 			It("rejects PUBS values that have the wrong length", func() {
 				tagMap[TagPUBS] = bytes.Repeat([]byte{'F'}, 100) // completely wrong length
+				err := scfg.parseValues(tagMap)
+				Expect(err).To(MatchError("CryptoInvalidValueLength: PUBS"))
+			})
+
+			It("rejects PUBS values that have a zero length", func() {
+				tagMap[TagPUBS] = bytes.Repeat([]byte{0}, 100) // completely wrong length
 				err := scfg.parseValues(tagMap)
 				Expect(err).To(MatchError("CryptoInvalidValueLength: PUBS"))
 			})


### PR DESCRIPTION
This now allows quic-go to contact servers announcing multiple KEXS methods, e.g. like Akamai.