### PR TITLE
Add Connect support to h2quic

### DIFF
--- a/h2quic/request.go
+++ b/h2quic/request.go
@@ -37,7 +37,7 @@ func requestFromHeaders(headers []hpack.HeaderField) (*http.Request, error) {
 		httpHeaders.Set("Cookie", strings.Join(httpHeaders["Cookie"], "; "))
 	}
 
-	if len(path) == 0 || len(authority) == 0 || len(method) == 0 {
+	if (len(path) == 0 && method != http.MethodConnect) || len(authority) == 0 || len(method) == 0 {
 		return nil, errors.New(":path, :authority and :method must not be empty")
 	}
 


### PR DESCRIPTION
Currently, I'm working on using h2quic as a CONNECT tunnel.
This pull request makes h2quic.Server allow `path` is empty if request method is `CONNECT`

Signed-off-by: Phus Lu <phuslu@hotmail.com>