### PR TITLE
rename the h2quic.QuicRoundTripper to h2quic.RoundTripper

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,4 +8,5 @@
 - Add a `quic.Config` option to configure the source address validation
 - Add a `quic.Config` option to configure the handshake timeout
 - Changed the log level environment variable to only accept strings ("DEBUG", "INFO", "ERROR"), see [the wiki](https://github.com/lucas-clemente/quic-go/wiki/Logging) for more details.
+- Rename the `h2quic.QuicRoundTripper` to `h2quic.RoundTripper`
 - Various bugfixes

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ h2quic.ListenAndServeQUIC("localhost:4242", "/path/to/cert/chain.pem", "/path/to
 
 ### As a client
 
-See the [example client](example/client/main.go). Use a `QuicRoundTripper` as a `Transport` in a `http.Client`.
+See the [example client](example/client/main.go). Use a `h2quic.RoundTripper` as a `Transport` in a `http.Client`.
 
 ```go
 http.Client{
-  Transport: &h2quic.QuicRoundTripper{},
+  Transport: &h2quic.RoundTripper{},
 }
 ```
 

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -24,7 +24,7 @@ func main() {
 	utils.SetLogTimeFormat("")
 
 	hclient := &http.Client{
-		Transport: &h2quic.QuicRoundTripper{},
+		Transport: &h2quic.RoundTripper{},
 	}
 
 	var wg sync.WaitGroup

--- a/h2quic/roundtrip.go
+++ b/h2quic/roundtrip.go
@@ -11,8 +11,8 @@ import (
 	"golang.org/x/net/lex/httplex"
 )
 
-// QuicRoundTripper implements the http.RoundTripper interface
-type QuicRoundTripper struct {
+// RoundTripper implements the http.RoundTripper interface
+type RoundTripper struct {
 	mutex sync.Mutex
 
 	// DisableCompression, if true, prevents the Transport from
@@ -32,10 +32,10 @@ type QuicRoundTripper struct {
 	clients map[string]http.RoundTripper
 }
 
-var _ http.RoundTripper = &QuicRoundTripper{}
+var _ http.RoundTripper = &RoundTripper{}
 
 // RoundTrip does a round trip
-func (r *QuicRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.URL == nil {
 		closeRequestBody(req)
 		return nil, errors.New("quic: nil Request.URL")
@@ -74,7 +74,7 @@ func (r *QuicRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	return r.getClient(hostname).RoundTrip(req)
 }
 
-func (r *QuicRoundTripper) getClient(hostname string) http.RoundTripper {
+func (r *RoundTripper) getClient(hostname string) http.RoundTripper {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 

--- a/h2quic/roundtrip_test.go
+++ b/h2quic/roundtrip_test.go
@@ -9,9 +9,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type mockQuicRoundTripper struct{}
+type mockRoundTripper struct{}
 
-func (m *mockQuicRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{Request: req}, nil
 }
 
@@ -43,12 +43,12 @@ var _ io.ReadCloser = &mockBody{}
 
 var _ = Describe("RoundTripper", func() {
 	var (
-		rt   *QuicRoundTripper
+		rt   *RoundTripper
 		req1 *http.Request
 	)
 
 	BeforeEach(func() {
-		rt = &QuicRoundTripper{}
+		rt = &RoundTripper{}
 		var err error
 		req1, err = http.NewRequest("GET", "https://www.example.org/file1.html", nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -56,7 +56,7 @@ var _ = Describe("RoundTripper", func() {
 
 	It("reuses existing clients", func() {
 		rt.clients = make(map[string]http.RoundTripper)
-		rt.clients["www.example.org:443"] = &mockQuicRoundTripper{}
+		rt.clients["www.example.org:443"] = &mockRoundTripper{}
 		rsp, err := rt.RoundTrip(req1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rsp.Request).To(Equal(req1))

--- a/integrationtests/client_test.go
+++ b/integrationtests/client_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Client tests", func() {
 			Fail("quic.clemente.io does not resolve to 127.0.0.1. Consider adding it to /etc/hosts.")
 		}
 		client = &http.Client{
-			Transport: &h2quic.QuicRoundTripper{},
+			Transport: &h2quic.RoundTripper{},
 		}
 	})
 

--- a/integrationtests/server_test.go
+++ b/integrationtests/server_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Server tests", func() {
 		certPool := x509.NewCertPool()
 		certPool.AddCert(CACert)
 		client = &http.Client{
-			Transport: &h2quic.QuicRoundTripper{
+			Transport: &h2quic.RoundTripper{
 				TLSClientConfig: &tls.Config{RootCAs: certPool},
 			},
 		}


### PR DESCRIPTION
Fixes #705.