### PR TITLE
Revert "use a finalizer to close the h2quic.RoundTripper"

### DIFF
--- a/h2quic/roundtrip.go
+++ b/h2quic/roundtrip.go
@@ -11,8 +11,6 @@ import (
 
 	quic "github.com/lucas-clemente/quic-go"
 
-	"runtime"
-
 	"golang.org/x/net/lex/httplex"
 )
 
@@ -93,7 +91,6 @@ func (r *RoundTripper) getClient(hostname string) http.RoundTripper {
 	defer r.mutex.Unlock()
 
 	if r.clients == nil {
-		runtime.SetFinalizer(r, finalizer)
 		r.clients = make(map[string]roundTripCloser)
 	}
 
@@ -103,10 +100,6 @@ func (r *RoundTripper) getClient(hostname string) http.RoundTripper {
 		r.clients[hostname] = client
 	}
 	return client
-}
-
-func finalizer(r *RoundTripper) {
-	_ = r.Close()
 }
 
 // Close closes the QUIC connections that this RoundTripper has used

--- a/h2quic/roundtrip_test.go
+++ b/h2quic/roundtrip_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"runtime"
 	"time"
 
 	quic "github.com/lucas-clemente/quic-go"
@@ -196,17 +195,6 @@ var _ = Describe("RoundTripper", func() {
 			err := rt.Close()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(rt.clients)).To(BeZero())
-		})
-
-		It("runs Close when the RoundTripper is garbage collected", func() {
-			// this is set by getClient, but we can't do that while at the same time injecting the mockClient
-			runtime.SetFinalizer(rt, finalizer)
-			rt.clients = make(map[string]roundTripCloser)
-			cl := &mockClient{}
-			rt.clients["foo.bar"] = cl
-			rt = nil // lose the references to the RoundTripper, such that it can be garbage collected
-			runtime.GC()
-			Eventually(func() bool { return cl.closed }).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Fixes #757.

The finalizer may run even before the `h2quic.RoundTripper` variable falls out of scope. This can result in closing the session before a HTTP transfer has completed.