### PR TITLE
remove the prioritisation of the H2 header stream

### DIFF
--- a/streams_map.go
+++ b/streams_map.go
@@ -277,21 +277,8 @@ func (m *streamsMap) RoundRobinIterate(fn streamLambda) error {
 	numStreams := len(m.streams)
 	startIndex := m.roundRobinIndex
 
-	// prioritize the header stream
-	cont, err := m.iterateFunc(3, fn)
-	if err != nil && err != errMapAccess {
-		return err
-	}
-	if !cont {
-		return nil
-	}
-
 	for i := 0; i < numStreams; i++ {
 		streamID := m.openStreams[(i+startIndex)%numStreams]
-		if streamID == 3 {
-			continue
-		}
-
 		cont, err := m.iterateFunc(streamID, fn)
 		if err != nil {
 			return err

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -685,29 +685,6 @@ var _ = Describe("Streams Map", func() {
 					Expect(m.roundRobinIndex).To(BeEquivalentTo(1))
 				})
 			})
-
-			Context("Prioritizing the header stream", func() {
-				BeforeEach(func() {
-					err := m.putStream(&stream{streamID: 3})
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("gets crypto- and header stream first, then picks up at the round-robin position", func() {
-					m.roundRobinIndex = 3 // stream 7
-					fn := func(str streamI) (bool, error) {
-						if numIterations >= 2 {
-							return false, nil
-						}
-						lambdaCalledForStream = append(lambdaCalledForStream, str.StreamID())
-						numIterations++
-						return true, nil
-					}
-					err := m.RoundRobinIterate(fn)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(numIterations).To(Equal(2))
-					Expect(lambdaCalledForStream).To(Equal([]protocol.StreamID{3, 7}))
-				})
-			})
 		})
 	})
 })


### PR DESCRIPTION
This was an optimization for H2/QUIC, which always violated the QUIC layering. The H2 header stream will (probably) be removed in IETF QUIC.

This will simplify things a lot when the crypto stream is moved to stream ID 0.

This PR depends on #891.