### PR TITLE
disable verbose logging for integration tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - export GOARCH=$TRAVIS_GOARCH
   - go env # for debugging
   - "export DISPLAY=:99.0"
-  - "Xvfb $DISPLAY &"
+  - "Xvfb $DISPLAY &> /dev/null &"
 
 script:
   - .travis/script.sh

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -4,17 +4,17 @@ set -e
 
 go get -t ./...
 if [ ${TESTMODE} == "unit" ]; then
-  ginkgo -r --cover --randomizeAllSpecs --randomizeSuites --trace --progress --skipPackage integrationtests,benchmark
+  ginkgo -r -v -cover -randomizeAllSpecs -randomizeSuites -trace -skipPackage integrationtests,benchmark
 fi
 
 if [ ${TESTMODE} == "integration" ]; then
   # run benchmark tests
-  ginkgo --randomizeAllSpecs --randomizeSuites --trace --progress benchmark -- -samples=1
+  ginkgo -randomizeAllSpecs -randomizeSuites -trace benchmark -- -samples=1
   # run benchmark tests with the Go race detector
   # The Go race detector only works on amd64.
   if [ ${TRAVIS_GOARCH} == 'amd64' ]; then
-    ginkgo --race --randomizeAllSpecs --randomizeSuites --trace --progress benchmark -- -samples=1 -size=10
+    ginkgo -race -randomizeAllSpecs -randomizeSuites -trace benchmark -- -samples=1 -size=10
   fi
   # run integration tests
-  ginkgo -v -r --randomizeAllSpecs --randomizeSuites --trace --progress integrationtests
+  ginkgo -r -v -randomizeAllSpecs -randomizeSuites -trace integrationtests
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,8 @@ install:
 
 build_script:
   - rm -r integrationtests
-  - ginkgo -r --randomizeAllSpecs --randomizeSuites --trace --progress -skipPackage benchmark
-  - ginkgo --randomizeAllSpecs --randomizeSuites --trace --progress benchmark -- -samples=1
+  - ginkgo -r -v -randomizeAllSpecs -randomizeSuites -trace -skipPackage benchmark
+  - ginkgo -randomizeAllSpecs -randomizeSuites -trace benchmark -- -samples=1
 
 test: off
 

--- a/integrationtests/chrome/chrome_suite_test.go
+++ b/integrationtests/chrome/chrome_suite_test.go
@@ -142,7 +142,7 @@ func chromeTestImpl(version protocol.VersionNumber, url string, blockUntilDone f
 	}
 	utils.Infof("Running chrome: %s '%s'", getChromePath(), strings.Join(args, "' '"))
 	command := exec.Command(path, args...)
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+	session, err := gexec.Start(command, nil, nil)
 	Expect(err).NotTo(HaveOccurred())
 	defer session.Kill()
 	const pollInterval = 100 * time.Millisecond


### PR DESCRIPTION
@lucas-clemente: Do you know why Chrome is dumping so much debug information into the Travis log? I disabled both `outWriter` and `errWriter` in `gexec.Start`, but that doesn't seem to change anything.