### PR TITLE
move benchmarks to separate package, speed up CI builds

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -9,11 +9,11 @@ fi
 
 if [ ${TESTMODE} == "integration" ]; then
   # run benchmark tests
-  ginkgo --randomizeAllSpecs --randomizeSuites --trace --progress benchmark
+  ginkgo --randomizeAllSpecs --randomizeSuites --trace --progress benchmark -- -samples=1
   # run benchmark tests with the Go race detector
   # The Go race detector only works on amd64.
   if [ ${TRAVIS_GOARCH} == 'amd64' ]; then
-    ginkgo --race --randomizeAllSpecs --randomizeSuites --trace --progress benchmark
+    ginkgo --race --randomizeAllSpecs --randomizeSuites --trace --progress benchmark -- -samples=1 -size=10
   fi
   # run integration tests
   ginkgo -v -r --randomizeAllSpecs --randomizeSuites --trace --progress integrationtests

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -4,16 +4,16 @@ set -e
 
 go get -t ./...
 if [ ${TESTMODE} == "unit" ]; then
-  ginkgo -r --cover --randomizeAllSpecs --randomizeSuites --trace --progress --skipPackage integrationtests --skipMeasurements
+  ginkgo -r --cover --randomizeAllSpecs --randomizeSuites --trace --progress --skipPackage integrationtests,benchmark
 fi
 
 if [ ${TESTMODE} == "integration" ]; then
   # run benchmark tests
-  ginkgo --randomizeAllSpecs --randomizeSuites --trace --progress -focus "Benchmark"
+  ginkgo --randomizeAllSpecs --randomizeSuites --trace --progress benchmark
   # run benchmark tests with the Go race detector
   # The Go race detector only works on amd64.
   if [ ${TRAVIS_GOARCH} == 'amd64' ]; then
-    ginkgo --race --randomizeAllSpecs --randomizeSuites --trace --progress -focus "Benchmark"
+    ginkgo --race --randomizeAllSpecs --randomizeSuites --trace --progress benchmark
   fi
   # run integration tests
   ginkgo -v -r --randomizeAllSpecs --randomizeSuites --trace --progress integrationtests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,8 @@ install:
 
 build_script:
   - rm -r integrationtests
-  - ginkgo -r --randomizeAllSpecs --randomizeSuites --trace --progress
+  - ginkgo -r --randomizeAllSpecs --randomizeSuites --trace --progress -skipPackage benchmark
+  - ginkgo --randomizeAllSpecs --randomizeSuites --trace --progress benchmark -- -samples=1
 
 test: off
 

--- a/benchmark/benchmark_suite_test.go
+++ b/benchmark/benchmark_suite_test.go
@@ -1,6 +1,8 @@
 package benchmark
 
 import (
+	"flag"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -10,4 +12,15 @@ import (
 func TestBenchmark(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Benchmark Suite")
+}
+
+var (
+	size    int // file size in MB, will be read from flags
+	samples int // number of samples for Measure, will be read from flags
+)
+
+func init() {
+	flag.IntVar(&size, "size", 50, "data length (in MB)")
+	flag.IntVar(&samples, "samples", 6, "number of samples")
+	flag.Parse()
 }

--- a/benchmark/benchmark_suite_test.go
+++ b/benchmark/benchmark_suite_test.go
@@ -1,0 +1,13 @@
+package benchmark
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestBenchmark(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Benchmark Suite")
+}

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -1,4 +1,4 @@
-package quic
+package benchmark
 
 import (
 	"bytes"
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net"
 
+	quic "github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/protocol"
 	"github.com/lucas-clemente/quic-go/testdata"
 	. "github.com/onsi/ginkgo"
@@ -25,14 +26,14 @@ var _ = Describe("Benchmarks", func() {
 
 		Context(fmt.Sprintf("with version %d", version), func() {
 			Measure("transferring a file", func(b Benchmarker) {
-				var ln Listener
+				var ln quic.Listener
 				serverAddr := make(chan net.Addr)
 				handshakeChan := make(chan struct{})
 				// start the server
 				go func() {
 					defer GinkgoRecover()
 					var err error
-					ln, err = ListenAddr("localhost:0", testdata.GetTLSConfig(), nil)
+					ln, err = quic.ListenAddr("localhost:0", testdata.GetTLSConfig(), nil)
 					Expect(err).ToNot(HaveOccurred())
 					serverAddr <- ln.Addr()
 					sess, err := ln.Accept()
@@ -50,7 +51,7 @@ var _ = Describe("Benchmarks", func() {
 
 				// start the client
 				addr := <-serverAddr
-				sess, err := DialAddr(addr.String(), &tls.Config{InsecureSkipVerify: true}, nil)
+				sess, err := quic.DialAddr(addr.String(), &tls.Config{InsecureSkipVerify: true}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				close(handshakeChan)
 				str, err := sess.AcceptStream()


### PR DESCRIPTION
Compared to #764, which already reduced the Travis build time by 100s, this PR achieves a further speedup by reducing the number of samples and the data size transferred (for the test run with the race detector), thus saving another:
* 25s on the benchmark tests run without the race detector (from 50s down to 25s)
* 160s on the benchmark tests run without the race detector (from ~170s down to less than 10s)

In total, we can reduce the Travis build time by around 3 minutes by merging this PR.
On AppVeyor, we save about 10 - 15s on every build, which is nice, however, that was never our bottleneck.