### PR TITLE
use TLSConfig.ServerName as the client hostname if provided

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,9 +73,16 @@ func DialNonFWSecure(pconn net.PacketConn, remoteAddr net.Addr, host string, con
 		return nil, err
 	}
 
-	hostname, _, err := net.SplitHostPort(host)
-	if err != nil {
-		return nil, err
+	var hostname string
+	if config.TLSConfig != nil {
+		hostname = config.TLSConfig.ServerName
+	}
+
+	if hostname == "" {
+		hostname, _, err = net.SplitHostPort(host)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	clientConfig := populateClientConfig(config)

--- a/crypto/cert_manager.go
+++ b/crypto/cert_manager.go
@@ -107,15 +107,14 @@ func (c *certManager) Verify(hostname string) error {
 	var opts x509.VerifyOptions
 	if c.config != nil {
 		opts.Roots = c.config.RootCAs
-		opts.DNSName = c.config.ServerName
 		if c.config.Time == nil {
 			opts.CurrentTime = time.Now()
 		} else {
 			opts.CurrentTime = c.config.Time()
 		}
-	} else {
-		opts.DNSName = hostname
 	}
+	// we don't need to care about the tls.Config.ServerName here, since hostname has already been set to that value in the session setup
+	opts.DNSName = hostname
 
 	// the first certificate is the leaf certificate, all others are intermediates
 	if len(c.chain) > 1 {

--- a/crypto/cert_manager_test.go
+++ b/crypto/cert_manager_test.go
@@ -268,52 +268,6 @@ var _ = Describe("Cert Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("uses a different hostname from a client TLS config", func() {
-			if runtime.GOOS == "windows" {
-				// certificate validation works different on windows, see https://golang.org/src/crypto/x509/verify.go line 238
-				Skip("windows")
-			}
-
-			template := &x509.Certificate{
-				SerialNumber: big.NewInt(1),
-				NotBefore:    time.Now().Add(-time.Hour),
-				NotAfter:     time.Now().Add(time.Hour),
-				Subject:      pkix.Name{CommonName: "google.com"},
-			}
-
-			_, leafCert := getCertificate(template)
-			cm.chain = []*x509.Certificate{leafCert}
-			cm.config = &tls.Config{
-				ServerName: "google.com",
-			}
-			err := cm.Verify("quic.clemente.io")
-			_, ok := err.(x509.UnknownAuthorityError)
-			Expect(ok).To(BeTrue())
-		})
-
-		It("rejects certificates with a different hostname than specified in the client TLS config", func() {
-			if runtime.GOOS == "windows" {
-				// certificate validation works different on windows, see https://golang.org/src/crypto/x509/verify.go line 238
-				Skip("windows")
-			}
-
-			template := &x509.Certificate{
-				SerialNumber: big.NewInt(1),
-				NotBefore:    time.Now().Add(-time.Hour),
-				NotAfter:     time.Now().Add(time.Hour),
-				Subject:      pkix.Name{CommonName: "quic.clemente.io"},
-			}
-
-			_, leafCert := getCertificate(template)
-			cm.chain = []*x509.Certificate{leafCert}
-			cm.config = &tls.Config{
-				ServerName: "google.com",
-			}
-			err := cm.Verify("quic.clemente.io")
-			_, ok := err.(x509.HostnameError)
-			Expect(ok).To(BeTrue())
-		})
-
 		It("uses the time specified in a client TLS config", func() {
 			if runtime.GOOS == "windows" {
 				// certificate validation works different on windows, see https://golang.org/src/crypto/x509/verify.go line 238
@@ -324,6 +278,7 @@ var _ = Describe("Cert Manager", func() {
 				SerialNumber: big.NewInt(1),
 				NotBefore:    time.Now().Add(-25 * time.Hour),
 				NotAfter:     time.Now().Add(-23 * time.Hour),
+				Subject:      pkix.Name{CommonName: "quic.clemente.io"},
 			}
 			_, leafCert := getCertificate(template)
 			cm.chain = []*x509.Certificate{leafCert}
@@ -384,10 +339,9 @@ var _ = Describe("Cert Manager", func() {
 
 			cm.chain = []*x509.Certificate{leafCert}
 			cm.config = &tls.Config{
-				RootCAs:    rootCAPool,
-				ServerName: "google.com",
+				RootCAs: rootCAPool,
 			}
-			err = cm.Verify("quic.clemente.io")
+			err = cm.Verify("google.com")
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
For some reason, Github didn't let me push into PR #686, so here's a new PR.