### PR TITLE
update CIs to Go 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
 language: go
 
 go:
-  - 1.9
+  - 1.9.2
 
 # first part of the GOARCH workaround
 # setting the GOARCH directly doesn't work, since the value will be overwritten later

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ clone_folder: c:\gopath\src\github.com\lucas-clemente\quic-go
 
 install:
   - rmdir c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.9.windows-amd64.zip
-  - 7z x go1.9.windows-amd64.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.9.2.windows-amd64.zip
+  - 7z x go1.9.2.windows-amd64.zip -y -oC:\ > NUL
   - set PATH=%PATH%;%GOPATH%\bin\windows_%GOARCH%;%GOPATH%\bin
   - echo %PATH%
   - echo %GOPATH%


### PR DESCRIPTION
Apparently Travis' gimme 1.9.x is broken, see https://travis-ci.org/lucas-clemente/quic-go/builds/293537020.
We have to hardcode the Go version in the .travis.yml.