### PR TITLE
rename want-help Github label to help wanted

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ http.Client{
 
 ## Contributing
 
-We are always happy to welcome new contributors! We have a number of self-contained issues that are suitable for first-time contributors, they are tagged with [want-help](https://github.com/lucas-clemente/quic-go/issues?q=is%3Aopen+is%3Aissue+label%3Awant-help). If you have any questions, please feel free to reach out by opening an issue or leaving a comment.
+We are always happy to welcome new contributors! We have a number of self-contained issues that are suitable for first-time contributors, they are tagged with [help wanted](https://github.com/lucas-clemente/quic-go/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). If you have any questions, please feel free to reach out by opening an issue or leaving a comment.


### PR DESCRIPTION
Github seems to make this a standard now.

<img width="1005" alt="screen shot 2017-10-13 at 23 15 55" src="https://user-images.githubusercontent.com/1478487/31573310-14a12bee-b06e-11e7-99f8-d8eade6b0c17.png">

(Didn't find a blog post about this.)