### PR TITLE
accept Public Resets without the RSEQ tag

### DIFF
--- a/internal/wire/public_reset.go
+++ b/internal/wire/public_reset.go
@@ -43,14 +43,15 @@ func ParsePublicReset(r *bytes.Reader) (*PublicReset, error) {
 		return nil, errors.New("wrong public reset tag")
 	}
 
-	rseq, ok := msg.Data[handshake.TagRSEQ]
-	if !ok {
-		return nil, errors.New("RSEQ missing")
+	// The RSEQ tag is mandatory according to the gQUIC wire spec.
+	// However, Google doesn't send RSEQ in their Public Resets.
+	// Therefore, we'll treat RSEQ as an optional field.
+	if rseq, ok := msg.Data[handshake.TagRSEQ]; ok {
+		if len(rseq) != 8 {
+			return nil, errors.New("invalid RSEQ tag")
+		}
+		pr.RejectedPacketNumber = protocol.PacketNumber(binary.LittleEndian.Uint64(rseq))
 	}
-	if len(rseq) != 8 {
-		return nil, errors.New("invalid RSEQ tag")
-	}
-	pr.RejectedPacketNumber = protocol.PacketNumber(binary.LittleEndian.Uint64(rseq))
 
 	rnon, ok := msg.Data[handshake.TagRNON]
 	if !ok {
@@ -60,6 +61,5 @@ func ParsePublicReset(r *bytes.Reader) (*PublicReset, error) {
 		return nil, errors.New("invalid RNON tag")
 	}
 	pr.Nonce = binary.LittleEndian.Uint64(rnon)
-
 	return &pr, nil
 }

--- a/internal/wire/public_reset_test.go
+++ b/internal/wire/public_reset_test.go
@@ -73,13 +73,14 @@ var _ = Describe("public reset", func() {
 			Expect(err).To(MatchError("invalid RNON tag"))
 		})
 
-		It("rejects packets missing the rejected packet number", func() {
+		It("accepts packets missing the rejected packet number", func() {
 			data := map[handshake.Tag][]byte{
 				handshake.TagRNON: []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37},
 			}
 			handshake.HandshakeMessage{Tag: handshake.TagPRST, Data: data}.Write(b)
-			_, err := ParsePublicReset(bytes.NewReader(b.Bytes()))
-			Expect(err).To(MatchError("RSEQ missing"))
+			pr, err := ParsePublicReset(bytes.NewReader(b.Bytes()))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pr.Nonce).To(Equal(uint64(0x3713fecaefbeadde)))
 		})
 
 		It("rejects packets with a wrong length rejected packet number", func() {


### PR DESCRIPTION
Fixes #941.

The RSEQ tag is mandatory according to the gQUIC spec, however, Google doesn't include that tag in its Public Resets.