### PR TITLE
fix parsing of long reason phrases in CONNECTION_CLOSE frames

### DIFF
--- a/internal/wire/connection_close_frame_test.go
+++ b/internal/wire/connection_close_frame_test.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"bytes"
+	"io"
 	"strings"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
@@ -32,7 +33,7 @@ var _ = Describe("ConnectionCloseFrame", func() {
 					0x0, 0xff, // reason phrase length
 				})
 				_, err := ParseConnectionCloseFrame(b, versionLittleEndian)
-				Expect(err).To(MatchError(qerr.Error(qerr.InvalidConnectionCloseData, "reason phrase too long")))
+				Expect(err).To(MatchError(io.EOF))
 			})
 
 			It("errors on EOFs", func() {
@@ -70,7 +71,7 @@ var _ = Describe("ConnectionCloseFrame", func() {
 					0xff, 0x0, // reason phrase length
 				})
 				_, err := ParseConnectionCloseFrame(b, versionBigEndian)
-				Expect(err).To(MatchError(qerr.Error(qerr.InvalidConnectionCloseData, "reason phrase too long")))
+				Expect(err).To(MatchError(io.EOF))
 			})
 
 			It("errors on EOFs", func() {


### PR DESCRIPTION
This is the same fix as I did in #883.