### PR TITLE
make flow control stricter when receiving final offsets

### DIFF
--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -52,6 +52,11 @@ func (c *streamFlowController) UpdateHighestReceived(byteOffset protocol.ByteCou
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
+	// when receiving a final offset, check that this final offset is consistent with a final offset we might have received earlier
+	if final && c.receivedFinalOffset && byteOffset != c.highestReceived {
+		return qerr.Error(qerr.StreamDataAfterTermination, fmt.Sprintf("Received inconsistent final offset for stream %d (old: %d, new: %d bytes)", c.streamID, c.highestReceived, byteOffset))
+	}
+	// if we already received a final offset, check that the offset in the STREAM frames is below the final offset
 	if c.receivedFinalOffset && byteOffset > c.highestReceived {
 		return qerr.StreamDataAfterTermination
 	}

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -124,6 +124,21 @@ var _ = Describe("Stream Flow controller", func() {
 				err = controller.UpdateHighestReceived(250, false)
 				Expect(err).To(MatchError(qerr.StreamDataAfterTermination))
 			})
+
+			It("accepts duplicate final offsets", func() {
+				err := controller.UpdateHighestReceived(200, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = controller.UpdateHighestReceived(200, true)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(controller.highestReceived).To(Equal(protocol.ByteCount(200)))
+			})
+
+			It("errors when receiving inconsistent final offsets", func() {
+				err := controller.UpdateHighestReceived(200, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = controller.UpdateHighestReceived(201, true)
+				Expect(err).To(MatchError("StreamDataAfterTermination: Received inconsistent final offset for stream 10 (old: 200, new: 201 bytes)"))
+			})
 		})
 
 		Context("registering data read", func() {

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -110,6 +110,20 @@ var _ = Describe("Stream Flow controller", func() {
 				err := controller.UpdateHighestReceived(99, true)
 				Expect(err).To(MatchError(qerr.StreamDataAfterTermination))
 			})
+
+			It("accepts delayed data after receiving a final offset", func() {
+				err := controller.UpdateHighestReceived(300, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = controller.UpdateHighestReceived(250, false)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("errors when receiving a higher offset after receiving a final offset", func() {
+				err := controller.UpdateHighestReceived(200, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = controller.UpdateHighestReceived(250, false)
+				Expect(err).To(MatchError(qerr.StreamDataAfterTermination))
+			})
 		})
 
 		Context("registering data read", func() {


### PR DESCRIPTION
1. Reject STREAM frames with a higher offset than a previously received highest offset.
2. Reject inconsistent final offsets.

Fixes #382.