### PR TITLE
Make max flow control windows configurable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.6.0 (unreleased)
 
+- Added `quic.Config` options for maximal flow control windows
 - Add a `quic.Config` option for QUIC versions
 - Add a `quic.Config` option to request truncation of the connection ID from a server
 - Add a `quic.Config` option to configure the source address validation

--- a/client.go
+++ b/client.go
@@ -123,15 +123,22 @@ func populateClientConfig(config *Config) *Config {
 		handshakeTimeout = config.HandshakeTimeout
 	}
 
+	maxReceiveStreamFlowControlWindow := config.MaxReceiveStreamFlowControlWindow
+	if maxReceiveStreamFlowControlWindow == 0 {
+		maxReceiveStreamFlowControlWindow = protocol.DefaultMaxReceiveStreamFlowControlWindowClient
+	}
+	maxReceiveConnectionFlowControlWindow := config.MaxReceiveConnectionFlowControlWindow
+	if maxReceiveConnectionFlowControlWindow == 0 {
+		maxReceiveConnectionFlowControlWindow = protocol.DefaultMaxReceiveConnectionFlowControlWindowClient
+	}
+
 	return &Config{
-		TLSConfig:                                   config.TLSConfig,
-		Versions:                                    versions,
-		HandshakeTimeout:                            handshakeTimeout,
-		RequestConnectionIDTruncation:               config.RequestConnectionIDTruncation,
-		MaxReceiveStreamFlowControlWindowServer:     config.MaxReceiveStreamFlowControlWindowServer,
-		MaxReceiveConnectionFlowControlWindowServer: config.MaxReceiveConnectionFlowControlWindowServer,
-		MaxReceiveStreamFlowControlWindowClient:     config.MaxReceiveStreamFlowControlWindowClient,
-		MaxReceiveConnectionFlowControlWindowClient: config.MaxReceiveConnectionFlowControlWindowClient,
+		TLSConfig:                             config.TLSConfig,
+		Versions:                              versions,
+		HandshakeTimeout:                      handshakeTimeout,
+		RequestConnectionIDTruncation:         config.RequestConnectionIDTruncation,
+		MaxReceiveStreamFlowControlWindow:     maxReceiveStreamFlowControlWindow,
+		MaxReceiveConnectionFlowControlWindow: maxReceiveConnectionFlowControlWindow,
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/protocol"
 	"github.com/lucas-clemente/quic-go/qerr"
-	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
 type client struct {
@@ -124,10 +124,14 @@ func populateClientConfig(config *Config) *Config {
 	}
 
 	return &Config{
-		TLSConfig:                     config.TLSConfig,
-		Versions:                      versions,
-		HandshakeTimeout:              handshakeTimeout,
-		RequestConnectionIDTruncation: config.RequestConnectionIDTruncation,
+		TLSConfig:                                   config.TLSConfig,
+		Versions:                                    versions,
+		HandshakeTimeout:                            handshakeTimeout,
+		RequestConnectionIDTruncation:               config.RequestConnectionIDTruncation,
+		MaxReceiveStreamFlowControlWindowServer:     config.MaxReceiveStreamFlowControlWindowServer,
+		MaxReceiveConnectionFlowControlWindowServer: config.MaxReceiveConnectionFlowControlWindowServer,
+		MaxReceiveStreamFlowControlWindowClient:     config.MaxReceiveStreamFlowControlWindowClient,
+		MaxReceiveConnectionFlowControlWindowClient: config.MaxReceiveConnectionFlowControlWindowClient,
 	}
 }
 

--- a/handshake/connection_parameters_manager.go
+++ b/handshake/connection_parameters_manager.go
@@ -50,11 +50,8 @@ type connectionParametersManager struct {
 	sendConnectionFlowControlWindow        protocol.ByteCount
 	receiveStreamFlowControlWindow         protocol.ByteCount
 	receiveConnectionFlowControlWindow     protocol.ByteCount
-
-	maxReceiveStreamFlowControlWindowServer     protocol.ByteCount
-	maxReceiveConnectionFlowControlWindowServer protocol.ByteCount
-	maxReceiveStreamFlowControlWindowClient     protocol.ByteCount
-	maxReceiveConnectionFlowControlWindowClient protocol.ByteCount
+	maxReceiveStreamFlowControlWindow      protocol.ByteCount
+	maxReceiveConnectionFlowControlWindow  protocol.ByteCount
 }
 
 var _ ConnectionParametersManager = &connectionParametersManager{}
@@ -68,34 +65,17 @@ var (
 // NewConnectionParamatersManager creates a new connection parameters manager
 func NewConnectionParamatersManager(
 	pers protocol.Perspective, v protocol.VersionNumber,
-	maxReceiveStreamFlowControlWindowServer protocol.ByteCount, maxReceiveConnectionFlowControlWindowServer protocol.ByteCount,
-	maxReceiveStreamFlowControlWindowClient protocol.ByteCount, maxReceiveConnectionFlowControlWindowClient protocol.ByteCount,
+	maxReceiveStreamFlowControlWindow protocol.ByteCount, maxReceiveConnectionFlowControlWindow protocol.ByteCount,
 ) ConnectionParametersManager {
-	if maxReceiveStreamFlowControlWindowServer == 0 {
-		maxReceiveStreamFlowControlWindowServer = protocol.DefaultMaxReceiveStreamFlowControlWindowServer
-	}
-	if maxReceiveConnectionFlowControlWindowServer == 0 {
-		maxReceiveConnectionFlowControlWindowServer = protocol.DefaultMaxReceiveConnectionFlowControlWindowServer
-	}
-	if maxReceiveStreamFlowControlWindowClient == 0 {
-		maxReceiveStreamFlowControlWindowClient = protocol.DefaultMaxReceiveStreamFlowControlWindowClient
-	}
-	if maxReceiveConnectionFlowControlWindowClient == 0 {
-		maxReceiveConnectionFlowControlWindowClient = protocol.DefaultMaxReceiveConnectionFlowControlWindowClient
-	}
-
 	h := &connectionParametersManager{
-		perspective:                        pers,
-		version:                            v,
-		sendStreamFlowControlWindow:        protocol.InitialStreamFlowControlWindow,     // can only be changed by the client
-		sendConnectionFlowControlWindow:    protocol.InitialConnectionFlowControlWindow, // can only be changed by the client
-		receiveStreamFlowControlWindow:     protocol.ReceiveStreamFlowControlWindow,
-		receiveConnectionFlowControlWindow: protocol.ReceiveConnectionFlowControlWindow,
-
-		maxReceiveStreamFlowControlWindowServer:     maxReceiveStreamFlowControlWindowServer,
-		maxReceiveConnectionFlowControlWindowServer: maxReceiveConnectionFlowControlWindowServer,
-		maxReceiveStreamFlowControlWindowClient:     maxReceiveStreamFlowControlWindowClient,
-		maxReceiveConnectionFlowControlWindowClient: maxReceiveConnectionFlowControlWindowClient,
+		perspective:                           pers,
+		version:                               v,
+		sendStreamFlowControlWindow:           protocol.InitialStreamFlowControlWindow,     // can only be changed by the client
+		sendConnectionFlowControlWindow:       protocol.InitialConnectionFlowControlWindow, // can only be changed by the client
+		receiveStreamFlowControlWindow:        protocol.ReceiveStreamFlowControlWindow,
+		receiveConnectionFlowControlWindow:    protocol.ReceiveConnectionFlowControlWindow,
+		maxReceiveStreamFlowControlWindow:     maxReceiveStreamFlowControlWindow,
+		maxReceiveConnectionFlowControlWindow: maxReceiveConnectionFlowControlWindow,
 	}
 
 	if h.perspective == protocol.PerspectiveServer {
@@ -234,10 +214,7 @@ func (h *connectionParametersManager) GetReceiveStreamFlowControlWindow() protoc
 
 // GetMaxReceiveStreamFlowControlWindow gets the maximum size of the stream-level flow control window for sending data
 func (h *connectionParametersManager) GetMaxReceiveStreamFlowControlWindow() protocol.ByteCount {
-	if h.perspective == protocol.PerspectiveServer {
-		return h.maxReceiveStreamFlowControlWindowServer
-	}
-	return h.maxReceiveStreamFlowControlWindowClient
+	return h.maxReceiveStreamFlowControlWindow
 }
 
 // GetReceiveConnectionFlowControlWindow gets the size of the stream-level flow control window for receiving data
@@ -249,10 +226,7 @@ func (h *connectionParametersManager) GetReceiveConnectionFlowControlWindow() pr
 
 // GetMaxReceiveConnectionFlowControlWindow gets the maximum size of the stream-level flow control window for sending data
 func (h *connectionParametersManager) GetMaxReceiveConnectionFlowControlWindow() protocol.ByteCount {
-	if h.perspective == protocol.PerspectiveServer {
-		return h.maxReceiveConnectionFlowControlWindowServer
-	}
-	return h.maxReceiveConnectionFlowControlWindowClient
+	return h.maxReceiveConnectionFlowControlWindow
 }
 
 // GetMaxOutgoingStreams gets the maximum number of outgoing streams per connection

--- a/handshake/connection_parameters_manager_test.go
+++ b/handshake/connection_parameters_manager_test.go
@@ -21,10 +21,8 @@ var _ = Describe("ConnectionsParameterManager", func() {
 	BeforeEach(func() {
 		cpm = NewConnectionParamatersManager(protocol.PerspectiveServer, protocol.Version36,
 			maxReceiveStreamFlowControlWindowServer, maxReceiveConnectionFlowControlWindowServer,
-			maxReceiveStreamFlowControlWindowClient, maxReceiveConnectionFlowControlWindowClient,
 		).(*connectionParametersManager)
 		cpmClient = NewConnectionParamatersManager(protocol.PerspectiveClient, protocol.Version36,
-			maxReceiveStreamFlowControlWindowServer, maxReceiveConnectionFlowControlWindowServer,
 			maxReceiveStreamFlowControlWindowClient, maxReceiveConnectionFlowControlWindowClient,
 		).(*connectionParametersManager)
 	})
@@ -155,8 +153,8 @@ var _ = Describe("ConnectionsParameterManager", func() {
 		})
 
 		It("defaults to the correct maximum flow control windows", func() {
-			cpmDefault := NewConnectionParamatersManager(protocol.PerspectiveServer, protocol.Version36, 0, 0, 0, 0).(*connectionParametersManager)
-			cpmClientDefault := NewConnectionParamatersManager(protocol.PerspectiveClient, protocol.Version36, 0, 0, 0, 0).(*connectionParametersManager)
+			cpmDefault := NewConnectionParamatersManager(protocol.PerspectiveServer, protocol.Version36, 0, 0).(*connectionParametersManager)
+			cpmClientDefault := NewConnectionParamatersManager(protocol.PerspectiveClient, protocol.Version36, 0, 0).(*connectionParametersManager)
 			Expect(cpmDefault.GetMaxReceiveStreamFlowControlWindow()).To(Equal(protocol.DefaultMaxReceiveStreamFlowControlWindowServer))
 			Expect(cpmDefault.GetMaxReceiveConnectionFlowControlWindow()).To(Equal(protocol.DefaultMaxReceiveConnectionFlowControlWindowServer))
 			Expect(cpmClientDefault.GetMaxReceiveStreamFlowControlWindow()).To(Equal(protocol.DefaultMaxReceiveStreamFlowControlWindowClient))

--- a/handshake/connection_parameters_manager_test.go
+++ b/handshake/connection_parameters_manager_test.go
@@ -152,15 +152,6 @@ var _ = Describe("ConnectionsParameterManager", func() {
 			Expect(cpmClient.GetMaxReceiveConnectionFlowControlWindow()).To(Equal(maxReceiveConnectionFlowControlWindowClient))
 		})
 
-		It("defaults to the correct maximum flow control windows", func() {
-			cpmDefault := NewConnectionParamatersManager(protocol.PerspectiveServer, protocol.Version36, 0, 0).(*connectionParametersManager)
-			cpmClientDefault := NewConnectionParamatersManager(protocol.PerspectiveClient, protocol.Version36, 0, 0).(*connectionParametersManager)
-			Expect(cpmDefault.GetMaxReceiveStreamFlowControlWindow()).To(Equal(protocol.DefaultMaxReceiveStreamFlowControlWindowServer))
-			Expect(cpmDefault.GetMaxReceiveConnectionFlowControlWindow()).To(Equal(protocol.DefaultMaxReceiveConnectionFlowControlWindowServer))
-			Expect(cpmClientDefault.GetMaxReceiveStreamFlowControlWindow()).To(Equal(protocol.DefaultMaxReceiveStreamFlowControlWindowClient))
-			Expect(cpmClientDefault.GetMaxReceiveConnectionFlowControlWindow()).To(Equal(protocol.DefaultMaxReceiveConnectionFlowControlWindowClient))
-		})
-
 		It("sets a new stream-level flow control window for sending", func() {
 			values := map[Tag][]byte{TagSFCW: {0xDE, 0xAD, 0xBE, 0xEF}}
 			err := cpm.SetFromMap(values)

--- a/handshake/crypto_setup_client_test.go
+++ b/handshake/crypto_setup_client_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/lucas-clemente/quic-go/crypto"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/protocol"
 	"github.com/lucas-clemente/quic-go/qerr"
-	"github.com/lucas-clemente/quic-go/internal/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -111,7 +111,10 @@ var _ = Describe("Client Crypto Setup", func() {
 			version,
 			stream,
 			nil,
-			NewConnectionParamatersManager(protocol.PerspectiveClient, version),
+			NewConnectionParamatersManager(protocol.PerspectiveClient, version,
+				protocol.DefaultMaxReceiveStreamFlowControlWindowServer, protocol.DefaultMaxReceiveConnectionFlowControlWindowServer,
+				protocol.DefaultMaxReceiveStreamFlowControlWindowClient, protocol.DefaultMaxReceiveConnectionFlowControlWindowClient,
+			),
 			aeadChanged,
 			&TransportParameters{},
 			nil,

--- a/handshake/crypto_setup_client_test.go
+++ b/handshake/crypto_setup_client_test.go
@@ -112,7 +112,6 @@ var _ = Describe("Client Crypto Setup", func() {
 			stream,
 			nil,
 			NewConnectionParamatersManager(protocol.PerspectiveClient, version,
-				protocol.DefaultMaxReceiveStreamFlowControlWindowServer, protocol.DefaultMaxReceiveConnectionFlowControlWindowServer,
 				protocol.DefaultMaxReceiveStreamFlowControlWindowClient, protocol.DefaultMaxReceiveConnectionFlowControlWindowClient,
 			),
 			aeadChanged,

--- a/handshake/crypto_setup_server_test.go
+++ b/handshake/crypto_setup_server_test.go
@@ -186,7 +186,6 @@ var _ = Describe("Server Crypto Setup", func() {
 		supportedVersions = []protocol.VersionNumber{version, 98, 99}
 		cpm = NewConnectionParamatersManager(protocol.PerspectiveServer, protocol.VersionWhatever,
 			protocol.DefaultMaxReceiveStreamFlowControlWindowServer, protocol.DefaultMaxReceiveConnectionFlowControlWindowServer,
-			protocol.DefaultMaxReceiveStreamFlowControlWindowClient, protocol.DefaultMaxReceiveConnectionFlowControlWindowClient,
 		)
 		csInt, err := NewCryptoSetup(
 			protocol.ConnectionID(42),

--- a/handshake/crypto_setup_server_test.go
+++ b/handshake/crypto_setup_server_test.go
@@ -7,9 +7,9 @@ import (
 	"net"
 
 	"github.com/lucas-clemente/quic-go/crypto"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/protocol"
 	"github.com/lucas-clemente/quic-go/qerr"
-	"github.com/lucas-clemente/quic-go/internal/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -184,7 +184,10 @@ var _ = Describe("Server Crypto Setup", func() {
 		Expect(err).NotTo(HaveOccurred())
 		version = protocol.SupportedVersions[len(protocol.SupportedVersions)-1]
 		supportedVersions = []protocol.VersionNumber{version, 98, 99}
-		cpm = NewConnectionParamatersManager(protocol.PerspectiveServer, protocol.VersionWhatever)
+		cpm = NewConnectionParamatersManager(protocol.PerspectiveServer, protocol.VersionWhatever,
+			protocol.DefaultMaxReceiveStreamFlowControlWindowServer, protocol.DefaultMaxReceiveConnectionFlowControlWindowServer,
+			protocol.DefaultMaxReceiveStreamFlowControlWindowClient, protocol.DefaultMaxReceiveConnectionFlowControlWindowClient,
+		)
 		csInt, err := NewCryptoSetup(
 			protocol.ConnectionID(42),
 			remoteAddr,

--- a/interface.go
+++ b/interface.go
@@ -80,6 +80,18 @@ type Config struct {
 	// If not set, it verifies that the address matches, and that the STK was issued within the last 24 hours
 	// This option is only valid for the server.
 	AcceptSTK func(clientAddr net.Addr, stk *STK) bool
+	// MaxReceiveStreamFlowControlWindowServer is the maximum stream-level flow control window for receiving data, for the server
+	// If this value is zero, the timeout is set to protocol.DefaultMaxReceiveStreamFlowControlWindowServer
+	MaxReceiveStreamFlowControlWindowServer protocol.ByteCount
+	// MaxReceiveConnectionFlowControlWindowServer is the connection-level flow control window for receiving data, for the server
+	// If this value is zero, the timeout is set to protocol.DefaultMaxReceiveConnectionFlowControlWindowServer
+	MaxReceiveConnectionFlowControlWindowServer protocol.ByteCount
+	// MaxReceiveStreamFlowControlWindowClient is the maximum stream-level flow control window for receiving data, for the client
+	// If this value is zero, the timeout is set to protocol.DefaultMaxReceiveStreamFlowControlWindowClient
+	MaxReceiveStreamFlowControlWindowClient protocol.ByteCount
+	// MaxReceiveConnectionFlowControlWindowClient is the connection-level flow control window for receiving data, for the client
+	// If this value is zero, the timeout is set to protocol.DefaultMaxReceiveConnectionFlowControlWindowClient
+	MaxReceiveConnectionFlowControlWindowClient protocol.ByteCount
 }
 
 // A Listener for incoming QUIC connections

--- a/interface.go
+++ b/interface.go
@@ -77,14 +77,14 @@ type Config struct {
 	HandshakeTimeout time.Duration
 	// AcceptSTK determines if an STK is accepted.
 	// It is called with stk = nil if the client didn't send an STK.
-	// If not set, it verifies that the address matches, and that the STK was issued within the last 24 hours
+	// If not set, it verifies that the address matches, and that the STK was issued within the last 24 hours.
 	// This option is only valid for the server.
 	AcceptSTK func(clientAddr net.Addr, stk *STK) bool
-	// MaxReceiveStreamFlowControlWindowServer is the maximum stream-level flow control window for receiving data
-	// If this value is zero, it will default to 1 MB for the server and 6 MB for the client
+	// MaxReceiveStreamFlowControlWindow is the maximum stream-level flow control window for receiving data.
+	// If this value is zero, it will default to 1 MB for the server and 6 MB for the client.
 	MaxReceiveStreamFlowControlWindow protocol.ByteCount
-	// MaxReceiveConnectionFlowControlWindowServer is the connection-level flow control window for receiving data
-	// If this value is zero, it will default to 1.5 MB for the server and 15 MB for the client
+	// MaxReceiveConnectionFlowControlWindow is the connection-level flow control window for receiving data.
+	// If this value is zero, it will default to 1.5 MB for the server and 15 MB for the client.
 	MaxReceiveConnectionFlowControlWindow protocol.ByteCount
 }
 

--- a/interface.go
+++ b/interface.go
@@ -80,18 +80,12 @@ type Config struct {
 	// If not set, it verifies that the address matches, and that the STK was issued within the last 24 hours
 	// This option is only valid for the server.
 	AcceptSTK func(clientAddr net.Addr, stk *STK) bool
-	// MaxReceiveStreamFlowControlWindowServer is the maximum stream-level flow control window for receiving data, for the server
-	// If this value is zero, the timeout is set to protocol.DefaultMaxReceiveStreamFlowControlWindowServer
-	MaxReceiveStreamFlowControlWindowServer protocol.ByteCount
-	// MaxReceiveConnectionFlowControlWindowServer is the connection-level flow control window for receiving data, for the server
-	// If this value is zero, the timeout is set to protocol.DefaultMaxReceiveConnectionFlowControlWindowServer
-	MaxReceiveConnectionFlowControlWindowServer protocol.ByteCount
-	// MaxReceiveStreamFlowControlWindowClient is the maximum stream-level flow control window for receiving data, for the client
-	// If this value is zero, the timeout is set to protocol.DefaultMaxReceiveStreamFlowControlWindowClient
-	MaxReceiveStreamFlowControlWindowClient protocol.ByteCount
-	// MaxReceiveConnectionFlowControlWindowClient is the connection-level flow control window for receiving data, for the client
-	// If this value is zero, the timeout is set to protocol.DefaultMaxReceiveConnectionFlowControlWindowClient
-	MaxReceiveConnectionFlowControlWindowClient protocol.ByteCount
+	// MaxReceiveStreamFlowControlWindowServer is the maximum stream-level flow control window for receiving data
+	// If this value is zero, it will default to 1 MB for the server and 6 MB for the client
+	MaxReceiveStreamFlowControlWindow protocol.ByteCount
+	// MaxReceiveConnectionFlowControlWindowServer is the connection-level flow control window for receiving data
+	// If this value is zero, it will default to 1.5 MB for the server and 15 MB for the client
+	MaxReceiveConnectionFlowControlWindow protocol.ByteCount
 }
 
 // A Listener for incoming QUIC connections

--- a/protocol/server_parameters.go
+++ b/protocol/server_parameters.go
@@ -39,11 +39,11 @@ const ReceiveStreamFlowControlWindow ByteCount = (1 << 10) * 32 // 32 kB
 // This is the value that Google servers are using
 const ReceiveConnectionFlowControlWindow ByteCount = (1 << 10) * 48 // 48 kB
 
-// MaxReceiveStreamFlowControlWindowServer is the maximum stream-level flow control window for receiving data
+// MaxReceiveStreamFlowControlWindowServer is the maximum stream-level flow control window for receiving data, for the server
 // This is the value that Google servers are using
 const MaxReceiveStreamFlowControlWindowServer ByteCount = 1 * (1 << 20) // 1 MB
 
-// MaxReceiveConnectionFlowControlWindowServer is the connection-level flow control window for receiving data
+// MaxReceiveConnectionFlowControlWindowServer is the connection-level flow control window for receiving data, for the server
 // This is the value that Google servers are using
 const MaxReceiveConnectionFlowControlWindowServer ByteCount = 1.5 * (1 << 20) // 1.5 MB
 
@@ -51,7 +51,7 @@ const MaxReceiveConnectionFlowControlWindowServer ByteCount = 1.5 * (1 << 20) //
 // This is the value that Chromium is using
 const MaxReceiveStreamFlowControlWindowClient ByteCount = 6 * (1 << 20) // 6 MB
 
-// MaxReceiveConnectionFlowControlWindowClient is the connection-level flow control window for receiving data, for the server
+// MaxReceiveConnectionFlowControlWindowClient is the connection-level flow control window for receiving data, for the client
 // This is the value that Google servers are using
 const MaxReceiveConnectionFlowControlWindowClient ByteCount = 15 * (1 << 20) // 15 MB
 

--- a/protocol/server_parameters.go
+++ b/protocol/server_parameters.go
@@ -39,21 +39,21 @@ const ReceiveStreamFlowControlWindow ByteCount = (1 << 10) * 32 // 32 kB
 // This is the value that Google servers are using
 const ReceiveConnectionFlowControlWindow ByteCount = (1 << 10) * 48 // 48 kB
 
-// MaxReceiveStreamFlowControlWindowServer is the maximum stream-level flow control window for receiving data, for the server
+// DefaultMaxReceiveStreamFlowControlWindowServer is the default maximum stream-level flow control window for receiving data, for the server
 // This is the value that Google servers are using
-const MaxReceiveStreamFlowControlWindowServer ByteCount = 1 * (1 << 20) // 1 MB
+const DefaultMaxReceiveStreamFlowControlWindowServer ByteCount = 1 * (1 << 20) // 1 MB
 
-// MaxReceiveConnectionFlowControlWindowServer is the connection-level flow control window for receiving data, for the server
+// DefaultMaxReceiveConnectionFlowControlWindowServer is the default connection-level flow control window for receiving data, for the server
 // This is the value that Google servers are using
-const MaxReceiveConnectionFlowControlWindowServer ByteCount = 1.5 * (1 << 20) // 1.5 MB
+const DefaultMaxReceiveConnectionFlowControlWindowServer ByteCount = 1.5 * (1 << 20) // 1.5 MB
 
-// MaxReceiveStreamFlowControlWindowClient is the maximum stream-level flow control window for receiving data, for the client
+// DefaultMaxReceiveStreamFlowControlWindowClient is the default maximum stream-level flow control window for receiving data, for the client
 // This is the value that Chromium is using
-const MaxReceiveStreamFlowControlWindowClient ByteCount = 6 * (1 << 20) // 6 MB
+const DefaultMaxReceiveStreamFlowControlWindowClient ByteCount = 6 * (1 << 20) // 6 MB
 
-// MaxReceiveConnectionFlowControlWindowClient is the connection-level flow control window for receiving data, for the client
+// DefaultMaxReceiveConnectionFlowControlWindowClient is the default connection-level flow control window for receiving data, for the client
 // This is the value that Google servers are using
-const MaxReceiveConnectionFlowControlWindowClient ByteCount = 15 * (1 << 20) // 15 MB
+const DefaultMaxReceiveConnectionFlowControlWindowClient ByteCount = 15 * (1 << 20) // 15 MB
 
 // ConnectionFlowControlMultiplier determines how much larger the connection flow control windows needs to be relative to any stream's flow control window
 // This is the value that Chromium is using

--- a/server.go
+++ b/server.go
@@ -117,15 +117,22 @@ func populateServerConfig(config *Config) *Config {
 		handshakeTimeout = config.HandshakeTimeout
 	}
 
+	maxReceiveStreamFlowControlWindow := config.MaxReceiveStreamFlowControlWindow
+	if maxReceiveStreamFlowControlWindow == 0 {
+		maxReceiveStreamFlowControlWindow = protocol.DefaultMaxReceiveStreamFlowControlWindowServer
+	}
+	maxReceiveConnectionFlowControlWindow := config.MaxReceiveConnectionFlowControlWindow
+	if maxReceiveConnectionFlowControlWindow == 0 {
+		maxReceiveConnectionFlowControlWindow = protocol.DefaultMaxReceiveConnectionFlowControlWindowServer
+	}
+
 	return &Config{
-		TLSConfig:        config.TLSConfig,
-		Versions:         versions,
-		HandshakeTimeout: handshakeTimeout,
-		AcceptSTK:        vsa,
-		MaxReceiveStreamFlowControlWindowServer:     config.MaxReceiveStreamFlowControlWindowServer,
-		MaxReceiveConnectionFlowControlWindowServer: config.MaxReceiveConnectionFlowControlWindowServer,
-		MaxReceiveStreamFlowControlWindowClient:     config.MaxReceiveStreamFlowControlWindowClient,
-		MaxReceiveConnectionFlowControlWindowClient: config.MaxReceiveConnectionFlowControlWindowClient,
+		TLSConfig:                             config.TLSConfig,
+		Versions:                              versions,
+		HandshakeTimeout:                      handshakeTimeout,
+		AcceptSTK:                             vsa,
+		MaxReceiveStreamFlowControlWindow:     maxReceiveStreamFlowControlWindow,
+		MaxReceiveConnectionFlowControlWindow: maxReceiveConnectionFlowControlWindow,
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/lucas-clemente/quic-go/crypto"
 	"github.com/lucas-clemente/quic-go/handshake"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/protocol"
 	"github.com/lucas-clemente/quic-go/qerr"
-	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
 // packetHandler handles packets
@@ -122,6 +122,10 @@ func populateServerConfig(config *Config) *Config {
 		Versions:         versions,
 		HandshakeTimeout: handshakeTimeout,
 		AcceptSTK:        vsa,
+		MaxReceiveStreamFlowControlWindowServer:     config.MaxReceiveStreamFlowControlWindowServer,
+		MaxReceiveConnectionFlowControlWindowServer: config.MaxReceiveConnectionFlowControlWindowServer,
+		MaxReceiveStreamFlowControlWindowClient:     config.MaxReceiveStreamFlowControlWindowClient,
+		MaxReceiveConnectionFlowControlWindowClient: config.MaxReceiveConnectionFlowControlWindowClient,
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -12,9 +12,9 @@ import (
 	"github.com/lucas-clemente/quic-go/flowcontrol"
 	"github.com/lucas-clemente/quic-go/frames"
 	"github.com/lucas-clemente/quic-go/handshake"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/protocol"
 	"github.com/lucas-clemente/quic-go/qerr"
-	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
 type unpacker interface {
@@ -172,7 +172,9 @@ func (s *session) setup(
 	s.sessionCreationTime = now
 
 	s.rttStats = &congestion.RTTStats{}
-	s.connectionParameters = handshake.NewConnectionParamatersManager(s.perspective, s.version)
+	s.connectionParameters = handshake.NewConnectionParamatersManager(s.perspective, s.version,
+		s.config.MaxReceiveStreamFlowControlWindowServer, s.config.MaxReceiveConnectionFlowControlWindowServer,
+		s.config.MaxReceiveStreamFlowControlWindowClient, s.config.MaxReceiveConnectionFlowControlWindowClient)
 	s.sentPacketHandler = ackhandler.NewSentPacketHandler(s.rttStats)
 	s.flowControlManager = flowcontrol.NewFlowControlManager(s.connectionParameters, s.rttStats)
 	s.receivedPacketHandler = ackhandler.NewReceivedPacketHandler(s.ackAlarmChanged)

--- a/session.go
+++ b/session.go
@@ -173,8 +173,7 @@ func (s *session) setup(
 
 	s.rttStats = &congestion.RTTStats{}
 	s.connectionParameters = handshake.NewConnectionParamatersManager(s.perspective, s.version,
-		s.config.MaxReceiveStreamFlowControlWindowServer, s.config.MaxReceiveConnectionFlowControlWindowServer,
-		s.config.MaxReceiveStreamFlowControlWindowClient, s.config.MaxReceiveConnectionFlowControlWindowClient)
+		s.config.MaxReceiveStreamFlowControlWindow, s.config.MaxReceiveConnectionFlowControlWindow)
 	s.sentPacketHandler = ackhandler.NewSentPacketHandler(s.rttStats)
 	s.flowControlManager = flowcontrol.NewFlowControlManager(s.connectionParameters, s.rttStats)
 	s.receivedPacketHandler = ackhandler.NewReceivedPacketHandler(s.ackAlarmChanged)


### PR DESCRIPTION
#526 

I'm not entirely satisfied with the new signature of NewConnectionParamatersManager. It's too long, certainly if `maxIncomingDynamicStreamsPerConnection` gets added too.
```
func NewConnectionParamatersManager(
	pers protocol.Perspective, v protocol.VersionNumber,
	maxReceiveStreamFlowControlWindowServer protocol.ByteCount, maxReceiveConnectionFlowControlWindowServer protocol.ByteCount,
	maxReceiveStreamFlowControlWindowClient protocol.ByteCount, maxReceiveConnectionFlowControlWindowClient protocol.ByteCount,
) ConnectionParametersManager
```