### PR TITLE
send IETF draft style version negotiation packets

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -321,7 +321,7 @@ var _ = Describe("Client", func() {
 				newVersion := protocol.VersionNumber(77)
 				Expect(newVersion).ToNot(Equal(cl.version))
 				Expect(config.Versions).To(ContainElement(newVersion))
-				packetConn.dataToRead = wire.ComposeVersionNegotiation(
+				packetConn.dataToRead = wire.ComposeGQUICVersionNegotiation(
 					cl.connectionID,
 					[]protocol.VersionNumber{newVersion},
 				)
@@ -395,17 +395,17 @@ var _ = Describe("Client", func() {
 				newVersion := protocol.VersionNumber(77)
 				Expect(newVersion).ToNot(Equal(cl.version))
 				Expect(config.Versions).To(ContainElement(newVersion))
-				cl.handlePacket(nil, wire.ComposeVersionNegotiation(0x1337, []protocol.VersionNumber{newVersion}))
+				cl.handlePacket(nil, wire.ComposeGQUICVersionNegotiation(0x1337, []protocol.VersionNumber{newVersion}))
 				Expect(atomic.LoadUint32(&sessionCounter)).To(BeEquivalentTo(2))
 				newVersion = protocol.VersionNumber(78)
 				Expect(newVersion).ToNot(Equal(cl.version))
 				Expect(config.Versions).To(ContainElement(newVersion))
-				cl.handlePacket(nil, wire.ComposeVersionNegotiation(0x1337, []protocol.VersionNumber{newVersion}))
+				cl.handlePacket(nil, wire.ComposeGQUICVersionNegotiation(0x1337, []protocol.VersionNumber{newVersion}))
 				Expect(atomic.LoadUint32(&sessionCounter)).To(BeEquivalentTo(2))
 			})
 
 			It("errors if no matching version is found", func() {
-				cl.handlePacket(nil, wire.ComposeVersionNegotiation(0x1337, []protocol.VersionNumber{1}))
+				cl.handlePacket(nil, wire.ComposeGQUICVersionNegotiation(0x1337, []protocol.VersionNumber{1}))
 				Expect(cl.session.(*mockSession).closed).To(BeTrue())
 				Expect(cl.session.(*mockSession).closeReason).To(MatchError(qerr.InvalidVersion))
 			})
@@ -414,13 +414,13 @@ var _ = Describe("Client", func() {
 				v := protocol.SupportedVersions[1]
 				Expect(v).ToNot(Equal(cl.version))
 				Expect(config.Versions).ToNot(ContainElement(v))
-				cl.handlePacket(nil, wire.ComposeVersionNegotiation(0x1337, []protocol.VersionNumber{v}))
+				cl.handlePacket(nil, wire.ComposeGQUICVersionNegotiation(0x1337, []protocol.VersionNumber{v}))
 				Expect(cl.session.(*mockSession).closed).To(BeTrue())
 				Expect(cl.session.(*mockSession).closeReason).To(MatchError(qerr.InvalidVersion))
 			})
 
 			It("changes to the version preferred by the quic.Config", func() {
-				cl.handlePacket(nil, wire.ComposeVersionNegotiation(0x1337, []protocol.VersionNumber{config.Versions[2], config.Versions[1]}))
+				cl.handlePacket(nil, wire.ComposeGQUICVersionNegotiation(0x1337, []protocol.VersionNumber{config.Versions[2], config.Versions[1]}))
 				Expect(cl.version).To(Equal(config.Versions[1]))
 			})
 
@@ -428,14 +428,14 @@ var _ = Describe("Client", func() {
 				// if the version was not yet negotiated, handlePacket would return a VersionNegotiationMismatch error, see above test
 				cl.versionNegotiated = true
 				Expect(sess.packetCount).To(BeZero())
-				cl.handlePacket(nil, wire.ComposeVersionNegotiation(0x1337, []protocol.VersionNumber{1}))
+				cl.handlePacket(nil, wire.ComposeGQUICVersionNegotiation(0x1337, []protocol.VersionNumber{1}))
 				Expect(cl.versionNegotiated).To(BeTrue())
 				Expect(sess.packetCount).To(BeZero())
 			})
 
 			It("drops version negotiation packets that contain the offered version", func() {
 				ver := cl.version
-				cl.handlePacket(nil, wire.ComposeVersionNegotiation(0x1337, []protocol.VersionNumber{ver}))
+				cl.handlePacket(nil, wire.ComposeGQUICVersionNegotiation(0x1337, []protocol.VersionNumber{ver}))
 				Expect(cl.version).To(Equal(ver))
 			})
 		})

--- a/internal/wire/public_header_test.go
+++ b/internal/wire/public_header_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Public Header", func() {
 			}
 
 			It("parses version negotiation packets sent by the server", func() {
-				b := bytes.NewReader(ComposeVersionNegotiation(0x1337, protocol.SupportedVersions))
+				b := bytes.NewReader(ComposeGQUICVersionNegotiation(0x1337, protocol.SupportedVersions))
 				hdr, err := parsePublicHeader(b, protocol.PerspectiveServer, protocol.VersionUnknown)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hdr.VersionFlag).To(BeTrue())
@@ -131,7 +131,7 @@ var _ = Describe("Public Header", func() {
 			})
 
 			It("errors on invalid version tags", func() {
-				data := ComposeVersionNegotiation(0x1337, protocol.SupportedVersions)
+				data := ComposeGQUICVersionNegotiation(0x1337, protocol.SupportedVersions)
 				data = append(data, []byte{0x13, 0x37}...)
 				b := bytes.NewReader(data)
 				_, err := parsePublicHeader(b, protocol.PerspectiveServer, protocol.VersionUnknown)

--- a/server.go
+++ b/server.go
@@ -266,15 +266,21 @@ func (s *server) handlePacket(pconn net.PacketConn, remoteAddr net.Addr, packet 
 		return nil
 	}
 
-	// Send Version Negotiation Packet if the client is speaking a different protocol version
+	// send a Version Negotiation Packet if the client is speaking a different protocol version
+	// since the client send a Public Header (only gQUIC has a Version Flag), we need to send a gQUIC Version Negotiation Packet
 	if hdr.VersionFlag && !protocol.IsSupportedVersion(s.config.Versions, hdr.Version) {
 		// drop packets that are too small to be valid first packets
 		if len(packet) < protocol.ClientHelloMinimumSize+len(hdr.Raw) {
 			return errors.New("dropping small packet with unknown version")
 		}
-		// TODO(894): send a IETF draft style Version Negotiation Packets
 		utils.Infof("Client offered version %s, sending VersionNegotiationPacket", hdr.Version)
-		_, err = pconn.WriteTo(wire.ComposeVersionNegotiation(hdr.ConnectionID, s.config.Versions), remoteAddr)
+		if _, err := pconn.WriteTo(wire.ComposeGQUICVersionNegotiation(hdr.ConnectionID, s.config.Versions), remoteAddr); err != nil {
+			return err
+		}
+	}
+	// send an IETF draft style Version Negotiation Packet, if the client sent an unsupported version with an IETF draft style header
+	if hdr.Type == protocol.PacketTypeClientInitial && !protocol.IsSupportedVersion(s.config.Versions, hdr.Version) {
+		_, err := pconn.WriteTo(wire.ComposeVersionNegotiation(hdr.ConnectionID, hdr.PacketNumber, s.config.Versions), remoteAddr)
 		return err
 	}
 


### PR DESCRIPTION
Fixes #894.

If we don't understand the version the client is offering, we don't know if this is an unsupported gQUIC version or an unsupported IETF QUIC version. We therefore send two Version Negotiation Packets, and let the client pick the one it is able to parse.