### PR TITLE
Start a unique quic server per integration test case

### DIFF
--- a/integrationtests/chrome_test.go
+++ b/integrationtests/chrome_test.go
@@ -79,6 +79,9 @@ var _ = Describe("Chrome tests", func() {
 				}
 				supportedVersionsBefore = protocol.SupportedVersions
 				protocol.SupportedVersions = []protocol.VersionNumber{version}
+			})
+
+			JustBeforeEach(func() {
 				wd = getWebdriverForVersion(version)
 			})
 

--- a/integrationtests/integrationtests_suite_test.go
+++ b/integrationtests/integrationtests_suite_test.go
@@ -61,14 +61,10 @@ func TestIntegration(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	setupHTTPHandlers()
-	setupQuicServer()
 	setupSelenium()
 })
 
 var _ = AfterSuite(func() {
-	err := server.Close()
-	Expect(err).NotTo(HaveOccurred())
-
 	stopSelenium()
 }, 10)
 
@@ -104,7 +100,11 @@ var _ = BeforeEach(func() {
 	}
 })
 
+var _ = JustBeforeEach(startQuicServer)
+
 var _ = AfterEach(func() {
+	stopQuicServer()
+
 	// remove uploadDir
 	if len(uploadDir) < 20 {
 		panic("uploadDir too short")
@@ -187,7 +187,7 @@ func setupHTTPHandlers() {
 	})
 }
 
-func setupQuicServer() {
+func startQuicServer() {
 	server = &h2quic.Server{
 		Server: &http.Server{
 			TLSConfig: testdata.GetTLSConfig(),
@@ -204,6 +204,10 @@ func setupQuicServer() {
 		defer GinkgoRecover()
 		server.Serve(conn)
 	}()
+}
+
+func stopQuicServer() {
+	Expect(server.Close()).NotTo(HaveOccurred())
 }
 
 func setupSelenium() {


### PR DESCRIPTION
This fixes a race condition that could lead to errors during version negotiation.

Fixes #676.