### PR TITLE
fix encoding of the idle timeout for the TLS transport parameters

### DIFF
--- a/internal/handshake/transport_parameter_test.go
+++ b/internal/handshake/transport_parameter_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Transport Parameters", func() {
 				params = &TransportParameters{
 					StreamFlowControlWindow:     0xdeadbeef,
 					ConnectionFlowControlWindow: 0xdecafbad,
-					IdleTimeout:                 0xcafe,
+					IdleTimeout:                 0xcafe * time.Second,
 				}
 			})
 

--- a/internal/handshake/transport_parameters.go
+++ b/internal/handshake/transport_parameters.go
@@ -150,7 +150,7 @@ func (p *TransportParameters) getTransportParameters() []transportParameter {
 	// TODO: use a reasonable value here
 	binary.BigEndian.PutUint32(initialMaxStreamID, math.MaxUint32)
 	idleTimeout := make([]byte, 2)
-	binary.BigEndian.PutUint16(idleTimeout, uint16(p.IdleTimeout))
+	binary.BigEndian.PutUint16(idleTimeout, uint16(p.IdleTimeout/time.Second))
 	maxPacketSize := make([]byte, 2)
 	binary.BigEndian.PutUint16(maxPacketSize, uint16(protocol.MaxReceivePacketSize))
 	params := []transportParameter{


### PR DESCRIPTION
This bug was found during interop testing with quant.