### PR TITLE
expose the quic.Config in h2quic.Server and h2quic.RoundTripper

### DIFF
--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -24,14 +24,15 @@ type roundTripperOpts struct {
 	DisableCompression bool
 }
 
+var dialAddr = quic.DialAddr
+
 // client is a HTTP2 client doing QUIC requests
 type client struct {
 	mutex sync.RWMutex
 
-	dialAddr func(hostname string, tlsConf *tls.Config, config *quic.Config) (quic.Session, error)
-	tlsConf  *tls.Config
-	config   *quic.Config
-	opts     *roundTripperOpts
+	tlsConf *tls.Config
+	config  *quic.Config
+	opts    *roundTripperOpts
 
 	hostname        string
 	encryptionLevel protocol.EncryptionLevel
@@ -52,7 +53,6 @@ var _ http.RoundTripper = &client{}
 // newClient creates a new client
 func newClient(tlsConfig *tls.Config, hostname string, opts *roundTripperOpts) *client {
 	return &client{
-		dialAddr:        quic.DialAddr,
 		hostname:        authorityAddr("https", hostname),
 		responses:       make(map[protocol.StreamID]chan *http.Response),
 		encryptionLevel: protocol.EncryptionUnencrypted,
@@ -69,7 +69,7 @@ func newClient(tlsConfig *tls.Config, hostname string, opts *roundTripperOpts) *
 // dial dials the connection
 func (c *client) dial() error {
 	var err error
-	c.session, err = c.dialAddr(c.hostname, c.tlsConf, c.config)
+	c.session, err = dialAddr(c.hostname, c.tlsConf, c.config)
 	if err != nil {
 		return err
 	}

--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -50,19 +50,30 @@ type client struct {
 
 var _ http.RoundTripper = &client{}
 
+var defaultQuicConfig = &quic.Config{
+	RequestConnectionIDTruncation: true,
+	KeepAlive:                     true,
+}
+
 // newClient creates a new client
-func newClient(hostname string, tlsConfig *tls.Config, opts *roundTripperOpts) *client {
+func newClient(
+	hostname string,
+	tlsConfig *tls.Config,
+	opts *roundTripperOpts,
+	quicConfig *quic.Config,
+) *client {
+	config := defaultQuicConfig
+	if quicConfig != nil {
+		config = quicConfig
+	}
 	return &client{
 		hostname:        authorityAddr("https", hostname),
 		responses:       make(map[protocol.StreamID]chan *http.Response),
 		encryptionLevel: protocol.EncryptionUnencrypted,
 		tlsConf:         tlsConfig,
-		config: &quic.Config{
-			RequestConnectionIDTruncation: true,
-			KeepAlive:                     true,
-		},
-		opts:          opts,
-		headerErrored: make(chan struct{}),
+		config:          config,
+		opts:            opts,
+		headerErrored:   make(chan struct{}),
 	}
 }
 

--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -51,7 +51,7 @@ type client struct {
 var _ http.RoundTripper = &client{}
 
 // newClient creates a new client
-func newClient(tlsConfig *tls.Config, hostname string, opts *roundTripperOpts) *client {
+func newClient(hostname string, tlsConfig *tls.Config, opts *roundTripperOpts) *client {
 	return &client{
 		hostname:        authorityAddr("https", hostname),
 		responses:       make(map[protocol.StreamID]chan *http.Response),

--- a/h2quic/client_test.go
+++ b/h2quic/client_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Client", func() {
 	BeforeEach(func() {
 		origDialAddr = dialAddr
 		hostname := "quic.clemente.io:1337"
-		client = newClient(nil, hostname, &roundTripperOpts{})
+		client = newClient(hostname, nil, &roundTripperOpts{})
 		Expect(client.hostname).To(Equal(hostname))
 		session = &mockSession{}
 		client.session = session
@@ -50,17 +50,17 @@ var _ = Describe("Client", func() {
 
 	It("saves the TLS config", func() {
 		tlsConf := &tls.Config{InsecureSkipVerify: true}
-		client = newClient(tlsConf, "", &roundTripperOpts{})
+		client = newClient("", tlsConf, &roundTripperOpts{})
 		Expect(client.tlsConf).To(Equal(tlsConf))
 	})
 
 	It("adds the port to the hostname, if none is given", func() {
-		client = newClient(nil, "quic.clemente.io", &roundTripperOpts{})
+		client = newClient("quic.clemente.io", nil, &roundTripperOpts{})
 		Expect(client.hostname).To(Equal("quic.clemente.io:443"))
 	})
 
 	It("dials", func(done Done) {
-		client = newClient(nil, "localhost:1337", &roundTripperOpts{})
+		client = newClient("localhost:1337", nil, &roundTripperOpts{})
 		session.streamsToOpen = []quic.Stream{newMockStream(3), newMockStream(5)}
 		dialAddr = func(hostname string, _ *tls.Config, _ *quic.Config) (quic.Session, error) {
 			return session, nil
@@ -73,7 +73,7 @@ var _ = Describe("Client", func() {
 
 	It("errors when dialing fails", func() {
 		testErr := errors.New("handshake error")
-		client = newClient(nil, "localhost:1337", &roundTripperOpts{})
+		client = newClient("localhost:1337", nil, &roundTripperOpts{})
 		dialAddr = func(hostname string, _ *tls.Config, _ *quic.Config) (quic.Session, error) {
 			return nil, testErr
 		}
@@ -82,7 +82,7 @@ var _ = Describe("Client", func() {
 	})
 
 	It("errors if the header stream has the wrong stream ID", func() {
-		client = newClient(nil, "localhost:1337", &roundTripperOpts{})
+		client = newClient("localhost:1337", nil, &roundTripperOpts{})
 		session.streamsToOpen = []quic.Stream{&mockStream{id: 2}}
 		dialAddr = func(hostname string, _ *tls.Config, _ *quic.Config) (quic.Session, error) {
 			return session, nil
@@ -93,7 +93,7 @@ var _ = Describe("Client", func() {
 
 	It("errors if it can't open a stream", func() {
 		testErr := errors.New("you shall not pass")
-		client = newClient(nil, "localhost:1337", &roundTripperOpts{})
+		client = newClient("localhost:1337", nil, &roundTripperOpts{})
 		session.streamOpenErr = testErr
 		dialAddr = func(hostname string, _ *tls.Config, _ *quic.Config) (quic.Session, error) {
 			return session, nil
@@ -252,7 +252,7 @@ var _ = Describe("Client", func() {
 
 			It("adds the port for request URLs without one", func(done Done) {
 				var err error
-				client = newClient(nil, "quic.clemente.io", &roundTripperOpts{})
+				client = newClient("quic.clemente.io", nil, &roundTripperOpts{})
 				req, err := http.NewRequest("https", "https://quic.clemente.io/foobar.html", nil)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/h2quic/roundtrip.go
+++ b/h2quic/roundtrip.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 
+	quic "github.com/lucas-clemente/quic-go"
+
 	"golang.org/x/net/lex/httplex"
 )
 
@@ -28,6 +30,10 @@ type RoundTripper struct {
 	// TLSClientConfig specifies the TLS configuration to use with
 	// tls.Client. If nil, the default configuration is used.
 	TLSClientConfig *tls.Config
+
+	// QuicConfig is the quic.Config used for dialing new connections.
+	// If nil, reasonable default values will be used.
+	QuicConfig *quic.Config
 
 	clients map[string]http.RoundTripper
 }
@@ -84,7 +90,7 @@ func (r *RoundTripper) getClient(hostname string) http.RoundTripper {
 
 	client, ok := r.clients[hostname]
 	if !ok {
-		client = newClient(hostname, r.TLSClientConfig, &roundTripperOpts{DisableCompression: r.DisableCompression})
+		client = newClient(hostname, r.TLSClientConfig, &roundTripperOpts{DisableCompression: r.DisableCompression}, r.QuicConfig)
 		r.clients[hostname] = client
 	}
 	return client

--- a/h2quic/roundtrip.go
+++ b/h2quic/roundtrip.go
@@ -84,7 +84,7 @@ func (r *RoundTripper) getClient(hostname string) http.RoundTripper {
 
 	client, ok := r.clients[hostname]
 	if !ok {
-		client = newClient(r.TLSClientConfig, hostname, &roundTripperOpts{DisableCompression: r.DisableCompression})
+		client = newClient(hostname, r.TLSClientConfig, &roundTripperOpts{DisableCompression: r.DisableCompression})
 		r.clients[hostname] = client
 	}
 	return client

--- a/h2quic/server.go
+++ b/h2quic/server.go
@@ -29,6 +29,12 @@ type remoteCloser interface {
 	CloseRemote(protocol.ByteCount)
 }
 
+// allows mocking of quic.Listen and quic.ListenAddr
+var (
+	quicListen     = quic.Listen
+	quicListenAddr = quic.ListenAddr
+)
+
 // Server is a HTTP2 server listening for QUIC connections.
 type Server struct {
 	*http.Server
@@ -90,9 +96,9 @@ func (s *Server) serveImpl(tlsConfig *tls.Config, conn net.PacketConn) error {
 	var ln quic.Listener
 	var err error
 	if conn == nil {
-		ln, err = quic.ListenAddr(s.Addr, tlsConfig, &config)
+		ln, err = quicListenAddr(s.Addr, tlsConfig, &config)
 	} else {
-		ln, err = quic.Listen(conn, tlsConfig, &config)
+		ln, err = quicListen(conn, tlsConfig, &config)
 	}
 	if err != nil {
 		s.listenerMutex.Unlock()

--- a/h2quic/server_test.go
+++ b/h2quic/server_test.go
@@ -2,13 +2,12 @@ package h2quic
 
 import (
 	"bytes"
+	"crypto/tls"
+	"errors"
 	"io"
 	"net"
 	"net/http"
-	"os"
-	"runtime"
 	"sync"
-	"syscall"
 	"time"
 
 	"golang.org/x/net/http2"
@@ -66,9 +65,10 @@ func (s *mockSession) WaitUntilClosed() { panic("not implemented") }
 
 var _ = Describe("H2 server", func() {
 	var (
-		s          *Server
-		session    *mockSession
-		dataStream *mockStream
+		s                  *Server
+		session            *mockSession
+		dataStream         *mockStream
+		origQuicListenAddr = quicListenAddr
 	)
 
 	BeforeEach(func() {
@@ -80,6 +80,11 @@ var _ = Describe("H2 server", func() {
 		dataStream = newMockStream(0)
 		close(dataStream.unblockRead)
 		session = &mockSession{dataStream: dataStream}
+		origQuicListenAddr = quicListenAddr
+	})
+
+	AfterEach(func() {
+		quicListenAddr = origQuicListenAddr
 	})
 
 	Context("handling requests", func() {
@@ -399,7 +404,6 @@ var _ = Describe("H2 server", func() {
 			Expect(err).To(MatchError("ListenAndServe may only be called once"))
 			err = s.Close()
 			Expect(err).NotTo(HaveOccurred())
-
 		}, 0.5)
 	})
 
@@ -436,31 +440,13 @@ var _ = Describe("H2 server", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("at least errors in global ListenAndServeQUIC", func() {
-		// It's quite hard to test this, since we cannot properly shutdown the server
-		// once it's started. So, we open a socket on the same port before the test,
-		// so that ListenAndServeQUIC definitely fails. This way we know it at least
-		// created a socket on the proper address :)
-		const addr = "127.0.0.1:4826"
-		udpAddr, err := net.ResolveUDPAddr("udp", addr)
-		Expect(err).NotTo(HaveOccurred())
-		c, err := net.ListenUDP("udp", udpAddr)
-		Expect(err).NotTo(HaveOccurred())
-		defer c.Close()
-		fullpem, privkey := testdata.GetCertificatePaths()
-		err = ListenAndServeQUIC(addr, fullpem, privkey, nil)
-		// Check that it's an EADDRINUSE
-		Expect(err).ToNot(BeNil())
-		opErr, ok := err.(*net.OpError)
-		Expect(ok).To(BeTrue())
-		syscallErr, ok := opErr.Err.(*os.SyscallError)
-		Expect(ok).To(BeTrue())
-		if runtime.GOOS == "windows" {
-			// for some reason, Windows return a different error number, corresponding to an WSAEADDRINUSE error
-			// see https://msdn.microsoft.com/en-us/library/windows/desktop/ms681391(v=vs.85).aspx
-			Expect(syscallErr.Err).To(Equal(syscall.Errno(0x2740)))
-		} else {
-			Expect(syscallErr.Err).To(MatchError(syscall.EADDRINUSE))
+	It("errors when listening fails", func() {
+		testErr := errors.New("listen error")
+		quicListenAddr = func(addr string, tlsConf *tls.Config, config *quic.Config) (quic.Listener, error) {
+			return nil, testErr
 		}
+		fullpem, privkey := testdata.GetCertificatePaths()
+		err := ListenAndServeQUIC("", fullpem, privkey, nil)
+		Expect(err).To(MatchError(testErr))
 	})
 })


### PR DESCRIPTION
Fixes #677.

I made dependency injection a bit easier to increase testabilty of the h2quic package.