### PR TITLE
fix check for STK generation time

### DIFF
--- a/handshake/stk_generator_test.go
+++ b/handshake/stk_generator_test.go
@@ -38,7 +38,9 @@ var _ = Describe("STK Generator", func() {
 		stk, err := stkGen.DecodeToken(token)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stk.RemoteAddr).To(Equal("192.168.0.1"))
-		Expect(stk.SentTime).To(BeTemporally("~", time.Now(), time.Second))
+		// the time resolution of the STK is just 1 second
+		// if STK generation and this check happen in "different seconds", the difference will be between 1 and 2 seconds
+		Expect(stk.SentTime).To(BeTemporally("~", time.Now(), 2*time.Second))
 	})
 
 	It("rejects invalid tokens", func() {
@@ -89,7 +91,9 @@ var _ = Describe("STK Generator", func() {
 			stk, err := stkGen.DecodeToken(token)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stk.RemoteAddr).To(Equal(ip.String()))
-			Expect(stk.SentTime).To(BeTemporally("~", time.Now(), time.Second))
+			// the time resolution of the STK is just 1 second
+			// if STK generation and this check happen in "different seconds", the difference will be between 1 and 2 seconds
+			Expect(stk.SentTime).To(BeTemporally("~", time.Now(), 2*time.Second))
 		}
 	})
 


### PR DESCRIPTION
This is analogous to what I already did in #711, but somehow I forgot to apply the fix to the other location where the STK generation time is checked.