### PR TITLE
move the max flow control increments out of the params negotiator

### DIFF
--- a/internal/flowcontrol/flow_control_manager_test.go
+++ b/internal/flowcontrol/flow_control_manager_test.go
@@ -18,9 +18,7 @@ var _ = Describe("Flow Control Manager", func() {
 		mockPn := mocks.NewMockParamsNegotiator(mockCtrl)
 		mockPn.EXPECT().GetReceiveStreamFlowControlWindow().AnyTimes().Return(protocol.ByteCount(100))
 		mockPn.EXPECT().GetReceiveConnectionFlowControlWindow().AnyTimes().Return(protocol.ByteCount(200))
-		mockPn.EXPECT().GetMaxReceiveStreamFlowControlWindow().AnyTimes().Return(protocol.MaxByteCount)
-		mockPn.EXPECT().GetMaxReceiveConnectionFlowControlWindow().AnyTimes().Return(protocol.MaxByteCount)
-		fcm = NewFlowControlManager(mockPn, &congestion.RTTStats{}).(*flowControlManager)
+		fcm = NewFlowControlManager(mockPn, protocol.MaxByteCount, protocol.MaxByteCount, &congestion.RTTStats{}).(*flowControlManager)
 	})
 
 	It("creates a connection level flow controller", func() {

--- a/internal/flowcontrol/flow_controller.go
+++ b/internal/flowcontrol/flow_controller.go
@@ -33,22 +33,27 @@ type flowController struct {
 var ErrReceivedSmallerByteOffset = errors.New("Received a smaller byte offset")
 
 // newFlowController gets a new flow controller
-func newFlowController(streamID protocol.StreamID, contributesToConnection bool, connParams handshake.ParamsNegotiator, rttStats *congestion.RTTStats) *flowController {
+func newFlowController(
+	streamID protocol.StreamID,
+	contributesToConnection bool,
+	connParams handshake.ParamsNegotiator,
+	maxReceiveWindow protocol.ByteCount,
+	rttStats *congestion.RTTStats,
+) *flowController {
 	fc := flowController{
-		streamID:                streamID,
-		contributesToConnection: contributesToConnection,
-		connParams:              connParams,
-		rttStats:                rttStats,
+		streamID:                  streamID,
+		contributesToConnection:   contributesToConnection,
+		connParams:                connParams,
+		rttStats:                  rttStats,
+		maxReceiveWindowIncrement: maxReceiveWindow,
 	}
 
 	if streamID == 0 {
 		fc.receiveWindow = connParams.GetReceiveConnectionFlowControlWindow()
 		fc.receiveWindowIncrement = fc.receiveWindow
-		fc.maxReceiveWindowIncrement = connParams.GetMaxReceiveConnectionFlowControlWindow()
 	} else {
 		fc.receiveWindow = connParams.GetReceiveStreamFlowControlWindow()
 		fc.receiveWindowIncrement = fc.receiveWindow
-		fc.maxReceiveWindowIncrement = connParams.GetMaxReceiveStreamFlowControlWindow()
 	}
 
 	return &fc

--- a/internal/handshake/crypto_setup_client_test.go
+++ b/internal/handshake/crypto_setup_client_test.go
@@ -114,11 +114,7 @@ var _ = Describe("Client Crypto Setup", func() {
 			0,
 			version,
 			nil,
-			&TransportParameters{
-				MaxReceiveStreamFlowControlWindow:     protocol.DefaultMaxReceiveStreamFlowControlWindowClient,
-				MaxReceiveConnectionFlowControlWindow: protocol.DefaultMaxReceiveConnectionFlowControlWindowClient,
-				IdleTimeout:                           protocol.DefaultIdleTimeout,
-			},
+			&TransportParameters{IdleTimeout: protocol.DefaultIdleTimeout},
 			aeadChanged,
 			nil,
 		)

--- a/internal/handshake/crypto_setup_server_test.go
+++ b/internal/handshake/crypto_setup_server_test.go
@@ -202,11 +202,7 @@ var _ = Describe("Server Crypto Setup", func() {
 			remoteAddr,
 			version,
 			scfg,
-			&TransportParameters{
-				MaxReceiveStreamFlowControlWindow:     protocol.DefaultMaxReceiveStreamFlowControlWindowServer,
-				MaxReceiveConnectionFlowControlWindow: protocol.DefaultMaxReceiveConnectionFlowControlWindowServer,
-				IdleTimeout:                           protocol.DefaultIdleTimeout,
-			},
+			&TransportParameters{IdleTimeout: protocol.DefaultIdleTimeout},
 			supportedVersions,
 			nil,
 			aeadChanged,

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -28,8 +28,6 @@ type CryptoSetup interface {
 
 // TransportParameters are parameters sent to the peer during the handshake
 type TransportParameters struct {
-	RequestConnectionIDOmission           bool
-	MaxReceiveStreamFlowControlWindow     protocol.ByteCount
-	MaxReceiveConnectionFlowControlWindow protocol.ByteCount
-	IdleTimeout                           time.Duration
+	RequestConnectionIDOmission bool
+	IdleTimeout                 time.Duration
 }

--- a/internal/handshake/params_negotiator_base.go
+++ b/internal/handshake/params_negotiator_base.go
@@ -14,9 +14,7 @@ type ParamsNegotiator interface {
 	GetSendStreamFlowControlWindow() protocol.ByteCount
 	GetSendConnectionFlowControlWindow() protocol.ByteCount
 	GetReceiveStreamFlowControlWindow() protocol.ByteCount
-	GetMaxReceiveStreamFlowControlWindow() protocol.ByteCount
 	GetReceiveConnectionFlowControlWindow() protocol.ByteCount
-	GetMaxReceiveConnectionFlowControlWindow() protocol.ByteCount
 	GetMaxOutgoingStreams() uint32
 	GetMaxIncomingStreams() uint32
 	// get the idle timeout that was sent by the peer
@@ -50,8 +48,6 @@ type paramsNegotiatorBase struct {
 	sendConnectionFlowControlWindow        protocol.ByteCount
 	receiveStreamFlowControlWindow         protocol.ByteCount
 	receiveConnectionFlowControlWindow     protocol.ByteCount
-	maxReceiveStreamFlowControlWindow      protocol.ByteCount
-	maxReceiveConnectionFlowControlWindow  protocol.ByteCount
 }
 
 func (h *paramsNegotiatorBase) init(params *TransportParameters) {
@@ -59,8 +55,6 @@ func (h *paramsNegotiatorBase) init(params *TransportParameters) {
 	h.sendConnectionFlowControlWindow = protocol.InitialConnectionFlowControlWindow // can only be changed by the client
 	h.receiveStreamFlowControlWindow = protocol.ReceiveStreamFlowControlWindow
 	h.receiveConnectionFlowControlWindow = protocol.ReceiveConnectionFlowControlWindow
-	h.maxReceiveStreamFlowControlWindow = params.MaxReceiveStreamFlowControlWindow
-	h.maxReceiveConnectionFlowControlWindow = params.MaxReceiveConnectionFlowControlWindow
 	h.requestConnectionIDOmission = params.RequestConnectionIDOmission
 
 	h.idleTimeout = params.IdleTimeout
@@ -101,20 +95,11 @@ func (h *paramsNegotiatorBase) GetReceiveStreamFlowControlWindow() protocol.Byte
 	return h.receiveStreamFlowControlWindow
 }
 
-// GetMaxReceiveStreamFlowControlWindow gets the maximum size of the stream-level flow control window for sending data
-func (h *paramsNegotiatorBase) GetMaxReceiveStreamFlowControlWindow() protocol.ByteCount {
-	return h.maxReceiveStreamFlowControlWindow
-}
-
 // GetReceiveConnectionFlowControlWindow gets the size of the stream-level flow control window for receiving data
 func (h *paramsNegotiatorBase) GetReceiveConnectionFlowControlWindow() protocol.ByteCount {
 	h.mutex.RLock()
 	defer h.mutex.RUnlock()
 	return h.receiveConnectionFlowControlWindow
-}
-
-func (h *paramsNegotiatorBase) GetMaxReceiveConnectionFlowControlWindow() protocol.ByteCount {
-	return h.maxReceiveConnectionFlowControlWindow
 }
 
 func (h *paramsNegotiatorBase) GetMaxOutgoingStreams() uint32 {

--- a/internal/handshake/params_negotiator_gquic_test.go
+++ b/internal/handshake/params_negotiator_gquic_test.go
@@ -2,7 +2,6 @@ package handshake
 
 import (
 	"encoding/binary"
-	"math"
 	"time"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
@@ -13,29 +12,20 @@ import (
 var _ = Describe("Params Negotiator (for gQUIC)", func() {
 	var pn *paramsNegotiatorGQUIC // a connectionParametersManager for a server
 	var pnClient *paramsNegotiatorGQUIC
-	const MB = 1 << 20
-	maxReceiveStreamFlowControlWindowServer := protocol.ByteCount(math.Floor(1.1 * MB))     // default is 1 MB
-	maxReceiveConnectionFlowControlWindowServer := protocol.ByteCount(math.Floor(1.5 * MB)) // default is 1.5 MB
-	maxReceiveStreamFlowControlWindowClient := protocol.ByteCount(math.Floor(6.4 * MB))     // default is 6 MB
-	maxReceiveConnectionFlowControlWindowClient := protocol.ByteCount(math.Floor(13 * MB))  // default is 15 MB
 	idleTimeout := 42 * time.Second
 	BeforeEach(func() {
 		pn = newParamsNegotiatorGQUIC(
 			protocol.PerspectiveServer,
 			protocol.VersionWhatever,
 			&TransportParameters{
-				MaxReceiveStreamFlowControlWindow:     maxReceiveStreamFlowControlWindowServer,
-				MaxReceiveConnectionFlowControlWindow: maxReceiveConnectionFlowControlWindowServer,
-				IdleTimeout:                           idleTimeout,
+				IdleTimeout: idleTimeout,
 			},
 		)
 		pnClient = newParamsNegotiatorGQUIC(
 			protocol.PerspectiveClient,
 			protocol.VersionWhatever,
 			&TransportParameters{
-				MaxReceiveStreamFlowControlWindow:     maxReceiveStreamFlowControlWindowClient,
-				MaxReceiveConnectionFlowControlWindow: maxReceiveConnectionFlowControlWindowClient,
-				IdleTimeout:                           idleTimeout,
+				IdleTimeout: idleTimeout,
 			},
 		)
 	})
@@ -156,13 +146,6 @@ var _ = Describe("Params Negotiator (for gQUIC)", func() {
 			Expect(pn.GetReceiveConnectionFlowControlWindow()).To(BeEquivalentTo(protocol.ReceiveConnectionFlowControlWindow))
 			Expect(pnClient.GetReceiveStreamFlowControlWindow()).To(BeEquivalentTo(protocol.ReceiveStreamFlowControlWindow))
 			Expect(pnClient.GetReceiveConnectionFlowControlWindow()).To(BeEquivalentTo(protocol.ReceiveConnectionFlowControlWindow))
-		})
-
-		It("has the correct maximum flow control windows", func() {
-			Expect(pn.GetMaxReceiveStreamFlowControlWindow()).To(Equal(maxReceiveStreamFlowControlWindowServer))
-			Expect(pn.GetMaxReceiveConnectionFlowControlWindow()).To(Equal(maxReceiveConnectionFlowControlWindowServer))
-			Expect(pnClient.GetMaxReceiveStreamFlowControlWindow()).To(Equal(maxReceiveStreamFlowControlWindowClient))
-			Expect(pnClient.GetMaxReceiveConnectionFlowControlWindow()).To(Equal(maxReceiveConnectionFlowControlWindowClient))
 		})
 
 		It("sets a new stream-level flow control window for sending", func() {

--- a/internal/mocks/params_negotiator.go
+++ b/internal/mocks/params_negotiator.go
@@ -5,10 +5,11 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
 )
 
 // MockParamsNegotiator is a mock of ParamsNegotiator interface
@@ -70,18 +71,6 @@ func (mr *MockParamsNegotiatorMockRecorder) GetReceiveStreamFlowControlWindow() 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceiveStreamFlowControlWindow", reflect.TypeOf((*MockParamsNegotiator)(nil).GetReceiveStreamFlowControlWindow))
 }
 
-// GetMaxReceiveStreamFlowControlWindow mocks base method
-func (m *MockParamsNegotiator) GetMaxReceiveStreamFlowControlWindow() protocol.ByteCount {
-	ret := m.ctrl.Call(m, "GetMaxReceiveStreamFlowControlWindow")
-	ret0, _ := ret[0].(protocol.ByteCount)
-	return ret0
-}
-
-// GetMaxReceiveStreamFlowControlWindow indicates an expected call of GetMaxReceiveStreamFlowControlWindow
-func (mr *MockParamsNegotiatorMockRecorder) GetMaxReceiveStreamFlowControlWindow() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxReceiveStreamFlowControlWindow", reflect.TypeOf((*MockParamsNegotiator)(nil).GetMaxReceiveStreamFlowControlWindow))
-}
-
 // GetReceiveConnectionFlowControlWindow mocks base method
 func (m *MockParamsNegotiator) GetReceiveConnectionFlowControlWindow() protocol.ByteCount {
 	ret := m.ctrl.Call(m, "GetReceiveConnectionFlowControlWindow")
@@ -92,18 +81,6 @@ func (m *MockParamsNegotiator) GetReceiveConnectionFlowControlWindow() protocol.
 // GetReceiveConnectionFlowControlWindow indicates an expected call of GetReceiveConnectionFlowControlWindow
 func (mr *MockParamsNegotiatorMockRecorder) GetReceiveConnectionFlowControlWindow() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceiveConnectionFlowControlWindow", reflect.TypeOf((*MockParamsNegotiator)(nil).GetReceiveConnectionFlowControlWindow))
-}
-
-// GetMaxReceiveConnectionFlowControlWindow mocks base method
-func (m *MockParamsNegotiator) GetMaxReceiveConnectionFlowControlWindow() protocol.ByteCount {
-	ret := m.ctrl.Call(m, "GetMaxReceiveConnectionFlowControlWindow")
-	ret0, _ := ret[0].(protocol.ByteCount)
-	return ret0
-}
-
-// GetMaxReceiveConnectionFlowControlWindow indicates an expected call of GetMaxReceiveConnectionFlowControlWindow
-func (mr *MockParamsNegotiatorMockRecorder) GetMaxReceiveConnectionFlowControlWindow() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxReceiveConnectionFlowControlWindow", reflect.TypeOf((*MockParamsNegotiator)(nil).GetMaxReceiveConnectionFlowControlWindow))
 }
 
 // GetMaxOutgoingStreams mocks base method

--- a/session.go
+++ b/session.go
@@ -183,9 +183,7 @@ func (s *session) setup(
 
 	s.rttStats = &congestion.RTTStats{}
 	transportParams := &handshake.TransportParameters{
-		MaxReceiveStreamFlowControlWindow:     protocol.ByteCount(s.config.MaxReceiveStreamFlowControlWindow),
-		MaxReceiveConnectionFlowControlWindow: protocol.ByteCount(s.config.MaxReceiveConnectionFlowControlWindow),
-		IdleTimeout:                           s.config.IdleTimeout,
+		IdleTimeout: s.config.IdleTimeout,
 	}
 	s.sentPacketHandler = ackhandler.NewSentPacketHandler(s.rttStats)
 	s.receivedPacketHandler = ackhandler.NewReceivedPacketHandler(s.version)
@@ -243,7 +241,12 @@ func (s *session) setup(
 		return nil, nil, err
 	}
 
-	s.flowControlManager = flowcontrol.NewFlowControlManager(s.connParams, s.rttStats)
+	s.flowControlManager = flowcontrol.NewFlowControlManager(
+		s.connParams,
+		protocol.ByteCount(s.config.MaxReceiveStreamFlowControlWindow),
+		protocol.ByteCount(s.config.MaxReceiveConnectionFlowControlWindow),
+		s.rttStats,
+	)
 	s.streamsMap = newStreamsMap(s.newStream, s.flowControlManager.RemoveStream, s.perspective, s.connParams)
 	s.streamFramer = newStreamFramer(s.streamsMap, s.flowControlManager)
 	s.packer = newPacketPacker(s.connectionID,

--- a/session_test.go
+++ b/session_test.go
@@ -155,14 +155,8 @@ func (m *mockParamsNegotiator) GetSendConnectionFlowControlWindow() protocol.Byt
 func (m *mockParamsNegotiator) GetReceiveStreamFlowControlWindow() protocol.ByteCount {
 	return protocol.ReceiveStreamFlowControlWindow
 }
-func (m *mockParamsNegotiator) GetMaxReceiveStreamFlowControlWindow() protocol.ByteCount {
-	return protocol.DefaultMaxReceiveStreamFlowControlWindowServer
-}
 func (m *mockParamsNegotiator) GetReceiveConnectionFlowControlWindow() protocol.ByteCount {
 	return protocol.ReceiveConnectionFlowControlWindow
-}
-func (m *mockParamsNegotiator) GetMaxReceiveConnectionFlowControlWindow() protocol.ByteCount {
-	return protocol.DefaultMaxReceiveConnectionFlowControlWindowServer
 }
 func (m *mockParamsNegotiator) GetMaxOutgoingStreams() uint32       { return 100 }
 func (m *mockParamsNegotiator) GetMaxIncomingStreams() uint32       { return 100 }


### PR DESCRIPTION
The params negotiator was just keeping track of the value set in the `quic.Config`. The max flow control increments are not subject to negotiation, but an independent implementation decision of every peer.