### PR TITLE
run benchmark tests with the race detector on Travis

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -8,6 +8,13 @@ if [ ${TESTMODE} == "unit" ]; then
 fi
 
 if [ ${TESTMODE} == "integration" ]; then
+  # run benchmark tests
   ginkgo --randomizeAllSpecs --randomizeSuites --trace --progress -focus "Benchmark"
+  # run benchmark tests with the Go race detector
+  # The Go race detector only works on amd64.
+  if [ ${TRAVIS_GOARCH} == 'amd64' ]; then
+    ginkgo --race --randomizeAllSpecs --randomizeSuites --trace --progress -focus "Benchmark"
+  fi
+  # run integration tests
   ginkgo -v -r --randomizeAllSpecs --randomizeSuites --trace --progress integrationtests
 fi


### PR DESCRIPTION
I already tried this a couple of months ago, but for some reason this failed on Travis (with an `ackhandler` error that I don't remember). Now it seems to work without any further changes, so we can merge this.

Running a benchmark test with race detector enabled takes about 4s (compared to about 1s without).