### PR TITLE
remove the tls.Config from the quic.Config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Add a `quic.Config` option to request truncation of the connection ID from a server
 - Add a `quic.Config` option to configure the source address validation
 - Add a `quic.Config` option to configure the handshake timeout
+- Remove the `tls.Config` from the `quic.Config`. The `tls.Config` must now be passed to the `Dial` and `Listen` functions as a separate parameter. See the [Godoc](https://godoc.org/github.com/lucas-clemente/quic-go) for details.
 - Changed the log level environment variable to only accept strings ("DEBUG", "INFO", "ERROR"), see [the wiki](https://github.com/lucas-clemente/quic-go/wiki/Logging) for more details.
 - Rename the `h2quic.QuicRoundTripper` to `h2quic.RoundTripper`
 - Various bugfixes

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Benchmarks", func() {
 				go func() {
 					defer GinkgoRecover()
 					var err error
-					ln, err = ListenAddr("localhost:0", &Config{TLSConfig: testdata.GetTLSConfig()})
+					ln, err = ListenAddr("localhost:0", testdata.GetTLSConfig(), nil)
 					Expect(err).ToNot(HaveOccurred())
 					serverAddr <- ln.Addr()
 					sess, err := ln.Accept()
@@ -49,11 +49,8 @@ var _ = Describe("Benchmarks", func() {
 				}()
 
 				// start the client
-				conf := &Config{
-					TLSConfig: &tls.Config{InsecureSkipVerify: true},
-				}
 				addr := <-serverAddr
-				sess, err := DialAddr(addr.String(), conf)
+				sess, err := DialAddr(addr.String(), &tls.Config{InsecureSkipVerify: true}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				str, err := sess.AcceptStream()
 				Expect(err).ToNot(HaveOccurred())

--- a/example/echo/echo.go
+++ b/example/echo/echo.go
@@ -31,10 +31,7 @@ func main() {
 
 // Start a server that echos all data on the first stream opened by the client
 func echoServer() error {
-	cfgServer := &quic.Config{
-		TLSConfig: generateTLSConfig(),
-	}
-	listener, err := quic.ListenAddr(addr, cfgServer)
+	listener, err := quic.ListenAddr(addr, generateTLSConfig(), nil)
 	if err != nil {
 		return err
 	}
@@ -52,10 +49,7 @@ func echoServer() error {
 }
 
 func clientMain() error {
-	cfgClient := &quic.Config{
-		TLSConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	session, err := quic.DialAddr(addr, cfgClient)
+	session, err := quic.DialAddr(addr, &tls.Config{InsecureSkipVerify: true}, nil)
 	if err != nil {
 		return err
 	}

--- a/h2quic/server.go
+++ b/h2quic/server.go
@@ -84,16 +84,15 @@ func (s *Server) serveImpl(tlsConfig *tls.Config, conn *net.UDPConn) error {
 	}
 
 	config := quic.Config{
-		TLSConfig: tlsConfig,
-		Versions:  protocol.SupportedVersions,
+		Versions: protocol.SupportedVersions,
 	}
 
 	var ln quic.Listener
 	var err error
 	if conn == nil {
-		ln, err = quic.ListenAddr(s.Addr, &config)
+		ln, err = quic.ListenAddr(s.Addr, tlsConfig, &config)
 	} else {
-		ln, err = quic.Listen(conn, &config)
+		ln, err = quic.Listen(conn, tlsConfig, &config)
 	}
 	if err != nil {
 		s.listenerMutex.Unlock()

--- a/interface.go
+++ b/interface.go
@@ -1,7 +1,6 @@
 package quic
 
 import (
-	"crypto/tls"
 	"io"
 	"net"
 	"time"
@@ -64,7 +63,6 @@ type STK struct {
 // Config contains all configuration data needed for a QUIC server or client.
 // More config parameters (such as timeouts) will be added soon, see e.g. https://github.com/lucas-clemente/quic-go/issues/441.
 type Config struct {
-	TLSConfig *tls.Config
 	// The QUIC versions that can be negotiated.
 	// If not set, it uses all versions available.
 	// Warning: This API should not be considered stable and will change soon.

--- a/session_test.go
+++ b/session_test.go
@@ -169,6 +169,7 @@ var _ = Describe("Session", func() {
 			protocol.Version35,
 			0,
 			scfg,
+			nil,
 			populateServerConfig(&Config{}),
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -220,6 +221,7 @@ var _ = Describe("Session", func() {
 				protocol.Version35,
 				0,
 				scfg,
+				nil,
 				conf,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1635,6 +1637,7 @@ var _ = Describe("Client Session", func() {
 			"hostname",
 			protocol.Version35,
 			0,
+			nil,
 			populateClientConfig(&Config{}),
 			nil,
 		)


### PR DESCRIPTION
The `tls.Config` now is a separate parameter to all Listen and Dial functions in the `quic` package.