### PR TITLE
speed up the benchmark test by fetching random data only once

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math/rand"
 	"net"
-	"time"
 
 	"github.com/lucas-clemente/quic-go/protocol"
 	"github.com/lucas-clemente/quic-go/testdata"
@@ -18,18 +17,15 @@ import (
 var _ = Describe("Benchmarks", func() {
 	dataLen := 50 /* MB */ * (1 << 20)
 	data := make([]byte, dataLen)
-
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(GinkgoRandomSeed())
+	rand.Read(data) // no need to check for an error. math.Rand.Read never errors
 
 	for i := range protocol.SupportedVersions {
 		version := protocol.SupportedVersions[i]
 
 		Context(fmt.Sprintf("with version %d", version), func() {
 			Measure("transferring a file", func(b Benchmarker) {
-				rand.Read(data) // no need to check for an error. math.Rand.Read never errors
-
 				var ln Listener
-
 				serverAddr := make(chan net.Addr)
 				// start the server
 				go func() {


### PR DESCRIPTION
Fixes #761.

Reading from `math.rand` takes a long time (ca. 5-6s on Travis) when running the benchmark with the race detector. By transferring the same data in every test, we only have to do that once.
Every benchmark test is repeated 6 times for every of the 3 QUIC versions, so reading only once will save us around 100 seconds on every travis build.