### PR TITLE
implement a h2quic.RoundTripOpt that allow to only use cached QUIC conns

### DIFF
--- a/h2quic/roundtrip_test.go
+++ b/h2quic/roundtrip_test.go
@@ -116,6 +116,13 @@ var _ = Describe("RoundTripper", func() {
 			Expect(err).To(MatchError(streamOpenErr))
 			Expect(rt.clients).To(HaveLen(1))
 		})
+
+		It("doesn't create new clients if RoundTripOpt.OnlyCachedConn is set", func() {
+			req, err := http.NewRequest("GET", "https://quic.clemente.io/foobar.html", nil)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = rt.RoundTripOpt(req, RoundTripOpt{OnlyCachedConn: true})
+			Expect(err).To(MatchError(ErrNoCachedConn))
+		})
 	})
 
 	Context("validating request", func() {


### PR DESCRIPTION
Fixes #734.

I created a new `h2quic.RoundTripOpt` instead of reusing the `http2.RoundTripOpt`, because the [documentation of that one](https://godoc.org/golang.org/x/net/http2#RoundTripOpt) only covers TCP connections. I'd be open to change that though.