### PR TITLE
implement a string representation of the version number

### DIFF
--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -26,7 +26,7 @@ func init() {
 		for i := range protocol.SupportedVersions {
 			version := protocol.SupportedVersions[i]
 
-			Context(fmt.Sprintf("with version %d", version), func() {
+			Context(fmt.Sprintf("with version %s", version), func() {
 				Measure(fmt.Sprintf("transferring a %d MB file", size), func(b Benchmarker) {
 					var ln quic.Listener
 					serverAddr := make(chan net.Addr)

--- a/client.go
+++ b/client.go
@@ -112,7 +112,7 @@ func DialNonFWSecure(
 		versionNegotiationChan: make(chan struct{}),
 	}
 
-	utils.Infof("Starting new connection to %s (%s -> %s), connectionID %x, version %d", hostname, c.conn.LocalAddr().String(), c.conn.RemoteAddr().String(), c.connectionID, c.version)
+	utils.Infof("Starting new connection to %s (%s -> %s), connectionID %x, version %s", hostname, c.conn.LocalAddr().String(), c.conn.RemoteAddr().String(), c.connectionID, c.version)
 
 	if err := c.establishSecureConnection(); err != nil {
 		return nil, err
@@ -338,7 +338,7 @@ func (c *client) handlePacketWithVersionFlag(hdr *wire.PublicHeader) error {
 	if err != nil {
 		return err
 	}
-	utils.Infof("Switching to QUIC version %d. New connection ID: %x", newVersion, c.connectionID)
+	utils.Infof("Switching to QUIC version %s. New connection ID: %x", newVersion, c.connectionID)
 
 	// create a new session and close the old one
 	// the new session must be created first to update client member variables

--- a/integrationtests/chrome/chrome_test.go
+++ b/integrationtests/chrome/chrome_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Chrome tests", func() {
 	for i := range protocol.SupportedVersions {
 		version = protocol.SupportedVersions[i]
 
-		Context(fmt.Sprintf("with quic version %d", version), func() {
+		Context(fmt.Sprintf("with quic version %s", version), func() {
 			It("downloads a small file", func() {
 				chromeTest(
 					version,

--- a/integrationtests/gquic/drop_test.go
+++ b/integrationtests/gquic/drop_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Drop tests", func() {
 	for _, v := range protocol.SupportedVersions {
 		version := v
 
-		Context(fmt.Sprintf("with QUIC version %d", version), func() {
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
 			Context("during the crypto handshake", func() {
 				for _, d := range directions {
 					direction := d

--- a/integrationtests/gquic/integration_test.go
+++ b/integrationtests/gquic/integration_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Integration tests", func() {
 	for i := range protocol.SupportedVersions {
 		version := protocol.SupportedVersions[i]
 
-		Context(fmt.Sprintf("with quic version %d", version), func() {
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
 			It("gets a simple file", func() {
 				command := exec.Command(
 					clientPath,

--- a/integrationtests/gquic/random_rtt_test.go
+++ b/integrationtests/gquic/random_rtt_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Random RTT", func() {
 	for i := range protocol.SupportedVersions {
 		version := protocol.SupportedVersions[i]
 
-		Context(fmt.Sprintf("with quic version %d", version), func() {
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
 			It("gets a file a random RTT between 10ms and 30ms", func() {
 				runRTTTest(10*time.Millisecond, 30*time.Millisecond, version)
 			})

--- a/integrationtests/gquic/rtt_test.go
+++ b/integrationtests/gquic/rtt_test.go
@@ -54,7 +54,7 @@ var _ = Describe("non-zero RTT", func() {
 	for i := range protocol.SupportedVersions {
 		version := protocol.SupportedVersions[i]
 
-		Context(fmt.Sprintf("with quic version %d", version), func() {
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
 			roundTrips := [...]int{10, 50, 100, 200}
 			for _, rtt := range roundTrips {
 				It(fmt.Sprintf("gets a 500kB file with %dms RTT", rtt), func() {

--- a/integrationtests/gquic/server_test.go
+++ b/integrationtests/gquic/server_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Server tests", func() {
 			tmpDir = ""
 		})
 
-		Context(fmt.Sprintf("with QUIC version %d", version), func() {
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
 			It("downloads a hello", func() {
 				data := []byte("Hello world!\n")
 				createDownloadFile("hello", data)

--- a/integrationtests/self/client_test.go
+++ b/integrationtests/self/client_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Client tests", func() {
 	for _, v := range protocol.SupportedVersions {
 		version := v
 
-		Context(fmt.Sprintf("with quic version %d", version), func() {
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
 			BeforeEach(func() {
 				client = &http.Client{
 					Transport: &h2quic.RoundTripper{

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -1,5 +1,7 @@
 package protocol
 
+import "fmt"
+
 // VersionNumber is a version number as int
 type VersionNumber int
 
@@ -25,6 +27,21 @@ var SupportedVersions = []VersionNumber{
 // UsesTLS says if this QUIC version uses TLS 1.3 for the handshake
 func (vn VersionNumber) UsesTLS() bool {
 	return vn == VersionTLS
+}
+
+func (vn VersionNumber) String() string {
+	switch vn {
+	case VersionWhatever:
+		return "whatever"
+	case VersionUnsupported:
+		return "unsupported"
+	case VersionUnknown:
+		return "unknown"
+	case VersionTLS:
+		return "TLS dev version (WIP)"
+	default:
+		return fmt.Sprintf("%d", vn)
+	}
 }
 
 // VersionNumberToTag maps version numbers ('32') to tags ('Q032')

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -13,6 +13,16 @@ var _ = Describe("Version", func() {
 		Expect(VersionTLS.UsesTLS()).To(BeTrue())
 	})
 
+	It("has the right string representation", func() {
+		Expect(Version37.String()).To(Equal("37"))
+		Expect(Version38.String()).To(Equal("38"))
+		Expect(Version39.String()).To(Equal("39"))
+		Expect(VersionTLS.String()).To(ContainSubstring("TLS"))
+		Expect(VersionWhatever.String()).To(Equal("whatever"))
+		Expect(VersionUnsupported.String()).To(Equal("unsupported"))
+		Expect(VersionUnknown.String()).To(Equal("unknown"))
+	})
+
 	It("converts tags to numbers", func() {
 		Expect(VersionTagToNumber('Q' + '1'<<8 + '2'<<16 + '3'<<24)).To(Equal(VersionNumber(123)))
 	})

--- a/server.go
+++ b/server.go
@@ -272,7 +272,7 @@ func (s *server) handlePacket(pconn net.PacketConn, remoteAddr net.Addr, packet 
 		if len(packet) < protocol.ClientHelloMinimumSize+len(hdr.Raw) {
 			return errors.New("dropping small packet with unknown version")
 		}
-		utils.Infof("Client offered version %d, sending VersionNegotiationPacket", hdr.VersionNumber)
+		utils.Infof("Client offered version %s, sending VersionNegotiationPacket", hdr.VersionNumber)
 		_, err = pconn.WriteTo(wire.ComposeVersionNegotiation(hdr.ConnectionID, s.config.Versions), remoteAddr)
 		return err
 	}
@@ -283,7 +283,7 @@ func (s *server) handlePacket(pconn net.PacketConn, remoteAddr net.Addr, packet 
 			return errors.New("Server BUG: negotiated version not supported")
 		}
 
-		utils.Infof("Serving new connection: %x, version %d from %v", hdr.ConnectionID, version, remoteAddr)
+		utils.Infof("Serving new connection: %x, version %s from %v", hdr.ConnectionID, version, remoteAddr)
 		var handshakeChan <-chan handshakeEvent
 		session, handshakeChan, err = s.newSession(
 			&conn{pconn: pconn, currentAddr: remoteAddr},


### PR DESCRIPTION
This will be useful as soon as we start supporting non-gQUIC versions.