### PR TITLE
Implement Timeout()/Temproary() for QuicError

### DIFF
--- a/qerr/quic_error.go
+++ b/qerr/quic_error.go
@@ -31,6 +31,16 @@ func (e *QuicError) Error() string {
 	return fmt.Sprintf("%s: %s", e.ErrorCode.String(), e.ErrorMessage)
 }
 
+func (e *QuicError) Timeout() bool {
+	switch e.ErrorCode {
+	case NetworkIdleTimeout,
+		HandshakeTimeout,
+		TimeoutsWithOpenStreams:
+		return true
+	}
+	return false
+}
+
 // ToQuicError converts an arbitrary error to a QuicError. It leaves QuicErrors
 // unchanged, and properly handles `ErrorCode`s.
 func ToQuicError(err error) *QuicError {

--- a/qerr/quic_error_test.go
+++ b/qerr/quic_error_test.go
@@ -22,6 +22,13 @@ var _ = Describe("Quic error", func() {
 		})
 	})
 
+	Context("TimeoutError", func() {
+		It("works as timeout error", func() {
+			err := Error(HandshakeTimeout, "handshake timeout")
+			Expect(err.Timeout()).Should(BeTrue())
+		})
+	})
+
 	Context("ToQuicError", func() {
 		It("leaves QuicError unchanged", func() {
 			err := Error(DecryptionFailure, "foo")


### PR DESCRIPTION
By adding Timeout()/Temparay() to QuicError, we could distinguish QuicError to different types.
Like idioms in golang net, context, http packages.

I'm not familar with quic very well, so I'm not sure current PR code is suitable or not.

Please give comments, thanks!
