### PR TITLE
disable connection migration

### DIFF
--- a/session.go
+++ b/session.go
@@ -448,14 +448,6 @@ func (s *session) handlePacketImpl(p *receivedPacket) error {
 		hdr.Log()
 	}
 	// if the decryption failed, this might be a packet sent by an attacker
-	// don't update the remote address
-	if quicErr, ok := err.(*qerr.QuicError); ok && quicErr.ErrorCode == qerr.DecryptionFailure {
-		return err
-	}
-	if s.perspective == protocol.PerspectiveServer {
-		// update the remote address, even if unpacking failed for any other reason than a decryption error
-		s.conn.SetCurrentRemoteAddr(p.remoteAddr)
-	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Connection migration is complicated: We need to verify the new path, and reset the congestion controller. In the IETF draft, connection migration is still work in progress.