### PR TITLE
add support for QUIC 38

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.6.0 (unreleased)
 
+- Add support for QUIC 38
 - Added `quic.Config` options for maximal flow control windows
 - Add a `quic.Config` option for QUIC versions
 - Add a `quic.Config` option to request truncation of the connection ID from a server

--- a/ackhandler/interfaces.go
+++ b/ackhandler/interfaces.go
@@ -25,7 +25,7 @@ type SentPacketHandler interface {
 // ReceivedPacketHandler handles ACKs needed to send for incoming packets
 type ReceivedPacketHandler interface {
 	ReceivedPacket(packetNumber protocol.PacketNumber, shouldInstigateAck bool) error
-	ReceivedStopWaiting(*frames.StopWaitingFrame) error
+	SetLowerLimit(protocol.PacketNumber)
 
 	GetAlarmTimeout() time.Time
 	GetAckFrame() *frames.AckFrame

--- a/ackhandler/received_packet_history.go
+++ b/ackhandler/received_packet_history.go
@@ -7,6 +7,8 @@ import (
 	"github.com/lucas-clemente/quic-go/qerr"
 )
 
+// The receivedPacketHistory stores if a packet number has already been received.
+// It does not store packet contents.
 type receivedPacketHistory struct {
 	ranges *utils.PacketIntervalList
 
@@ -84,20 +86,20 @@ func (h *receivedPacketHistory) ReceivedPacket(p protocol.PacketNumber) error {
 	return nil
 }
 
-// DeleteBelow deletes all entries below the leastUnacked packet number
-func (h *receivedPacketHistory) DeleteBelow(leastUnacked protocol.PacketNumber) {
-	h.lowestInReceivedPacketNumbers = utils.MaxPacketNumber(h.lowestInReceivedPacketNumbers, leastUnacked)
+// DeleteUpTo deletes all entries up to (and including) p
+func (h *receivedPacketHistory) DeleteUpTo(p protocol.PacketNumber) {
+	h.lowestInReceivedPacketNumbers = utils.MaxPacketNumber(h.lowestInReceivedPacketNumbers, p+1)
 
 	nextEl := h.ranges.Front()
 	for el := h.ranges.Front(); nextEl != nil; el = nextEl {
 		nextEl = el.Next()
 
-		if leastUnacked > el.Value.Start && leastUnacked <= el.Value.End {
-			for i := el.Value.Start; i < leastUnacked; i++ { // adjust start value of a range
+		if p >= el.Value.Start && p < el.Value.End {
+			for i := el.Value.Start; i <= p; i++ { // adjust start value of a range
 				delete(h.receivedPacketNumbers, i)
 			}
-			el.Value.Start = leastUnacked
-		} else if el.Value.End < leastUnacked { // delete a whole range
+			el.Value.Start = p + 1
+		} else if el.Value.End <= p { // delete a whole range
 			for i := el.Value.Start; i <= el.Value.End; i++ {
 				delete(h.receivedPacketNumbers, i)
 			}

--- a/ackhandler/received_packet_history_test.go
+++ b/ackhandler/received_packet_history_test.go
@@ -168,7 +168,7 @@ var _ = Describe("receivedPacketHistory", func() {
 
 	Context("deleting", func() {
 		It("does nothing when the history is empty", func() {
-			hist.DeleteBelow(5)
+			hist.DeleteUpTo(5)
 			Expect(hist.ranges.Len()).To(BeZero())
 			Expect(historiesConsistent()).To(BeTrue())
 		})
@@ -177,7 +177,7 @@ var _ = Describe("receivedPacketHistory", func() {
 			hist.ReceivedPacket(4)
 			hist.ReceivedPacket(5)
 			hist.ReceivedPacket(10)
-			hist.DeleteBelow(6)
+			hist.DeleteUpTo(5)
 			Expect(hist.ranges.Len()).To(Equal(1))
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 10, End: 10}))
 			Expect(historiesConsistent()).To(BeTrue())
@@ -187,37 +187,38 @@ var _ = Describe("receivedPacketHistory", func() {
 			hist.ReceivedPacket(1)
 			hist.ReceivedPacket(5)
 			hist.ReceivedPacket(10)
-			hist.DeleteBelow(8)
+			hist.DeleteUpTo(8)
 			Expect(hist.ranges.Len()).To(Equal(1))
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 10, End: 10}))
 			Expect(historiesConsistent()).To(BeTrue())
 		})
 
-		It("adjusts a range, if leastUnacked lies inside it", func() {
+		It("adjusts a range, if packets are delete from an existing range", func() {
 			hist.ReceivedPacket(3)
 			hist.ReceivedPacket(4)
 			hist.ReceivedPacket(5)
 			hist.ReceivedPacket(6)
-			hist.DeleteBelow(4)
+			hist.ReceivedPacket(7)
+			hist.DeleteUpTo(4)
 			Expect(hist.ranges.Len()).To(Equal(1))
-			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 4, End: 6}))
+			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 5, End: 7}))
 			Expect(historiesConsistent()).To(BeTrue())
 		})
 
-		It("adjusts a range, if leastUnacked is the last of the range", func() {
+		It("adjusts a range, if only one packet remains in the range", func() {
 			hist.ReceivedPacket(4)
 			hist.ReceivedPacket(5)
 			hist.ReceivedPacket(10)
-			hist.DeleteBelow(5)
+			hist.DeleteUpTo(4)
 			Expect(hist.ranges.Len()).To(Equal(2))
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 5, End: 5}))
 			Expect(hist.ranges.Back().Value).To(Equal(utils.PacketInterval{Start: 10, End: 10}))
 			Expect(historiesConsistent()).To(BeTrue())
 		})
 
-		It("keeps a one-packet range, if leastUnacked is exactly that value", func() {
+		It("keeps a one-packet range, if deleting up to the packet directly below", func() {
 			hist.ReceivedPacket(4)
-			hist.DeleteBelow(4)
+			hist.DeleteUpTo(3)
 			Expect(hist.ranges.Len()).To(Equal(1))
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 4, End: 4}))
 			Expect(historiesConsistent()).To(BeTrue())
@@ -252,7 +253,7 @@ var _ = Describe("receivedPacketHistory", func() {
 				}
 				err := hist.ReceivedPacket(2*protocol.MaxTrackedReceivedAckRanges + 2)
 				Expect(err).To(MatchError(errTooManyOutstandingReceivedAckRanges))
-				hist.DeleteBelow(protocol.MaxTrackedReceivedAckRanges) // deletes about half of the ranges
+				hist.DeleteUpTo(protocol.MaxTrackedReceivedAckRanges) // deletes about half of the ranges
 				err = hist.ReceivedPacket(2*protocol.MaxTrackedReceivedAckRanges + 4)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(historiesConsistent()).To(BeTrue())
@@ -277,7 +278,7 @@ var _ = Describe("receivedPacketHistory", func() {
 			hist.ReceivedPacket(2)
 			hist.ReceivedPacket(3)
 			hist.ReceivedPacket(6)
-			hist.DeleteBelow(5)
+			hist.DeleteUpTo(4)
 			for i := 1; i < 5; i++ {
 				Expect(hist.IsDuplicate(protocol.PacketNumber(i))).To(BeTrue())
 			}

--- a/frames/stop_waiting_frame.go
+++ b/frames/stop_waiting_frame.go
@@ -81,7 +81,7 @@ func ParseStopWaitingFrame(r *bytes.Reader, packetNumber protocol.PacketNumber, 
 		return nil, err
 	}
 
-	if leastUnackedDelta > uint64(packetNumber) {
+	if leastUnackedDelta >= uint64(packetNumber) {
 		return nil, qerr.Error(qerr.InvalidStopWaitingData, "invalid LeastUnackedDelta")
 	}
 

--- a/frames/stop_waiting_frame_test.go
+++ b/frames/stop_waiting_frame_test.go
@@ -18,9 +18,16 @@ var _ = Describe("StopWaitingFrame", func() {
 			Expect(b.Len()).To(BeZero())
 		})
 
-		It("rejects frames with an invalid LeastUnackedDelta", func() {
+		It("rejects frames that would have a negative LeastUnacked value", func() {
 			b := bytes.NewReader([]byte{0x06, 0xD})
 			_, err := ParseStopWaitingFrame(b, 10, 1, protocol.VersionWhatever)
+			Expect(err).To(HaveOccurred())
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("rejects frames that would have 0 as LeastUnacked", func() {
+			b := bytes.NewReader([]byte{0x6, 0x8})
+			_, err := ParseStopWaitingFrame(b, 8, 1, protocol.VersionWhatever)
 			Expect(err).To(HaveOccurred())
 			Expect(b.Len()).To(BeZero())
 		})

--- a/handshake/crypto_setup_server.go
+++ b/handshake/crypto_setup_server.go
@@ -54,10 +54,14 @@ type cryptoSetupServer struct {
 
 var _ CryptoSetup = &cryptoSetupServer{}
 
-// ErrHOLExperiment is returned when the client sends the FHL2 tag in the CHLO
-// this is an expiremnt implemented by Chrome in QUIC 36, which we don't support
+// ErrHOLExperiment is returned when the client sends the FHL2 tag in the CHLO.
+// This is an experiment implemented by Chrome in QUIC 36, which we don't support.
 // TODO: remove this when dropping support for QUIC 36
 var ErrHOLExperiment = qerr.Error(qerr.InvalidCryptoMessageParameter, "HOL experiment. Unsupported")
+
+// ErrNSTPExperiment is returned when the client sends the NSTP tag in the CHLO.
+// This is an experiment implemented by Chrome in QUIC 38, which we don't support at this point.
+var ErrNSTPExperiment = qerr.Error(qerr.InvalidCryptoMessageParameter, "NSTP experiment. Unsupported")
 
 // NewCryptoSetup creates a new CryptoSetup instance for a server
 func NewCryptoSetup(
@@ -119,6 +123,9 @@ func (h *cryptoSetupServer) HandleCryptoStream() error {
 func (h *cryptoSetupServer) handleMessage(chloData []byte, cryptoData map[Tag][]byte) (bool, error) {
 	if _, isHOLExperiment := cryptoData[TagFHL2]; isHOLExperiment {
 		return false, ErrHOLExperiment
+	}
+	if _, isNSTPExperiment := cryptoData[TagNSTP]; isNSTPExperiment {
+		return false, ErrNSTPExperiment
 	}
 
 	sniSlice, ok := cryptoData[TagSNI]

--- a/handshake/crypto_setup_server_test.go
+++ b/handshake/crypto_setup_server_test.go
@@ -435,7 +435,7 @@ var _ = Describe("Server Crypto Setup", func() {
 		})
 
 		It("detects version downgrade attacks", func() {
-			highestSupportedVersion := supportedVersions[len(protocol.SupportedVersions)-1]
+			highestSupportedVersion := supportedVersions[len(supportedVersions)-1]
 			lowestSupportedVersion := supportedVersions[0]
 			Expect(highestSupportedVersion).ToNot(Equal(lowestSupportedVersion))
 			cs.version = highestSupportedVersion

--- a/handshake/crypto_setup_server_test.go
+++ b/handshake/crypto_setup_server_test.go
@@ -264,6 +264,17 @@ var _ = Describe("Server Crypto Setup", func() {
 			Expect(err).To(MatchError(ErrHOLExperiment))
 		})
 
+		It("doesn't support Chrome's no STOP_WAITING experiment", func() {
+			HandshakeMessage{
+				Tag: TagCHLO,
+				Data: map[Tag][]byte{
+					TagNSTP: []byte("foobar"),
+				},
+			}.Write(&stream.dataToRead)
+			err := cs.HandleCryptoStream()
+			Expect(err).To(MatchError(ErrNSTPExperiment))
+		})
+
 		It("generates REJ messages", func() {
 			sourceAddrValid = false
 			response, err := cs.handleInchoateCHLO("", bytes.Repeat([]byte{'a'}, protocol.ClientHelloMinimumSize), nil)

--- a/handshake/tags.go
+++ b/handshake/tags.go
@@ -54,6 +54,9 @@ const (
 	// Chrome experiment (see https://codereview.chromium.org/2115033002)
 	// unsupported by quic-go
 	TagFHL2 Tag = 'F' + 'H'<<8 + 'L'<<16 + '2'<<24
+	// TagNSTP is the no STOP_WAITING experiment
+	// currently unsupported by quic-go
+	TagNSTP Tag = 'N' + 'S'<<8 + 'T'<<16 + 'P'<<24
 
 	// TagSTK is the source-address token
 	TagSTK Tag = 'S' + 'T'<<8 + 'K'<<16

--- a/protocol/version.go
+++ b/protocol/version.go
@@ -8,6 +8,7 @@ const (
 	Version35 VersionNumber = 35 + iota
 	Version36
 	Version37
+	Version38
 	VersionWhatever    VersionNumber = 0 // for when the version doesn't matter
 	VersionUnsupported VersionNumber = -1
 )
@@ -15,7 +16,10 @@ const (
 // SupportedVersions lists the versions that the server supports
 // must be in sorted descending order
 var SupportedVersions = []VersionNumber{
-	Version37, Version36, Version35,
+	Version38,
+	Version37,
+	Version36,
+	Version35,
 }
 
 // VersionNumberToTag maps version numbers ('32') to tags ('Q032')

--- a/session.go
+++ b/session.go
@@ -446,7 +446,9 @@ func (s *session) handleFrames(fs []frames.Frame) error {
 		case *frames.GoawayFrame:
 			err = errors.New("unimplemented: handling GOAWAY frames")
 		case *frames.StopWaitingFrame:
-			err = s.receivedPacketHandler.ReceivedStopWaiting(frame)
+			// LeastUnacked is guaranteed to have LeastUnacked > 0
+			// therefore this will never underflow
+			s.receivedPacketHandler.SetLowerLimit(frame.LeastUnacked - 1)
 		case *frames.RstStreamFrame:
 			err = s.handleRstStreamFrame(frame)
 		case *frames.WindowUpdateFrame:

--- a/session.go
+++ b/session.go
@@ -578,7 +578,9 @@ func (s *session) handleCloseError(closeErr closeError) error {
 		return nil
 	}
 
-	if quicErr.ErrorCode == qerr.DecryptionFailure || quicErr == handshake.ErrHOLExperiment {
+	if quicErr.ErrorCode == qerr.DecryptionFailure ||
+		quicErr == handshake.ErrHOLExperiment ||
+		quicErr == handshake.ErrNSTPExperiment {
 		return s.sendPublicReset(s.lastRcvdPacketNumber)
 	}
 	return s.sendConnectionClose(quicErr)

--- a/session_test.go
+++ b/session_test.go
@@ -113,7 +113,7 @@ func (m *mockReceivedPacketHandler) GetAckFrame() *frames.AckFrame {
 func (m *mockReceivedPacketHandler) ReceivedPacket(packetNumber protocol.PacketNumber, shouldInstigateAck bool) error {
 	panic("not implemented")
 }
-func (m *mockReceivedPacketHandler) ReceivedStopWaiting(*frames.StopWaitingFrame) error {
+func (m *mockReceivedPacketHandler) SetLowerLimit(protocol.PacketNumber) {
 	panic("not implemented")
 }
 func (m *mockReceivedPacketHandler) GetAlarmTimeout() time.Time { return m.ackAlarm }
@@ -866,14 +866,6 @@ var _ = Describe("Session", func() {
 			hdr.PacketNumber = 5
 			err := sess.handlePacketImpl(&receivedPacket{publicHeader: hdr})
 			Expect(err).ToNot(HaveOccurred())
-			err = sess.handlePacketImpl(&receivedPacket{publicHeader: hdr})
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("handles packets smaller than the highest LeastUnacked of a StopWaiting", func() {
-			err := sess.receivedPacketHandler.ReceivedStopWaiting(&frames.StopWaitingFrame{LeastUnacked: 10})
-			Expect(err).ToNot(HaveOccurred())
-			hdr.PacketNumber = 5
 			err = sess.handlePacketImpl(&receivedPacket{publicHeader: hdr})
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/session_test.go
+++ b/session_test.go
@@ -804,6 +804,13 @@ var _ = Describe("Session", func() {
 			Expect(sess.Context().Done()).To(BeClosed())
 		})
 
+		It("sends a Public Reset if the client is initiating the no STOP_WAITING experiment", func() {
+			sess.Close(handshake.ErrHOLExperiment)
+			Expect(mconn.written).To(HaveLen(1))
+			Expect(mconn.written[0][0] & 0x02).ToNot(BeZero()) // Public Reset
+			Expect(sess.Context().Done()).To(BeClosed())
+		})
+
 		It("cancels the context when the run loop exists", func() {
 			returned := make(chan struct{})
 			go func() {


### PR DESCRIPTION
Fixes #529.

This PR contains two commits that are strictly speaking not necessary for supporting QUIC 38, but that I'd like to merge anyway:

1. It makes the `h2quic` server tests independent of the configured QUIC versions. It was always annoying to edit these tests when adding a new QUIC version.
2. A change to the `ackhandler`, which would have been necessary for eliminating the STOP_WAITING frames, as it was planned with the NSTP option. However, this isn't coming in QUIC 38 (apparently).