### PR TITLE
handle the crypto stream separately

### DIFF
--- a/internal/crypto/key_derivation_test.go
+++ b/internal/crypto/key_derivation_test.go
@@ -10,16 +10,16 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type mockMintController struct {
+type mockTLSExporter struct {
 	hash          crypto.Hash
 	computerError error
 }
 
-var _ MintController = &mockMintController{}
+var _ TLSExporter = &mockTLSExporter{}
 
-func (c *mockMintController) Handshake() mint.Alert { panic("not implemented") }
+func (c *mockTLSExporter) Handshake() mint.Alert { panic("not implemented") }
 
-func (c *mockMintController) GetCipherSuite() mint.CipherSuiteParams {
+func (c *mockTLSExporter) GetCipherSuite() mint.CipherSuiteParams {
 	return mint.CipherSuiteParams{
 		Hash:   c.hash,
 		KeyLen: 32,
@@ -27,7 +27,7 @@ func (c *mockMintController) GetCipherSuite() mint.CipherSuiteParams {
 	}
 }
 
-func (c *mockMintController) ComputeExporter(label string, context []byte, keyLength int) ([]byte, error) {
+func (c *mockTLSExporter) ComputeExporter(label string, context []byte, keyLength int) ([]byte, error) {
 	if c.computerError != nil {
 		return nil, c.computerError
 	}
@@ -36,9 +36,9 @@ func (c *mockMintController) ComputeExporter(label string, context []byte, keyLe
 
 var _ = Describe("Key Derivation", func() {
 	It("derives keys", func() {
-		clientAEAD, err := DeriveAESKeys(&mockMintController{hash: crypto.SHA256}, protocol.PerspectiveClient)
+		clientAEAD, err := DeriveAESKeys(&mockTLSExporter{hash: crypto.SHA256}, protocol.PerspectiveClient)
 		Expect(err).ToNot(HaveOccurred())
-		serverAEAD, err := DeriveAESKeys(&mockMintController{hash: crypto.SHA256}, protocol.PerspectiveServer)
+		serverAEAD, err := DeriveAESKeys(&mockTLSExporter{hash: crypto.SHA256}, protocol.PerspectiveServer)
 		Expect(err).ToNot(HaveOccurred())
 		ciphertext := clientAEAD.Seal(nil, []byte("foobar"), 0, []byte("aad"))
 		data, err := serverAEAD.Open(nil, ciphertext, 0, []byte("aad"))
@@ -47,9 +47,9 @@ var _ = Describe("Key Derivation", func() {
 	})
 
 	It("fails when different hash functions are used", func() {
-		clientAEAD, err := DeriveAESKeys(&mockMintController{hash: crypto.SHA256}, protocol.PerspectiveClient)
+		clientAEAD, err := DeriveAESKeys(&mockTLSExporter{hash: crypto.SHA256}, protocol.PerspectiveClient)
 		Expect(err).ToNot(HaveOccurred())
-		serverAEAD, err := DeriveAESKeys(&mockMintController{hash: crypto.SHA512}, protocol.PerspectiveServer)
+		serverAEAD, err := DeriveAESKeys(&mockTLSExporter{hash: crypto.SHA512}, protocol.PerspectiveServer)
 		Expect(err).ToNot(HaveOccurred())
 		ciphertext := clientAEAD.Seal(nil, []byte("foobar"), 0, []byte("aad"))
 		_, err = serverAEAD.Open(nil, ciphertext, 0, []byte("aad"))
@@ -58,7 +58,7 @@ var _ = Describe("Key Derivation", func() {
 
 	It("fails when computing the exporter fails", func() {
 		testErr := errors.New("test error")
-		_, err := DeriveAESKeys(&mockMintController{hash: crypto.SHA256, computerError: testErr}, protocol.PerspectiveClient)
+		_, err := DeriveAESKeys(&mockTLSExporter{hash: crypto.SHA256, computerError: testErr}, protocol.PerspectiveClient)
 		Expect(err).To(MatchError(testErr))
 	})
 })

--- a/internal/handshake/crypto_setup_client.go
+++ b/internal/handshake/crypto_setup_client.go
@@ -66,6 +66,7 @@ var (
 
 // NewCryptoSetupClient creates a new CryptoSetup instance for a client
 func NewCryptoSetupClient(
+	cryptoStream io.ReadWriter,
 	hostname string,
 	connID protocol.ConnectionID,
 	version protocol.VersionNumber,
@@ -76,6 +77,7 @@ func NewCryptoSetupClient(
 	negotiatedVersions []protocol.VersionNumber,
 ) (CryptoSetup, error) {
 	return &cryptoSetupClient{
+		cryptoStream:       cryptoStream,
 		hostname:           hostname,
 		connID:             connID,
 		version:            version,
@@ -91,11 +93,9 @@ func NewCryptoSetupClient(
 	}, nil
 }
 
-func (h *cryptoSetupClient) HandleCryptoStream(stream io.ReadWriter) error {
+func (h *cryptoSetupClient) HandleCryptoStream() error {
 	messageChan := make(chan HandshakeMessage)
 	errorChan := make(chan error)
-
-	h.cryptoStream = stream
 
 	go func() {
 		for {

--- a/internal/handshake/crypto_setup_server.go
+++ b/internal/handshake/crypto_setup_server.go
@@ -67,6 +67,7 @@ var ErrNSTPExperiment = qerr.Error(qerr.InvalidCryptoMessageParameter, "NSTP exp
 
 // NewCryptoSetup creates a new CryptoSetup instance for a server
 func NewCryptoSetup(
+	cryptoStream io.ReadWriter,
 	connID protocol.ConnectionID,
 	remoteAddr net.Addr,
 	version protocol.VersionNumber,
@@ -78,6 +79,7 @@ func NewCryptoSetup(
 	aeadChanged chan<- protocol.EncryptionLevel,
 ) (CryptoSetup, error) {
 	return &cryptoSetupServer{
+		cryptoStream:      cryptoStream,
 		connID:            connID,
 		remoteAddr:        remoteAddr,
 		version:           version,
@@ -95,9 +97,7 @@ func NewCryptoSetup(
 }
 
 // HandleCryptoStream reads and writes messages on the crypto stream
-func (h *cryptoSetupServer) HandleCryptoStream(stream io.ReadWriter) error {
-	h.cryptoStream = stream
-
+func (h *cryptoSetupServer) HandleCryptoStream() error {
 	for {
 		var chloData bytes.Buffer
 		message, err := ParseHandshakeMessage(io.TeeReader(h.cryptoStream, &chloData))

--- a/internal/handshake/crypto_setup_server_test.go
+++ b/internal/handshake/crypto_setup_server_test.go
@@ -202,6 +202,7 @@ var _ = Describe("Server Crypto Setup", func() {
 		version = protocol.SupportedVersions[len(protocol.SupportedVersions)-1]
 		supportedVersions = []protocol.VersionNumber{version, 98, 99}
 		csInt, err := NewCryptoSetup(
+			stream,
 			protocol.ConnectionID(42),
 			remoteAddr,
 			version,
@@ -275,7 +276,7 @@ var _ = Describe("Server Crypto Setup", func() {
 					TagFHL2: []byte("foobar"),
 				},
 			}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(ErrHOLExperiment))
 		})
 
@@ -286,7 +287,7 @@ var _ = Describe("Server Crypto Setup", func() {
 					TagNSTP: []byte("foobar"),
 				},
 			}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(ErrNSTPExperiment))
 		})
 
@@ -369,7 +370,7 @@ var _ = Describe("Server Crypto Setup", func() {
 				},
 			}.Write(&stream.dataToRead)
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stream.dataWritten.Bytes()).To(HavePrefix("REJ"))
 			Expect(aeadChanged).To(Receive(Equal(protocol.EncryptionSecure)))
@@ -381,14 +382,14 @@ var _ = Describe("Server Crypto Setup", func() {
 		It("rejects client nonces that have the wrong length", func() {
 			fullCHLO[TagNONC] = []byte("too short client nonce")
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.InvalidCryptoMessageParameter, "invalid client nonce length")))
 		})
 
 		It("rejects client nonces that have the wrong OBIT value", func() {
 			fullCHLO[TagNONC] = make([]byte, 32) // the OBIT value is nonce[4:12] and here just initialized to 0
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.InvalidCryptoMessageParameter, "OBIT not matching")))
 		})
 
@@ -396,13 +397,13 @@ var _ = Describe("Server Crypto Setup", func() {
 			testErr := errors.New("test error")
 			kex.sharedKeyError = testErr
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(testErr))
 		})
 
 		It("handles 0-RTT handshake", func() {
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stream.dataWritten.Bytes()).To(HavePrefix("SHLO"))
 			Expect(stream.dataWritten.Bytes()).ToNot(ContainSubstring("REJ"))
@@ -459,14 +460,14 @@ var _ = Describe("Server Crypto Setup", func() {
 					TagSNI:  []byte("quic.clemente.io"),
 				},
 			}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.InvalidCryptoMessageParameter, "client hello missing version tag")))
 		})
 
 		It("rejects CHLOs with a version tag that has the wrong length", func() {
 			fullCHLO[TagVER] = []byte{0x13, 0x37} // should be 4 bytes
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.InvalidCryptoMessageParameter, "incorrect version tag")))
 		})
 
@@ -479,7 +480,7 @@ var _ = Describe("Server Crypto Setup", func() {
 			binary.LittleEndian.PutUint32(b, protocol.VersionNumberToTag(lowestSupportedVersion))
 			fullCHLO[TagVER] = b
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.VersionNegotiationMismatch, "Downgrade attack detected")))
 		})
 
@@ -492,35 +493,35 @@ var _ = Describe("Server Crypto Setup", func() {
 			binary.LittleEndian.PutUint32(b, protocol.VersionNumberToTag(unsupportedVersion))
 			fullCHLO[TagVER] = b
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("errors if the AEAD tag is missing", func() {
 			delete(fullCHLO, TagAEAD)
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.CryptoNoSupport, "Unsupported AEAD or KEXS")))
 		})
 
 		It("errors if the AEAD tag has the wrong value", func() {
 			fullCHLO[TagAEAD] = []byte("wrong")
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.CryptoNoSupport, "Unsupported AEAD or KEXS")))
 		})
 
 		It("errors if the KEXS tag is missing", func() {
 			delete(fullCHLO, TagKEXS)
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.CryptoNoSupport, "Unsupported AEAD or KEXS")))
 		})
 
 		It("errors if the KEXS tag has the wrong value", func() {
 			fullCHLO[TagKEXS] = []byte("wrong")
 			HandshakeMessage{Tag: TagCHLO, Data: fullCHLO}.Write(&stream.dataToRead)
-			err := cs.HandleCryptoStream(stream)
+			err := cs.HandleCryptoStream()
 			Expect(err).To(MatchError(qerr.Error(qerr.CryptoNoSupport, "Unsupported AEAD or KEXS")))
 		})
 	})
@@ -532,7 +533,7 @@ var _ = Describe("Server Crypto Setup", func() {
 				TagSTK: validSTK,
 			},
 		}.Write(&stream.dataToRead)
-		err := cs.HandleCryptoStream(stream)
+		err := cs.HandleCryptoStream()
 		Expect(err).To(MatchError("CryptoMessageParameterNotFound: SNI required"))
 	})
 
@@ -544,19 +545,19 @@ var _ = Describe("Server Crypto Setup", func() {
 				TagSNI: nil,
 			},
 		}.Write(&stream.dataToRead)
-		err := cs.HandleCryptoStream(stream)
+		err := cs.HandleCryptoStream()
 		Expect(err).To(MatchError("CryptoMessageParameterNotFound: SNI required"))
 	})
 
 	It("errors with invalid message", func() {
 		stream.dataToRead.Write([]byte("invalid message"))
-		err := cs.HandleCryptoStream(stream)
+		err := cs.HandleCryptoStream()
 		Expect(err).To(MatchError(qerr.HandshakeFailed))
 	})
 
 	It("errors with non-CHLO message", func() {
 		HandshakeMessage{Tag: TagPAD, Data: nil}.Write(&stream.dataToRead)
-		err := cs.HandleCryptoStream(stream)
+		err := cs.HandleCryptoStream()
 		Expect(err).To(MatchError(qerr.InvalidCryptoMessageType))
 	})
 

--- a/internal/handshake/crypto_setup_tls_test.go
+++ b/internal/handshake/crypto_setup_tls_test.go
@@ -43,6 +43,7 @@ var _ = Describe("TLS Crypto Setup", func() {
 		paramsChan = make(chan TransportParameters)
 		aeadChanged = make(chan protocol.EncryptionLevel, 2)
 		csInt, err := NewCryptoSetupTLSServer(
+			nil,
 			testdata.GetTLSConfig(),
 			&TransportParameters{},
 			paramsChan,
@@ -63,7 +64,7 @@ var _ = Describe("TLS Crypto Setup", func() {
 		newMintController = func(*mint.Conn) crypto.MintController {
 			return &fakeMintController{result: alert}
 		}
-		err := cs.HandleCryptoStream(nil)
+		err := cs.HandleCryptoStream()
 		Expect(err).To(MatchError(fmt.Errorf("TLS handshake error: %s (Alert %d)", alert.String(), alert)))
 	})
 
@@ -72,7 +73,7 @@ var _ = Describe("TLS Crypto Setup", func() {
 			return &fakeMintController{result: mint.AlertNoAlert}
 		}
 		cs.keyDerivation = mockKeyDerivation
-		err := cs.HandleCryptoStream(nil)
+		err := cs.HandleCryptoStream()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(aeadChanged).To(Receive(Equal(protocol.EncryptionForwardSecure)))
 		Expect(aeadChanged).To(BeClosed())
@@ -86,7 +87,7 @@ var _ = Describe("TLS Crypto Setup", func() {
 				return &fakeMintController{result: mint.AlertNoAlert}
 			}
 			cs.keyDerivation = mockKeyDerivation
-			err := cs.HandleCryptoStream(nil)
+			err := cs.HandleCryptoStream()
 			Expect(err).ToNot(HaveOccurred())
 		}
 

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -1,8 +1,6 @@
 package handshake
 
 import (
-	"io"
-
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 )
 
@@ -15,7 +13,7 @@ type Sealer interface {
 // CryptoSetup is a crypto setup
 type CryptoSetup interface {
 	Open(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte) ([]byte, protocol.EncryptionLevel, error)
-	HandleCryptoStream(io.ReadWriter) error
+	HandleCryptoStream() error
 	// TODO: clean up this interface
 	DiversificationNonce() []byte   // only needed for cryptoSetupServer
 	SetDiversificationNonce([]byte) // only needed for cryptoSetupClient

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -2,7 +2,6 @@ package quic
 
 import (
 	"bytes"
-	"io"
 	"math"
 
 	"github.com/lucas-clemente/quic-go/ackhandler"
@@ -33,7 +32,7 @@ type mockCryptoSetup struct {
 
 var _ handshake.CryptoSetup = &mockCryptoSetup{}
 
-func (m *mockCryptoSetup) HandleCryptoStream(io.ReadWriter) error {
+func (m *mockCryptoSetup) HandleCryptoStream() error {
 	return m.handleErr
 }
 func (m *mockCryptoSetup) Open(dst, src []byte, packetNumber protocol.PacketNumber, associatedData []byte) ([]byte, protocol.EncryptionLevel, error) {

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -61,11 +61,8 @@ var _ = Describe("Packet packer", func() {
 
 	BeforeEach(func() {
 		cryptoStream = &stream{flowController: flowcontrol.NewStreamFlowController(1, false, flowcontrol.NewConnectionFlowController(1000, 1000, nil), 1000, 1000, 1000, nil)}
-
 		streamsMap := newStreamsMap(nil, protocol.PerspectiveServer)
-		streamsMap.streams[1] = cryptoStream
-		streamsMap.openStreams = []protocol.StreamID{1}
-		streamFramer = newStreamFramer(streamsMap, nil)
+		streamFramer = newStreamFramer(cryptoStream, streamsMap, nil)
 
 		packer = &packetPacker{
 			cryptoSetup:           &mockCryptoSetup{encLevelSeal: protocol.EncryptionForwardSecure},

--- a/session_test.go
+++ b/session_test.go
@@ -157,6 +157,7 @@ var _ = Describe("Session", func() {
 
 		cryptoSetup = &mockCryptoSetup{}
 		newCryptoSetup = func(
+			_ io.ReadWriter,
 			_ protocol.ConnectionID,
 			_ net.Addr,
 			_ protocol.VersionNumber,
@@ -206,6 +207,7 @@ var _ = Describe("Session", func() {
 
 		BeforeEach(func() {
 			newCryptoSetup = func(
+				_ io.ReadWriter,
 				_ protocol.ConnectionID,
 				_ net.Addr,
 				_ protocol.VersionNumber,
@@ -1512,6 +1514,7 @@ var _ = Describe("Client Session", func() {
 
 		cryptoSetup = &mockCryptoSetup{}
 		newCryptoSetupClient = func(
+			_ io.ReadWriter,
 			_ string,
 			_ protocol.ConnectionID,
 			_ protocol.VersionNumber,

--- a/stream_framer_test.go
+++ b/stream_framer_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Stream Framer", func() {
 		streamsMap.putStream(stream2)
 
 		connFC = mocks.NewMockConnectionFlowController(mockCtrl)
-		framer = newStreamFramer(streamsMap, connFC)
+		framer = newStreamFramer(nil, streamsMap, connFC)
 	})
 
 	setNoData := func(str *mocks.MockStreamI) {


### PR DESCRIPTION
This will be very useful when moving forward with the IETF draft implementation, especially when (if) the crypto stream gets stream ID 0.

This also fixes #668.
Should be merged after #881.