### PR TITLE
make the integration tests race free

### DIFF
--- a/integrationtests/chrome/chrome_suite_test.go
+++ b/integrationtests/chrome/chrome_suite_test.go
@@ -38,6 +38,7 @@ var (
 	nFilesUploaded     int32 // should be used atomically
 	testEndpointCalled utils.AtomicBool
 	doneCalled         utils.AtomicBool
+	version            protocol.VersionNumber
 )
 
 func TestChrome(t *testing.T) {
@@ -88,7 +89,9 @@ func init() {
 	})
 }
 
-var _ = JustBeforeEach(testserver.StartQuicServer)
+var _ = JustBeforeEach(func() {
+	testserver.StartQuicServer([]protocol.VersionNumber{version})
+})
 
 var _ = AfterEach(func() {
 	testserver.StopQuicServer()

--- a/integrationtests/chrome/chrome_test.go
+++ b/integrationtests/chrome/chrome_test.go
@@ -11,20 +11,13 @@ import (
 
 var _ = Describe("Chrome tests", func() {
 	for i := range protocol.SupportedVersions {
-		version := protocol.SupportedVersions[i]
+		version = protocol.SupportedVersions[i]
 
 		Context(fmt.Sprintf("with quic version %d", version), func() {
-			supportedVersionsBefore := protocol.SupportedVersions
-
 			BeforeEach(func() {
 				if version == protocol.Version39 && os.Getenv("TRAVIS") == "true" {
 					Skip("The chrome version running on Travis doesn't support QUIC 39 yet.")
 				}
-				protocol.SupportedVersions = []protocol.VersionNumber{version}
-			})
-
-			AfterEach(func() {
-				protocol.SupportedVersions = supportedVersionsBefore
 			})
 
 			It("downloads a small file", func() {

--- a/integrationtests/gquic/gquic_suite_test.go
+++ b/integrationtests/gquic/gquic_suite_test.go
@@ -24,7 +24,9 @@ func TestIntegration(t *testing.T) {
 	RunSpecs(t, "GQuic Tests Suite")
 }
 
-var _ = JustBeforeEach(testserver.StartQuicServer)
+var _ = JustBeforeEach(func() {
+	testserver.StartQuicServer(nil)
+})
 
 var _ = AfterEach(testserver.StopQuicServer)
 

--- a/integrationtests/gquic/server_test.go
+++ b/integrationtests/gquic/server_test.go
@@ -79,19 +79,17 @@ var _ = Describe("Server tests", func() {
 	// download files must be create *before* the quic_server is started
 	// the quic_server reads its data dir on startup, and only serves those files that were already present then
 	startServer := func() {
-		go func() {
-			defer GinkgoRecover()
-			var err error
-			command := exec.Command(
-				serverPath,
-				"--quic_response_cache_dir="+filepath.Join(tmpDir, "quic.clemente.io"),
-				"--key_file="+filepath.Join(tmpDir, "key.pkcs8"),
-				"--certificate_file="+filepath.Join(tmpDir, "cert.pem"),
-				"--port="+serverPort,
-			)
-			session, err = Start(command, nil, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-		}()
+		defer GinkgoRecover()
+		var err error
+		command := exec.Command(
+			serverPath,
+			"--quic_response_cache_dir="+filepath.Join(tmpDir, "quic.clemente.io"),
+			"--key_file="+filepath.Join(tmpDir, "key.pkcs8"),
+			"--certificate_file="+filepath.Join(tmpDir, "cert.pem"),
+			"--port="+serverPort,
+		)
+		session, err = Start(command, nil, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	stopServer := func() {

--- a/integrationtests/self/client_test.go
+++ b/integrationtests/self/client_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Client tests", func() {
 		if addr.String() != "127.0.0.1:0" {
 			Fail("quic.clemente.io does not resolve to 127.0.0.1. Consider adding it to /etc/hosts.")
 		}
-		testserver.StartQuicServer()
+		testserver.StartQuicServer(nil)
 	})
 
 	AfterEach(func() {

--- a/integrationtests/tools/testserver/server.go
+++ b/integrationtests/tools/testserver/server.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"strconv"
 
+	quic "github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/h2quic"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/testdata"
 
 	. "github.com/onsi/ginkgo"
@@ -75,10 +77,15 @@ func GeneratePRData(l int) []byte {
 	return res
 }
 
-func StartQuicServer() {
+// StartQuicServer starts a h2quic.Server.
+// versions is a slice of supported QUIC versions. It may be nil, then all supported versions are used.
+func StartQuicServer(versions []protocol.VersionNumber) {
 	server = &h2quic.Server{
 		Server: &http.Server{
 			TLSConfig: testdata.GetTLSConfig(),
+		},
+		QuicConfig: &quic.Config{
+			Versions: versions,
 		},
 	}
 


### PR DESCRIPTION
Fixes #558.

This PR fixes a bunch of race conditions in the integration tests. We're now at a point where can run the whole test suite with the Go race detector.

However, I'm not what the right way to do so is. Running the tests with the race detector takes considerably longer (see the Travis build log of the last commit), slowing down our Travis build even more.