### PR TITLE
rename connection ID truncation to connection ID omission

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 - Add support for QUIC 38 and 39, drop support for QUIC 35 and 36
 - Added `quic.Config` options for maximal flow control windows
 - Add a `quic.Config` option for QUIC versions
-- Add a `quic.Config` option to request truncation of the connection ID from a server
+- Add a `quic.Config` option to request omission of the connection ID from a server
 - Add a `quic.Config` option to configure the source address validation
 - Add a `quic.Config` option to configure the handshake timeout
 - Add a `quic.Config` option to configure the idle timeout

--- a/client.go
+++ b/client.go
@@ -172,7 +172,7 @@ func populateClientConfig(config *Config) *Config {
 		Versions:                              versions,
 		HandshakeTimeout:                      handshakeTimeout,
 		IdleTimeout:                           idleTimeout,
-		RequestConnectionIDTruncation:         config.RequestConnectionIDTruncation,
+		RequestConnectionIDOmission:           config.RequestConnectionIDOmission,
 		MaxReceiveStreamFlowControlWindow:     maxReceiveStreamFlowControlWindow,
 		MaxReceiveConnectionFlowControlWindow: maxReceiveConnectionFlowControlWindow,
 		KeepAlive: config.KeepAlive,
@@ -256,11 +256,11 @@ func (c *client) handlePacket(remoteAddr net.Addr, packet []byte) {
 		return
 	}
 	// reject packets with truncated connection id if we didn't request truncation
-	if hdr.TruncateConnectionID && !c.config.RequestConnectionIDTruncation {
+	if hdr.OmitConnectionID && !c.config.RequestConnectionIDOmission {
 		return
 	}
 	// reject packets with the wrong connection ID
-	if !hdr.TruncateConnectionID && hdr.ConnectionID != c.connectionID {
+	if !hdr.OmitConnectionID && hdr.ConnectionID != c.connectionID {
 		return
 	}
 	hdr.Raw = packet[:len(packet)-r.Len()]

--- a/client_test.go
+++ b/client_test.go
@@ -253,14 +253,14 @@ var _ = Describe("Client", func() {
 
 		It("setups with the right values", func() {
 			config := &Config{
-				HandshakeTimeout:              1337 * time.Minute,
-				IdleTimeout:                   42 * time.Hour,
-				RequestConnectionIDTruncation: true,
+				HandshakeTimeout:            1337 * time.Minute,
+				IdleTimeout:                 42 * time.Hour,
+				RequestConnectionIDOmission: true,
 			}
 			c := populateClientConfig(config)
 			Expect(c.HandshakeTimeout).To(Equal(1337 * time.Minute))
 			Expect(c.IdleTimeout).To(Equal(42 * time.Hour))
-			Expect(c.RequestConnectionIDTruncation).To(BeTrue())
+			Expect(c.RequestConnectionIDOmission).To(BeTrue())
 		})
 
 		It("fills in default values if options are not set in the Config", func() {
@@ -268,7 +268,7 @@ var _ = Describe("Client", func() {
 			Expect(c.Versions).To(Equal(protocol.SupportedVersions))
 			Expect(c.HandshakeTimeout).To(Equal(protocol.DefaultHandshakeTimeout))
 			Expect(c.IdleTimeout).To(Equal(protocol.DefaultIdleTimeout))
-			Expect(c.RequestConnectionIDTruncation).To(BeFalse())
+			Expect(c.RequestConnectionIDOmission).To(BeFalse())
 		})
 
 		It("errors when receiving an error from the connection", func(done Done) {
@@ -438,12 +438,12 @@ var _ = Describe("Client", func() {
 	})
 
 	It("ignores packets without connection id, if it didn't request connection id trunctation", func() {
-		cl.config.RequestConnectionIDTruncation = false
+		cl.config.RequestConnectionIDOmission = false
 		buf := &bytes.Buffer{}
 		(&wire.PublicHeader{
-			TruncateConnectionID: true,
-			PacketNumber:         1,
-			PacketNumberLen:      1,
+			OmitConnectionID: true,
+			PacketNumber:     1,
+			PacketNumberLen:  1,
 		}).Write(buf, protocol.VersionWhatever, protocol.PerspectiveServer)
 		cl.handlePacket(addr, buf.Bytes())
 		Expect(sess.packetCount).To(BeZero())

--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -51,8 +51,8 @@ type client struct {
 var _ http.RoundTripper = &client{}
 
 var defaultQuicConfig = &quic.Config{
-	RequestConnectionIDTruncation: true,
-	KeepAlive:                     true,
+	RequestConnectionIDOmission: true,
+	KeepAlive:                   true,
 }
 
 // newClient creates a new client

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -21,10 +21,10 @@ var _ = Describe("QUIC Proxy", func() {
 	makePacket := func(p protocol.PacketNumber, payload []byte) []byte {
 		b := &bytes.Buffer{}
 		hdr := wire.PublicHeader{
-			PacketNumber:         p,
-			PacketNumberLen:      protocol.PacketNumberLen6,
-			ConnectionID:         1337,
-			TruncateConnectionID: false,
+			PacketNumber:     p,
+			PacketNumberLen:  protocol.PacketNumberLen6,
+			ConnectionID:     1337,
+			OmitConnectionID: false,
 		}
 		hdr.Write(b, protocol.VersionWhatever, protocol.PerspectiveServer)
 		raw := b.Bytes()

--- a/interface.go
+++ b/interface.go
@@ -89,10 +89,10 @@ type Config struct {
 	// If not set, it uses all versions available.
 	// Warning: This API should not be considered stable and will change soon.
 	Versions []VersionNumber
-	// Ask the server to truncate the connection ID sent in the Public Header.
+	// Ask the server to omit the connection ID sent in the Public Header.
 	// This saves 8 bytes in the Public Header in every packet. However, if the IP address of the server changes, the connection cannot be migrated.
 	// Currently only valid for the client.
-	RequestConnectionIDTruncation bool
+	RequestConnectionIDOmission bool
 	// HandshakeTimeout is the maximum duration that the cryptographic handshake may take.
 	// If the timeout is exceeded, the connection is closed.
 	// If this value is zero, the timeout is set to 10 seconds.

--- a/internal/handshake/crypto_setup_client.go
+++ b/internal/handshake/crypto_setup_client.go
@@ -51,8 +51,8 @@ type cryptoSetupClient struct {
 	forwardSecureAEAD    crypto.AEAD
 	aeadChanged          chan<- protocol.EncryptionLevel
 
-	requestConnIDTruncation bool
-	params                  *paramsNegotiatorGQUIC
+	requestConnIDOmission bool
+	params                *paramsNegotiatorGQUIC
 }
 
 var _ CryptoSetup = &cryptoSetupClient{}
@@ -75,18 +75,18 @@ func NewCryptoSetupClient(
 ) (CryptoSetup, ParamsNegotiator, error) {
 	pn := newParamsNegotiatorGQUIC(protocol.PerspectiveClient, version, params)
 	return &cryptoSetupClient{
-		hostname:                hostname,
-		connID:                  connID,
-		version:                 version,
-		certManager:             crypto.NewCertManager(tlsConfig),
-		params:                  pn,
-		requestConnIDTruncation: params.RequestConnectionIDTruncation,
-		keyDerivation:           crypto.DeriveQuicCryptoAESKeys,
-		keyExchange:             getEphermalKEX,
-		nullAEAD:                crypto.NewNullAEAD(protocol.PerspectiveClient, version),
-		aeadChanged:             aeadChanged,
-		negotiatedVersions:      negotiatedVersions,
-		divNonceChan:            make(chan []byte),
+		hostname:              hostname,
+		connID:                connID,
+		version:               version,
+		certManager:           crypto.NewCertManager(tlsConfig),
+		params:                pn,
+		requestConnIDOmission: params.RequestConnectionIDOmission,
+		keyDerivation:         crypto.DeriveQuicCryptoAESKeys,
+		keyExchange:           getEphermalKEX,
+		nullAEAD:              crypto.NewNullAEAD(protocol.PerspectiveClient, version),
+		aeadChanged:           aeadChanged,
+		negotiatedVersions:    negotiatedVersions,
+		divNonceChan:          make(chan []byte),
 	}, pn, nil
 }
 
@@ -421,7 +421,7 @@ func (h *cryptoSetupClient) getTags() (map[Tag][]byte, error) {
 	binary.LittleEndian.PutUint32(versionTag, protocol.VersionNumberToTag(h.version))
 	tags[TagVER] = versionTag
 
-	if h.requestConnIDTruncation {
+	if h.requestConnIDOmission {
 		tags[TagTCID] = []byte{0, 0, 0, 0}
 	}
 	if len(h.stk) > 0 {

--- a/internal/handshake/crypto_setup_client_test.go
+++ b/internal/handshake/crypto_setup_client_test.go
@@ -491,8 +491,8 @@ var _ = Describe("Client Crypto Setup", func() {
 			Expect(tags).ToNot(HaveKey(TagTCID))
 		})
 
-		It("requests to truncate the connection ID", func() {
-			cs.requestConnIDTruncation = true
+		It("requests to omit the connection ID", func() {
+			cs.requestConnIDOmission = true
 			tags, err := cs.getTags()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(tags).To(HaveKeyWithValue(TagTCID, []byte{0, 0, 0, 0}))

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -28,7 +28,7 @@ type CryptoSetup interface {
 
 // TransportParameters are parameters sent to the peer during the handshake
 type TransportParameters struct {
-	RequestConnectionIDTruncation         bool
+	RequestConnectionIDOmission           bool
 	MaxReceiveStreamFlowControlWindow     protocol.ByteCount
 	MaxReceiveConnectionFlowControlWindow protocol.ByteCount
 	IdleTimeout                           time.Duration

--- a/internal/handshake/params_negotiator.go
+++ b/internal/handshake/params_negotiator.go
@@ -68,7 +68,7 @@ func (h *paramsNegotiator) SetFromTransportParameters(params []transportParamete
 			if len(p.Value) != 0 {
 				return fmt.Errorf("wrong length for omit_connection_id: %d (expected empty)", len(p.Value))
 			}
-			h.truncateConnectionID = true
+			h.omitConnectionID = true
 		}
 	}
 
@@ -96,14 +96,14 @@ func (h *paramsNegotiator) GetTransportParameters() []transportParameter {
 	}
 	h.mutex.RLock()
 	defer h.mutex.RUnlock()
-	if h.truncateConnectionID {
+	if h.omitConnectionID {
 		params = append(params, transportParameter{omitConnectionIDParameterID, []byte{}})
 	}
 	return params
 }
 
-func (h *paramsNegotiator) TruncateConnectionID() bool {
+func (h *paramsNegotiator) OmitConnectionID() bool {
 	h.mutex.RLock()
 	defer h.mutex.RUnlock()
-	return h.truncateConnectionID
+	return h.omitConnectionID
 }

--- a/internal/handshake/params_negotiator_base.go
+++ b/internal/handshake/params_negotiator_base.go
@@ -20,9 +20,8 @@ type ParamsNegotiator interface {
 	GetMaxOutgoingStreams() uint32
 	GetMaxIncomingStreams() uint32
 	GetIdleConnectionStateLifetime() time.Duration
-	// determines if the client requests truncated ConnectionIDs.
-	// It always returns false for the server.
-	TruncateConnectionID() bool
+	// determines if the client requests omission of connection IDs.
+	OmitConnectionID() bool
 }
 
 // For the server:
@@ -39,8 +38,8 @@ type paramsNegotiatorBase struct {
 
 	flowControlNegotiated bool
 
-	truncateConnectionID          bool
-	requestConnectionIDTruncation bool
+	omitConnectionID            bool
+	requestConnectionIDOmission bool
 
 	maxStreamsPerConnection                uint32
 	maxIncomingDynamicStreamsPerConnection uint32
@@ -60,7 +59,7 @@ func (h *paramsNegotiatorBase) init(params *TransportParameters) {
 	h.receiveConnectionFlowControlWindow = protocol.ReceiveConnectionFlowControlWindow
 	h.maxReceiveStreamFlowControlWindow = params.MaxReceiveStreamFlowControlWindow
 	h.maxReceiveConnectionFlowControlWindow = params.MaxReceiveConnectionFlowControlWindow
-	h.requestConnectionIDTruncation = params.RequestConnectionIDTruncation
+	h.requestConnectionIDOmission = params.RequestConnectionIDOmission
 
 	h.idleConnectionStateLifetime = params.IdleTimeout
 	if h.perspective == protocol.PerspectiveServer {

--- a/internal/handshake/params_negotiator_gquic.go
+++ b/internal/handshake/params_negotiator_gquic.go
@@ -40,7 +40,7 @@ func (h *paramsNegotiatorGQUIC) SetFromMap(params map[Tag][]byte) error {
 		if err != nil {
 			return errMalformedTag
 		}
-		h.truncateConnectionID = (clientValue == 0)
+		h.omitConnectionID = (clientValue == 0)
 	}
 	if value, ok := params[TagMSPC]; ok {
 		clientValue, err := utils.LittleEndian.ReadUint32(bytes.NewBuffer(value))
@@ -115,12 +115,12 @@ func (h *paramsNegotiatorGQUIC) GetHelloMap() (map[Tag][]byte, error) {
 	}, nil
 }
 
-func (h *paramsNegotiatorGQUIC) TruncateConnectionID() bool {
+func (h *paramsNegotiatorGQUIC) OmitConnectionID() bool {
 	if h.perspective == protocol.PerspectiveClient {
 		return false
 	}
 
 	h.mutex.RLock()
 	defer h.mutex.RUnlock()
-	return h.truncateConnectionID
+	return h.omitConnectionID
 }

--- a/internal/handshake/params_negotiator_gquic_test.go
+++ b/internal/handshake/params_negotiator_gquic_test.go
@@ -119,21 +119,21 @@ var _ = Describe("Params Negotiator (for gQUIC)", func() {
 		})
 	})
 
-	Context("Truncated connection IDs", func() {
-		It("does not send truncated connection IDs if the TCID tag is missing", func() {
-			Expect(pn.TruncateConnectionID()).To(BeFalse())
+	Context("Omitted connection IDs", func() {
+		It("does not send omitted connection IDs if the TCID tag is missing", func() {
+			Expect(pn.OmitConnectionID()).To(BeFalse())
 		})
 
-		It("reads the tag for truncated connection IDs", func() {
+		It("reads the tag for omitted connection IDs", func() {
 			values := map[Tag][]byte{TagTCID: {0, 0, 0, 0}}
 			pn.SetFromMap(values)
-			Expect(pn.TruncateConnectionID()).To(BeTrue())
+			Expect(pn.OmitConnectionID()).To(BeTrue())
 		})
 
 		It("ignores the TCID tag, as a client", func() {
 			values := map[Tag][]byte{TagTCID: {0, 0, 0, 0}}
 			pnClient.SetFromMap(values)
-			Expect(pnClient.TruncateConnectionID()).To(BeFalse())
+			Expect(pnClient.OmitConnectionID()).To(BeFalse())
 		})
 
 		It("errors when given an invalid value", func() {

--- a/internal/handshake/params_negotiator_test.go
+++ b/internal/handshake/params_negotiator_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Params Negotiator (for TLS)", func() {
 		})
 
 		It("request ommision of the connection ID", func() {
-			pn.truncateConnectionID = true
+			pn.omitConnectionID = true
 			values := paramsListToMap(pn.GetTransportParameters())
 			Expect(values).To(HaveKeyWithValue(omitConnectionIDParameterID, []byte{}))
 		})
@@ -72,7 +72,7 @@ var _ = Describe("Params Negotiator (for TLS)", func() {
 			Expect(pn.GetSendStreamFlowControlWindow()).To(Equal(protocol.ByteCount(0x11223344)))
 			Expect(pn.GetSendConnectionFlowControlWindow()).To(Equal(protocol.ByteCount(0x22334455)))
 			Expect(pn.GetIdleConnectionStateLifetime()).To(Equal(0x1337 * time.Second))
-			Expect(pn.TruncateConnectionID()).To(BeFalse())
+			Expect(pn.OmitConnectionID()).To(BeFalse())
 		})
 
 		It("negotiates a smaller idle timeout, if the peer suggest a higher value than configured", func() {
@@ -86,7 +86,7 @@ var _ = Describe("Params Negotiator (for TLS)", func() {
 			params[omitConnectionIDParameterID] = []byte{}
 			err := pn.SetFromTransportParameters(paramsMapToList(params))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pn.TruncateConnectionID()).To(BeTrue())
+			Expect(pn.OmitConnectionID()).To(BeTrue())
 		})
 
 		It("rejects the parameters if the initial_max_stream_data is missing", func() {

--- a/internal/mocks/params_negotiator.go
+++ b/internal/mocks/params_negotiator.go
@@ -142,14 +142,14 @@ func (_mr *MockParamsNegotiatorMockRecorder) GetIdleConnectionStateLifetime() *g
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "GetIdleConnectionStateLifetime", reflect.TypeOf((*MockParamsNegotiator)(nil).GetIdleConnectionStateLifetime))
 }
 
-// TruncateConnectionID mocks base method
-func (_m *MockParamsNegotiator) TruncateConnectionID() bool {
-	ret := _m.ctrl.Call(_m, "TruncateConnectionID")
+// OmitConnectionID mocks base method
+func (_m *MockParamsNegotiator) OmitConnectionID() bool {
+	ret := _m.ctrl.Call(_m, "OmitConnectionID")
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// TruncateConnectionID indicates an expected call of TruncateConnectionID
-func (_mr *MockParamsNegotiatorMockRecorder) TruncateConnectionID() *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "TruncateConnectionID", reflect.TypeOf((*MockParamsNegotiator)(nil).TruncateConnectionID))
+// OmitConnectionID indicates an expected call of OmitConnectionID
+func (_mr *MockParamsNegotiatorMockRecorder) OmitConnectionID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "OmitConnectionID", reflect.TypeOf((*MockParamsNegotiator)(nil).OmitConnectionID))
 }

--- a/internal/wire/public_header_test.go
+++ b/internal/wire/public_header_test.go
@@ -13,10 +13,10 @@ import (
 
 var _ = Describe("Public Header", func() {
 	Context("parsing the connection ID", func() {
-		It("does not accept truncated connection ID as a server", func() {
+		It("does not accept an omitted connection ID as a server", func() {
 			b := bytes.NewReader([]byte{0x00, 0x01})
 			_, err := PeekConnectionID(b, protocol.PerspectiveClient)
-			Expect(err).To(MatchError(errReceivedTruncatedConnectionID))
+			Expect(err).To(MatchError(errReceivedOmittedConnectionID))
 		})
 
 		It("gets the connection ID", func() {
@@ -40,7 +40,7 @@ var _ = Describe("Public Header", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("accepts a truncated connection ID as a client", func() {
+		It("accepts an ommitted connection ID as a client", func() {
 			b := bytes.NewReader([]byte{0x00, 0x01})
 			len := b.Len()
 			connID, err := PeekConnectionID(b, protocol.PerspectiveServer)
@@ -64,17 +64,17 @@ var _ = Describe("Public Header", func() {
 			Expect(b.Len()).To(BeZero())
 		})
 
-		It("does not accept truncated connection ID as a server", func() {
+		It("does not accept an omittedd connection ID as a server", func() {
 			b := bytes.NewReader([]byte{0x00, 0x01})
 			_, err := ParsePublicHeader(b, protocol.PerspectiveClient, protocol.VersionWhatever)
-			Expect(err).To(MatchError(errReceivedTruncatedConnectionID))
+			Expect(err).To(MatchError(errReceivedOmittedConnectionID))
 		})
 
-		It("accepts a truncated connection ID as a client", func() {
+		It("accepts aan d connection ID as a client", func() {
 			b := bytes.NewReader([]byte{0x00, 0x01})
 			hdr, err := ParsePublicHeader(b, protocol.PerspectiveServer, protocol.VersionWhatever)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(hdr.TruncateConnectionID).To(BeTrue())
+			Expect(hdr.OmitConnectionID).To(BeTrue())
 			Expect(hdr.ConnectionID).To(BeZero())
 			Expect(b.Len()).To(BeZero())
 		})
@@ -303,13 +303,13 @@ var _ = Describe("Public Header", func() {
 			Expect(err).To(MatchError("PublicHeader: PacketNumberLen not set"))
 		})
 
-		It("truncates the connection ID", func() {
+		It("omits the connection ID", func() {
 			b := &bytes.Buffer{}
 			hdr := PublicHeader{
-				ConnectionID:         0x4cfa9f9b668619f6,
-				TruncateConnectionID: true,
-				PacketNumberLen:      protocol.PacketNumberLen6,
-				PacketNumber:         1,
+				ConnectionID:     0x4cfa9f9b668619f6,
+				OmitConnectionID: true,
+				PacketNumberLen:  protocol.PacketNumberLen6,
+				PacketNumber:     1,
 			}
 			err := hdr.Write(b, protocol.VersionWhatever, protocol.PerspectiveServer)
 			Expect(err).ToNot(HaveOccurred())
@@ -450,24 +450,24 @@ var _ = Describe("Public Header", func() {
 
 			It("gets the lengths of a packet sent by the client with the VersionFlag set", func() {
 				hdr := PublicHeader{
-					ConnectionID:         0x4cfa9f9b668619f6,
-					TruncateConnectionID: true,
-					PacketNumber:         0xDECAFBAD,
-					PacketNumberLen:      protocol.PacketNumberLen6,
-					VersionFlag:          true,
-					VersionNumber:        versionLittleEndian,
+					ConnectionID:     0x4cfa9f9b668619f6,
+					OmitConnectionID: true,
+					PacketNumber:     0xDECAFBAD,
+					PacketNumberLen:  protocol.PacketNumberLen6,
+					VersionFlag:      true,
+					VersionNumber:    versionLittleEndian,
 				}
 				length, err := hdr.GetLength(protocol.PerspectiveClient)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(length).To(Equal(protocol.ByteCount(1 + 4 + 6))) // 1 byte public flag, 4 version number, and packet number
 			})
 
-			It("gets the length of a packet with longest packet number length and truncated connectionID", func() {
+			It("gets the length of a packet with longest packet number length and omitted connectionID", func() {
 				hdr := PublicHeader{
-					ConnectionID:         0x4cfa9f9b668619f6,
-					TruncateConnectionID: true,
-					PacketNumber:         0xDECAFBAD,
-					PacketNumberLen:      protocol.PacketNumberLen6,
+					ConnectionID:     0x4cfa9f9b668619f6,
+					OmitConnectionID: true,
+					PacketNumber:     0xDECAFBAD,
+					PacketNumberLen:  protocol.PacketNumberLen6,
 				}
 				length, err := hdr.GetLength(protocol.PerspectiveServer)
 				Expect(err).ToNot(HaveOccurred())

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -268,10 +268,10 @@ func (p *packetPacker) getPublicHeader(encLevel protocol.EncryptionLevel) *wire.
 	pnum := p.packetNumberGenerator.Peek()
 	packetNumberLen := protocol.GetPacketNumberLengthForPublicHeader(pnum, p.leastUnacked)
 	publicHeader := &wire.PublicHeader{
-		ConnectionID:         p.connectionID,
-		PacketNumber:         pnum,
-		PacketNumberLen:      packetNumberLen,
-		TruncateConnectionID: p.connParams.TruncateConnectionID(),
+		ConnectionID:     p.connectionID,
+		PacketNumber:     pnum,
+		PacketNumberLen:  packetNumberLen,
+		OmitConnectionID: p.connParams.OmitConnectionID(),
 	}
 
 	if p.perspective == protocol.PerspectiveServer && encLevel == protocol.EncryptionSecure {

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Packet packer", func() {
 
 	BeforeEach(func() {
 		mockPn := mocks.NewMockParamsNegotiator(mockCtrl)
-		mockPn.EXPECT().TruncateConnectionID().Return(false).AnyTimes()
+		mockPn.EXPECT().OmitConnectionID().Return(false).AnyTimes()
 
 		cryptoStream = &stream{}
 

--- a/session.go
+++ b/session.go
@@ -225,7 +225,7 @@ func (s *session) setup(
 				aeadChanged,
 			)
 		} else {
-			transportParams.RequestConnectionIDTruncation = s.config.RequestConnectionIDTruncation
+			transportParams.RequestConnectionIDOmission = s.config.RequestConnectionIDOmission
 			s.cryptoSetup, s.connParams, err = newCryptoSetupClient(
 				hostname,
 				s.connectionID,

--- a/session_test.go
+++ b/session_test.go
@@ -170,7 +170,7 @@ func (m *mockParamsNegotiator) GetMaxIncomingStreams() uint32 { return 100 }
 func (m *mockParamsNegotiator) GetIdleConnectionStateLifetime() time.Duration {
 	return time.Hour
 }
-func (m *mockParamsNegotiator) TruncateConnectionID() bool { return false }
+func (m *mockParamsNegotiator) OmitConnectionID() bool { return false }
 
 var _ = Describe("Session", func() {
 	var (
@@ -1559,7 +1559,7 @@ var _ = Describe("Session", func() {
 			sess.lastNetworkActivityTime = time.Now().Add(-time.Minute)
 			mockPn := mocks.NewMockParamsNegotiator(mockCtrl)
 			mockPn.EXPECT().GetIdleConnectionStateLifetime().Return(9999 * time.Second).AnyTimes()
-			mockPn.EXPECT().TruncateConnectionID().Return(false).AnyTimes()
+			mockPn.EXPECT().OmitConnectionID().Return(false).AnyTimes()
 			sess.connParams = mockPn
 			sess.packer.connParams = mockPn
 			// the handshake timeout is irrelevant here, since it depends on the time the session was created,
@@ -1576,7 +1576,7 @@ var _ = Describe("Session", func() {
 			close(aeadChanged)
 			mockPn := mocks.NewMockParamsNegotiator(mockCtrl)
 			mockPn.EXPECT().GetIdleConnectionStateLifetime().Return(0 * time.Second)
-			mockPn.EXPECT().TruncateConnectionID().Return(false).AnyTimes()
+			mockPn.EXPECT().OmitConnectionID().Return(false).AnyTimes()
 			sess.connParams = mockPn
 			sess.packer.connParams = mockPn
 			mockPn.EXPECT().GetIdleConnectionStateLifetime().Return(0 * time.Second).AnyTimes()


### PR DESCRIPTION
The IETF draft uses omit instead of truncate, e.g. here: https://quicwg.github.io/base-drafts/draft-ietf-quic-transport.html#rfc.section.7.3.

No functional change.