### PR TITLE
increase RTT and make assertion more lenient in handshake test

### DIFF
--- a/integrationtests/handshake/rtt.go
+++ b/integrationtests/handshake/rtt.go
@@ -24,7 +24,7 @@ var _ = Describe("Handshake integration tets", func() {
 		serverConfig  *quic.Config
 		testStartedAt time.Time
 	)
-	rtt := 350 * time.Millisecond
+	rtt := 400 * time.Millisecond
 
 	BeforeEach(func() {
 		serverConfig = &quic.Config{}
@@ -61,7 +61,7 @@ var _ = Describe("Handshake integration tets", func() {
 		expectedDuration := time.Duration(num) * rtt
 		Expect(testDuration).To(SatisfyAll(
 			BeNumerically(">=", expectedDuration),
-			BeNumerically("<", expectedDuration+rtt/2),
+			BeNumerically("<", expectedDuration+rtt),
 		))
 	}
 


### PR DESCRIPTION
Hopefully fixes #700.

Let's see if this works. I increased the RTT to 400 ms, and made the assertion more lenient. If this doesn't fix the flakiness, we'll really have to switch to something mean-based.