### PR TITLE
use TLSConfig.ServerName as the client hostname if provided

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,9 +73,16 @@ func DialNonFWSecure(pconn net.PacketConn, remoteAddr net.Addr, host string, con
 		return nil, err
 	}
 
-	hostname, _, err := net.SplitHostPort(host)
-	if err != nil {
-		return nil, err
+	var hostname string
+	if config.TLSConfig != nil {
+		hostname = config.TLSConfig.ServerName
+	}
+
+	if hostname == "" {
+		hostname, _, err = net.SplitHostPort(host)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	clientConfig := populateClientConfig(config)


### PR DESCRIPTION
Currently quic client always parse `hostname` from the addr. It prevent us to specific a different `hostname` to the client.

This PR is to enable this by the `TLSConfig.ServerName` field. Thanks.

Signed-off-by: Phus Lu <phuslu@hotmail.com>