### PR TITLE
only use little endian byte order for gQUIC 37 and 38

### DIFF
--- a/internal/utils/byteorder.go
+++ b/internal/utils/byteorder.go
@@ -29,7 +29,7 @@ type ByteOrder interface {
 // GetByteOrder gets the ByteOrder (little endian or big endian) used to represent values on the wire
 // from QUIC 39, values are encoded in big endian, before that in little endian
 func GetByteOrder(v protocol.VersionNumber) ByteOrder {
-	if v < protocol.Version39 {
+	if v == protocol.Version37 || v == protocol.Version38 {
 		return LittleEndian
 	}
 	return BigEndian

--- a/internal/wire/public_header_test.go
+++ b/internal/wire/public_header_test.go
@@ -270,12 +270,12 @@ var _ = Describe("Public Header", func() {
 			hdr := Header{
 				ConnectionID:     0x4cfa9f9b668619f6,
 				OmitConnectionID: true,
-				PacketNumberLen:  protocol.PacketNumberLen6,
+				PacketNumberLen:  protocol.PacketNumberLen1,
 				PacketNumber:     1,
 			}
 			err := hdr.writePublicHeader(b, protocol.PerspectiveServer, protocol.VersionWhatever)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(b.Bytes()).To(Equal([]byte{0x30, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0}))
+			Expect(b.Bytes()).To(Equal([]byte{0x0, 0x1}))
 		})
 
 		It("writes diversification nonces", func() {
@@ -329,18 +329,18 @@ var _ = Describe("Public Header", func() {
 					VersionFlag:     true,
 					Version:         protocol.Version38,
 					ConnectionID:    0x4cfa9f9b668619f6,
-					PacketNumber:    0x1337,
-					PacketNumberLen: protocol.PacketNumberLen6,
+					PacketNumber:    0x42,
+					PacketNumberLen: protocol.PacketNumberLen1,
 				}
 				err := hdr.writePublicHeader(b, protocol.PerspectiveClient, protocol.VersionWhatever)
 				Expect(err).ToNot(HaveOccurred())
 				// must be the first assertion
-				Expect(b.Len()).To(Equal(1 + 8 + 4 + 6)) // 1 FlagByte + 8 ConnectionID + 4 version number + 6 PacketNumber
+				Expect(b.Len()).To(Equal(1 + 8 + 4 + 1)) // 1 FlagByte + 8 ConnectionID + 4 version number + 1 PacketNumber
 				firstByte, _ := b.ReadByte()
 				Expect(firstByte & 0x01).To(Equal(uint8(1)))
-				Expect(firstByte & 0x30).To(Equal(uint8(0x30)))
+				Expect(firstByte & 0x30).To(Equal(uint8(0x0)))
 				Expect(string(b.Bytes()[8:12])).To(Equal("Q038"))
-				Expect(b.Bytes()[12:18]).To(Equal([]byte{0x37, 0x13, 0, 0, 0, 0}))
+				Expect(b.Bytes()[12:13]).To(Equal([]byte{0x42}))
 			})
 		})
 

--- a/session_test.go
+++ b/session_test.go
@@ -813,7 +813,7 @@ var _ = Describe("Session", func() {
 			Expect(sess.sentPacketHandler.(*mockSentPacketHandler).sentPackets[0].Frames).To(ContainElement(&wire.PingFrame{}))
 		})
 
-		It("sends two WindowUpdate frames", func() {
+		It("sends two WINDOW_UPDATE frames", func() {
 			mockFC := mocks.NewMockStreamFlowController(mockCtrl)
 			mockFC.EXPECT().GetWindowUpdate().Return(protocol.ByteCount(0x1000))
 			mockFC.EXPECT().GetWindowUpdate().Return(protocol.ByteCount(0)).Times(2)
@@ -830,7 +830,7 @@ var _ = Describe("Session", func() {
 			(&wire.WindowUpdateFrame{
 				StreamID:   5,
 				ByteOffset: 0x1000,
-			}).Write(buf, protocol.VersionWhatever)
+			}).Write(buf, sess.version)
 			Expect(mconn.written).To(HaveLen(2))
 			Expect(mconn.written).To(Receive(ContainSubstring(string(buf.Bytes()))))
 			Expect(mconn.written).To(Receive(ContainSubstring(string(buf.Bytes()))))


### PR DESCRIPTION
Fixes #914.

That way, when adding new non-gQUIC versions, they will use big endian.