### PR TITLE
fix encryption level bug check in the client

### DIFF
--- a/client.go
+++ b/client.go
@@ -214,7 +214,7 @@ func (c *client) establishSecureConnection() error {
 		if ev.err != nil {
 			return ev.err
 		}
-		if c.version.UsesTLS() && ev.encLevel != protocol.EncryptionSecure {
+		if !c.version.UsesTLS() && ev.encLevel != protocol.EncryptionSecure {
 			return fmt.Errorf("Client BUG: Expected encryption level to be secure, was %s", ev.encLevel)
 		}
 		return nil


### PR DESCRIPTION
This was introduced by #840.

It's time that we finally run some basic integration tests with TLS 1.3, that would've caught this bug.