### PR TITLE
fix Public Header parsing in the proxy

### DIFF
--- a/integrationtests/tools/proxy/proxy.go
+++ b/integrationtests/tools/proxy/proxy.go
@@ -165,7 +165,7 @@ func (p *QuicProxy) runProxy() error {
 		atomic.AddUint64(&conn.incomingPacketCounter, 1)
 
 		r := bytes.NewReader(raw)
-		hdr, err := wire.ParsePublicHeader(r, protocol.PerspectiveClient, protocol.VersionWhatever)
+		hdr, err := wire.ParsePublicHeader(r, protocol.PerspectiveClient, p.version)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #805.

The version number was not correctly passes to the Public Header parser, which lead to wrong decoding of the packet number for QUIC 39 (the only version so far that uses big endian encoding), as soon as the packet number was encoded using more than 1 byte.
Under some circumstances, the proxy would then drop *every* packet, eventually making the transfer fail.