### PR TITLE
reduce bytes_in_flight before reporting packets to congestion

### DIFF
--- a/ackhandler/sent_packet_handler.go
+++ b/ackhandler/sent_packet_handler.go
@@ -282,11 +282,12 @@ func (h *sentPacketHandler) detectLostPackets() {
 		}
 	}
 
-	if len(lostPackets) > 0 {
-		for _, p := range lostPackets {
-			h.queuePacketForRetransmission(p)
-			h.congestion.OnPacketLost(p.Value.PacketNumber, p.Value.Length, h.bytesInFlight)
-		}
+	for _, p := range lostPackets {
+		h.bytesInFlight -= p.Value.Length
+	}
+	for _, p := range lostPackets {
+		h.queuePacketForRetransmission(p)
+		h.congestion.OnPacketLost(p.Value.PacketNumber, p.Value.Length, h.bytesInFlight)
 	}
 }
 
@@ -374,7 +375,6 @@ func (h *sentPacketHandler) queueRTO(el *PacketElement) {
 
 func (h *sentPacketHandler) queuePacketForRetransmission(packetElement *PacketElement) {
 	packet := &packetElement.Value
-	h.bytesInFlight -= packet.Length
 	h.retransmissionQueue = append(h.retransmissionQueue, packet)
 	h.packetHistory.Remove(packetElement)
 	h.stopWaitingManager.QueuedRetransmissionForPacketNumber(packet.PacketNumber)


### PR DESCRIPTION
According the Loss Recovery Draft (https://quicwg.github.io/base-drafts/draft-ietf-quic-recovery.html#rfc.section.4.7.6), we should reduce the `bytes_in_flight` value before reporting a packet as lost to the congestion controller.

Note that due to this change, we don't reduce the `bytes_in_flight` value for RTOs. This is consistent with the Draft, I suspect this is a bug in the Draft though (https://github.com/quicwg/base-drafts/issues/790). We should probably delay merging this PR until we get feedback on that issue.