### PR TITLE
fix a race condition in a session test

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -1377,7 +1377,7 @@ var _ = Describe("Session", func() {
 		})
 
 		It("ignores undecryptable packets after the handshake is complete", func() {
-			close(aeadChanged)
+			sess.handshakeComplete = true
 			go sess.run()
 			sendUndecryptablePackets()
 			Consistently(sess.undecryptablePackets).Should(BeEmpty())


### PR DESCRIPTION
Fixes #641.

We were relying on the run-loop to set `handshakeComplete` to `true`, while at the same time sending packets. `select` doesn't guarantee the order of execution when multiple cases can run. The fix is setting `handshakeComplete` to `true` directly.