### PR TITLE
use sort.Slice to sort the tags in the handshake message

### DIFF
--- a/handshake/handshake_message.go
+++ b/handshake/handshake_message.go
@@ -87,7 +87,7 @@ func (h HandshakeMessage) Write(b *bytes.Buffer) {
 		v := data[Tag(t)]
 		b.Write(v)
 		offset += uint32(len(v))
-		binary.LittleEndian.PutUint32(indexData[i*8:], t)
+		binary.LittleEndian.PutUint32(indexData[i*8:], uint32(t))
 		binary.LittleEndian.PutUint32(indexData[i*8+4:], offset)
 	}
 
@@ -95,14 +95,16 @@ func (h HandshakeMessage) Write(b *bytes.Buffer) {
 	copy(b.Bytes()[indexStart:], indexData)
 }
 
-func (h *HandshakeMessage) getTagsSorted() []uint32 {
-	tags := make([]uint32, len(h.Data))
+func (h *HandshakeMessage) getTagsSorted() []Tag {
+	tags := make([]Tag, len(h.Data))
 	i := 0
 	for t := range h.Data {
-		tags[i] = uint32(t)
+		tags[i] = t
 		i++
 	}
-	sort.Sort(utils.Uint32Slice(tags))
+	sort.Slice(tags, func(i, j int) bool {
+		return tags[i] < tags[j]
+	})
 	return tags
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -127,10 +127,3 @@ func WriteUint24(b *bytes.Buffer, i uint32) {
 func WriteUint16(b *bytes.Buffer, i uint16) {
 	b.Write([]byte{uint8(i), uint8(i >> 8)})
 }
-
-// Uint32Slice attaches the methods of sort.Interface to []uint32, sorting in increasing order.
-type Uint32Slice []uint32
-
-func (s Uint32Slice) Len() int           { return len(s) }
-func (s Uint32Slice) Less(i, j int) bool { return s[i] < s[j] }
-func (s Uint32Slice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"bytes"
 	"io"
-	"sort"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -193,11 +192,5 @@ var _ = Describe("Utils", func() {
 			_, err := ReadUintN(b, 3)
 			Expect(err).To(HaveOccurred())
 		})
-	})
-
-	It("sorts uint32 slices", func() {
-		s := Uint32Slice{1, 5, 2, 4, 3}
-		sort.Sort(s)
-		Expect(s).To(Equal(Uint32Slice{1, 2, 3, 4, 5}))
 	})
 })


### PR DESCRIPTION
`sort.Slice` was added in Go 1.8. Now that we've dropped support for Go 1.7, we can make use of it.