### PR TITLE
implement receiving of Public Resets for the client

### DIFF
--- a/server.go
+++ b/server.go
@@ -20,6 +20,7 @@ type packetHandler interface {
 	Session
 	handlePacket(*receivedPacket)
 	run() error
+	closeRemote(error)
 }
 
 // A Listener of QUIC

--- a/server_test.go
+++ b/server_test.go
@@ -23,6 +23,7 @@ type mockSession struct {
 	packetCount       int
 	closed            bool
 	closeReason       error
+	closedRemote      bool
 	stopRunLoop       chan struct{} // run returns as soon as this channel receives a value
 	handshakeChan     chan handshakeEvent
 	handshakeComplete chan error // for WaitUntilHandshakeComplete
@@ -50,6 +51,12 @@ func (s *mockSession) Close(e error) error {
 	s.closed = true
 	close(s.stopRunLoop)
 	return nil
+}
+func (s *mockSession) closeRemote(e error) {
+	s.closeReason = e
+	s.closed = true
+	s.closedRemote = true
+	close(s.stopRunLoop)
 }
 func (s *mockSession) AcceptStream() (Stream, error) {
 	panic("not implemented")


### PR DESCRIPTION
When a Public Reset is received, the client validates if it was sent from the correct remote address and if the connection ID matches. When a valid Public Reset is received, the connection is closed immediately.

This fixes #34. For the server-side, there's no need to receive Public Resets.