### PR TITLE
implement a context for streams and for the session

### DIFF
--- a/h2quic/response_writer_test.go
+++ b/h2quic/response_writer_test.go
@@ -2,6 +2,7 @@ package h2quic
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"sync"
@@ -37,6 +38,7 @@ func (s *mockStream) Close() error                          { s.closed = true; r
 func (s *mockStream) Reset(error)                           { s.reset = true }
 func (s *mockStream) CloseRemote(offset protocol.ByteCount) { s.remoteClosed = true }
 func (s mockStream) StreamID() protocol.StreamID            { return s.id }
+func (s *mockStream) Context() context.Context              { panic("not implemented") }
 func (s *mockStream) SetDeadline(time.Time) error           { panic("not implemented") }
 func (s *mockStream) SetReadDeadline(time.Time) error       { panic("not implemented") }
 func (s *mockStream) SetWriteDeadline(time.Time) error      { panic("not implemented") }

--- a/h2quic/server_test.go
+++ b/h2quic/server_test.go
@@ -2,6 +2,7 @@ package h2quic
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -61,7 +62,7 @@ func (s *mockSession) LocalAddr() net.Addr {
 func (s *mockSession) RemoteAddr() net.Addr {
 	return &net.UDPAddr{IP: []byte{127, 0, 0, 1}, Port: 42}
 }
-func (s *mockSession) WaitUntilClosed() { panic("not implemented") }
+func (s *mockSession) Context() context.Context { panic("not implemented") }
 
 var _ = Describe("H2 server", func() {
 	var (
@@ -323,7 +324,7 @@ var _ = Describe("H2 server", func() {
 
 	Context("setting http headers", func() {
 		expected := http.Header{
-			"Alt-Svc":            {`quic=":443"; ma=2592000; v="37,36,35"`},
+			"Alt-Svc": {`quic=":443"; ma=2592000; v="37,36,35"`},
 		}
 
 		It("sets proper headers with numeric port", func() {

--- a/interface.go
+++ b/interface.go
@@ -23,6 +23,10 @@ type Stream interface {
 	StreamID() protocol.StreamID
 	// Reset closes the stream with an error.
 	Reset(error)
+	// The context is canceled as soon as the write-side of the stream is closed.
+	// This happens when Close() is called, or when the stream is reset (either locally or remotely).
+	// Warning: This API should not be considered stable and might change soon.
+	Context() context.Context
 	// SetReadDeadline sets the deadline for future Read calls and
 	// any currently-blocked Read call.
 	// A zero value for t means Read will not time out.

--- a/interface.go
+++ b/interface.go
@@ -1,6 +1,7 @@
 package quic
 
 import (
+	"context"
 	"io"
 	"net"
 	"time"
@@ -56,9 +57,9 @@ type Session interface {
 	RemoteAddr() net.Addr
 	// Close closes the connection. The error will be sent to the remote peer in a CONNECTION_CLOSE frame. An error value of nil is allowed and will cause a normal PeerGoingAway to be sent.
 	Close(error) error
-	// WaitUntilClosed() blocks until the session is closed.
+	// The context is cancelled when the session is closed.
 	// Warning: This API should not be considered stable and might change soon.
-	WaitUntilClosed()
+	Context() context.Context
 }
 
 // A NonFWSession is a QUIC connection between two peers half-way through the handshake.

--- a/server_test.go
+++ b/server_test.go
@@ -2,6 +2,7 @@ package quic
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"net"
@@ -40,9 +41,6 @@ func (s *mockSession) run() error {
 func (s *mockSession) WaitUntilHandshakeComplete() error {
 	return <-s.handshakeComplete
 }
-func (*mockSession) WaitUntilClosed() {
-	panic("not implemented")
-}
 func (s *mockSession) Close(e error) error {
 	if s.closed {
 		return nil
@@ -58,21 +56,14 @@ func (s *mockSession) closeRemote(e error) {
 	s.closedRemote = true
 	close(s.stopRunLoop)
 }
-func (s *mockSession) AcceptStream() (Stream, error) {
-	panic("not implemented")
-}
 func (s *mockSession) OpenStream() (Stream, error) {
 	return &stream{streamID: 1337}, nil
 }
-func (s *mockSession) OpenStreamSync() (Stream, error) {
-	panic("not implemented")
-}
-func (s *mockSession) LocalAddr() net.Addr {
-	panic("not implemented")
-}
-func (s *mockSession) RemoteAddr() net.Addr {
-	panic("not implemented")
-}
+func (s *mockSession) AcceptStream() (Stream, error)   { panic("not implemented") }
+func (s *mockSession) OpenStreamSync() (Stream, error) { panic("not implemented") }
+func (s *mockSession) LocalAddr() net.Addr             { panic("not implemented") }
+func (s *mockSession) RemoteAddr() net.Addr            { panic("not implemented") }
+func (*mockSession) Context() context.Context          { panic("not implemented") }
 
 var _ Session = &mockSession{}
 var _ NonFWSession = &mockSession{}

--- a/stream.go
+++ b/stream.go
@@ -1,6 +1,7 @@
 package quic
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -18,6 +19,9 @@ import (
 // Read() and Write() may be called concurrently, but multiple calls to Read() or Write() individually must be synchronized manually.
 type stream struct {
 	mutex sync.Mutex
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
 
 	streamID protocol.StreamID
 	onData   func()
@@ -55,6 +59,8 @@ type stream struct {
 	flowControlManager flowcontrol.FlowControlManager
 }
 
+var _ Stream = &stream{}
+
 type deadlineError struct{}
 
 func (deadlineError) Error() string   { return "deadline exceeded" }
@@ -68,7 +74,7 @@ func newStream(StreamID protocol.StreamID,
 	onData func(),
 	onReset func(protocol.StreamID, protocol.ByteCount),
 	flowControlManager flowcontrol.FlowControlManager) *stream {
-	return &stream{
+	s := &stream{
 		onData:             onData,
 		onReset:            onReset,
 		streamID:           StreamID,
@@ -77,6 +83,8 @@ func newStream(StreamID protocol.StreamID,
 		readChan:           make(chan struct{}, 1),
 		writeChan:          make(chan struct{}, 1),
 	}
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+	return s
 }
 
 // Read implements io.Reader. It is not thread safe!
@@ -257,6 +265,7 @@ func (s *stream) getDataForWriting(maxBytes protocol.ByteCount) []byte {
 // Close implements io.Closer
 func (s *stream) Close() error {
 	s.finishedWriting.Set(true)
+	s.ctxCancel()
 	s.onData()
 	return nil
 }
@@ -352,6 +361,7 @@ func (s *stream) CloseRemote(offset protocol.ByteCount) {
 func (s *stream) Cancel(err error) {
 	s.mutex.Lock()
 	s.cancelled.Set(true)
+	s.ctxCancel()
 	// errors must not be changed!
 	if s.err == nil {
 		s.err = err
@@ -368,6 +378,7 @@ func (s *stream) Reset(err error) {
 	}
 	s.mutex.Lock()
 	s.resetLocally.Set(true)
+	s.ctxCancel()
 	// errors must not be changed!
 	if s.err == nil {
 		s.err = err
@@ -388,6 +399,7 @@ func (s *stream) RegisterRemoteError(err error) {
 	}
 	s.mutex.Lock()
 	s.resetRemotely.Set(true)
+	s.ctxCancel()
 	// errors must not be changed!
 	if s.err == nil {
 		s.err = err
@@ -410,6 +422,10 @@ func (s *stream) finished() bool {
 		(s.resetRemotely.Get() && s.rstSent.Get()) ||
 		(s.finishedReading.Get() && s.rstSent.Get()) ||
 		(s.finishedWriteAndSentFin() && s.resetRemotely.Get())
+}
+
+func (s *stream) Context() context.Context {
+	return s.ctx
 }
 
 func (s *stream) StreamID() protocol.StreamID {

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Streams Map", func() {
 
 		m = newStreamsMap(nil, p, mockCpm)
 		m.newStream = func(id protocol.StreamID) *stream {
-			return &stream{streamID: id}
+			return newStream(id, nil, nil, nil)
 		}
 	}
 


### PR DESCRIPTION
This came up in #698 and is a prerequisite for implementing the `http.CloseNotifier` in h2quic.