### PR TITLE
accept duplicate and delayed packets

### DIFF
--- a/ackhandler/received_packet_handler_test.go
+++ b/ackhandler/received_packet_handler_test.go
@@ -40,24 +40,6 @@ var _ = Describe("receivedPacketHandler", func() {
 			Expect(err).To(MatchError(errInvalidPacketNumber))
 		})
 
-		It("rejects a duplicate package", func() {
-			for i := 1; i < 5; i++ {
-				err := handler.ReceivedPacket(protocol.PacketNumber(i), true)
-				Expect(err).ToNot(HaveOccurred())
-			}
-			err := handler.ReceivedPacket(4, true)
-			Expect(err).To(MatchError(ErrDuplicatePacket))
-		})
-
-		It("ignores a packet with PacketNumber less than the LeastUnacked of a previously received StopWaiting", func() {
-			err := handler.ReceivedPacket(5, true)
-			Expect(err).ToNot(HaveOccurred())
-			err = handler.ReceivedStopWaiting(&frames.StopWaitingFrame{LeastUnacked: 10})
-			Expect(err).ToNot(HaveOccurred())
-			err = handler.ReceivedPacket(9, true)
-			Expect(err).To(MatchError(ErrPacketSmallerThanLastStopWaiting))
-		})
-
 		It("does not ignore a packet with PacketNumber equal to LeastUnacked of a previously received StopWaiting", func() {
 			err := handler.ReceivedPacket(5, true)
 			Expect(err).ToNot(HaveOccurred())
@@ -272,6 +254,19 @@ var _ = Describe("receivedPacketHandler", func() {
 				Expect(ack.AckRanges).To(HaveLen(2))
 				Expect(ack.AckRanges[0]).To(Equal(frames.AckRange{FirstPacketNumber: 4, LastPacketNumber: 4}))
 				Expect(ack.AckRanges[1]).To(Equal(frames.AckRange{FirstPacketNumber: 1, LastPacketNumber: 1}))
+			})
+
+			It("doesn't add delayed packets to the packetHistory", func() {
+				err := handler.ReceivedStopWaiting(&frames.StopWaitingFrame{LeastUnacked: protocol.PacketNumber(6)})
+				Expect(err).ToNot(HaveOccurred())
+				err = handler.ReceivedPacket(4, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = handler.ReceivedPacket(10, true)
+				Expect(err).ToNot(HaveOccurred())
+				ack := handler.GetAckFrame()
+				Expect(ack).ToNot(BeNil())
+				Expect(ack.LargestAcked).To(Equal(protocol.PacketNumber(10)))
+				Expect(ack.LowestAcked).To(Equal(protocol.PacketNumber(10)))
 			})
 
 			It("deletes packets from the packetHistory after receiving a StopWaiting, after continuously received packets", func() {

--- a/session.go
+++ b/session.go
@@ -396,19 +396,7 @@ func (s *session) handlePacketImpl(p *receivedPacket) error {
 	// Only do this after decrypting, so we are sure the packet is not attacker-controlled
 	s.largestRcvdPacketNumber = utils.MaxPacketNumber(s.largestRcvdPacketNumber, hdr.PacketNumber)
 
-	err = s.receivedPacketHandler.ReceivedPacket(hdr.PacketNumber, packet.IsRetransmittable())
-	// ignore duplicate packets
-	if err == ackhandler.ErrDuplicatePacket {
-		utils.Infof("Ignoring packet 0x%x due to ErrDuplicatePacket", hdr.PacketNumber)
-		return nil
-	}
-	// ignore packets with packet numbers smaller than the LeastUnacked of a StopWaiting
-	if err == ackhandler.ErrPacketSmallerThanLastStopWaiting {
-		utils.Infof("Ignoring packet 0x%x due to ErrPacketSmallerThanLastStopWaiting", hdr.PacketNumber)
-		return nil
-	}
-
-	if err != nil {
+	if err = s.receivedPacketHandler.ReceivedPacket(hdr.PacketNumber, packet.IsRetransmittable()); err != nil {
 		return err
 	}
 

--- a/session_test.go
+++ b/session_test.go
@@ -813,7 +813,7 @@ var _ = Describe("Session", func() {
 			Expect(sess.largestRcvdPacketNumber).To(Equal(protocol.PacketNumber(5)))
 		})
 
-		It("ignores duplicate packets", func() {
+		It("handles duplicate packets", func() {
 			hdr.PacketNumber = 5
 			err := sess.handlePacketImpl(&receivedPacket{publicHeader: hdr})
 			Expect(err).ToNot(HaveOccurred())
@@ -821,7 +821,7 @@ var _ = Describe("Session", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("ignores packets smaller than the highest LeastUnacked of a StopWaiting", func() {
+		It("handles packets smaller than the highest LeastUnacked of a StopWaiting", func() {
 			err := sess.receivedPacketHandler.ReceivedStopWaiting(&frames.StopWaitingFrame{LeastUnacked: 10})
 			Expect(err).ToNot(HaveOccurred())
 			hdr.PacketNumber = 5


### PR DESCRIPTION
We used to reject duplicate and packets with packet numbers lower than the LeastUnacked we received in a STOP_WAITING frame, because we didn't accept overlapping stream data. For all other frames, duplicates never were an issue. Now that we accept overlapping stream data (#454), there's no need to reject those packets, in fact, processing a delayed packet will be beneficial for performance.

This will also be really nice for implementing QUIC 38, since we lose the explicit lower boundary on which packets to accept, that was provided by the STOP_WAITING.