### PR TITLE
Add HandshakeTimeout to h2quic.QuicRoundTripper

### DIFF
--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
@@ -22,6 +23,7 @@ import (
 
 type roundTripperOpts struct {
 	DisableCompression bool
+	HandshakeTimeout   time.Duration
 }
 
 // client is a HTTP2 client doing QUIC requests
@@ -57,6 +59,7 @@ func newClient(tlsConfig *tls.Config, hostname string, opts *roundTripperOpts) *
 		encryptionLevel: protocol.EncryptionUnencrypted,
 		config: &quic.Config{
 			TLSConfig:                     tlsConfig,
+			HandshakeTimeout:              opts.HandshakeTimeout,
 			RequestConnectionIDTruncation: true,
 		},
 		opts:          opts,

--- a/h2quic/client_test.go
+++ b/h2quic/client_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"time"
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
@@ -73,6 +74,16 @@ var _ = Describe("Client", func() {
 		}
 		_, err := client.RoundTrip(req)
 		Expect(err).To(MatchError(testErr))
+	})
+
+	It("errors when set handshake timeout", func() {
+		transport := QuicRoundTripper{
+			// set 1ms timeout to enforce error
+			HandshakeTimeout: 1 * time.Millisecond,
+		}
+
+		_, err := transport.RoundTrip(req)
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("errors if the header stream has the wrong stream ID", func() {


### PR DESCRIPTION
Currently h2quic.QuicRoundTripper always use default handshake timeout(10s).
This PR is to expose HandshakeTimeout for QuicRoundTripper.

For tests parts, I'm not sure the added unittest is a right one, please comment that.
Thanks!
