### PR TITLE
fix gQUIC version numbers

### DIFF
--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -7,13 +7,15 @@ import (
 // VersionNumber is a version number as int
 type VersionNumber int
 
-// gquicVersion0 is the "base" for gQUIC versions
-// e.g. version 39 is gquicVersion + 0x39
-const gquicVersion0 = 0x51303300
+// gQUIC version range as defined in the wiki: https://github.com/quicwg/base-drafts/wiki/QUIC-Versions
+const (
+	gquicVersion0   = 0x51303030
+	maxGquicVersion = 0x51303439
+)
 
 // The version numbers, making grepping easier
 const (
-	Version37 VersionNumber = gquicVersion0 + 0x37 + iota
+	Version37 VersionNumber = gquicVersion0 + 3*0x100 + 0x7 + iota
 	Version38
 	Version39
 	VersionTLS         VersionNumber = 101
@@ -46,8 +48,8 @@ func (vn VersionNumber) String() string {
 	case VersionTLS:
 		return "TLS dev version (WIP)"
 	default:
-		if vn > gquicVersion0 && vn <= gquicVersion0+0x99 {
-			return fmt.Sprintf("gQUIC %x", uint32(vn-gquicVersion0))
+		if vn > gquicVersion0 && vn <= maxGquicVersion {
+			return fmt.Sprintf("gQUIC %d", vn.toGQUICVersion())
 		}
 		return fmt.Sprintf("%d", vn)
 	}
@@ -55,10 +57,14 @@ func (vn VersionNumber) String() string {
 
 // ToAltSvc returns the representation of the version for the H2 Alt-Svc parameters
 func (vn VersionNumber) ToAltSvc() string {
-	if vn > gquicVersion0 && vn <= gquicVersion0+0x99 {
-		return fmt.Sprintf("%x", uint32(vn-gquicVersion0))
+	if vn > gquicVersion0 && vn <= maxGquicVersion {
+		return fmt.Sprintf("%d", vn.toGQUICVersion())
 	}
 	return fmt.Sprintf("%d", vn)
+}
+
+func (vn VersionNumber) toGQUICVersion() int {
+	return int(10*(vn-gquicVersion0)/0x100) + int(vn%0x10)
 }
 
 // IsSupportedVersion returns true if the server supports this version

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -6,6 +6,13 @@ import (
 )
 
 var _ = Describe("Version", func() {
+	// version numbers taken from the wiki: https://github.com/quicwg/base-drafts/wiki/QUIC-Versions
+	It("has the right gQUIC version number", func() {
+		Expect(Version37).To(BeEquivalentTo(0x51303337))
+		Expect(Version38).To(BeEquivalentTo(0x51303338))
+		Expect(Version39).To(BeEquivalentTo(0x51303339))
+	})
+
 	It("says if a version supports TLS", func() {
 		Expect(Version37.UsesTLS()).To(BeFalse())
 		Expect(Version38.UsesTLS()).To(BeFalse())
@@ -21,6 +28,11 @@ var _ = Describe("Version", func() {
 		Expect(VersionWhatever.String()).To(Equal("whatever"))
 		Expect(VersionUnsupported.String()).To(Equal("unsupported"))
 		Expect(VersionUnknown.String()).To(Equal("unknown"))
+		// check with unsupported version numbers from the wiki
+		Expect(VersionNumber(0x51303039).String()).To(Equal("gQUIC 9"))
+		Expect(VersionNumber(0x51303133).String()).To(Equal("gQUIC 13"))
+		Expect(VersionNumber(0x51303235).String()).To(Equal("gQUIC 25"))
+		Expect(VersionNumber(0x51303438).String()).To(Equal("gQUIC 48"))
 	})
 
 	It("has the right representation for the H2 Alt-Svc tag", func() {
@@ -28,6 +40,11 @@ var _ = Describe("Version", func() {
 		Expect(Version38.ToAltSvc()).To(Equal("38"))
 		Expect(Version39.ToAltSvc()).To(Equal("39"))
 		Expect(VersionTLS.ToAltSvc()).To(Equal("101"))
+		// check with unsupported version numbers from the wiki
+		Expect(VersionNumber(0x51303133).ToAltSvc()).To(Equal("13"))
+		Expect(VersionNumber(0x51303235).ToAltSvc()).To(Equal("25"))
+		Expect(VersionNumber(0x51303438).ToAltSvc()).To(Equal("48"))
+
 	})
 
 	It("recognizes supported versions", func() {


### PR DESCRIPTION
Fixes #911.

I got the math wrong in #896, it only worked for gQUIC version numbers Q030 - Q039.
I now added tests with unsupported version numbers from the QUIC WG wiki.