### PR TITLE
reject packets with truncated connection ID, if truncation was disabled

### DIFF
--- a/client.go
+++ b/client.go
@@ -253,6 +253,10 @@ func (c *client) handlePacket(remoteAddr net.Addr, packet []byte) {
 		// drop this packet if we can't parse the Public Header
 		return
 	}
+	// reject packets with truncated connection id if we didn't request truncation
+	if hdr.TruncateConnectionID && !c.config.RequestConnectionIDTruncation {
+		return
+	}
 	hdr.Raw = packet[:len(packet)-r.Len()]
 
 	c.mutex.Lock()

--- a/client_test.go
+++ b/client_test.go
@@ -423,7 +423,21 @@ var _ = Describe("Client", func() {
 
 	It("ignores packets with an invalid public header", func() {
 		cl.handlePacket(addr, []byte("invalid packet"))
-		Expect(cl.session.(*mockSession).closed).To(BeFalse())
+		Expect(sess.packetCount).To(BeZero())
+		Expect(sess.closed).To(BeFalse())
+	})
+
+	It("ignores packets without connection id, if it didn't request connection id trunctation", func() {
+		cl.config.RequestConnectionIDTruncation = false
+		buf := &bytes.Buffer{}
+		(&wire.PublicHeader{
+			TruncateConnectionID: true,
+			PacketNumber:         1,
+			PacketNumberLen:      1,
+		}).Write(buf, protocol.VersionWhatever, protocol.PerspectiveServer)
+		cl.handlePacket(addr, buf.Bytes())
+		Expect(sess.packetCount).To(BeZero())
+		Expect(sess.closed).To(BeFalse())
 	})
 
 	It("creates new sessions with the right parameters", func(done Done) {


### PR DESCRIPTION
Fixes #826.