### PR TITLE
delete empty files in the integration tests folder

### DIFF
--- a/integrationtests/chrome/chrome.go
+++ b/integrationtests/chrome/chrome.go
@@ -1,1 +1,0 @@
-package chrome

--- a/integrationtests/gquic/gquic.go
+++ b/integrationtests/gquic/gquic.go
@@ -1,1 +1,0 @@
-package gquic

--- a/integrationtests/self/self.go
+++ b/integrationtests/self/self.go
@@ -1,1 +1,0 @@
-package self


### PR DESCRIPTION
These empty files were necessary in Go 1.7, but are obsolete now.