### PR TITLE
Make error chan not block for a single write

### DIFF
--- a/internal/handshake/crypto_setup_client.go
+++ b/internal/handshake/crypto_setup_client.go
@@ -102,7 +102,7 @@ func NewCryptoSetupClient(
 
 func (h *cryptoSetupClient) HandleCryptoStream() error {
 	messageChan := make(chan HandshakeMessage)
-	errorChan := make(chan error)
+	errorChan := make(chan error, 1)
 
 	go func() {
 		for {


### PR DESCRIPTION
This fixes #953 

It allows the ParseHandshakeMessage goroutine to gracefully exit if the cryptoSetupClient has already exited.