### PR TITLE
implement a function to close the h2quic.RoundTripper and run it as a finalizer

### DIFF
--- a/h2quic/roundtrip.go
+++ b/h2quic/roundtrip.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -12,6 +13,11 @@ import (
 
 	"golang.org/x/net/lex/httplex"
 )
+
+type roundTripCloser interface {
+	http.RoundTripper
+	io.Closer
+}
 
 // RoundTripper implements the http.RoundTripper interface
 type RoundTripper struct {
@@ -35,10 +41,10 @@ type RoundTripper struct {
 	// If nil, reasonable default values will be used.
 	QuicConfig *quic.Config
 
-	clients map[string]http.RoundTripper
+	clients map[string]roundTripCloser
 }
 
-var _ http.RoundTripper = &RoundTripper{}
+var _ roundTripCloser = &RoundTripper{}
 
 // RoundTrip does a round trip
 func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -85,7 +91,7 @@ func (r *RoundTripper) getClient(hostname string) http.RoundTripper {
 	defer r.mutex.Unlock()
 
 	if r.clients == nil {
-		r.clients = make(map[string]http.RoundTripper)
+		r.clients = make(map[string]roundTripCloser)
 	}
 
 	client, ok := r.clients[hostname]
@@ -94,6 +100,19 @@ func (r *RoundTripper) getClient(hostname string) http.RoundTripper {
 		r.clients[hostname] = client
 	}
 	return client
+}
+
+// Close closes the QUIC connections that this RoundTripper has used
+func (r *RoundTripper) Close() error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	for _, client := range r.clients {
+		if err := client.Close(); err != nil {
+			return err
+		}
+	}
+	r.clients = nil
+	return nil
 }
 
 func closeRequestBody(req *http.Request) {

--- a/h2quic/roundtrip.go
+++ b/h2quic/roundtrip.go
@@ -11,6 +11,8 @@ import (
 
 	quic "github.com/lucas-clemente/quic-go"
 
+	"runtime"
+
 	"golang.org/x/net/lex/httplex"
 )
 
@@ -91,6 +93,7 @@ func (r *RoundTripper) getClient(hostname string) http.RoundTripper {
 	defer r.mutex.Unlock()
 
 	if r.clients == nil {
+		runtime.SetFinalizer(r, finalizer)
 		r.clients = make(map[string]roundTripCloser)
 	}
 
@@ -100,6 +103,10 @@ func (r *RoundTripper) getClient(hostname string) http.RoundTripper {
 		r.clients[hostname] = client
 	}
 	return client
+}
+
+func finalizer(r *RoundTripper) {
+	_ = r.Close()
 }
 
 // Close closes the QUIC connections that this RoundTripper has used

--- a/h2quic/roundtrip_test.go
+++ b/h2quic/roundtrip_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"runtime"
 	"time"
 
 	quic "github.com/lucas-clemente/quic-go"
@@ -195,6 +196,17 @@ var _ = Describe("RoundTripper", func() {
 			err := rt.Close()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(rt.clients)).To(BeZero())
+		})
+
+		It("runs Close when the RoundTripper is garbage collected", func() {
+			// this is set by getClient, but we can't do that while at the same time injecting the mockClient
+			runtime.SetFinalizer(rt, finalizer)
+			rt.clients = make(map[string]roundTripCloser)
+			cl := &mockClient{}
+			rt.clients["foo.bar"] = cl
+			rt = nil // lose the references to the RoundTripper, such that it can be garbage collected
+			runtime.GC()
+			Eventually(func() bool { return cl.closed }).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Fixes #735.