### PR TITLE
rename the Cleartext Long Header type to Handshake

### DIFF
--- a/internal/handshake/crypto_setup_tls.go
+++ b/internal/handshake/crypto_setup_tls.go
@@ -213,7 +213,7 @@ func (h *cryptoSetupTLS) determineNextPacketType() error {
 		case "ServerStateStart": // if we're still at ServerStateStart when writing the first packet, that means we've come back to that state by sending a HelloRetryRequest
 			h.nextPacketType = protocol.PacketTypeRetry
 		case "ServerStateWaitFinished":
-			h.nextPacketType = protocol.PacketTypeCleartext
+			h.nextPacketType = protocol.PacketTypeHandshake
 		default:
 			// TODO: accept 0-RTT data
 			return fmt.Errorf("Unexpected handshake state: %s", state)
@@ -222,7 +222,7 @@ func (h *cryptoSetupTLS) determineNextPacketType() error {
 	}
 	// client
 	if state != "ClientStateWaitSH" {
-		h.nextPacketType = protocol.PacketTypeCleartext
+		h.nextPacketType = protocol.PacketTypeHandshake
 	}
 	return nil
 }

--- a/internal/handshake/crypto_setup_tls_test.go
+++ b/internal/handshake/crypto_setup_tls_test.go
@@ -102,7 +102,7 @@ var _ = Describe("TLS Crypto Setup", func() {
 				Expect(csClient.GetNextPacketType()).To(Equal(protocol.PacketTypeInitial))
 			})
 
-			It("sends a Client Cleartext after the server sent a Server Hello", func() {
+			It("sends a Handshake packet after the server sent a Server Hello", func() {
 				csClient.tls.(*mockhandshake.MockmintTLS).EXPECT().State().Return(mint.ConnectionState{HandshakeState: "ClientStateWaitEE"})
 				err := csClient.determineNextPacketType()
 				Expect(err).ToNot(HaveOccurred())
@@ -121,11 +121,11 @@ var _ = Describe("TLS Crypto Setup", func() {
 				Expect(cs.GetNextPacketType()).To(Equal(protocol.PacketTypeRetry))
 			})
 
-			It("sends a Server Cleartext packet", func() {
+			It("sends Handshake packet", func() {
 				cs.tls.(*mockhandshake.MockmintTLS).EXPECT().State().Return(mint.ConnectionState{HandshakeState: "ServerStateWaitFinished"})
 				err := cs.determineNextPacketType()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cs.GetNextPacketType()).To(Equal(protocol.PacketTypeCleartext))
+				Expect(cs.GetNextPacketType()).To(Equal(protocol.PacketTypeHandshake))
 			})
 		})
 	})

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -31,8 +31,8 @@ const (
 	PacketTypeInitial PacketType = 2
 	// PacketTypeRetry is the packet type of a Retry packet
 	PacketTypeRetry PacketType = 3
-	// PacketTypeCleartext is the packet type of a Cleartext packet
-	PacketTypeCleartext PacketType = 4
+	// PacketTypeHandshake is the packet type of a Cleartext packet
+	PacketTypeHandshake PacketType = 4
 	// PacketType0RTT is the packet type of a 0-RTT packet
 	PacketType0RTT PacketType = 5
 )

--- a/internal/wire/ietf_header.go
+++ b/internal/wire/ietf_header.go
@@ -35,13 +35,13 @@ func parseLongHeader(b *bytes.Reader, sentBy protocol.Perspective, typeByte byte
 		return nil, err
 	}
 	packetType := protocol.PacketType(typeByte & 0x7f)
-	if sentBy == protocol.PerspectiveClient && (packetType != protocol.PacketTypeInitial && packetType != protocol.PacketTypeCleartext && packetType != protocol.PacketType0RTT) {
+	if sentBy == protocol.PerspectiveClient && (packetType != protocol.PacketTypeInitial && packetType != protocol.PacketTypeHandshake && packetType != protocol.PacketType0RTT) {
 		if packetType == protocol.PacketTypeVersionNegotiation {
 			return nil, qerr.Error(qerr.InvalidVersionNegotiationPacket, "sent by the client")
 		}
 		return nil, qerr.Error(qerr.InvalidPacketHeader, fmt.Sprintf("Received packet with invalid packet type: %d", packetType))
 	}
-	if sentBy == protocol.PerspectiveServer && (packetType != protocol.PacketTypeVersionNegotiation && packetType != protocol.PacketTypeRetry && packetType != protocol.PacketTypeCleartext) {
+	if sentBy == protocol.PerspectiveServer && (packetType != protocol.PacketTypeVersionNegotiation && packetType != protocol.PacketTypeRetry && packetType != protocol.PacketTypeHandshake) {
 		return nil, qerr.Error(qerr.InvalidPacketHeader, fmt.Sprintf("Received packet with invalid packet type: %d", packetType))
 	}
 	h := &Header{


### PR DESCRIPTION
This is the restored branch from #950. For some reason, Github doesn't allow me to restore the PR. It was already approved there.
Fixes #946.

This was recently changed in the draft.