### PR TITLE
accept lower case log levels for the QUIC_GO_LOG_LEVEL flag

### DIFF
--- a/internal/utils/log.go
+++ b/internal/utils/log.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -79,14 +80,14 @@ func init() {
 }
 
 func readLoggingEnv() {
-	switch os.Getenv(logEnv) {
+	switch strings.ToLower(os.Getenv(logEnv)) {
 	case "":
 		return
-	case "DEBUG":
+	case "debug":
 		logLevel = LogLevelDebug
-	case "INFO":
+	case "info":
 		logLevel = LogLevelInfo
-	case "ERROR":
+	case "error":
 		logLevel = LogLevelError
 	default:
 		fmt.Fprintln(os.Stderr, "invalid quic-go log level, see https://github.com/lucas-clemente/quic-go/wiki/Logging")

--- a/internal/utils/log_test.go
+++ b/internal/utils/log_test.go
@@ -108,6 +108,12 @@ var _ = Describe("Log", func() {
 			Expect(logLevel).To(Equal(LogLevelDebug))
 		})
 
+		It("reads debug", func() {
+			os.Setenv(logEnv, "debug")
+			readLoggingEnv()
+			Expect(logLevel).To(Equal(LogLevelDebug))
+		})
+
 		It("reads INFO", func() {
 			os.Setenv(logEnv, "INFO")
 			readLoggingEnv()


### PR DESCRIPTION
There's no actual need for this PR, other than that I keep mixing up how to properly set the log level.