### PR TITLE
Always send retransmissions, irrespective of congestion state

### DIFF
--- a/ackhandler/sent_packet_handler.go
+++ b/ackhandler/sent_packet_handler.go
@@ -333,7 +333,11 @@ func (h *sentPacketHandler) SendingAllowed() bool {
 			h.bytesInFlight,
 			h.congestion.GetCongestionWindow())
 	}
-	return !(congestionLimited || maxTrackedLimited)
+	// Workaround for #555:
+	// Always allow sending of retransmissions. This should probably be limited
+	// to RTOs, but we currently don't have a nice way of distinguishing them.
+	haveRetransmissions := len(h.retransmissionQueue) > 0
+	return !maxTrackedLimited && (!congestionLimited || haveRetransmissions)
 }
 
 func (h *sentPacketHandler) retransmitOldestTwoPackets() {

--- a/ackhandler/sent_packet_handler_test.go
+++ b/ackhandler/sent_packet_handler_test.go
@@ -678,6 +678,14 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.retransmissionQueue = make([]*Packet, protocol.MaxTrackedSentPackets)
 			Expect(handler.SendingAllowed()).To(BeFalse())
 		})
+
+		It("allows sending if there are retransmisisons outstanding", func() {
+			err := handler.SentPacket(&Packet{PacketNumber: 1, Frames: []frames.Frame{}, Length: protocol.DefaultTCPMSS + 1})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(handler.SendingAllowed()).To(BeFalse())
+			handler.retransmissionQueue = []*Packet{nil}
+			Expect(handler.SendingAllowed()).To(BeTrue())
+		})
 	})
 
 	Context("calculating RTO", func() {


### PR DESCRIPTION
This seems to work around part of #555, but I'm still seeing a similar failure. I propose to merge this (temporary) workaround now anyway, so that can collect logs for the other issue(s).