### PR TITLE
implement the new varint frame types

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"fmt"
-	"math"
 )
 
 // A PacketNumber in QUIC
@@ -57,13 +56,13 @@ func (t PacketType) String() string {
 type ConnectionID uint64
 
 // A StreamID in QUIC
-type StreamID uint32
+type StreamID uint64
 
 // A ByteCount in QUIC
 type ByteCount uint64
 
 // MaxByteCount is the maximum value of a ByteCount
-const MaxByteCount = ByteCount(math.MaxUint64)
+const MaxByteCount = ByteCount(1<<62 - 1)
 
 // MaxReceivePacketSize maximum packet size of any QUIC packet, based on
 // ethernet's max size, minus the IP and UDP headers. IPv6 has a 40 byte header,

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -66,9 +66,9 @@ func (vn VersionNumber) CryptoStreamID() StreamID {
 	return 0
 }
 
-// UsesMaxDataFrame tells if this version uses MAX_DATA, MAX_STREAM_DATA, BLOCKED and STREAM_BLOCKED instead of WINDOW_UDPATE and BLOCKED frames
-func (vn VersionNumber) UsesMaxDataFrame() bool {
-	return vn.CryptoStreamID() == 0
+// UsesIETFFrameFormat tells if this version uses the IETF frame format
+func (vn VersionNumber) UsesIETFFrameFormat() bool {
+	return vn != Version39
 }
 
 // StreamContributesToConnectionFlowControl says if a stream contributes to connection-level flow control

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -51,9 +51,9 @@ var _ = Describe("Version", func() {
 		Expect(VersionTLS.CryptoStreamID()).To(Equal(StreamID(0)))
 	})
 
-	It("tells if a version uses the MAX_DATA, MAX_STREAM_DATA, BLOCKED and STREAM_BLOCKED frames", func() {
-		Expect(Version39.UsesMaxDataFrame()).To(BeFalse())
-		Expect(VersionTLS.UsesMaxDataFrame()).To(BeTrue())
+	It("tells if a version uses the IETF frame types", func() {
+		Expect(Version39.UsesIETFFrameFormat()).To(BeFalse())
+		Expect(VersionTLS.UsesIETFFrameFormat()).To(BeTrue())
 	})
 
 	It("says if a stream contributes to connection-level flowcontrol, for gQUIC", func() {

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -56,6 +56,11 @@ var _ = Describe("Version", func() {
 		Expect(VersionTLS.UsesIETFFrameFormat()).To(BeTrue())
 	})
 
+	It("tells if a version uses the IETF frame types", func() {
+		Expect(Version39.UsesIETFFrameFormat()).To(BeFalse())
+		Expect(VersionTLS.UsesIETFFrameFormat()).To(BeTrue())
+	})
+
 	It("says if a stream contributes to connection-level flowcontrol, for gQUIC", func() {
 		Expect(Version39.StreamContributesToConnectionFlowControl(1)).To(BeFalse())
 		Expect(Version39.StreamContributesToConnectionFlowControl(2)).To(BeTrue())

--- a/internal/utils/varint.go
+++ b/internal/utils/varint.go
@@ -1,0 +1,101 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+)
+
+// taken from the QUIC draft
+const (
+	maxVarInt1 = 63
+	maxVarInt2 = 16383
+	maxVarInt4 = 1073741823
+	maxVarInt8 = 4611686018427387903
+)
+
+// ReadVarInt reads a number in the QUIC varint format
+func ReadVarInt(b io.ByteReader) (uint64, error) {
+	firstByte, err := b.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	// the first two bits of the first byte encode the length
+	len := 1 << ((firstByte & 0xc0) >> 6)
+	b1 := firstByte & (0xff - 0xc0)
+	if len == 1 {
+		return uint64(b1), nil
+	}
+	b2, err := b.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	if len == 2 {
+		return uint64(b2) + uint64(b1)<<8, nil
+	}
+	b3, err := b.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	b4, err := b.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	if len == 4 {
+		return uint64(b4) + uint64(b3)<<8 + uint64(b2)<<16 + uint64(b1)<<24, nil
+	}
+	b5, err := b.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	b6, err := b.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	b7, err := b.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	b8, err := b.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(b8) + uint64(b7)<<8 + uint64(b6)<<16 + uint64(b5)<<24 + uint64(b4)<<32 + uint64(b3)<<40 + uint64(b2)<<48 + uint64(b1)<<56, nil
+}
+
+// WriteVarInt writes a number in the QUIC varint format
+func WriteVarInt(b *bytes.Buffer, i uint64) {
+	if i <= maxVarInt1 {
+		b.WriteByte(uint8(i))
+	} else if i <= maxVarInt2 {
+		b.Write([]byte{uint8(i>>8) | 0x40, uint8(i)})
+	} else if i <= maxVarInt4 {
+		b.Write([]byte{uint8(i>>24) | 0x80, uint8(i >> 16), uint8(i >> 8), uint8(i)})
+	} else if i <= maxVarInt8 {
+		b.Write([]byte{
+			uint8(i>>56) | 0xc0, uint8(i >> 48), uint8(i >> 40), uint8(i >> 32),
+			uint8(i >> 24), uint8(i >> 16), uint8(i >> 8), uint8(i),
+		})
+	} else {
+		panic(fmt.Sprintf("%#x doesn't fit into 62 bits", i))
+	}
+}
+
+// VarIntLen determines the number of bytes that will be needed to write a number
+func VarIntLen(i uint64) protocol.ByteCount {
+	if i <= maxVarInt1 {
+		return 1
+	}
+	if i <= maxVarInt2 {
+		return 2
+	}
+	if i <= maxVarInt4 {
+		return 4
+	}
+	if i <= maxVarInt8 {
+		return 8
+	}
+	panic(fmt.Sprintf("%#x doesn't fit into 62 bits", i))
+}

--- a/internal/utils/varint_test.go
+++ b/internal/utils/varint_test.go
@@ -1,0 +1,157 @@
+package utils
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Varint encoding / decoding", func() {
+	Context("decoding", func() {
+		It("reads a 1 byte number", func() {
+			b := bytes.NewReader([]byte{25}) // 00011001
+			val, err := ReadVarInt(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(uint64(25)))
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("reads a number that is encoded too long", func() {
+			b := bytes.NewReader([]byte{0x40, 0x25}) // first byte: 01000000
+			val, err := ReadVarInt(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(uint64(37)))
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("reads a 2 byte number", func() {
+			b := bytes.NewReader([]byte{0x7b, 0xbd}) // first byte: 01111011
+			val, err := ReadVarInt(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(uint64(15293)))
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("reads a 4 byte number", func() {
+			b := bytes.NewReader([]byte{0x9d, 0x7f, 0x3e, 0x7d}) // first byte: 10011011
+			val, err := ReadVarInt(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(uint64(494878333)))
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("reads an 8 byte number", func() {
+			b := bytes.NewReader([]byte{0xc2, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c}) // first byte: 10000010
+			val, err := ReadVarInt(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(val).To(Equal(uint64(151288809941952652)))
+			Expect(b.Len()).To(BeZero())
+		})
+	})
+
+	Context("encoding", func() {
+		It("writes a 1 byte number", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, 37)
+			Expect(b.Bytes()).To(Equal([]byte{0x25}))
+		})
+
+		It("writes the maximum 1 byte number in 1 byte", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, maxVarInt1)
+			Expect(b.Bytes()).To(Equal([]byte{0x3f /* 00111111 */}))
+		})
+
+		It("writes the minimum 2 byte number in 2 bytes", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, maxVarInt1+1)
+			Expect(b.Bytes()).To(Equal([]byte{0x40, maxVarInt1 + 1}))
+		})
+
+		It("writes a 2 byte number", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, 15293)
+			Expect(b.Bytes()).To(Equal([]byte{0x7b, 0xbd}))
+		})
+
+		It("writes the maximum 2 byte number in 2 bytes", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, maxVarInt2)
+			Expect(b.Bytes()).To(Equal([]byte{0x7f /* 01111111 */, 0xff}))
+		})
+
+		It("writes the minimum 4 byte number in 4 bytes", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, maxVarInt2+1)
+			Expect(b.Len()).To(Equal(4))
+			num, err := ReadVarInt(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(num).To(Equal(uint64(maxVarInt2 + 1)))
+		})
+
+		It("writes a 4 byte number", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, 494878333)
+			Expect(b.Bytes()).To(Equal([]byte{0x9d, 0x7f, 0x3e, 0x7d}))
+		})
+
+		It("writes the maximum 4 byte number in 4 bytes", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, maxVarInt4)
+			Expect(b.Bytes()).To(Equal([]byte{0xbf /* 10111111 */, 0xff, 0xff, 0xff}))
+		})
+
+		It("writes the minimum 8 byte number in 8 bytes", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, maxVarInt4+1)
+			Expect(b.Len()).To(Equal(8))
+			num, err := ReadVarInt(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(num).To(Equal(uint64(maxVarInt4 + 1)))
+		})
+
+		It("writes an 8 byte number", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, 151288809941952652)
+			Expect(b.Bytes()).To(Equal([]byte{0xc2, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c}))
+		})
+
+		It("writes the maximum 8 byte number in 8 bytes", func() {
+			b := &bytes.Buffer{}
+			WriteVarInt(b, maxVarInt8)
+			Expect(b.Bytes()).To(Equal([]byte{0xff /* 11111111 */, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}))
+		})
+
+		It("panics when given a too large number (> 62 bit)", func() {
+			b := &bytes.Buffer{}
+			Expect(func() { WriteVarInt(b, maxVarInt8+1) }).Should(Panic())
+		})
+	})
+
+	Context("determining the length needed for encoding", func() {
+		It("for numbers that need 1 byte", func() {
+			Expect(VarIntLen(0)).To(BeEquivalentTo(1))
+			Expect(VarIntLen(maxVarInt1)).To(BeEquivalentTo(1))
+		})
+
+		It("for numbers that need 2 bytes", func() {
+			Expect(VarIntLen(maxVarInt1 + 1)).To(BeEquivalentTo(2))
+			Expect(VarIntLen(maxVarInt2)).To(BeEquivalentTo(2))
+		})
+
+		It("for numbers that need 4 bytes", func() {
+			Expect(VarIntLen(maxVarInt2 + 1)).To(BeEquivalentTo(4))
+			Expect(VarIntLen(maxVarInt4)).To(BeEquivalentTo(4))
+		})
+
+		It("for numbers that need 8 bytes", func() {
+			Expect(VarIntLen(maxVarInt4 + 1)).To(BeEquivalentTo(8))
+			Expect(VarIntLen(maxVarInt8)).To(BeEquivalentTo(8))
+		})
+
+		It("panics when given a too large number (> 62 bit)", func() {
+			Expect(func() { VarIntLen(maxVarInt8 + 1) }).Should(Panic())
+		})
+	})
+})

--- a/internal/wire/ack_frame.go
+++ b/internal/wire/ack_frame.go
@@ -9,340 +9,166 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
-var (
-	// ErrInvalidAckRanges occurs when a client sends inconsistent ACK ranges
-	ErrInvalidAckRanges = errors.New("AckFrame: ACK frame contains invalid ACK ranges")
-	// ErrInvalidFirstAckRange occurs when the first ACK range contains no packets
-	ErrInvalidFirstAckRange = errors.New("AckFrame: ACK frame has invalid first ACK range")
-)
+// TODO: use the value sent in the transport parameters
+const ackDelayExponent = 3
 
-var (
-	errInconsistentAckLargestAcked = errors.New("internal inconsistency: LargestAcked does not match ACK ranges")
-	errInconsistentAckLowestAcked  = errors.New("internal inconsistency: LowestAcked does not match ACK ranges")
-)
-
-// An AckFrame is an ACK frame in QUIC
+// An AckFrame is an ACK frame
 type AckFrame struct {
 	LargestAcked protocol.PacketNumber
 	LowestAcked  protocol.PacketNumber
 	AckRanges    []AckRange // has to be ordered. The highest ACK range goes first, the lowest ACK range goes last
 
 	// time when the LargestAcked was receiveid
-	// this field Will not be set for received ACKs frames
+	// this field will not be set for received ACKs frames
 	PacketReceivedTime time.Time
 	DelayTime          time.Duration
 }
 
 // ParseAckFrame reads an ACK frame
 func ParseAckFrame(r *bytes.Reader, version protocol.VersionNumber) (*AckFrame, error) {
-	frame := &AckFrame{}
+	if !version.UsesIETFFrameFormat() {
+		return parseAckFrameLegacy(r, version)
+	}
 
-	typeByte, err := r.ReadByte()
-	if err != nil {
+	if _, err := r.ReadByte(); err != nil {
 		return nil, err
 	}
 
-	hasMissingRanges := false
-	if typeByte&0x20 == 0x20 {
-		hasMissingRanges = true
-	}
+	frame := &AckFrame{}
 
-	largestAckedLen := 2 * ((typeByte & 0x0C) >> 2)
-	if largestAckedLen == 0 {
-		largestAckedLen = 1
-	}
-
-	missingSequenceNumberDeltaLen := 2 * (typeByte & 0x03)
-	if missingSequenceNumberDeltaLen == 0 {
-		missingSequenceNumberDeltaLen = 1
-	}
-
-	largestAcked, err := utils.GetByteOrder(version).ReadUintN(r, largestAckedLen)
+	largestAcked, err := utils.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
 	frame.LargestAcked = protocol.PacketNumber(largestAcked)
-
-	delay, err := utils.GetByteOrder(version).ReadUfloat16(r)
+	delay, err := utils.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
-	frame.DelayTime = time.Duration(delay) * time.Microsecond
+	frame.DelayTime = time.Duration(delay*1<<ackDelayExponent) * time.Microsecond
+	numBlocks, err := utils.ReadVarInt(r)
+	if err != nil {
+		return nil, err
+	}
 
-	var numAckBlocks uint8
-	if hasMissingRanges {
-		numAckBlocks, err = r.ReadByte()
+	// read the first ACK range
+	ab, err := utils.ReadVarInt(r)
+	if err != nil {
+		return nil, err
+	}
+	ackBlock := protocol.PacketNumber(ab)
+	if ackBlock > frame.LargestAcked {
+		return nil, errors.New("invalid first ACK range")
+	}
+	smallest := frame.LargestAcked - protocol.PacketNumber(ackBlock)
+
+	// read all the other ACK ranges
+	if numBlocks > 0 {
+		frame.AckRanges = append(frame.AckRanges, AckRange{First: smallest, Last: frame.LargestAcked})
+	}
+	for i := uint64(0); i < numBlocks; i++ {
+		g, err := utils.ReadVarInt(r)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if hasMissingRanges && numAckBlocks == 0 {
-		return nil, ErrInvalidAckRanges
-	}
-
-	ackBlockLength, err := utils.GetByteOrder(version).ReadUintN(r, missingSequenceNumberDeltaLen)
-	if err != nil {
-		return nil, err
-	}
-	if frame.LargestAcked > 0 && ackBlockLength < 1 {
-		return nil, ErrInvalidFirstAckRange
-	}
-
-	if ackBlockLength > largestAcked+1 {
-		return nil, ErrInvalidAckRanges
-	}
-
-	if hasMissingRanges {
-		ackRange := AckRange{
-			First: protocol.PacketNumber(largestAcked-ackBlockLength) + 1,
-			Last:  frame.LargestAcked,
+		gap := protocol.PacketNumber(g)
+		if smallest < gap+2 {
+			return nil, errInvalidAckRanges
 		}
-		frame.AckRanges = append(frame.AckRanges, ackRange)
+		largest := smallest - gap - 2
 
-		var inLongBlock bool
-		var lastRangeComplete bool
-		for i := uint8(0); i < numAckBlocks; i++ {
-			var gap uint8
-			gap, err = r.ReadByte()
-			if err != nil {
-				return nil, err
-			}
-
-			ackBlockLength, err = utils.GetByteOrder(version).ReadUintN(r, missingSequenceNumberDeltaLen)
-			if err != nil {
-				return nil, err
-			}
-
-			length := protocol.PacketNumber(ackBlockLength)
-
-			if inLongBlock {
-				frame.AckRanges[len(frame.AckRanges)-1].First -= protocol.PacketNumber(gap) + length
-				frame.AckRanges[len(frame.AckRanges)-1].Last -= protocol.PacketNumber(gap)
-			} else {
-				lastRangeComplete = false
-				ackRange := AckRange{
-					Last: frame.AckRanges[len(frame.AckRanges)-1].First - protocol.PacketNumber(gap) - 1,
-				}
-				ackRange.First = ackRange.Last - length + 1
-				frame.AckRanges = append(frame.AckRanges, ackRange)
-			}
-
-			if length > 0 {
-				lastRangeComplete = true
-			}
-
-			inLongBlock = (ackBlockLength == 0)
+		ab, err := utils.ReadVarInt(r)
+		if err != nil {
+			return nil, err
 		}
+		ackBlock := protocol.PacketNumber(ab)
 
-		// if the last range was not complete, First and Last make no sense
-		// remove the range from frame.AckRanges
-		if !lastRangeComplete {
-			frame.AckRanges = frame.AckRanges[:len(frame.AckRanges)-1]
+		if ackBlock > largest {
+			return nil, errInvalidAckRanges
 		}
-
-		frame.LowestAcked = frame.AckRanges[len(frame.AckRanges)-1].First
-	} else {
-		if frame.LargestAcked == 0 {
-			frame.LowestAcked = 0
-		} else {
-			frame.LowestAcked = protocol.PacketNumber(largestAcked + 1 - ackBlockLength)
-		}
+		smallest = largest - protocol.PacketNumber(ackBlock)
+		frame.AckRanges = append(frame.AckRanges, AckRange{First: smallest, Last: largest})
 	}
 
+	frame.LowestAcked = smallest
 	if !frame.validateAckRanges() {
-		return nil, ErrInvalidAckRanges
+		return nil, errInvalidAckRanges
 	}
 
-	var numTimestamp byte
-	numTimestamp, err = r.ReadByte()
-	if err != nil {
-		return nil, err
-	}
-
-	if numTimestamp > 0 {
-		// Delta Largest acked
-		_, err = r.ReadByte()
-		if err != nil {
-			return nil, err
-		}
-		// First Timestamp
-		_, err = utils.GetByteOrder(version).ReadUint32(r)
-		if err != nil {
-			return nil, err
-		}
-
-		for i := 0; i < int(numTimestamp)-1; i++ {
-			// Delta Largest acked
-			_, err = r.ReadByte()
-			if err != nil {
-				return nil, err
-			}
-
-			// Time Since Previous Timestamp
-			_, err = utils.GetByteOrder(version).ReadUint16(r)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
 	return frame, nil
 }
 
 // Write writes an ACK frame.
 func (f *AckFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
-	largestAckedLen := protocol.GetPacketNumberLength(f.LargestAcked)
-
-	typeByte := uint8(0x40)
-
-	if largestAckedLen != protocol.PacketNumberLen1 {
-		typeByte ^= (uint8(largestAckedLen / 2)) << 2
+	if !version.UsesIETFFrameFormat() {
+		return f.writeLegacy(b, version)
 	}
 
-	missingSequenceNumberDeltaLen := f.getMissingSequenceNumberDeltaLen()
-	if missingSequenceNumberDeltaLen != protocol.PacketNumberLen1 {
-		typeByte ^= (uint8(missingSequenceNumberDeltaLen / 2))
-	}
+	b.WriteByte(0xe)
+	utils.WriteVarInt(b, uint64(f.LargestAcked))
+	utils.WriteVarInt(b, encodeAckDelay(f.DelayTime))
 
+	// TODO: limit the number of ACK ranges, such that the frame doesn't grow larger than an upper bound
+	var lowestInFirstRange protocol.PacketNumber
 	if f.HasMissingRanges() {
-		typeByte |= 0x20
-	}
-
-	b.WriteByte(typeByte)
-
-	switch largestAckedLen {
-	case protocol.PacketNumberLen1:
-		b.WriteByte(uint8(f.LargestAcked))
-	case protocol.PacketNumberLen2:
-		utils.GetByteOrder(version).WriteUint16(b, uint16(f.LargestAcked))
-	case protocol.PacketNumberLen4:
-		utils.GetByteOrder(version).WriteUint32(b, uint32(f.LargestAcked))
-	case protocol.PacketNumberLen6:
-		utils.GetByteOrder(version).WriteUint48(b, uint64(f.LargestAcked)&(1<<48-1))
-	}
-
-	f.DelayTime = time.Since(f.PacketReceivedTime)
-	utils.GetByteOrder(version).WriteUfloat16(b, uint64(f.DelayTime/time.Microsecond))
-
-	var numRanges uint64
-	var numRangesWritten uint64
-	if f.HasMissingRanges() {
-		numRanges = f.numWritableNackRanges()
-		if numRanges > 0xFF {
-			panic("AckFrame: Too many ACK ranges")
-		}
-		b.WriteByte(uint8(numRanges - 1))
-	}
-
-	var firstAckBlockLength protocol.PacketNumber
-	if !f.HasMissingRanges() {
-		firstAckBlockLength = f.LargestAcked - f.LowestAcked + 1
+		utils.WriteVarInt(b, uint64(len(f.AckRanges)-1))
+		lowestInFirstRange = f.AckRanges[0].First
 	} else {
-		if f.LargestAcked != f.AckRanges[0].Last {
-			return errInconsistentAckLargestAcked
-		}
-		if f.LowestAcked != f.AckRanges[len(f.AckRanges)-1].First {
-			return errInconsistentAckLowestAcked
-		}
-		firstAckBlockLength = f.LargestAcked - f.AckRanges[0].First + 1
-		numRangesWritten++
+		utils.WriteVarInt(b, 0)
+		lowestInFirstRange = f.LowestAcked
 	}
 
-	switch missingSequenceNumberDeltaLen {
-	case protocol.PacketNumberLen1:
-		b.WriteByte(uint8(firstAckBlockLength))
-	case protocol.PacketNumberLen2:
-		utils.GetByteOrder(version).WriteUint16(b, uint16(firstAckBlockLength))
-	case protocol.PacketNumberLen4:
-		utils.GetByteOrder(version).WriteUint32(b, uint32(firstAckBlockLength))
-	case protocol.PacketNumberLen6:
-		utils.GetByteOrder(version).WriteUint48(b, uint64(firstAckBlockLength)&(1<<48-1))
-	}
+	// write the first range
+	utils.WriteVarInt(b, uint64(f.LargestAcked-lowestInFirstRange))
 
+	// write all the other range
+	if !f.HasMissingRanges() {
+		return nil
+	}
+	var lowest protocol.PacketNumber
 	for i, ackRange := range f.AckRanges {
 		if i == 0 {
+			lowest = lowestInFirstRange
 			continue
 		}
-
-		length := ackRange.Last - ackRange.First + 1
-		gap := f.AckRanges[i-1].First - ackRange.Last - 1
-
-		num := gap/0xFF + 1
-		if gap%0xFF == 0 {
-			num--
-		}
-
-		if num == 1 {
-			b.WriteByte(uint8(gap))
-			switch missingSequenceNumberDeltaLen {
-			case protocol.PacketNumberLen1:
-				b.WriteByte(uint8(length))
-			case protocol.PacketNumberLen2:
-				utils.GetByteOrder(version).WriteUint16(b, uint16(length))
-			case protocol.PacketNumberLen4:
-				utils.GetByteOrder(version).WriteUint32(b, uint32(length))
-			case protocol.PacketNumberLen6:
-				utils.GetByteOrder(version).WriteUint48(b, uint64(length)&(1<<48-1))
-			}
-			numRangesWritten++
-		} else {
-			for i := 0; i < int(num); i++ {
-				var lengthWritten uint64
-				var gapWritten uint8
-
-				if i == int(num)-1 { // last block
-					lengthWritten = uint64(length)
-					gapWritten = uint8(1 + ((gap - 1) % 255))
-				} else {
-					lengthWritten = 0
-					gapWritten = 0xFF
-				}
-
-				b.WriteByte(gapWritten)
-				switch missingSequenceNumberDeltaLen {
-				case protocol.PacketNumberLen1:
-					b.WriteByte(uint8(lengthWritten))
-				case protocol.PacketNumberLen2:
-					utils.GetByteOrder(version).WriteUint16(b, uint16(lengthWritten))
-				case protocol.PacketNumberLen4:
-					utils.GetByteOrder(version).WriteUint32(b, uint32(lengthWritten))
-				case protocol.PacketNumberLen6:
-					utils.GetByteOrder(version).WriteUint48(b, lengthWritten&(1<<48-1))
-				}
-
-				numRangesWritten++
-			}
-		}
-
-		// this is needed if not all AckRanges can be written to the ACK frame (if there are more than 0xFF)
-		if numRangesWritten >= numRanges {
-			break
-		}
+		utils.WriteVarInt(b, uint64(lowest-ackRange.Last-2))
+		utils.WriteVarInt(b, uint64(ackRange.Last-ackRange.First))
+		lowest = ackRange.First
 	}
-
-	if numRanges != numRangesWritten {
-		return errors.New("BUG: Inconsistent number of ACK ranges written")
-	}
-
-	b.WriteByte(0) // no timestamps
 	return nil
 }
 
 // MinLength of a written frame
 func (f *AckFrame) MinLength(version protocol.VersionNumber) (protocol.ByteCount, error) {
-	length := protocol.ByteCount(1 + 2 + 1) // 1 TypeByte, 2 ACK delay time, 1 Num Timestamp
-	length += protocol.ByteCount(protocol.GetPacketNumberLength(f.LargestAcked))
-
-	missingSequenceNumberDeltaLen := protocol.ByteCount(f.getMissingSequenceNumberDeltaLen())
-
-	if f.HasMissingRanges() {
-		length += (1 + missingSequenceNumberDeltaLen) * protocol.ByteCount(f.numWritableNackRanges())
-	} else {
-		length += missingSequenceNumberDeltaLen
+	if !version.UsesIETFFrameFormat() {
+		return f.minLengthLegacy(version)
 	}
 
-	length += (1 + 2) * 0 /* TODO: num_timestamps */
+	length := 1 + utils.VarIntLen(uint64(f.LargestAcked)) + utils.VarIntLen(uint64(encodeAckDelay(f.DelayTime)))
 
+	var lowestInFirstRange protocol.PacketNumber
+	if f.HasMissingRanges() {
+		length += utils.VarIntLen(uint64(len(f.AckRanges) - 1))
+		lowestInFirstRange = f.AckRanges[0].First
+	} else {
+		length += utils.VarIntLen(0)
+		lowestInFirstRange = f.LowestAcked
+	}
+	length += utils.VarIntLen(uint64(f.LargestAcked - lowestInFirstRange))
+
+	if !f.HasMissingRanges() {
+		return length, nil
+	}
+	var lowest protocol.PacketNumber
+	for i, ackRange := range f.AckRanges {
+		if i == 0 {
+			lowest = ackRange.First
+			continue
+		}
+		length += utils.VarIntLen(uint64(lowest - ackRange.Last - 2))
+		length += utils.VarIntLen(uint64(ackRange.Last - ackRange.First))
+		lowest = ackRange.First
+	}
 	return length, nil
 }
 
@@ -389,63 +215,6 @@ func (f *AckFrame) validateAckRanges() bool {
 	return true
 }
 
-// numWritableNackRanges calculates the number of ACK blocks that are about to be written
-// this number is different from len(f.AckRanges) for the case of long gaps (> 255 packets)
-func (f *AckFrame) numWritableNackRanges() uint64 {
-	if len(f.AckRanges) == 0 {
-		return 0
-	}
-
-	var numRanges uint64
-	for i, ackRange := range f.AckRanges {
-		if i == 0 {
-			continue
-		}
-
-		lastAckRange := f.AckRanges[i-1]
-		gap := lastAckRange.First - ackRange.Last - 1
-		rangeLength := 1 + uint64(gap)/0xFF
-		if uint64(gap)%0xFF == 0 {
-			rangeLength--
-		}
-
-		if numRanges+rangeLength < 0xFF {
-			numRanges += rangeLength
-		} else {
-			break
-		}
-	}
-
-	return numRanges + 1
-}
-
-func (f *AckFrame) getMissingSequenceNumberDeltaLen() protocol.PacketNumberLen {
-	var maxRangeLength protocol.PacketNumber
-
-	if f.HasMissingRanges() {
-		for _, ackRange := range f.AckRanges {
-			rangeLength := ackRange.Last - ackRange.First + 1
-			if rangeLength > maxRangeLength {
-				maxRangeLength = rangeLength
-			}
-		}
-	} else {
-		maxRangeLength = f.LargestAcked - f.LowestAcked + 1
-	}
-
-	if maxRangeLength <= 0xFF {
-		return protocol.PacketNumberLen1
-	}
-	if maxRangeLength <= 0xFFFF {
-		return protocol.PacketNumberLen2
-	}
-	if maxRangeLength <= 0xFFFFFFFF {
-		return protocol.PacketNumberLen4
-	}
-
-	return protocol.PacketNumberLen6
-}
-
 // AcksPacket determines if this ACK frame acks a certain packet number
 func (f *AckFrame) AcksPacket(p protocol.PacketNumber) bool {
 	if p < f.LowestAcked || p > f.LargestAcked { // this is just a performance optimization
@@ -463,4 +232,8 @@ func (f *AckFrame) AcksPacket(p protocol.PacketNumber) bool {
 	}
 	// if packet doesn't have missing ranges
 	return (p >= f.LowestAcked && p <= f.LargestAcked)
+}
+
+func encodeAckDelay(delay time.Duration) uint64 {
+	return uint64(delay.Nanoseconds() / (1000 * (1 << ackDelayExponent)))
 }

--- a/internal/wire/ack_frame_legacy.go
+++ b/internal/wire/ack_frame_legacy.go
@@ -1,0 +1,381 @@
+package wire
+
+import (
+	"bytes"
+	"errors"
+	"time"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+)
+
+var (
+	errInconsistentAckLargestAcked = errors.New("internal inconsistency: LargestAcked does not match ACK ranges")
+	errInconsistentAckLowestAcked  = errors.New("internal inconsistency: LowestAcked does not match ACK ranges")
+	errInvalidAckRanges            = errors.New("AckFrame: ACK frame contains invalid ACK ranges")
+)
+
+func parseAckFrameLegacy(r *bytes.Reader, version protocol.VersionNumber) (*AckFrame, error) {
+	frame := &AckFrame{}
+
+	typeByte, err := r.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+
+	hasMissingRanges := false
+	if typeByte&0x20 == 0x20 {
+		hasMissingRanges = true
+	}
+
+	largestAckedLen := 2 * ((typeByte & 0x0C) >> 2)
+	if largestAckedLen == 0 {
+		largestAckedLen = 1
+	}
+
+	missingSequenceNumberDeltaLen := 2 * (typeByte & 0x03)
+	if missingSequenceNumberDeltaLen == 0 {
+		missingSequenceNumberDeltaLen = 1
+	}
+
+	largestAcked, err := utils.GetByteOrder(version).ReadUintN(r, largestAckedLen)
+	if err != nil {
+		return nil, err
+	}
+	frame.LargestAcked = protocol.PacketNumber(largestAcked)
+
+	delay, err := utils.GetByteOrder(version).ReadUfloat16(r)
+	if err != nil {
+		return nil, err
+	}
+	frame.DelayTime = time.Duration(delay) * time.Microsecond
+
+	var numAckBlocks uint8
+	if hasMissingRanges {
+		numAckBlocks, err = r.ReadByte()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if hasMissingRanges && numAckBlocks == 0 {
+		return nil, errInvalidAckRanges
+	}
+
+	ackBlockLength, err := utils.GetByteOrder(version).ReadUintN(r, missingSequenceNumberDeltaLen)
+	if err != nil {
+		return nil, err
+	}
+	if frame.LargestAcked > 0 && ackBlockLength < 1 {
+		return nil, errors.New("invalid first ACK range")
+	}
+
+	if ackBlockLength > largestAcked+1 {
+		return nil, errInvalidAckRanges
+	}
+
+	if hasMissingRanges {
+		ackRange := AckRange{
+			First: protocol.PacketNumber(largestAcked-ackBlockLength) + 1,
+			Last:  frame.LargestAcked,
+		}
+		frame.AckRanges = append(frame.AckRanges, ackRange)
+
+		var inLongBlock bool
+		var lastRangeComplete bool
+		for i := uint8(0); i < numAckBlocks; i++ {
+			var gap uint8
+			gap, err = r.ReadByte()
+			if err != nil {
+				return nil, err
+			}
+
+			ackBlockLength, err = utils.GetByteOrder(version).ReadUintN(r, missingSequenceNumberDeltaLen)
+			if err != nil {
+				return nil, err
+			}
+
+			length := protocol.PacketNumber(ackBlockLength)
+
+			if inLongBlock {
+				frame.AckRanges[len(frame.AckRanges)-1].First -= protocol.PacketNumber(gap) + length
+				frame.AckRanges[len(frame.AckRanges)-1].Last -= protocol.PacketNumber(gap)
+			} else {
+				lastRangeComplete = false
+				ackRange := AckRange{
+					Last: frame.AckRanges[len(frame.AckRanges)-1].First - protocol.PacketNumber(gap) - 1,
+				}
+				ackRange.First = ackRange.Last - length + 1
+				frame.AckRanges = append(frame.AckRanges, ackRange)
+			}
+
+			if length > 0 {
+				lastRangeComplete = true
+			}
+
+			inLongBlock = (ackBlockLength == 0)
+		}
+
+		// if the last range was not complete, First and Last make no sense
+		// remove the range from frame.AckRanges
+		if !lastRangeComplete {
+			frame.AckRanges = frame.AckRanges[:len(frame.AckRanges)-1]
+		}
+
+		frame.LowestAcked = frame.AckRanges[len(frame.AckRanges)-1].First
+	} else {
+		if frame.LargestAcked == 0 {
+			frame.LowestAcked = 0
+		} else {
+			frame.LowestAcked = protocol.PacketNumber(largestAcked + 1 - ackBlockLength)
+		}
+	}
+
+	if !frame.validateAckRanges() {
+		return nil, errInvalidAckRanges
+	}
+
+	var numTimestamp byte
+	numTimestamp, err = r.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+
+	if numTimestamp > 0 {
+		// Delta Largest acked
+		_, err = r.ReadByte()
+		if err != nil {
+			return nil, err
+		}
+		// First Timestamp
+		_, err = utils.GetByteOrder(version).ReadUint32(r)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := 0; i < int(numTimestamp)-1; i++ {
+			// Delta Largest acked
+			_, err = r.ReadByte()
+			if err != nil {
+				return nil, err
+			}
+
+			// Time Since Previous Timestamp
+			_, err = utils.GetByteOrder(version).ReadUint16(r)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return frame, nil
+}
+
+func (f *AckFrame) writeLegacy(b *bytes.Buffer, version protocol.VersionNumber) error {
+	largestAckedLen := protocol.GetPacketNumberLength(f.LargestAcked)
+
+	typeByte := uint8(0x40)
+
+	if largestAckedLen != protocol.PacketNumberLen1 {
+		typeByte ^= (uint8(largestAckedLen / 2)) << 2
+	}
+
+	missingSequenceNumberDeltaLen := f.getMissingSequenceNumberDeltaLen()
+	if missingSequenceNumberDeltaLen != protocol.PacketNumberLen1 {
+		typeByte ^= (uint8(missingSequenceNumberDeltaLen / 2))
+	}
+
+	if f.HasMissingRanges() {
+		typeByte |= 0x20
+	}
+
+	b.WriteByte(typeByte)
+
+	switch largestAckedLen {
+	case protocol.PacketNumberLen1:
+		b.WriteByte(uint8(f.LargestAcked))
+	case protocol.PacketNumberLen2:
+		utils.GetByteOrder(version).WriteUint16(b, uint16(f.LargestAcked))
+	case protocol.PacketNumberLen4:
+		utils.GetByteOrder(version).WriteUint32(b, uint32(f.LargestAcked))
+	case protocol.PacketNumberLen6:
+		utils.GetByteOrder(version).WriteUint48(b, uint64(f.LargestAcked)&(1<<48-1))
+	}
+
+	f.DelayTime = time.Since(f.PacketReceivedTime)
+	utils.GetByteOrder(version).WriteUfloat16(b, uint64(f.DelayTime/time.Microsecond))
+
+	var numRanges uint64
+	var numRangesWritten uint64
+	if f.HasMissingRanges() {
+		numRanges = f.numWritableNackRanges()
+		if numRanges > 0xFF {
+			panic("AckFrame: Too many ACK ranges")
+		}
+		b.WriteByte(uint8(numRanges - 1))
+	}
+
+	var firstAckBlockLength protocol.PacketNumber
+	if !f.HasMissingRanges() {
+		firstAckBlockLength = f.LargestAcked - f.LowestAcked + 1
+	} else {
+		if f.LargestAcked != f.AckRanges[0].Last {
+			return errInconsistentAckLargestAcked
+		}
+		if f.LowestAcked != f.AckRanges[len(f.AckRanges)-1].First {
+			return errInconsistentAckLowestAcked
+		}
+		firstAckBlockLength = f.LargestAcked - f.AckRanges[0].First + 1
+		numRangesWritten++
+	}
+
+	switch missingSequenceNumberDeltaLen {
+	case protocol.PacketNumberLen1:
+		b.WriteByte(uint8(firstAckBlockLength))
+	case protocol.PacketNumberLen2:
+		utils.GetByteOrder(version).WriteUint16(b, uint16(firstAckBlockLength))
+	case protocol.PacketNumberLen4:
+		utils.GetByteOrder(version).WriteUint32(b, uint32(firstAckBlockLength))
+	case protocol.PacketNumberLen6:
+		utils.GetByteOrder(version).WriteUint48(b, uint64(firstAckBlockLength)&(1<<48-1))
+	}
+
+	for i, ackRange := range f.AckRanges {
+		if i == 0 {
+			continue
+		}
+
+		length := ackRange.Last - ackRange.First + 1
+		gap := f.AckRanges[i-1].First - ackRange.Last - 1
+
+		num := gap/0xFF + 1
+		if gap%0xFF == 0 {
+			num--
+		}
+
+		if num == 1 {
+			b.WriteByte(uint8(gap))
+			switch missingSequenceNumberDeltaLen {
+			case protocol.PacketNumberLen1:
+				b.WriteByte(uint8(length))
+			case protocol.PacketNumberLen2:
+				utils.GetByteOrder(version).WriteUint16(b, uint16(length))
+			case protocol.PacketNumberLen4:
+				utils.GetByteOrder(version).WriteUint32(b, uint32(length))
+			case protocol.PacketNumberLen6:
+				utils.GetByteOrder(version).WriteUint48(b, uint64(length)&(1<<48-1))
+			}
+			numRangesWritten++
+		} else {
+			for i := 0; i < int(num); i++ {
+				var lengthWritten uint64
+				var gapWritten uint8
+
+				if i == int(num)-1 { // last block
+					lengthWritten = uint64(length)
+					gapWritten = uint8(1 + ((gap - 1) % 255))
+				} else {
+					lengthWritten = 0
+					gapWritten = 0xFF
+				}
+
+				b.WriteByte(gapWritten)
+				switch missingSequenceNumberDeltaLen {
+				case protocol.PacketNumberLen1:
+					b.WriteByte(uint8(lengthWritten))
+				case protocol.PacketNumberLen2:
+					utils.GetByteOrder(version).WriteUint16(b, uint16(lengthWritten))
+				case protocol.PacketNumberLen4:
+					utils.GetByteOrder(version).WriteUint32(b, uint32(lengthWritten))
+				case protocol.PacketNumberLen6:
+					utils.GetByteOrder(version).WriteUint48(b, lengthWritten&(1<<48-1))
+				}
+
+				numRangesWritten++
+			}
+		}
+
+		// this is needed if not all AckRanges can be written to the ACK frame (if there are more than 0xFF)
+		if numRangesWritten >= numRanges {
+			break
+		}
+	}
+
+	if numRanges != numRangesWritten {
+		return errors.New("BUG: Inconsistent number of ACK ranges written")
+	}
+
+	b.WriteByte(0) // no timestamps
+	return nil
+}
+
+func (f *AckFrame) minLengthLegacy(version protocol.VersionNumber) (protocol.ByteCount, error) {
+	length := protocol.ByteCount(1 + 2 + 1) // 1 TypeByte, 2 ACK delay time, 1 Num Timestamp
+	length += protocol.ByteCount(protocol.GetPacketNumberLength(f.LargestAcked))
+
+	missingSequenceNumberDeltaLen := protocol.ByteCount(f.getMissingSequenceNumberDeltaLen())
+
+	if f.HasMissingRanges() {
+		length += (1 + missingSequenceNumberDeltaLen) * protocol.ByteCount(f.numWritableNackRanges())
+	} else {
+		length += missingSequenceNumberDeltaLen
+	}
+	// we don't write
+	return length, nil
+}
+
+// numWritableNackRanges calculates the number of ACK blocks that are about to be written
+// this number is different from len(f.AckRanges) for the case of long gaps (> 255 packets)
+func (f *AckFrame) numWritableNackRanges() uint64 {
+	if len(f.AckRanges) == 0 {
+		return 0
+	}
+
+	var numRanges uint64
+	for i, ackRange := range f.AckRanges {
+		if i == 0 {
+			continue
+		}
+
+		lastAckRange := f.AckRanges[i-1]
+		gap := lastAckRange.First - ackRange.Last - 1
+		rangeLength := 1 + uint64(gap)/0xFF
+		if uint64(gap)%0xFF == 0 {
+			rangeLength--
+		}
+
+		if numRanges+rangeLength < 0xFF {
+			numRanges += rangeLength
+		} else {
+			break
+		}
+	}
+
+	return numRanges + 1
+}
+
+func (f *AckFrame) getMissingSequenceNumberDeltaLen() protocol.PacketNumberLen {
+	var maxRangeLength protocol.PacketNumber
+
+	if f.HasMissingRanges() {
+		for _, ackRange := range f.AckRanges {
+			rangeLength := ackRange.Last - ackRange.First + 1
+			if rangeLength > maxRangeLength {
+				maxRangeLength = rangeLength
+			}
+		}
+	} else {
+		maxRangeLength = f.LargestAcked - f.LowestAcked + 1
+	}
+
+	if maxRangeLength <= 0xFF {
+		return protocol.PacketNumberLen1
+	}
+	if maxRangeLength <= 0xFFFF {
+		return protocol.PacketNumberLen2
+	}
+	if maxRangeLength <= 0xFFFFFFFF {
+		return protocol.PacketNumberLen4
+	}
+
+	return protocol.PacketNumberLen6
+}

--- a/internal/wire/ack_frame_legacy_test.go
+++ b/internal/wire/ack_frame_legacy_test.go
@@ -1,0 +1,1281 @@
+package wire
+
+import (
+	"bytes"
+	"io"
+	"time"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ACK Frame (for gQUIC)", func() {
+	Context("when parsing", func() {
+		It("accepts a sample frame", func() {
+			b := bytes.NewReader([]byte{0x40,
+				0x1c,     // largest acked
+				0x0, 0x0, // delay time
+				0x1c, // block length
+				0,
+			})
+			frame, err := ParseAckFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x1c)))
+			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
+			Expect(frame.HasMissingRanges()).To(BeFalse())
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("parses a frame that acks packet number 0", func() {
+			b := bytes.NewReader([]byte{0x40,
+				0x0,      // largest acked
+				0x0, 0x0, // delay time
+				0x1, // block length
+				0,
+			})
+			frame, err := ParseAckFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0)))
+			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0)))
+			Expect(frame.HasMissingRanges()).To(BeFalse())
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("parses a frame with 1 ACKed packet", func() {
+			b := bytes.NewReader([]byte{0x40,
+				0x10,     // largest acked
+				0x0, 0x0, // delay time
+				0x1, // block length
+				0,
+			})
+			frame, err := ParseAckFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x10)))
+			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0x10)))
+			Expect(frame.HasMissingRanges()).To(BeFalse())
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("parses a frame that acks multiple packets, starting with 0", func() {
+			b := bytes.NewReader([]byte{0x40,
+				0x10,     // largest acked
+				0x0, 0x0, // delay time
+				0x11, // block length
+				0,
+			})
+			frame, err := ParseAckFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x10)))
+			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0)))
+			Expect(frame.HasMissingRanges()).To(BeFalse())
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("parses a frame with multiple timestamps", func() {
+			b := bytes.NewReader([]byte{0x40,
+				0x10,     // largest acked
+				0x0, 0x0, // timestamp
+				0x10,                      // block length
+				0x4,                       // num timestamps
+				0x1, 0x6b, 0x26, 0x4, 0x0, // 1st timestamp
+				0x3, 0, 0, // 2nd timestamp
+				0x2, 0, 0, // 3rd timestamp
+				0x1, 0, 0, // 4th timestamp
+			})
+			_, err := ParseAckFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("errors when the ACK range is too large", func() {
+			// LargestAcked: 0x1c
+			// Length: 0x1d => LowestAcked would be -1
+			b := bytes.NewReader([]byte{0x40,
+				0x1c,     // largest acked
+				0x0, 0x0, // delay time
+				0x1e, // block length
+				0,
+			})
+			_, err := ParseAckFrame(b, versionBigEndian)
+			Expect(err).To(MatchError(errInvalidAckRanges))
+		})
+
+		It("errors when the first ACK range is empty", func() {
+			b := bytes.NewReader([]byte{0x40,
+				0x9,      // largest acked
+				0x0, 0x0, // delay time
+				0x0, // block length
+				0,
+			})
+			_, err := ParseAckFrame(b, versionBigEndian)
+			Expect(err).To(MatchError("invalid first ACK range"))
+		})
+
+		It("parses the delay time", func() {
+			b := bytes.NewReader([]byte{0x40,
+				0x3,       // largest acked
+				0x0, 0x8e, // delay time
+				0x3, // block length
+				0,
+			})
+			frame, err := ParseAckFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(3)))
+			Expect(frame.DelayTime).To(Equal(142 * time.Microsecond))
+		})
+
+		It("errors on EOFs", func() {
+			data := []byte{0x60 ^ 0x4 ^ 0x1,
+				0x9, 0x66, // largest acked
+				0x23, 0x1, // delay time
+				0x7,      // num ACk blocks
+				0x0, 0x7, // 1st block
+				0xff, 0x0, 0x0, // 2nd block
+				0xf5, 0x2, 0x8a, // 3rd block
+				0xc8, 0x0, 0xe6, // 4th block
+				0xff, 0x0, 0x0, // 5th block
+				0xff, 0x0, 0x0, // 6th block
+				0xff, 0x0, 0x0, // 7th block
+				0x23, 0x0, 0x13, // 8th blocks
+				0x2,                       // num timestamps
+				0x1, 0x13, 0xae, 0xb, 0x0, // 1st timestamp
+				0x0, 0x80, 0x5, // 2nd timestamp
+			}
+			_, err := ParseAckFrame(bytes.NewReader(data), versionBigEndian)
+			Expect(err).NotTo(HaveOccurred())
+			for i := range data {
+				_, err := ParseAckFrame(bytes.NewReader(data[0:i]), versionBigEndian)
+				Expect(err).To(MatchError(io.EOF))
+			}
+		})
+
+		Context("largest acked length", func() {
+			It("parses a frame with a 2 byte packet number", func() {
+				b := bytes.NewReader([]byte{0x40 | 0x4,
+					0x13, 0x37, // largest acked
+					0x0, 0x0, // delay time
+					0x9, // block length
+					0,
+				})
+				frame, err := ParseAckFrame(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x1337)))
+				Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0x1337 - 0x9 + 1)))
+				Expect(frame.HasMissingRanges()).To(BeFalse())
+				Expect(b.Len()).To(BeZero())
+			})
+
+			It("parses a frame with a 4 byte packet number", func() {
+				b := bytes.NewReader([]byte{0x40 | 0x8,
+					0xde, 0xca, 0xfb, 0xad, // largest acked
+					0x0, 0x0, // timesatmp
+					0x5, // block length
+					0,
+				})
+				frame, err := ParseAckFrame(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0xdecafbad)))
+				Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0xdecafbad - 5 + 1)))
+				Expect(frame.HasMissingRanges()).To(BeFalse())
+				Expect(b.Len()).To(BeZero())
+			})
+
+			It("parses a frame with a 6 byte packet number", func() {
+				b := bytes.NewReader([]byte{0x4 | 0xc,
+					0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, // largest acked
+					0x0, 0x0, // delay time
+					0x5, // block length
+					0,
+				})
+				frame, err := ParseAckFrame(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0xdeadbeefcafe)))
+				Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0xdeadbeefcafe - 5 + 1)))
+				Expect(frame.HasMissingRanges()).To(BeFalse())
+				Expect(b.Len()).To(BeZero())
+			})
+		})
+
+		Context("ACK blocks", func() {
+			It("parses a frame with two ACK blocks", func() {
+				b := bytes.NewReader([]byte{0x60,
+					0x18,     // largest acked
+					0x0, 0x0, // delay time
+					0x1,       // num ACK blocks
+					0x3,       // 1st block
+					0x2, 0x10, // 2nd block
+					0,
+				})
+				frame, err := ParseAckFrame(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x18)))
+				Expect(frame.HasMissingRanges()).To(BeTrue())
+				Expect(frame.AckRanges).To(HaveLen(2))
+				Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 0x18 - 0x3 + 1, Last: 0x18}))
+				Expect(frame.AckRanges[1]).To(Equal(AckRange{First: (0x18 - 0x3 + 1) - (0x2 + 1) - (0x10 - 1), Last: (0x18 - 0x3 + 1) - (0x2 + 1)}))
+				Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(4)))
+				Expect(b.Len()).To(BeZero())
+			})
+
+			It("rejects a frame with invalid ACK ranges", func() {
+				// like the test before, but increased the last ACK range, such that the First would be negative
+				b := bytes.NewReader([]byte{0x60,
+					0x18,     // largest acked
+					0x0, 0x0, // delay time
+					0x1,       // num ACK blocks
+					0x3,       // 1st block
+					0x2, 0x15, // 2nd block
+					0,
+				})
+				_, err := ParseAckFrame(b, versionBigEndian)
+				Expect(err).To(MatchError(errInvalidAckRanges))
+			})
+
+			It("rejects a frame that says it has ACK blocks in the typeByte, but doesn't have any", func() {
+				b := bytes.NewReader([]byte{0x60 ^ 0x3,
+					0x4,      // largest acked
+					0x0, 0x0, // delay time
+					0, // num ACK blocks
+					0,
+				})
+				_, err := ParseAckFrame(b, versionBigEndian)
+				Expect(err).To(MatchError(errInvalidAckRanges))
+			})
+
+			It("parses a frame with multiple single packets missing", func() {
+				b := bytes.NewReader([]byte{0x60,
+					0x27,     // largest acked
+					0x0, 0x0, // delay time
+					0x6,      // num ACK blocks
+					0x9,      // 1st block
+					0x1, 0x1, // 2nd block
+					0x1, 0x1, // 3rd block
+					0x1, 0x1, // 4th block
+					0x1, 0x1, // 5th block
+					0x1, 0x1, // 6th block
+					0x1, 0x13, // 7th block
+					0,
+				})
+				frame, err := ParseAckFrame(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x27)))
+				Expect(frame.HasMissingRanges()).To(BeTrue())
+				Expect(frame.AckRanges).To(HaveLen(7))
+				Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 31, Last: 0x27}))
+				Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 29, Last: 29}))
+				Expect(frame.AckRanges[2]).To(Equal(AckRange{First: 27, Last: 27}))
+				Expect(frame.AckRanges[3]).To(Equal(AckRange{First: 25, Last: 25}))
+				Expect(frame.AckRanges[4]).To(Equal(AckRange{First: 23, Last: 23}))
+				Expect(frame.AckRanges[5]).To(Equal(AckRange{First: 21, Last: 21}))
+				Expect(frame.AckRanges[6]).To(Equal(AckRange{First: 1, Last: 19}))
+				Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
+				Expect(b.Len()).To(BeZero())
+			})
+
+			It("parses a frame with multiple longer ACK blocks", func() {
+				b := bytes.NewReader([]byte{0x60,
+					0x52,      // largest acked
+					0xd1, 0x0, //delay time
+					0x3,       // num ACK blocks
+					0x17,      // 1st block
+					0xa, 0x10, // 2nd block
+					0x4, 0x8, // 3rd block
+					0x2, 0x12, // 4th block
+					0,
+				})
+				frame, err := ParseAckFrame(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x52)))
+				Expect(frame.HasMissingRanges()).To(BeTrue())
+				Expect(frame.AckRanges).To(HaveLen(4))
+				Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 60, Last: 0x52}))
+				Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 34, Last: 49}))
+				Expect(frame.AckRanges[2]).To(Equal(AckRange{First: 22, Last: 29}))
+				Expect(frame.AckRanges[3]).To(Equal(AckRange{First: 2, Last: 19}))
+				Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(2)))
+				Expect(b.Len()).To(BeZero())
+			})
+
+			Context("more than 256 lost packets in a row", func() {
+				// 255 missing packets fit into a single ACK block
+				It("parses a frame with a range of 255 missing packets", func() {
+					b := bytes.NewReader([]byte{0x60 ^ 0x4,
+						0x1, 0x15, // largest acked
+						0x0, 0x0, // delay time
+						0x1,        // num ACK blocks
+						0x3,        // 1st block
+						0xff, 0x13, // 2nd block
+						0,
+					})
+					frame, err := ParseAckFrame(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x115)))
+					Expect(frame.HasMissingRanges()).To(BeTrue())
+					Expect(frame.AckRanges).To(HaveLen(2))
+					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 20 + 255, Last: 0x115}))
+					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1, Last: 19}))
+					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
+					Expect(b.Len()).To(BeZero())
+				})
+
+				// 256 missing packets fit into two ACK blocks
+				It("parses a frame with a range of 256 missing packets", func() {
+					b := bytes.NewReader([]byte{0x60 ^ 0x4,
+						0x1, 0x14, // largest acked
+						0x0, 0x0, // delay time
+						0x2,       // num ACK blocks
+						0x1,       // 1st block
+						0xff, 0x0, // 2nd block
+						0x1, 0x13, // 3rd block
+						0,
+					})
+					frame, err := ParseAckFrame(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x114)))
+					Expect(frame.HasMissingRanges()).To(BeTrue())
+					Expect(frame.AckRanges).To(HaveLen(2))
+					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 20 + 256, Last: 0x114}))
+					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1, Last: 19}))
+					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
+					Expect(b.Len()).To(BeZero())
+				})
+
+				It("parses a frame with an incomplete range at the end", func() {
+					// this is a modified ACK frame that has 5 instead of originally 6 written ranges
+					// each gap is 300 packets and thus takes 2 ranges
+					// the last range is incomplete, and should be completely ignored
+					b := bytes.NewReader([]byte{0x60 ^ 0x4,
+						0x3, 0x9b, // largest acked
+						0x0, 0x0, // delay time
+						0x5,       // num ACK blocks, instead of 0x6
+						0x1,       // 1st block
+						0xff, 0x0, // 2nd block
+						0x2d, 0x1, // 3rd block
+						0xff, 0x0, // 4th block
+						0x2d, 0x1, // 5th block
+						0xff, 0x0, /*0x2d, 0x14,*/ // 6th block
+						0,
+					})
+					frame, err := ParseAckFrame(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x39b)))
+					Expect(frame.HasMissingRanges()).To(BeTrue())
+					Expect(frame.AckRanges).To(HaveLen(3))
+					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 20 + 3*301, Last: 20 + 3*301}))
+					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 20 + 2*301, Last: 20 + 2*301}))
+					Expect(frame.AckRanges[2]).To(Equal(AckRange{First: 20 + 1*301, Last: 20 + 1*301}))
+					Expect(b.Len()).To(BeZero())
+				})
+
+				It("parses a frame with one long range, spanning 2 blocks, of missing packets", func() {
+					// 280 missing packets
+					b := bytes.NewReader([]byte{0x60 ^ 0x4,
+						0x1, 0x44, // largest acked
+						0x0, 0x0, // delay time
+						0x2,       // num ACK blocks
+						0x19,      // 1st block
+						0xff, 0x0, // 2nd block
+						0x19, 0x13, // 3rd block
+						0,
+					})
+					frame, err := ParseAckFrame(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x144)))
+					Expect(frame.HasMissingRanges()).To(BeTrue())
+					Expect(frame.AckRanges).To(HaveLen(2))
+					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 300, Last: 0x144}))
+					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1, Last: 19}))
+					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
+					Expect(b.Len()).To(BeZero())
+				})
+
+				It("parses a frame with one long range, spanning multiple blocks, of missing packets", func() {
+					// 2345 missing packets
+					b := bytes.NewReader([]byte{0x60 ^ 0x4,
+						0x9, 0x5b, // largest acked
+						0x0, 0x0, // delay time
+						0xa,       // num ACK blocks
+						0x1f,      // 1st block
+						0xff, 0x0, // 2nd block
+						0xff, 0x0, // 3rd block
+						0xff, 0x0, // 4th block
+						0xff, 0x0, // 5th block
+						0xff, 0x0, // 6th block
+						0xff, 0x0, // 7th block
+						0xff, 0x0, // 8th block
+						0xff, 0x0, // 9th block
+						0xff, 0x0, // 10th block
+						0x32, 0x13, // 11th block
+						0,
+					})
+					frame, err := ParseAckFrame(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x95b)))
+					Expect(frame.HasMissingRanges()).To(BeTrue())
+					Expect(frame.AckRanges).To(HaveLen(2))
+					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 2365, Last: 0x95b}))
+					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1, Last: 19}))
+					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
+					Expect(b.Len()).To(BeZero())
+				})
+
+				It("parses a frame with multiple 2 byte long ranges of missing packets", func() {
+					b := bytes.NewReader([]byte{0x60 ^ 0x4 ^ 0x1,
+						0x9, 0x66, // largest acked
+						0x0, 0x0, // delay time
+						0x7,      // num ACK blocks
+						0x0, 0x7, // 1st block
+						0xff, 0x0, 0x0, // 2nd block
+						0xf5, 0x2, 0x8a, // 3rd block
+						0xc8, 0x0, 0xe6, // 4th block
+						0xff, 0x0, 0x0, // 5th block
+						0xff, 0x0, 0x0, // 6th block
+						0xff, 0x0, 0x0, // 7th block
+						0x23, 0x0, 0x13, // 8th block
+						0,
+					})
+					frame, err := ParseAckFrame(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x966)))
+					Expect(frame.HasMissingRanges()).To(BeTrue())
+					Expect(frame.AckRanges).To(HaveLen(4))
+					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 2400, Last: 0x966}))
+					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1250, Last: 1899}))
+					Expect(frame.AckRanges[2]).To(Equal(AckRange{First: 820, Last: 1049}))
+					Expect(frame.AckRanges[3]).To(Equal(AckRange{First: 1, Last: 19}))
+					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
+					Expect(b.Len()).To(BeZero())
+				})
+
+				It("parses a frame with with a 4 byte ack block length", func() {
+					b := bytes.NewReader([]byte{0x60 ^ 0xc ^ 0x2,
+						0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, // largest acked
+						0x0, 0x0, // delay time
+						0x1,              // num ACK blocks
+						0, 0, 0x13, 0x37, // 1st block
+						0x20, 0x12, 0x34, 0x56, 0x78, // 2nd block
+						0,
+					})
+					frame, err := ParseAckFrame(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0xdeadbeefcafe)))
+					Expect(frame.HasMissingRanges()).To(BeTrue())
+					Expect(frame.AckRanges).To(HaveLen(2))
+					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 0xdeadbeefcafe - 0x1337 + 1, Last: 0xdeadbeefcafe}))
+					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: (0xdeadbeefcafe - 0x1337 + 1) - (0x20 + 1) - (0x12345678 - 1), Last: (0xdeadbeefcafe - 0x1337 + 1) - (0x20 + 1)}))
+				})
+
+				It("parses a frame with with a 6 byte ack block length", func() {
+					b := bytes.NewReader([]byte{0x60 ^ 0xc ^ 0x3,
+						0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, // largest acked
+						0x0, 0x0, // delay time
+						0x1,                    // num ACk blocks
+						0, 0, 0, 0, 0x13, 0x37, // 1st block
+						0x20, 0x0, 0xab, 0x12, 0x34, 0x56, 0x78, // 2nd block
+						0,
+					})
+					frame, err := ParseAckFrame(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0xdeadbeefcafe)))
+					Expect(frame.HasMissingRanges()).To(BeTrue())
+					Expect(frame.AckRanges).To(HaveLen(2))
+					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 0xdeadbeefcafe - 0x1337 + 1, Last: 0xdeadbeefcafe}))
+					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: (0xdeadbeefcafe - 0x1337 + 1) - (0x20 + 1) - (0xab12345678 - 1), Last: (0xdeadbeefcafe - 0x1337 + 1) - (0x20 + 1)}))
+				})
+			})
+		})
+	})
+
+	Context("when writing", func() {
+		var b *bytes.Buffer
+
+		BeforeEach(func() {
+			b = &bytes.Buffer{}
+		})
+
+		Context("self-consistency", func() {
+			It("writes a simple ACK frame", func() {
+				frameOrig := &AckFrame{
+					LargestAcked: 1,
+					LowestAcked:  1,
+				}
+				err := frameOrig.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				r := bytes.NewReader(b.Bytes())
+				frame, err := ParseAckFrame(r, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+				Expect(frame.HasMissingRanges()).To(BeFalse())
+				Expect(r.Len()).To(BeZero())
+			})
+
+			It("writes an ACK that also acks packet 0", func() {
+				frameOrig := &AckFrame{
+					LargestAcked: 1,
+					LowestAcked:  0,
+				}
+				err := frameOrig.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				r := bytes.NewReader(b.Bytes())
+				frame, err := ParseAckFrame(r, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+				Expect(frame.HasMissingRanges()).To(BeFalse())
+				Expect(r.Len()).To(BeZero())
+			})
+
+			It("writes the correct block length in a simple ACK frame", func() {
+				frameOrig := &AckFrame{
+					LargestAcked: 20,
+					LowestAcked:  10,
+				}
+				err := frameOrig.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				r := bytes.NewReader(b.Bytes())
+				frame, err := ParseAckFrame(r, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+				Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+				Expect(frame.HasMissingRanges()).To(BeFalse())
+				Expect(r.Len()).To(BeZero())
+			})
+
+			It("writes a simple ACK frame with a high packet number", func() {
+				frameOrig := &AckFrame{
+					LargestAcked: 0xdeadbeefcafe,
+					LowestAcked:  0xdeadbeefcafe,
+				}
+				err := frameOrig.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				r := bytes.NewReader(b.Bytes())
+				frame, err := ParseAckFrame(r, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+				Expect(frame.HasMissingRanges()).To(BeFalse())
+				Expect(r.Len()).To(BeZero())
+			})
+
+			It("writes an ACK frame with one packet missing", func() {
+				frameOrig := &AckFrame{
+					LargestAcked: 40,
+					LowestAcked:  0,
+					AckRanges: []AckRange{
+						{First: 25, Last: 40},
+						{First: 0, Last: 23},
+					},
+				}
+				err := frameOrig.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				r := bytes.NewReader(b.Bytes())
+				frame, err := ParseAckFrame(r, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+				Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+				Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				Expect(r.Len()).To(BeZero())
+			})
+
+			It("writes an ACK frame with multiple missing packets", func() {
+				frameOrig := &AckFrame{
+					LargestAcked: 25,
+					LowestAcked:  1,
+					AckRanges: []AckRange{
+						{First: 22, Last: 25},
+						{First: 15, Last: 18},
+						{First: 13, Last: 13},
+						{First: 1, Last: 10},
+					},
+				}
+				err := frameOrig.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				r := bytes.NewReader(b.Bytes())
+				frame, err := ParseAckFrame(r, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+				Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+				Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				Expect(r.Len()).To(BeZero())
+			})
+
+			It("rejects a frame with incorrect LargestObserved value", func() {
+				frame := &AckFrame{
+					LargestAcked: 26,
+					LowestAcked:  1,
+					AckRanges: []AckRange{
+						{First: 12, Last: 25},
+						{First: 1, Last: 10},
+					},
+				}
+				err := frame.Write(b, versionBigEndian)
+				Expect(err).To(MatchError(errInconsistentAckLargestAcked))
+			})
+
+			It("rejects a frame with incorrect LargestObserved value", func() {
+				frame := &AckFrame{
+					LargestAcked: 25,
+					LowestAcked:  2,
+					AckRanges: []AckRange{
+						{First: 12, Last: 25},
+						{First: 1, Last: 10},
+					},
+				}
+				err := frame.Write(b, versionBigEndian)
+				Expect(err).To(MatchError(errInconsistentAckLowestAcked))
+			})
+
+			Context("longer gaps between ACK blocks", func() {
+				It("only writes one block for 254 lost packets", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 300,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 20 + 254, Last: 300},
+							{First: 1, Last: 19},
+						},
+					}
+					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(2)))
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				})
+
+				It("only writes one block for 255 lost packets", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 300,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 20 + 255, Last: 300},
+							{First: 1, Last: 19},
+						},
+					}
+					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(2)))
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				})
+
+				It("writes two blocks for 256 lost packets", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 300,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 20 + 256, Last: 300},
+							{First: 1, Last: 19},
+						},
+					}
+					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(3)))
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				})
+
+				It("writes two blocks for 510 lost packets", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 600,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 20 + 510, Last: 600},
+							{First: 1, Last: 19},
+						},
+					}
+					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(3)))
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				})
+
+				It("writes three blocks for 511 lost packets", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 600,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 20 + 511, Last: 600},
+							{First: 1, Last: 19},
+						},
+					}
+					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(4)))
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				})
+
+				It("writes three blocks for 512 lost packets", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 600,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 20 + 512, Last: 600},
+							{First: 1, Last: 19},
+						},
+					}
+					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(4)))
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				})
+
+				It("writes multiple blocks for a lot of lost packets", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 3000,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 2900, Last: 3000},
+							{First: 1, Last: 19},
+						},
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				})
+
+				It("writes multiple longer blocks for 256 lost packets", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 3600,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 2900, Last: 3600},
+							{First: 1000, Last: 2500},
+							{First: 1, Last: 19},
+						},
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+				})
+			})
+
+			Context("largest acked length", func() {
+				It("writes a 1 largest acked", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 200,
+						LowestAcked:  1,
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x0)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(r.Len()).To(BeZero())
+				})
+
+				It("writes a 2 byte largest acked", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 0x100,
+						LowestAcked:  1,
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x1)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(r.Len()).To(BeZero())
+				})
+
+				It("writes a 4 byte largest acked", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 0x10000,
+						LowestAcked:  1,
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x2)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(r.Len()).To(BeZero())
+				})
+
+				It("writes a 6 byte largest acked", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 0x100000000,
+						LowestAcked:  1,
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x3)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(r.Len()).To(BeZero())
+				})
+			})
+
+			Context("ack block length", func() {
+				It("writes a 1 byte ack block length, if all ACK blocks are short", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 5001,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 5000, Last: 5001},
+							{First: 250, Last: 300},
+							{First: 1, Last: 200},
+						},
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x0)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+					Expect(r.Len()).To(BeZero())
+				})
+
+				It("writes a 2 byte ack block length, for a frame with one ACK block", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 10000,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 9990, Last: 10000},
+							{First: 1, Last: 9988},
+						},
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x1)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+					Expect(r.Len()).To(BeZero())
+				})
+
+				It("writes a 2 byte ack block length, for a frame with multiple ACK blocks", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 10000,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 9990, Last: 10000},
+							{First: 1, Last: 256},
+						},
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x1)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+					Expect(r.Len()).To(BeZero())
+				})
+
+				It("writes a 4 byte ack block length, for a frame with single ACK blocks", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 0xdeadbeef,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 9990, Last: 0xdeadbeef},
+							{First: 1, Last: 9988},
+						},
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x2)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+					Expect(r.Len()).To(BeZero())
+				})
+
+				It("writes a 4 byte ack block length, for a frame with multiple ACK blocks", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 0xdeadbeef,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 9990, Last: 0xdeadbeef},
+							{First: 1, Last: 256},
+						},
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x2)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+					Expect(r.Len()).To(BeZero())
+				})
+
+				It("writes a 6 byte ack block length, for a frame with a single ACK blocks", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 0xdeadbeefcafe,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 9990, Last: 0xdeadbeefcafe},
+							{First: 1, Last: 9988},
+						},
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x3)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+					Expect(r.Len()).To(BeZero())
+				})
+
+				It("writes a 6 byte ack block length, for a frame with multiple ACK blocks", func() {
+					frameOrig := &AckFrame{
+						LargestAcked: 0xdeadbeefcafe,
+						LowestAcked:  1,
+						AckRanges: []AckRange{
+							{First: 9990, Last: 0xdeadbeefcafe},
+							{First: 1, Last: 256},
+						},
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x3)))
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
+					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
+					Expect(r.Len()).To(BeZero())
+				})
+			})
+
+			Context("too many ACK blocks", func() {
+				It("skips the lowest ACK ranges, if there are more than 255 AckRanges", func() {
+					ackRanges := make([]AckRange, 300)
+					for i := 1; i <= 300; i++ {
+						ackRanges[300-i] = AckRange{First: protocol.PacketNumber(3 * i), Last: protocol.PacketNumber(3*i + 1)}
+					}
+					frameOrig := &AckFrame{
+						LargestAcked: ackRanges[0].Last,
+						LowestAcked:  ackRanges[len(ackRanges)-1].First,
+						AckRanges:    ackRanges,
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(ackRanges[254].First))
+					Expect(frame.AckRanges).To(HaveLen(0xFF))
+					Expect(frame.validateAckRanges()).To(BeTrue())
+				})
+
+				It("skips the lowest ACK ranges, if the gaps are large", func() {
+					ackRanges := make([]AckRange, 100)
+					// every AckRange will take 4 written ACK ranges
+					for i := 1; i <= 100; i++ {
+						ackRanges[100-i] = AckRange{First: protocol.PacketNumber(1000 * i), Last: protocol.PacketNumber(1000*i + 1)}
+					}
+					frameOrig := &AckFrame{
+						LargestAcked: ackRanges[0].Last,
+						LowestAcked:  ackRanges[len(ackRanges)-1].First,
+						AckRanges:    ackRanges,
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.LowestAcked).To(Equal(ackRanges[255/4].First))
+					Expect(frame.validateAckRanges()).To(BeTrue())
+				})
+
+				It("works with huge gaps", func() {
+					ackRanges := []AckRange{
+						{First: 2 * 255 * 200, Last: 2*255*200 + 1},
+						{First: 1 * 255 * 200, Last: 1*255*200 + 1},
+						{First: 1, Last: 2},
+					}
+					frameOrig := &AckFrame{
+						LargestAcked: ackRanges[0].Last,
+						LowestAcked:  ackRanges[len(ackRanges)-1].First,
+						AckRanges:    ackRanges,
+					}
+					err := frameOrig.Write(b, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					r := bytes.NewReader(b.Bytes())
+					frame, err := ParseAckFrame(r, versionBigEndian)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
+					Expect(frame.AckRanges).To(HaveLen(2))
+					Expect(frame.LowestAcked).To(Equal(ackRanges[1].First))
+					Expect(frame.validateAckRanges()).To(BeTrue())
+				})
+			})
+		})
+
+		Context("min length", func() {
+			It("has proper min length", func() {
+				f := &AckFrame{
+					LargestAcked: 1,
+				}
+				err := f.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(b.Len())))
+			})
+
+			It("has proper min length with a large LargestObserved", func() {
+				f := &AckFrame{
+					LargestAcked: 0xDEADBEEFCAFE,
+				}
+				err := f.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(b.Len())))
+			})
+
+			It("has the proper min length for an ACK with missing packets", func() {
+				f := &AckFrame{
+					LargestAcked: 2000,
+					LowestAcked:  10,
+					AckRanges: []AckRange{
+						{First: 1000, Last: 2000},
+						{First: 50, Last: 900},
+						{First: 10, Last: 23},
+					},
+				}
+				err := f.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(b.Len())))
+			})
+
+			It("has the proper min length for an ACK with long gaps of missing packets", func() {
+				f := &AckFrame{
+					LargestAcked: 2000,
+					LowestAcked:  1,
+					AckRanges: []AckRange{
+						{First: 1500, Last: 2000},
+						{First: 290, Last: 295},
+						{First: 1, Last: 19},
+					},
+				}
+				err := f.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(b.Len())))
+			})
+
+			It("has the proper min length for an ACK with a long ACK range", func() {
+				largestAcked := protocol.PacketNumber(2 + 0xFFFFFF)
+				f := &AckFrame{
+					LargestAcked: largestAcked,
+					LowestAcked:  1,
+					AckRanges: []AckRange{
+						{First: 1500, Last: largestAcked},
+						{First: 290, Last: 295},
+						{First: 1, Last: 19},
+					},
+				}
+				err := f.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(b.Len())))
+			})
+		})
+	})
+
+	Context("ACK range validator", func() {
+		It("accepts an ACK without NACK Ranges", func() {
+			ack := AckFrame{LargestAcked: 7}
+			Expect(ack.validateAckRanges()).To(BeTrue())
+		})
+
+		It("rejects ACK ranges with a single range", func() {
+			ack := AckFrame{
+				LargestAcked: 10,
+				AckRanges:    []AckRange{{First: 1, Last: 10}},
+			}
+			Expect(ack.validateAckRanges()).To(BeFalse())
+		})
+
+		It("rejects ACK ranges with Last of the first range unequal to LargestObserved", func() {
+			ack := AckFrame{
+				LargestAcked: 10,
+				AckRanges: []AckRange{
+					{First: 8, Last: 9},
+					{First: 2, Last: 3},
+				},
+			}
+			Expect(ack.validateAckRanges()).To(BeFalse())
+		})
+
+		It("rejects ACK ranges with First greater than Last", func() {
+			ack := AckFrame{
+				LargestAcked: 10,
+				AckRanges: []AckRange{
+					{First: 8, Last: 10},
+					{First: 4, Last: 3},
+				},
+			}
+			Expect(ack.validateAckRanges()).To(BeFalse())
+		})
+
+		It("rejects ACK ranges with First greater than LargestObserved", func() {
+			ack := AckFrame{
+				LargestAcked: 5,
+				AckRanges: []AckRange{
+					{First: 4, Last: 10},
+					{First: 1, Last: 2},
+				},
+			}
+			Expect(ack.validateAckRanges()).To(BeFalse())
+		})
+
+		It("rejects ACK ranges in the wrong order", func() {
+			ack := AckFrame{
+				LargestAcked: 7,
+				AckRanges: []AckRange{
+					{First: 2, Last: 2},
+					{First: 6, Last: 7},
+				},
+			}
+			Expect(ack.validateAckRanges()).To(BeFalse())
+		})
+
+		It("rejects with overlapping ACK ranges", func() {
+			ack := AckFrame{
+				LargestAcked: 7,
+				AckRanges: []AckRange{
+					{First: 5, Last: 7},
+					{First: 2, Last: 5},
+				},
+			}
+			Expect(ack.validateAckRanges()).To(BeFalse())
+		})
+
+		It("rejects ACK ranges that are part of a larger ACK range", func() {
+			ack := AckFrame{
+				LargestAcked: 7,
+				AckRanges: []AckRange{
+					{First: 4, Last: 7},
+					{First: 5, Last: 6},
+				},
+			}
+			Expect(ack.validateAckRanges()).To(BeFalse())
+		})
+
+		It("rejects with directly adjacent ACK ranges", func() {
+			ack := AckFrame{
+				LargestAcked: 7,
+				AckRanges: []AckRange{
+					{First: 5, Last: 7},
+					{First: 2, Last: 4},
+				},
+			}
+			Expect(ack.validateAckRanges()).To(BeFalse())
+		})
+
+		It("accepts an ACK with one lost packet", func() {
+			ack := AckFrame{
+				LargestAcked: 10,
+				AckRanges: []AckRange{
+					{First: 5, Last: 10},
+					{First: 1, Last: 3},
+				},
+			}
+			Expect(ack.validateAckRanges()).To(BeTrue())
+		})
+
+		It("accepts an ACK with multiple lost packets", func() {
+			ack := AckFrame{
+				LargestAcked: 20,
+				AckRanges: []AckRange{
+					{First: 15, Last: 20},
+					{First: 10, Last: 12},
+					{First: 1, Last: 3},
+				},
+			}
+			Expect(ack.validateAckRanges()).To(BeTrue())
+		})
+	})
+
+	Context("check if ACK frame acks a certain packet", func() {
+		It("works with an ACK without any ranges", func() {
+			f := AckFrame{
+				LowestAcked:  5,
+				LargestAcked: 10,
+			}
+			Expect(f.AcksPacket(1)).To(BeFalse())
+			Expect(f.AcksPacket(4)).To(BeFalse())
+			Expect(f.AcksPacket(5)).To(BeTrue())
+			Expect(f.AcksPacket(8)).To(BeTrue())
+			Expect(f.AcksPacket(10)).To(BeTrue())
+			Expect(f.AcksPacket(11)).To(BeFalse())
+			Expect(f.AcksPacket(20)).To(BeFalse())
+		})
+
+		It("works with an ACK with multiple ACK ranges", func() {
+			f := AckFrame{
+				LowestAcked:  5,
+				LargestAcked: 20,
+				AckRanges: []AckRange{
+					{First: 15, Last: 20},
+					{First: 5, Last: 8},
+				},
+			}
+			Expect(f.AcksPacket(4)).To(BeFalse())
+			Expect(f.AcksPacket(5)).To(BeTrue())
+			Expect(f.AcksPacket(7)).To(BeTrue())
+			Expect(f.AcksPacket(8)).To(BeTrue())
+			Expect(f.AcksPacket(9)).To(BeFalse())
+			Expect(f.AcksPacket(14)).To(BeFalse())
+			Expect(f.AcksPacket(15)).To(BeTrue())
+			Expect(f.AcksPacket(18)).To(BeTrue())
+			Expect(f.AcksPacket(20)).To(BeTrue())
+			Expect(f.AcksPacket(21)).To(BeFalse())
+		})
+	})
+})

--- a/internal/wire/ack_frame_test.go
+++ b/internal/wire/ack_frame_test.go
@@ -10,1124 +10,206 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("AckFrame", func() {
-	Context("when parsing", func() {
-		It("accepts a sample frame", func() {
-			b := bytes.NewReader([]byte{0x40,
-				0x1c,     // largest acked
-				0x0, 0x0, // delay time
-				0x1c, // block length
-				0,
-			})
-			frame, err := ParseAckFrame(b, protocol.VersionWhatever)
+var _ = Describe("ACK Frame (for IETF QUIC)", func() {
+	Context("parsing", func() {
+		It("parses an ACK frame without any ranges", func() {
+			data := []byte{0xe}
+			data = append(data, encodeVarInt(100)...) // largest acked
+			data = append(data, encodeVarInt(0)...)   // delay
+			data = append(data, encodeVarInt(0)...)   // num blocks
+			data = append(data, encodeVarInt(10)...)  // first ack block
+			b := bytes.NewReader(data)
+			frame, err := ParseAckFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x1c)))
-			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(100)))
+			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(90)))
 			Expect(frame.HasMissingRanges()).To(BeFalse())
 			Expect(b.Len()).To(BeZero())
 		})
 
-		It("parses a frame that acks packet number 0", func() {
-			b := bytes.NewReader([]byte{0x40,
-				0x0,      // largest acked
-				0x0, 0x0, // delay time
-				0x1, // block length
-				0,
-			})
-			frame, err := ParseAckFrame(b, protocol.VersionWhatever)
+		It("parses an ACK frame that only acks a single packet", func() {
+			data := []byte{0xe}
+			data = append(data, encodeVarInt(55)...) // largest acked
+			data = append(data, encodeVarInt(0)...)  // delay
+			data = append(data, encodeVarInt(0)...)  // num blocks
+			data = append(data, encodeVarInt(0)...)  // first ack block
+			b := bytes.NewReader(data)
+			frame, err := ParseAckFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0)))
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(55)))
+			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(55)))
+			Expect(frame.HasMissingRanges()).To(BeFalse())
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("accepts an ACK frame that acks all packets from 0 to largest", func() {
+			data := []byte{0xe}
+			data = append(data, encodeVarInt(20)...) // largest acked
+			data = append(data, encodeVarInt(0)...)  // delay
+			data = append(data, encodeVarInt(0)...)  // num blocks
+			data = append(data, encodeVarInt(20)...) // first ack block
+			b := bytes.NewReader(data)
+			frame, err := ParseAckFrame(b, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(20)))
 			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0)))
 			Expect(frame.HasMissingRanges()).To(BeFalse())
 			Expect(b.Len()).To(BeZero())
 		})
 
-		It("parses a frame with 1 ACKed packet", func() {
-			b := bytes.NewReader([]byte{0x40,
-				0x10,     // largest acked
-				0x0, 0x0, // delay time
-				0x1, // block length
-				0,
-			})
-			frame, err := ParseAckFrame(b, protocol.VersionWhatever)
+		It("rejects an ACK frame that has a first ACK block which is larger than LargestAcked", func() {
+			data := []byte{0xe}
+			data = append(data, encodeVarInt(20)...) // largest acked
+			data = append(data, encodeVarInt(0)...)  // delay
+			data = append(data, encodeVarInt(0)...)  // num blocks
+			data = append(data, encodeVarInt(21)...) // first ack block
+			b := bytes.NewReader(data)
+			_, err := ParseAckFrame(b, versionIETFFrames)
+			Expect(err).To(MatchError("invalid first ACK range"))
+		})
+
+		It("parses an ACK frame that has a single block", func() {
+			data := []byte{0xe}
+			data = append(data, encodeVarInt(1000)...) // largest acked
+			data = append(data, encodeVarInt(0)...)    // delay
+			data = append(data, encodeVarInt(1)...)    // num blocks
+			data = append(data, encodeVarInt(100)...)  // first ack block
+			data = append(data, encodeVarInt(98)...)   // gap
+			data = append(data, encodeVarInt(50)...)   // ack block
+			b := bytes.NewReader(data)
+			frame, err := ParseAckFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x10)))
-			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0x10)))
-			Expect(frame.HasMissingRanges()).To(BeFalse())
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(1000)))
+			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(750)))
+			Expect(frame.HasMissingRanges()).To(BeTrue())
+			Expect(frame.AckRanges).To(Equal([]AckRange{
+				AckRange{Last: 1000, First: 900},
+				AckRange{Last: 800, First: 750},
+			}))
 			Expect(b.Len()).To(BeZero())
 		})
 
-		It("parses a frame that acks multiple packets, starting with 0", func() {
-			b := bytes.NewReader([]byte{0x40,
-				0x10,     // largest acked
-				0x0, 0x0, // delay time
-				0x11, // block length
-				0,
-			})
-			frame, err := ParseAckFrame(b, protocol.VersionWhatever)
+		It("parses an ACK frame that has a multiple blocks", func() {
+			data := []byte{0xe}
+			data = append(data, encodeVarInt(100)...) // largest acked
+			data = append(data, encodeVarInt(0)...)   // delay
+			data = append(data, encodeVarInt(2)...)   // num blocks
+			data = append(data, encodeVarInt(0)...)   // first ack block
+			data = append(data, encodeVarInt(0)...)   // gap
+			data = append(data, encodeVarInt(0)...)   // ack block
+			data = append(data, encodeVarInt(1)...)   // gap
+			data = append(data, encodeVarInt(1)...)   // ack block
+			b := bytes.NewReader(data)
+			frame, err := ParseAckFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x10)))
-			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0)))
-			Expect(frame.HasMissingRanges()).To(BeFalse())
+			Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(100)))
+			Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(94)))
+			Expect(frame.HasMissingRanges()).To(BeTrue())
+			Expect(frame.AckRanges).To(Equal([]AckRange{
+				AckRange{Last: 100, First: 100},
+				AckRange{Last: 98, First: 98},
+				AckRange{Last: 95, First: 94},
+			}))
 			Expect(b.Len()).To(BeZero())
 		})
 
-		It("parses a frame with multiple timestamps", func() {
-			b := bytes.NewReader([]byte{0x40,
-				0x10,     // largest acked
-				0x0, 0x0, // timestamp
-				0x10,                      // block length
-				0x4,                       // num timestamps
-				0x1, 0x6b, 0x26, 0x4, 0x0, // 1st timestamp
-				0x3, 0, 0, // 2nd timestamp
-				0x2, 0, 0, // 3rd timestamp
-				0x1, 0, 0, // 4th timestamp
-			})
-			_, err := ParseAckFrame(b, protocol.VersionWhatever)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(b.Len()).To(BeZero())
-		})
-
-		It("errors when the ACK range is too large", func() {
-			// LargestAcked: 0x1c
-			// Length: 0x1d => LowestAcked would be -1
-			b := bytes.NewReader([]byte{0x40,
-				0x1c,     // largest acked
-				0x0, 0x0, // delay time
-				0x1e, // block length
-				0,
-			})
-			_, err := ParseAckFrame(b, protocol.VersionWhatever)
-			Expect(err).To(MatchError(ErrInvalidAckRanges))
-		})
-
-		It("errors when the first ACK range is empty", func() {
-			b := bytes.NewReader([]byte{0x40,
-				0x9,      // largest acked
-				0x0, 0x0, // delay time
-				0x0, // block length
-				0,
-			})
-			_, err := ParseAckFrame(b, protocol.VersionWhatever)
-			Expect(err).To(MatchError(ErrInvalidFirstAckRange))
-		})
-
-		Context("in big endian", func() {
-			It("parses the delay time", func() {
-				b := bytes.NewReader([]byte{0x40,
-					0x3,       // largest acked
-					0x0, 0x8e, // delay time
-					0x3, // block length
-					0,
-				})
-				frame, err := ParseAckFrame(b, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(3)))
-				Expect(frame.DelayTime).To(Equal(142 * time.Microsecond))
-			})
-
-			It("errors on EOFs", func() {
-				data := []byte{0x60 ^ 0x4 ^ 0x1,
-					0x9, 0x66, // largest acked
-					0x23, 0x1, // delay time
-					0x7,      // num ACk blocks
-					0x0, 0x7, // 1st block
-					0xff, 0x0, 0x0, // 2nd block
-					0xf5, 0x2, 0x8a, // 3rd block
-					0xc8, 0x0, 0xe6, // 4th block
-					0xff, 0x0, 0x0, // 5th block
-					0xff, 0x0, 0x0, // 6th block
-					0xff, 0x0, 0x0, // 7th block
-					0x23, 0x0, 0x13, // 8th blocks
-					0x2,                       // num timestamps
-					0x1, 0x13, 0xae, 0xb, 0x0, // 1st timestamp
-					0x0, 0x80, 0x5, // 2nd timestamp
-				}
-				_, err := ParseAckFrame(bytes.NewReader(data), versionBigEndian)
-				Expect(err).NotTo(HaveOccurred())
-				for i := range data {
-					_, err := ParseAckFrame(bytes.NewReader(data[0:i]), versionBigEndian)
-					Expect(err).To(MatchError(io.EOF))
-				}
-			})
-
-			Context("largest acked length", func() {
-				It("parses a frame with a 2 byte packet number", func() {
-					b := bytes.NewReader([]byte{0x40 | 0x4,
-						0x13, 0x37, // largest acked
-						0x0, 0x0, // delay time
-						0x9, // block length
-						0,
-					})
-					frame, err := ParseAckFrame(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x1337)))
-					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0x1337 - 0x9 + 1)))
-					Expect(frame.HasMissingRanges()).To(BeFalse())
-					Expect(b.Len()).To(BeZero())
-				})
-
-				It("parses a frame with a 4 byte packet number", func() {
-					b := bytes.NewReader([]byte{0x40 | 0x8,
-						0xde, 0xca, 0xfb, 0xad, // largest acked
-						0x0, 0x0, // timesatmp
-						0x5, // block length
-						0,
-					})
-					frame, err := ParseAckFrame(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0xdecafbad)))
-					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0xdecafbad - 5 + 1)))
-					Expect(frame.HasMissingRanges()).To(BeFalse())
-					Expect(b.Len()).To(BeZero())
-				})
-
-				It("parses a frame with a 6 byte packet number", func() {
-					b := bytes.NewReader([]byte{0x4 | 0xc,
-						0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, // largest acked
-						0x0, 0x0, // delay time
-						0x5, // block length
-						0,
-					})
-					frame, err := ParseAckFrame(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0xdeadbeefcafe)))
-					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(0xdeadbeefcafe - 5 + 1)))
-					Expect(frame.HasMissingRanges()).To(BeFalse())
-					Expect(b.Len()).To(BeZero())
-				})
-			})
-		})
-
-		Context("ACK blocks", func() {
-			It("parses a frame with two ACK blocks", func() {
-				b := bytes.NewReader([]byte{0x60,
-					0x18,     // largest acked
-					0x0, 0x0, // delay time
-					0x1,       // num ACK blocks
-					0x3,       // 1st block
-					0x2, 0x10, // 2nd block
-					0,
-				})
-				frame, err := ParseAckFrame(b, protocol.VersionWhatever)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x18)))
-				Expect(frame.HasMissingRanges()).To(BeTrue())
-				Expect(frame.AckRanges).To(HaveLen(2))
-				Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 0x18 - 0x3 + 1, Last: 0x18}))
-				Expect(frame.AckRanges[1]).To(Equal(AckRange{First: (0x18 - 0x3 + 1) - (0x2 + 1) - (0x10 - 1), Last: (0x18 - 0x3 + 1) - (0x2 + 1)}))
-				Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(4)))
-				Expect(b.Len()).To(BeZero())
-			})
-
-			It("rejects a frame with invalid ACK ranges", func() {
-				// like the test before, but increased the last ACK range, such that the First would be negative
-				b := bytes.NewReader([]byte{0x60,
-					0x18,     // largest acked
-					0x0, 0x0, // delay time
-					0x1,       // num ACK blocks
-					0x3,       // 1st block
-					0x2, 0x15, // 2nd block
-					0,
-				})
-				_, err := ParseAckFrame(b, protocol.VersionWhatever)
-				Expect(err).To(MatchError(ErrInvalidAckRanges))
-			})
-
-			It("rejects a frame that says it has ACK blocks in the typeByte, but doesn't have any", func() {
-				b := bytes.NewReader([]byte{0x60 ^ 0x3,
-					0x4,      // largest acked
-					0x0, 0x0, // delay time
-					0, // num ACK blocks
-					0,
-				})
-				_, err := ParseAckFrame(b, protocol.VersionWhatever)
-				Expect(err).To(MatchError(ErrInvalidAckRanges))
-			})
-
-			It("parses a frame with multiple single packets missing", func() {
-				b := bytes.NewReader([]byte{0x60,
-					0x27,     // largest acked
-					0x0, 0x0, // delay time
-					0x6,      // num ACK blocks
-					0x9,      // 1st block
-					0x1, 0x1, // 2nd block
-					0x1, 0x1, // 3rd block
-					0x1, 0x1, // 4th block
-					0x1, 0x1, // 5th block
-					0x1, 0x1, // 6th block
-					0x1, 0x13, // 7th block
-					0,
-				})
-				frame, err := ParseAckFrame(b, protocol.VersionWhatever)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x27)))
-				Expect(frame.HasMissingRanges()).To(BeTrue())
-				Expect(frame.AckRanges).To(HaveLen(7))
-				Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 31, Last: 0x27}))
-				Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 29, Last: 29}))
-				Expect(frame.AckRanges[2]).To(Equal(AckRange{First: 27, Last: 27}))
-				Expect(frame.AckRanges[3]).To(Equal(AckRange{First: 25, Last: 25}))
-				Expect(frame.AckRanges[4]).To(Equal(AckRange{First: 23, Last: 23}))
-				Expect(frame.AckRanges[5]).To(Equal(AckRange{First: 21, Last: 21}))
-				Expect(frame.AckRanges[6]).To(Equal(AckRange{First: 1, Last: 19}))
-				Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
-				Expect(b.Len()).To(BeZero())
-			})
-
-			It("parses a frame with multiple longer ACK blocks", func() {
-				b := bytes.NewReader([]byte{0x60,
-					0x52,      // largest acked
-					0xd1, 0x0, //delay time
-					0x3,       // num ACK blocks
-					0x17,      // 1st block
-					0xa, 0x10, // 2nd block
-					0x4, 0x8, // 3rd block
-					0x2, 0x12, // 4th block
-					0,
-				})
-				frame, err := ParseAckFrame(b, protocol.VersionWhatever)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x52)))
-				Expect(frame.HasMissingRanges()).To(BeTrue())
-				Expect(frame.AckRanges).To(HaveLen(4))
-				Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 60, Last: 0x52}))
-				Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 34, Last: 49}))
-				Expect(frame.AckRanges[2]).To(Equal(AckRange{First: 22, Last: 29}))
-				Expect(frame.AckRanges[3]).To(Equal(AckRange{First: 2, Last: 19}))
-				Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(2)))
-				Expect(b.Len()).To(BeZero())
-			})
-
-			Context("more than 256 lost packets in a row", func() {
-				// 255 missing packets fit into a single ACK block
-				It("parses a frame with a range of 255 missing packets", func() {
-					b := bytes.NewReader([]byte{0x60 ^ 0x4,
-						0x1, 0x15, // largest acked
-						0x0, 0x0, // delay time
-						0x1,        // num ACK blocks
-						0x3,        // 1st block
-						0xff, 0x13, // 2nd block
-						0,
-					})
-					frame, err := ParseAckFrame(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x115)))
-					Expect(frame.HasMissingRanges()).To(BeTrue())
-					Expect(frame.AckRanges).To(HaveLen(2))
-					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 20 + 255, Last: 0x115}))
-					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1, Last: 19}))
-					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
-					Expect(b.Len()).To(BeZero())
-				})
-
-				// 256 missing packets fit into two ACK blocks
-				It("parses a frame with a range of 256 missing packets", func() {
-					b := bytes.NewReader([]byte{0x60 ^ 0x4,
-						0x1, 0x14, // largest acked
-						0x0, 0x0, // delay time
-						0x2,       // num ACK blocks
-						0x1,       // 1st block
-						0xff, 0x0, // 2nd block
-						0x1, 0x13, // 3rd block
-						0,
-					})
-					frame, err := ParseAckFrame(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x114)))
-					Expect(frame.HasMissingRanges()).To(BeTrue())
-					Expect(frame.AckRanges).To(HaveLen(2))
-					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 20 + 256, Last: 0x114}))
-					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1, Last: 19}))
-					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
-					Expect(b.Len()).To(BeZero())
-				})
-
-				It("parses a frame with an incomplete range at the end", func() {
-					// this is a modified ACK frame that has 5 instead of originally 6 written ranges
-					// each gap is 300 packets and thus takes 2 ranges
-					// the last range is incomplete, and should be completely ignored
-					b := bytes.NewReader([]byte{0x60 ^ 0x4,
-						0x3, 0x9b, // largest acked
-						0x0, 0x0, // delay time
-						0x5,       // num ACK blocks, instead of 0x6
-						0x1,       // 1st block
-						0xff, 0x0, // 2nd block
-						0x2d, 0x1, // 3rd block
-						0xff, 0x0, // 4th block
-						0x2d, 0x1, // 5th block
-						0xff, 0x0, /*0x2d, 0x14,*/ // 6th block
-						0,
-					})
-					frame, err := ParseAckFrame(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x39b)))
-					Expect(frame.HasMissingRanges()).To(BeTrue())
-					Expect(frame.AckRanges).To(HaveLen(3))
-					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 20 + 3*301, Last: 20 + 3*301}))
-					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 20 + 2*301, Last: 20 + 2*301}))
-					Expect(frame.AckRanges[2]).To(Equal(AckRange{First: 20 + 1*301, Last: 20 + 1*301}))
-					Expect(b.Len()).To(BeZero())
-				})
-
-				It("parses a frame with one long range, spanning 2 blocks, of missing packets", func() {
-					// 280 missing packets
-					b := bytes.NewReader([]byte{0x60 ^ 0x4,
-						0x1, 0x44, // largest acked
-						0x0, 0x0, // delay time
-						0x2,       // num ACK blocks
-						0x19,      // 1st block
-						0xff, 0x0, // 2nd block
-						0x19, 0x13, // 3rd block
-						0,
-					})
-					frame, err := ParseAckFrame(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x144)))
-					Expect(frame.HasMissingRanges()).To(BeTrue())
-					Expect(frame.AckRanges).To(HaveLen(2))
-					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 300, Last: 0x144}))
-					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1, Last: 19}))
-					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
-					Expect(b.Len()).To(BeZero())
-				})
-
-				It("parses a frame with one long range, spanning multiple blocks, of missing packets", func() {
-					// 2345 missing packets
-					b := bytes.NewReader([]byte{0x60 ^ 0x4,
-						0x9, 0x5b, // largest acked
-						0x0, 0x0, // delay time
-						0xa,       // num ACK blocks
-						0x1f,      // 1st block
-						0xff, 0x0, // 2nd block
-						0xff, 0x0, // 3rd block
-						0xff, 0x0, // 4th block
-						0xff, 0x0, // 5th block
-						0xff, 0x0, // 6th block
-						0xff, 0x0, // 7th block
-						0xff, 0x0, // 8th block
-						0xff, 0x0, // 9th block
-						0xff, 0x0, // 10th block
-						0x32, 0x13, // 11th block
-						0,
-					})
-					frame, err := ParseAckFrame(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x95b)))
-					Expect(frame.HasMissingRanges()).To(BeTrue())
-					Expect(frame.AckRanges).To(HaveLen(2))
-					Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 2365, Last: 0x95b}))
-					Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1, Last: 19}))
-					Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
-					Expect(b.Len()).To(BeZero())
-				})
-
-				Context("in big endian", func() {
-					It("parses a frame with multiple 2 byte long ranges of missing packets", func() {
-						b := bytes.NewReader([]byte{0x60 ^ 0x4 ^ 0x1,
-							0x9, 0x66, // largest acked
-							0x0, 0x0, // delay time
-							0x7,      // num ACK blocks
-							0x0, 0x7, // 1st block
-							0xff, 0x0, 0x0, // 2nd block
-							0xf5, 0x2, 0x8a, // 3rd block
-							0xc8, 0x0, 0xe6, // 4th block
-							0xff, 0x0, 0x0, // 5th block
-							0xff, 0x0, 0x0, // 6th block
-							0xff, 0x0, 0x0, // 7th block
-							0x23, 0x0, 0x13, // 8th block
-							0,
-						})
-						frame, err := ParseAckFrame(b, versionBigEndian)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0x966)))
-						Expect(frame.HasMissingRanges()).To(BeTrue())
-						Expect(frame.AckRanges).To(HaveLen(4))
-						Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 2400, Last: 0x966}))
-						Expect(frame.AckRanges[1]).To(Equal(AckRange{First: 1250, Last: 1899}))
-						Expect(frame.AckRanges[2]).To(Equal(AckRange{First: 820, Last: 1049}))
-						Expect(frame.AckRanges[3]).To(Equal(AckRange{First: 1, Last: 19}))
-						Expect(frame.LowestAcked).To(Equal(protocol.PacketNumber(1)))
-						Expect(b.Len()).To(BeZero())
-					})
-
-					It("parses a frame with with a 4 byte ack block length", func() {
-						b := bytes.NewReader([]byte{0x60 ^ 0xc ^ 0x2,
-							0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, // largest acked
-							0x0, 0x0, // delay time
-							0x1,              // num ACK blocks
-							0, 0, 0x13, 0x37, // 1st block
-							0x20, 0x12, 0x34, 0x56, 0x78, // 2nd block
-							0,
-						})
-						frame, err := ParseAckFrame(b, versionBigEndian)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0xdeadbeefcafe)))
-						Expect(frame.HasMissingRanges()).To(BeTrue())
-						Expect(frame.AckRanges).To(HaveLen(2))
-						Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 0xdeadbeefcafe - 0x1337 + 1, Last: 0xdeadbeefcafe}))
-						Expect(frame.AckRanges[1]).To(Equal(AckRange{First: (0xdeadbeefcafe - 0x1337 + 1) - (0x20 + 1) - (0x12345678 - 1), Last: (0xdeadbeefcafe - 0x1337 + 1) - (0x20 + 1)}))
-					})
-
-					It("parses a frame with with a 6 byte ack block length", func() {
-						b := bytes.NewReader([]byte{0x60 ^ 0xc ^ 0x3,
-							0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, // largest acked
-							0x0, 0x0, // delay time
-							0x1,                    // num ACk blocks
-							0, 0, 0, 0, 0x13, 0x37, // 1st block
-							0x20, 0x0, 0xab, 0x12, 0x34, 0x56, 0x78, // 2nd block
-							0,
-						})
-						frame, err := ParseAckFrame(b, versionBigEndian)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(frame.LargestAcked).To(Equal(protocol.PacketNumber(0xdeadbeefcafe)))
-						Expect(frame.HasMissingRanges()).To(BeTrue())
-						Expect(frame.AckRanges).To(HaveLen(2))
-						Expect(frame.AckRanges[0]).To(Equal(AckRange{First: 0xdeadbeefcafe - 0x1337 + 1, Last: 0xdeadbeefcafe}))
-						Expect(frame.AckRanges[1]).To(Equal(AckRange{First: (0xdeadbeefcafe - 0x1337 + 1) - (0x20 + 1) - (0xab12345678 - 1), Last: (0xdeadbeefcafe - 0x1337 + 1) - (0x20 + 1)}))
-					})
-				})
-			})
+		It("errors on EOF", func() {
+			data := []byte{0xe}
+			data = append(data, encodeVarInt(1000)...) // largest acked
+			data = append(data, encodeVarInt(0)...)    // delay
+			data = append(data, encodeVarInt(1)...)    // num blocks
+			data = append(data, encodeVarInt(100)...)  // first ack block
+			data = append(data, encodeVarInt(98)...)   // gap
+			data = append(data, encodeVarInt(50)...)   // ack block
+			_, err := ParseAckFrame(bytes.NewReader(data), versionIETFFrames)
+			Expect(err).NotTo(HaveOccurred())
+			for i := range data {
+				_, err := ParseAckFrame(bytes.NewReader(data[0:i]), versionIETFFrames)
+				Expect(err).To(MatchError(io.EOF))
+			}
 		})
 	})
 
 	Context("when writing", func() {
-		var b *bytes.Buffer
-
-		BeforeEach(func() {
-			b = &bytes.Buffer{}
+		It("writes a frame that acks a single packet", func() {
+			buf := &bytes.Buffer{}
+			f := &AckFrame{
+				LargestAcked: 0xdeadbeef,
+				LowestAcked:  0xdeadbeef,
+				DelayTime:    18 * time.Second,
+			}
+			err := f.Write(buf, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.MinLength(versionIETFFrames)).To(BeEquivalentTo(buf.Len()))
+			b := bytes.NewReader(buf.Bytes())
+			frame, err := ParseAckFrame(b, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame).To(Equal(f))
+			Expect(frame.HasMissingRanges()).To(BeFalse())
+			Expect(b.Len()).To(BeZero())
 		})
 
-		Context("self-consistency", func() {
-			It("writes a simple ACK frame", func() {
-				frameOrig := &AckFrame{
-					LargestAcked: 1,
-					LowestAcked:  1,
-				}
-				err := frameOrig.Write(b, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				r := bytes.NewReader(b.Bytes())
-				frame, err := ParseAckFrame(r, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-				Expect(frame.HasMissingRanges()).To(BeFalse())
-				Expect(r.Len()).To(BeZero())
-			})
-
-			It("writes an ACK that also acks packet 0", func() {
-				frameOrig := &AckFrame{
-					LargestAcked: 1,
-					LowestAcked:  0,
-				}
-				err := frameOrig.Write(b, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				r := bytes.NewReader(b.Bytes())
-				frame, err := ParseAckFrame(r, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-				Expect(frame.HasMissingRanges()).To(BeFalse())
-				Expect(r.Len()).To(BeZero())
-			})
-
-			It("writes the correct block length in a simple ACK frame", func() {
-				frameOrig := &AckFrame{
-					LargestAcked: 20,
-					LowestAcked:  10,
-				}
-				err := frameOrig.Write(b, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				r := bytes.NewReader(b.Bytes())
-				frame, err := ParseAckFrame(r, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-				Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-				Expect(frame.HasMissingRanges()).To(BeFalse())
-				Expect(r.Len()).To(BeZero())
-			})
-
-			It("writes a simple ACK frame with a high packet number", func() {
-				frameOrig := &AckFrame{
-					LargestAcked: 0xdeadbeefcafe,
-					LowestAcked:  0xdeadbeefcafe,
-				}
-				err := frameOrig.Write(b, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				r := bytes.NewReader(b.Bytes())
-				frame, err := ParseAckFrame(r, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-				Expect(frame.HasMissingRanges()).To(BeFalse())
-				Expect(r.Len()).To(BeZero())
-			})
-
-			It("writes an ACK frame with one packet missing", func() {
-				frameOrig := &AckFrame{
-					LargestAcked: 40,
-					LowestAcked:  0,
-					AckRanges: []AckRange{
-						{First: 25, Last: 40},
-						{First: 0, Last: 23},
-					},
-				}
-				err := frameOrig.Write(b, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				r := bytes.NewReader(b.Bytes())
-				frame, err := ParseAckFrame(r, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-				Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-				Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				Expect(r.Len()).To(BeZero())
-			})
-
-			It("writes an ACK frame with multiple missing packets", func() {
-				frameOrig := &AckFrame{
-					LargestAcked: 25,
-					LowestAcked:  1,
-					AckRanges: []AckRange{
-						{First: 22, Last: 25},
-						{First: 15, Last: 18},
-						{First: 13, Last: 13},
-						{First: 1, Last: 10},
-					},
-				}
-				err := frameOrig.Write(b, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				r := bytes.NewReader(b.Bytes())
-				frame, err := ParseAckFrame(r, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-				Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-				Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				Expect(r.Len()).To(BeZero())
-			})
-
-			It("rejects a frame with incorrect LargestObserved value", func() {
-				frame := &AckFrame{
-					LargestAcked: 26,
-					LowestAcked:  1,
-					AckRanges: []AckRange{
-						{First: 12, Last: 25},
-						{First: 1, Last: 10},
-					},
-				}
-				err := frame.Write(b, versionBigEndian)
-				Expect(err).To(MatchError(errInconsistentAckLargestAcked))
-			})
-
-			It("rejects a frame with incorrect LargestObserved value", func() {
-				frame := &AckFrame{
-					LargestAcked: 25,
-					LowestAcked:  2,
-					AckRanges: []AckRange{
-						{First: 12, Last: 25},
-						{First: 1, Last: 10},
-					},
-				}
-				err := frame.Write(b, versionBigEndian)
-				Expect(err).To(MatchError(errInconsistentAckLowestAcked))
-			})
-
-			Context("longer gaps between ACK blocks", func() {
-				It("only writes one block for 254 lost packets", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 300,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 20 + 254, Last: 300},
-							{First: 1, Last: 19},
-						},
-					}
-					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(2)))
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				})
-
-				It("only writes one block for 255 lost packets", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 300,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 20 + 255, Last: 300},
-							{First: 1, Last: 19},
-						},
-					}
-					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(2)))
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				})
-
-				It("writes two blocks for 256 lost packets", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 300,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 20 + 256, Last: 300},
-							{First: 1, Last: 19},
-						},
-					}
-					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(3)))
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				})
-
-				It("writes two blocks for 510 lost packets", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 600,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 20 + 510, Last: 600},
-							{First: 1, Last: 19},
-						},
-					}
-					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(3)))
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				})
-
-				It("writes three blocks for 511 lost packets", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 600,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 20 + 511, Last: 600},
-							{First: 1, Last: 19},
-						},
-					}
-					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(4)))
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				})
-
-				It("writes three blocks for 512 lost packets", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 600,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 20 + 512, Last: 600},
-							{First: 1, Last: 19},
-						},
-					}
-					Expect(frameOrig.numWritableNackRanges()).To(Equal(uint64(4)))
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				})
-
-				It("writes multiple blocks for a lot of lost packets", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 3000,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 2900, Last: 3000},
-							{First: 1, Last: 19},
-						},
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				})
-
-				It("writes multiple longer blocks for 256 lost packets", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 3600,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 2900, Last: 3600},
-							{First: 1000, Last: 2500},
-							{First: 1, Last: 19},
-						},
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-				})
-			})
-
-			Context("largest acked length", func() {
-				It("writes a 1 largest acked", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 200,
-						LowestAcked:  1,
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x0)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(r.Len()).To(BeZero())
-				})
-
-				It("writes a 2 byte largest acked", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 0x100,
-						LowestAcked:  1,
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x1)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(r.Len()).To(BeZero())
-				})
-
-				It("writes a 4 byte largest acked", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 0x10000,
-						LowestAcked:  1,
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x2)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(r.Len()).To(BeZero())
-				})
-
-				It("writes a 6 byte largest acked", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 0x100000000,
-						LowestAcked:  1,
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x3)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(r.Len()).To(BeZero())
-				})
-			})
-
-			Context("ack block length", func() {
-				It("writes a 1 byte ack block length, if all ACK blocks are short", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 5001,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 5000, Last: 5001},
-							{First: 250, Last: 300},
-							{First: 1, Last: 200},
-						},
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x0)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-					Expect(r.Len()).To(BeZero())
-				})
-
-				It("writes a 2 byte ack block length, for a frame with one ACK block", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 10000,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 9990, Last: 10000},
-							{First: 1, Last: 9988},
-						},
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x1)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-					Expect(r.Len()).To(BeZero())
-				})
-
-				It("writes a 2 byte ack block length, for a frame with multiple ACK blocks", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 10000,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 9990, Last: 10000},
-							{First: 1, Last: 256},
-						},
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x1)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-					Expect(r.Len()).To(BeZero())
-				})
-
-				It("writes a 4 byte ack block length, for a frame with single ACK blocks", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 0xdeadbeef,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 9990, Last: 0xdeadbeef},
-							{First: 1, Last: 9988},
-						},
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x2)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-					Expect(r.Len()).To(BeZero())
-				})
-
-				It("writes a 4 byte ack block length, for a frame with multiple ACK blocks", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 0xdeadbeef,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 9990, Last: 0xdeadbeef},
-							{First: 1, Last: 256},
-						},
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x2)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-					Expect(r.Len()).To(BeZero())
-				})
-
-				It("writes a 6 byte ack block length, for a frame with a single ACK blocks", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 0xdeadbeefcafe,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 9990, Last: 0xdeadbeefcafe},
-							{First: 1, Last: 9988},
-						},
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x3)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-					Expect(r.Len()).To(BeZero())
-				})
-
-				It("writes a 6 byte ack block length, for a frame with multiple ACK blocks", func() {
-					frameOrig := &AckFrame{
-						LargestAcked: 0xdeadbeefcafe,
-						LowestAcked:  1,
-						AckRanges: []AckRange{
-							{First: 9990, Last: 0xdeadbeefcafe},
-							{First: 1, Last: 256},
-						},
-					}
-					err := frameOrig.Write(b, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(b.Bytes()[0] & 0x3).To(Equal(byte(0x3)))
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, versionBigEndian)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(frameOrig.LowestAcked))
-					Expect(frame.AckRanges).To(Equal(frameOrig.AckRanges))
-					Expect(r.Len()).To(BeZero())
-				})
-			})
-
-			Context("too many ACK blocks", func() {
-				It("skips the lowest ACK ranges, if there are more than 255 AckRanges", func() {
-					ackRanges := make([]AckRange, 300)
-					for i := 1; i <= 300; i++ {
-						ackRanges[300-i] = AckRange{First: protocol.PacketNumber(3 * i), Last: protocol.PacketNumber(3*i + 1)}
-					}
-					frameOrig := &AckFrame{
-						LargestAcked: ackRanges[0].Last,
-						LowestAcked:  ackRanges[len(ackRanges)-1].First,
-						AckRanges:    ackRanges,
-					}
-					err := frameOrig.Write(b, protocol.VersionWhatever)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, protocol.VersionWhatever)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(ackRanges[254].First))
-					Expect(frame.AckRanges).To(HaveLen(0xFF))
-					Expect(frame.validateAckRanges()).To(BeTrue())
-				})
-
-				It("skips the lowest ACK ranges, if the gaps are large", func() {
-					ackRanges := make([]AckRange, 100)
-					// every AckRange will take 4 written ACK ranges
-					for i := 1; i <= 100; i++ {
-						ackRanges[100-i] = AckRange{First: protocol.PacketNumber(1000 * i), Last: protocol.PacketNumber(1000*i + 1)}
-					}
-					frameOrig := &AckFrame{
-						LargestAcked: ackRanges[0].Last,
-						LowestAcked:  ackRanges[len(ackRanges)-1].First,
-						AckRanges:    ackRanges,
-					}
-					err := frameOrig.Write(b, protocol.VersionWhatever)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, protocol.VersionWhatever)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.LowestAcked).To(Equal(ackRanges[255/4].First))
-					Expect(frame.validateAckRanges()).To(BeTrue())
-				})
-
-				It("works with huge gaps", func() {
-					ackRanges := []AckRange{
-						{First: 2 * 255 * 200, Last: 2*255*200 + 1},
-						{First: 1 * 255 * 200, Last: 1*255*200 + 1},
-						{First: 1, Last: 2},
-					}
-					frameOrig := &AckFrame{
-						LargestAcked: ackRanges[0].Last,
-						LowestAcked:  ackRanges[len(ackRanges)-1].First,
-						AckRanges:    ackRanges,
-					}
-					err := frameOrig.Write(b, protocol.VersionWhatever)
-					Expect(err).ToNot(HaveOccurred())
-					r := bytes.NewReader(b.Bytes())
-					frame, err := ParseAckFrame(r, protocol.VersionWhatever)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(frame.LargestAcked).To(Equal(frameOrig.LargestAcked))
-					Expect(frame.AckRanges).To(HaveLen(2))
-					Expect(frame.LowestAcked).To(Equal(ackRanges[1].First))
-					Expect(frame.validateAckRanges()).To(BeTrue())
-				})
-			})
+		It("writes a frame that acks many packets", func() {
+			buf := &bytes.Buffer{}
+			f := &AckFrame{
+				LargestAcked: 0xdecafbad,
+				LowestAcked:  0x1337,
+			}
+			err := f.Write(buf, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.MinLength(versionIETFFrames)).To(BeEquivalentTo(buf.Len()))
+			b := bytes.NewReader(buf.Bytes())
+			frame, err := ParseAckFrame(b, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame).To(Equal(f))
+			Expect(frame.HasMissingRanges()).To(BeFalse())
+			Expect(b.Len()).To(BeZero())
 		})
 
-		Context("min length", func() {
-			It("has proper min length", func() {
-				f := &AckFrame{
-					LargestAcked: 1,
-				}
-				err := f.Write(b, protocol.VersionWhatever)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(f.MinLength(0)).To(Equal(protocol.ByteCount(b.Len())))
-			})
+		It("writes a frame with a a single gap", func() {
+			buf := &bytes.Buffer{}
+			f := &AckFrame{
+				LargestAcked: 1000,
+				LowestAcked:  100,
+				AckRanges: []AckRange{
+					{First: 400, Last: 1000},
+					{First: 100, Last: 200},
+				},
+			}
+			Expect(f.validateAckRanges()).To(BeTrue())
+			err := f.Write(buf, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.MinLength(versionIETFFrames)).To(BeEquivalentTo(buf.Len()))
+			b := bytes.NewReader(buf.Bytes())
+			frame, err := ParseAckFrame(b, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame).To(Equal(f))
+			Expect(frame.HasMissingRanges()).To(BeTrue())
+			Expect(b.Len()).To(BeZero())
+		})
 
-			It("has proper min length with a large LargestObserved", func() {
-				f := &AckFrame{
-					LargestAcked: 0xDEADBEEFCAFE,
-				}
-				err := f.Write(b, protocol.VersionWhatever)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(f.MinLength(0)).To(Equal(protocol.ByteCount(b.Len())))
-			})
-
-			It("has the proper min length for an ACK with missing packets", func() {
-				f := &AckFrame{
-					LargestAcked: 2000,
-					LowestAcked:  10,
-					AckRanges: []AckRange{
-						{First: 1000, Last: 2000},
-						{First: 50, Last: 900},
-						{First: 10, Last: 23},
-					},
-				}
-				err := f.Write(b, protocol.VersionWhatever)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(f.MinLength(0)).To(Equal(protocol.ByteCount(b.Len())))
-			})
-
-			It("has the proper min length for an ACK with long gaps of missing packets", func() {
-				f := &AckFrame{
-					LargestAcked: 2000,
-					LowestAcked:  1,
-					AckRanges: []AckRange{
-						{First: 1500, Last: 2000},
-						{First: 290, Last: 295},
-						{First: 1, Last: 19},
-					},
-				}
-				err := f.Write(b, protocol.VersionWhatever)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(f.MinLength(0)).To(Equal(protocol.ByteCount(b.Len())))
-			})
-
-			It("has the proper min length for an ACK with a long ACK range", func() {
-				largestAcked := protocol.PacketNumber(2 + 0xFFFFFF)
-				f := &AckFrame{
-					LargestAcked: largestAcked,
-					LowestAcked:  1,
-					AckRanges: []AckRange{
-						{First: 1500, Last: largestAcked},
-						{First: 290, Last: 295},
-						{First: 1, Last: 19},
-					},
-				}
-				err := f.Write(b, protocol.VersionWhatever)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(f.MinLength(0)).To(Equal(protocol.ByteCount(b.Len())))
-			})
+		It("writes a frame with multiple ranges", func() {
+			buf := &bytes.Buffer{}
+			f := &AckFrame{
+				LargestAcked: 10,
+				LowestAcked:  1,
+				AckRanges: []AckRange{
+					{First: 10, Last: 10},
+					{First: 8, Last: 8},
+					{First: 5, Last: 6},
+					{First: 1, Last: 3},
+				},
+			}
+			Expect(f.validateAckRanges()).To(BeTrue())
+			err := f.Write(buf, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.MinLength(versionIETFFrames)).To(BeEquivalentTo(buf.Len()))
+			b := bytes.NewReader(buf.Bytes())
+			frame, err := ParseAckFrame(b, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame).To(Equal(f))
+			Expect(frame.HasMissingRanges()).To(BeTrue())
+			Expect(b.Len()).To(BeZero())
 		})
 	})
 

--- a/internal/wire/blocked_frame.go
+++ b/internal/wire/blocked_frame.go
@@ -18,7 +18,7 @@ func ParseBlockedFrame(r *bytes.Reader, version protocol.VersionNumber) (*Blocke
 }
 
 func (f *BlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
-	if !version.UsesMaxDataFrame() {
+	if !version.UsesIETFFrameFormat() {
 		return (&blockedFrameLegacy{}).Write(b, version)
 	}
 	typeByte := uint8(0x08)
@@ -28,7 +28,7 @@ func (f *BlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) er
 
 // MinLength of a written frame
 func (f *BlockedFrame) MinLength(version protocol.VersionNumber) (protocol.ByteCount, error) {
-	if !version.UsesMaxDataFrame() { // writing this frame would result in a legacy BLOCKED being written, which is longer
+	if !version.UsesIETFFrameFormat() { // writing this frame would result in a legacy BLOCKED being written, which is longer
 		return 1 + 4, nil
 	}
 	return 1, nil

--- a/internal/wire/blocked_frame_legacy.go
+++ b/internal/wire/blocked_frame_legacy.go
@@ -16,8 +16,7 @@ type blockedFrameLegacy struct {
 // * a STREAM_BLOCKED frame, if the BLOCKED applies to a stream
 // * a BLOCKED frame, if the BLOCKED applies to the connection
 func ParseBlockedFrameLegacy(r *bytes.Reader, version protocol.VersionNumber) (Frame, error) {
-	// read the TypeByte
-	if _, err := r.ReadByte(); err != nil {
+	if _, err := r.ReadByte(); err != nil { // read the TypeByte
 		return nil, err
 	}
 	streamID, err := utils.GetByteOrder(version).ReadUint32(r)

--- a/internal/wire/blocked_frame_legacy_test.go
+++ b/internal/wire/blocked_frame_legacy_test.go
@@ -10,60 +10,56 @@ import (
 
 var _ = Describe("legacy BLOCKED Frame", func() {
 	Context("when parsing", func() {
-		Context("in big endian", func() {
-			It("accepts sample frame for a stream", func() {
-				b := bytes.NewReader([]byte{0x5, 0xde, 0xad, 0xbe, 0xef})
-				f, err := ParseBlockedFrameLegacy(b, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(f).To(BeAssignableToTypeOf(&StreamBlockedFrame{}))
-				frame := f.(*StreamBlockedFrame)
-				Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
-			})
-
-			It("accepts sample frame for the connection", func() {
-				b := bytes.NewReader([]byte{0x5, 0x0, 0x0, 0x0, 0x0})
-				f, err := ParseBlockedFrameLegacy(b, versionBigEndian)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(f).To(BeAssignableToTypeOf(&BlockedFrame{}))
-			})
+		It("accepts sample frame for a stream", func() {
+			b := bytes.NewReader([]byte{0x5, 0xde, 0xad, 0xbe, 0xef})
+			f, err := ParseBlockedFrameLegacy(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f).To(BeAssignableToTypeOf(&StreamBlockedFrame{}))
+			frame := f.(*StreamBlockedFrame)
+			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
 		})
 
-		It("errors on EOFs", func() {
-			data := []byte{0x5, 0xef, 0xbe, 0xad, 0xde}
-			_, err := ParseBlockedFrameLegacy(bytes.NewReader(data), protocol.VersionWhatever)
-			Expect(err).NotTo(HaveOccurred())
-			for i := range data {
-				_, err := ParseBlockedFrameLegacy(bytes.NewReader(data[0:i]), protocol.VersionWhatever)
-				Expect(err).To(HaveOccurred())
-			}
+		It("accepts sample frame for the connection", func() {
+			b := bytes.NewReader([]byte{0x5, 0x0, 0x0, 0x0, 0x0})
+			f, err := ParseBlockedFrameLegacy(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f).To(BeAssignableToTypeOf(&BlockedFrame{}))
 		})
 	})
 
+	It("errors on EOFs", func() {
+		data := []byte{0x5, 0xef, 0xbe, 0xad, 0xde}
+		_, err := ParseBlockedFrameLegacy(bytes.NewReader(data), protocol.VersionWhatever)
+		Expect(err).NotTo(HaveOccurred())
+		for i := range data {
+			_, err := ParseBlockedFrameLegacy(bytes.NewReader(data[0:i]), protocol.VersionWhatever)
+			Expect(err).To(HaveOccurred())
+		}
+	})
+
 	Context("when writing", func() {
-		Context("in big endian", func() {
-			It("writes a BLOCKED frame for a stream", func() {
-				b := &bytes.Buffer{}
-				frame := StreamBlockedFrame{StreamID: 0x1337}
-				frame.Write(b, versionBigEndian)
-				Expect(b.Bytes()).To(Equal([]byte{0x5, 0x0, 0x0, 0x13, 0x37}))
-			})
+		It("writes a BLOCKED frame for a stream", func() {
+			b := &bytes.Buffer{}
+			frame := StreamBlockedFrame{StreamID: 0x1337}
+			frame.Write(b, versionBigEndian)
+			Expect(b.Bytes()).To(Equal([]byte{0x5, 0x0, 0x0, 0x13, 0x37}))
+		})
 
-			It("has the correct min length for a BLOCKED frame for a stream", func() {
-				frame := StreamBlockedFrame{StreamID: 3}
-				Expect(frame.MinLength(0)).To(Equal(protocol.ByteCount(5)))
-			})
+		It("has the correct min length for a BLOCKED frame for a stream", func() {
+			frame := StreamBlockedFrame{StreamID: 3}
+			Expect(frame.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(5)))
+		})
 
-			It("writes a BLOCKED frame for the connection", func() {
-				b := &bytes.Buffer{}
-				frame := BlockedFrame{}
-				frame.Write(b, versionBigEndian)
-				Expect(b.Bytes()).To(Equal([]byte{0x5, 0x0, 0x0, 0x0, 0x0}))
-			})
+		It("writes a BLOCKED frame for the connection", func() {
+			b := &bytes.Buffer{}
+			frame := BlockedFrame{}
+			frame.Write(b, versionBigEndian)
+			Expect(b.Bytes()).To(Equal([]byte{0x5, 0x0, 0x0, 0x0, 0x0}))
+		})
 
-			It("has the correct min length for a BLOCKED frame for the connection", func() {
-				frame := BlockedFrame{}
-				Expect(frame.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(5)))
-			})
+		It("has the correct min length for a BLOCKED frame for the connection", func() {
+			frame := BlockedFrame{}
+			Expect(frame.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(5)))
 		})
 	})
 })

--- a/internal/wire/blocked_frame_test.go
+++ b/internal/wire/blocked_frame_test.go
@@ -35,7 +35,7 @@ var _ = Describe("BLOCKED frame", func() {
 
 		It("has the correct min length", func() {
 			frame := BlockedFrame{}
-			Expect(frame.MinLength(versionMaxDataFrame)).To(Equal(protocol.ByteCount(1)))
+			Expect(frame.MinLength(versionIETFFrames)).To(Equal(protocol.ByteCount(1)))
 		})
 	})
 })

--- a/internal/wire/max_data_frame.go
+++ b/internal/wire/max_data_frame.go
@@ -20,7 +20,7 @@ func ParseMaxDataFrame(r *bytes.Reader, version protocol.VersionNumber) (*MaxDat
 	}
 
 	frame := &MaxDataFrame{}
-	byteOffset, err := utils.GetByteOrder(version).ReadUint64(r)
+	byteOffset, err := utils.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (f *MaxDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) er
 		}).Write(b, version)
 	}
 	b.WriteByte(0x4)
-	utils.GetByteOrder(version).WriteUint64(b, uint64(f.ByteOffset))
+	utils.WriteVarInt(b, uint64(f.ByteOffset))
 	return nil
 }
 
@@ -47,5 +47,5 @@ func (f *MaxDataFrame) MinLength(version protocol.VersionNumber) (protocol.ByteC
 	if !version.UsesIETFFrameFormat() { // writing this frame would result in a gQUIC WINDOW_UPDATE being written, which is longer
 		return 1 + 4 + 8, nil
 	}
-	return 1 + 8, nil
+	return 1 + utils.VarIntLen(uint64(f.ByteOffset)), nil
 }

--- a/internal/wire/max_data_frame.go
+++ b/internal/wire/max_data_frame.go
@@ -30,7 +30,7 @@ func ParseMaxDataFrame(r *bytes.Reader, version protocol.VersionNumber) (*MaxDat
 
 //Write writes a MAX_STREAM_DATA frame
 func (f *MaxDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
-	if !version.UsesMaxDataFrame() {
+	if !version.UsesIETFFrameFormat() {
 		// write a gQUIC WINDOW_UPDATE frame (with stream ID 0, which means connection-level there)
 		return (&windowUpdateFrame{
 			StreamID:   0,
@@ -44,7 +44,7 @@ func (f *MaxDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) er
 
 // MinLength of a written frame
 func (f *MaxDataFrame) MinLength(version protocol.VersionNumber) (protocol.ByteCount, error) {
-	if !version.UsesMaxDataFrame() { // writing this frame would result in a gQUIC WINDOW_UPDATE being written, which is longer
+	if !version.UsesIETFFrameFormat() { // writing this frame would result in a gQUIC WINDOW_UPDATE being written, which is longer
 		return 1 + 4 + 8, nil
 	}
 	return 1 + 8, nil

--- a/internal/wire/max_data_frame_test.go
+++ b/internal/wire/max_data_frame_test.go
@@ -24,10 +24,10 @@ var _ = Describe("MAX_DATA frame", func() {
 			data := []byte{0x4,
 				0x44, 0x33, 0x22, 0x11, 0xad, 0xfb, 0xca, 0xde, // byte offset
 			}
-			_, err := ParseMaxDataFrame(bytes.NewReader(data), versionMaxDataFrame)
+			_, err := ParseMaxDataFrame(bytes.NewReader(data), versionIETFFrames)
 			Expect(err).NotTo(HaveOccurred())
 			for i := range data {
-				_, err := ParseMaxDataFrame(bytes.NewReader(data[0:i]), versionMaxDataFrame)
+				_, err := ParseMaxDataFrame(bytes.NewReader(data[0:i]), versionIETFFrames)
 				Expect(err).To(HaveOccurred())
 			}
 		})
@@ -38,7 +38,7 @@ var _ = Describe("MAX_DATA frame", func() {
 			f := &MaxDataFrame{
 				ByteOffset: 0xdeadbeef,
 			}
-			Expect(f.MinLength(versionMaxDataFrame)).To(Equal(protocol.ByteCount(1 + 8)))
+			Expect(f.MinLength(versionIETFFrames)).To(Equal(protocol.ByteCount(1 + 8)))
 		})
 
 		It("writes a MAX_DATA frame", func() {
@@ -46,7 +46,7 @@ var _ = Describe("MAX_DATA frame", func() {
 			f := &MaxDataFrame{
 				ByteOffset: 0xdeadbeefcafe1337,
 			}
-			err := f.Write(b, versionMaxDataFrame)
+			err := f.Write(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(b.Bytes()).To(Equal([]byte{0x4,
 				0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37, // byte offset

--- a/internal/wire/max_data_frame_test.go
+++ b/internal/wire/max_data_frame_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -11,19 +12,18 @@ import (
 var _ = Describe("MAX_DATA frame", func() {
 	Context("when parsing", func() {
 		It("accepts sample frame", func() {
-			b := bytes.NewReader([]byte{0x4,
-				0xde, 0xca, 0xfb, 0xad, 0x11, 0x22, 0x33, 0x44, // byte offset
-			})
+			data := []byte{0x4}
+			data = append(data, encodeVarInt(0xdecafbad123456)...) // byte offset
+			b := bytes.NewReader(data)
 			frame, err := ParseMaxDataFrame(b, versionBigEndian)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(frame.ByteOffset).To(Equal(protocol.ByteCount(0xdecafbad11223344)))
+			Expect(frame.ByteOffset).To(Equal(protocol.ByteCount(0xdecafbad123456)))
 			Expect(b.Len()).To(BeZero())
 		})
 
 		It("errors on EOFs", func() {
-			data := []byte{0x4,
-				0x44, 0x33, 0x22, 0x11, 0xad, 0xfb, 0xca, 0xde, // byte offset
-			}
+			data := []byte{0x4}
+			data = append(data, encodeVarInt(0xdecafbad1234567)...) // byte offset
 			_, err := ParseMaxDataFrame(bytes.NewReader(data), versionIETFFrames)
 			Expect(err).NotTo(HaveOccurred())
 			for i := range data {
@@ -38,19 +38,19 @@ var _ = Describe("MAX_DATA frame", func() {
 			f := &MaxDataFrame{
 				ByteOffset: 0xdeadbeef,
 			}
-			Expect(f.MinLength(versionIETFFrames)).To(Equal(protocol.ByteCount(1 + 8)))
+			Expect(f.MinLength(versionIETFFrames)).To(Equal(1 + utils.VarIntLen(0xdeadbeef)))
 		})
 
 		It("writes a MAX_DATA frame", func() {
 			b := &bytes.Buffer{}
 			f := &MaxDataFrame{
-				ByteOffset: 0xdeadbeefcafe1337,
+				ByteOffset: 0xdeadbeefcafe,
 			}
 			err := f.Write(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(b.Bytes()).To(Equal([]byte{0x4,
-				0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37, // byte offset
-			}))
+			expected := []byte{0x4}
+			expected = append(expected, encodeVarInt(0xdeadbeefcafe)...)
+			Expect(b.Bytes()).To(Equal(expected))
 		})
 	})
 })

--- a/internal/wire/max_stream_data_frame.go
+++ b/internal/wire/max_stream_data_frame.go
@@ -38,7 +38,7 @@ func ParseMaxStreamDataFrame(r *bytes.Reader, version protocol.VersionNumber) (*
 
 // Write writes a MAX_STREAM_DATA frame
 func (f *MaxStreamDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
-	if !version.UsesMaxDataFrame() {
+	if !version.UsesIETFFrameFormat() {
 		return (&windowUpdateFrame{
 			StreamID:   f.StreamID,
 			ByteOffset: f.ByteOffset,

--- a/internal/wire/max_stream_data_frame_test.go
+++ b/internal/wire/max_stream_data_frame_test.go
@@ -15,7 +15,7 @@ var _ = Describe("MAX_STREAM_DATA frame", func() {
 				0xde, 0xad, 0xbe, 0xef, // stream id
 				0xde, 0xca, 0xfb, 0xad, 0x11, 0x22, 0x33, 0x44, // byte offset
 			})
-			frame, err := ParseMaxStreamDataFrame(b, versionMaxDataFrame)
+			frame, err := ParseMaxStreamDataFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
 			Expect(frame.ByteOffset).To(Equal(protocol.ByteCount(0xdecafbad11223344)))
@@ -27,10 +27,10 @@ var _ = Describe("MAX_STREAM_DATA frame", func() {
 				0xef, 0xbe, 0xad, 0xde, // stream id
 				0x44, 0x33, 0x22, 0x11, 0xad, 0xfb, 0xca, 0xde, // byte offset
 			}
-			_, err := ParseMaxStreamDataFrame(bytes.NewReader(data), versionMaxDataFrame)
+			_, err := ParseMaxStreamDataFrame(bytes.NewReader(data), versionIETFFrames)
 			Expect(err).NotTo(HaveOccurred())
 			for i := range data {
-				_, err := ParseMaxStreamDataFrame(bytes.NewReader(data[0:i]), versionMaxDataFrame)
+				_, err := ParseMaxStreamDataFrame(bytes.NewReader(data[0:i]), versionIETFFrames)
 				Expect(err).To(HaveOccurred())
 			}
 		})
@@ -51,7 +51,7 @@ var _ = Describe("MAX_STREAM_DATA frame", func() {
 				StreamID:   0xdecafbad,
 				ByteOffset: 0xdeadbeefcafe1337,
 			}
-			err := f.Write(b, versionMaxDataFrame)
+			err := f.Write(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(b.Bytes()).To(Equal([]byte{0x5,
 				0xde, 0xca, 0xfb, 0xad, // stream id

--- a/internal/wire/rst_stream_frame_test.go
+++ b/internal/wire/rst_stream_frame_test.go
@@ -4,12 +4,41 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("RstStreamFrame", func() {
+var _ = Describe("RST_STREAM frame", func() {
 	Context("when parsing", func() {
+		Context("in varint encoding", func() {
+			It("accepts sample frame", func() {
+				data := []byte{0x1}
+				data = append(data, encodeVarInt(0xdeadbeef)...)  // stream ID
+				data = append(data, []byte{0x13, 0x37}...)        // error code
+				data = append(data, encodeVarInt(0x987654321)...) // byte offset
+				b := bytes.NewReader(data)
+				frame, err := ParseRstStreamFrame(b, versionIETFFrames)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
+				Expect(frame.ByteOffset).To(Equal(protocol.ByteCount(0x987654321)))
+				Expect(frame.ErrorCode).To(Equal(uint32(0x1337)))
+			})
+
+			It("errors on EOFs", func() {
+				data := []byte{0x1}
+				data = append(data, encodeVarInt(0xdeadbeef)...)  // stream ID
+				data = append(data, []byte{0x13, 0x37}...)        // error code
+				data = append(data, encodeVarInt(0x987654321)...) // byte offset
+				_, err := ParseRstStreamFrame(bytes.NewReader(data), versionIETFFrames)
+				Expect(err).NotTo(HaveOccurred())
+				for i := range data {
+					_, err := ParseRstStreamFrame(bytes.NewReader(data[0:i]), versionIETFFrames)
+					Expect(err).To(HaveOccurred())
+				}
+			})
+		})
+
 		Context("in big endian", func() {
 			It("accepts sample frame", func() {
 				b := bytes.NewReader([]byte{0x1,
@@ -23,26 +52,54 @@ var _ = Describe("RstStreamFrame", func() {
 				Expect(frame.ByteOffset).To(Equal(protocol.ByteCount(0x8877665544332211)))
 				Expect(frame.ErrorCode).To(Equal(uint32(0x34123713)))
 			})
-		})
 
-		It("errors on EOFs", func() {
-			data := []byte{0x1,
-				0xef, 0xbe, 0xad, 0xde, 0x44, // stream id
-				0x33, 0x22, 0x11, 0xad, 0xfb, 0xca, 0xde, 0x34, // byte offset
-				0x12, 0x37, 0x13, // error code
-			}
-			_, err := ParseRstStreamFrame(bytes.NewReader(data), protocol.VersionWhatever)
-			Expect(err).NotTo(HaveOccurred())
-			for i := range data {
-				_, err := ParseRstStreamFrame(bytes.NewReader(data[0:i]), protocol.VersionWhatever)
-				Expect(err).To(HaveOccurred())
-			}
+			It("errors on EOFs", func() {
+				data := []byte{0x1,
+					0xef, 0xbe, 0xad, 0xde, 0x44, // stream id
+					0x33, 0x22, 0x11, 0xad, 0xfb, 0xca, 0xde, 0x34, // byte offset
+					0x12, 0x37, 0x13, // error code
+				}
+				_, err := ParseRstStreamFrame(bytes.NewReader(data), versionBigEndian)
+				Expect(err).NotTo(HaveOccurred())
+				for i := range data {
+					_, err := ParseRstStreamFrame(bytes.NewReader(data[0:i]), versionBigEndian)
+					Expect(err).To(HaveOccurred())
+				}
+			})
 		})
 	})
 
 	Context("when writing", func() {
+		Context("in varint encoding", func() {
+			It("writes a sample frame", func() {
+				frame := RstStreamFrame{
+					StreamID:   0x1337,
+					ByteOffset: 0x11223344decafbad,
+					ErrorCode:  0xcafe,
+				}
+				b := &bytes.Buffer{}
+				err := frame.Write(b, versionIETFFrames)
+				Expect(err).ToNot(HaveOccurred())
+				expected := []byte{0x1}
+				expected = append(expected, encodeVarInt(0x1337)...)
+				expected = append(expected, []byte{0xca, 0xfe}...)
+				expected = append(expected, encodeVarInt(0x11223344decafbad)...)
+				Expect(b.Bytes()).To(Equal(expected))
+			})
+
+			It("has the correct min length", func() {
+				rst := RstStreamFrame{
+					StreamID:   0x1337,
+					ByteOffset: 0x1234567,
+					ErrorCode:  0xde,
+				}
+				expectedLen := 1 + utils.VarIntLen(0x1337) + utils.VarIntLen(0x1234567) + 2
+				Expect(rst.MinLength(versionIETFFrames)).To(Equal(expectedLen))
+			})
+		})
+
 		Context("in big endian", func() {
-			It("writes a sample RstStreamFrame", func() {
+			It("writes a sample frame", func() {
 				frame := RstStreamFrame{
 					StreamID:   0x1337,
 					ByteOffset: 0x11223344decafbad,
@@ -57,15 +114,15 @@ var _ = Describe("RstStreamFrame", func() {
 					0xde, 0xad, 0xbe, 0xef, // error code
 				}))
 			})
-		})
 
-		It("has the correct min length", func() {
-			rst := RstStreamFrame{
-				StreamID:   0x1337,
-				ByteOffset: 0x1000,
-				ErrorCode:  0xde,
-			}
-			Expect(rst.MinLength(0)).To(Equal(protocol.ByteCount(17)))
+			It("has the correct min length", func() {
+				rst := RstStreamFrame{
+					StreamID:   0x1337,
+					ByteOffset: 0x1000,
+					ErrorCode:  0xde,
+				}
+				Expect(rst.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(17)))
+			})
 		})
 	})
 })

--- a/internal/wire/stream_blocked_frame.go
+++ b/internal/wire/stream_blocked_frame.go
@@ -30,7 +30,7 @@ func ParseStreamBlockedFrame(r *bytes.Reader, version protocol.VersionNumber) (*
 
 // Write writes a STREAM_BLOCKED frame
 func (f *StreamBlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
-	if !version.UsesMaxDataFrame() {
+	if !version.UsesIETFFrameFormat() {
 		return (&blockedFrameLegacy{StreamID: f.StreamID}).Write(b, version)
 	}
 	b.WriteByte(0x09)

--- a/internal/wire/stream_blocked_frame.go
+++ b/internal/wire/stream_blocked_frame.go
@@ -14,18 +14,14 @@ type StreamBlockedFrame struct {
 
 // ParseStreamBlockedFrame parses a STREAM_BLOCKED frame
 func ParseStreamBlockedFrame(r *bytes.Reader, version protocol.VersionNumber) (*StreamBlockedFrame, error) {
-	frame := &StreamBlockedFrame{}
-
-	// read the TypeByte
-	if _, err := r.ReadByte(); err != nil {
+	if _, err := r.ReadByte(); err != nil { // read the TypeByte
 		return nil, err
 	}
-	sid, err := utils.GetByteOrder(version).ReadUint32(r)
+	sid, err := utils.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
-	frame.StreamID = protocol.StreamID(sid)
-	return frame, nil
+	return &StreamBlockedFrame{StreamID: protocol.StreamID(sid)}, nil
 }
 
 // Write writes a STREAM_BLOCKED frame
@@ -34,11 +30,14 @@ func (f *StreamBlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumb
 		return (&blockedFrameLegacy{StreamID: f.StreamID}).Write(b, version)
 	}
 	b.WriteByte(0x09)
-	utils.GetByteOrder(version).WriteUint32(b, uint32(f.StreamID))
+	utils.WriteVarInt(b, uint64(f.StreamID))
 	return nil
 }
 
 // MinLength of a written frame
 func (f *StreamBlockedFrame) MinLength(version protocol.VersionNumber) (protocol.ByteCount, error) {
-	return 1 + 4, nil
+	if !version.UsesIETFFrameFormat() {
+		return 1 + 4, nil
+	}
+	return 1 + utils.VarIntLen(uint64(f.StreamID)), nil
 }

--- a/internal/wire/stream_blocked_frame_test.go
+++ b/internal/wire/stream_blocked_frame_test.go
@@ -15,7 +15,7 @@ var _ = Describe("STREAM_BLOCKED frame", func() {
 			b := bytes.NewReader([]byte{0x9,
 				0xde, 0xad, 0xbe, 0xef, // stream id
 			})
-			frame, err := ParseStreamBlockedFrame(b, versionMaxDataFrame)
+			frame, err := ParseStreamBlockedFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
 			Expect(b.Len()).To(BeZero())
@@ -25,10 +25,10 @@ var _ = Describe("STREAM_BLOCKED frame", func() {
 			data := []byte{0x9,
 				0xef, 0xbe, 0xad, 0xde, // stream id
 			}
-			_, err := ParseStreamBlockedFrame(bytes.NewReader(data), versionMaxDataFrame)
+			_, err := ParseStreamBlockedFrame(bytes.NewReader(data), versionIETFFrames)
 			Expect(err).NotTo(HaveOccurred())
 			for i := range data {
-				_, err := ParseStreamBlockedFrame(bytes.NewReader(data[0:i]), versionMaxDataFrame)
+				_, err := ParseStreamBlockedFrame(bytes.NewReader(data[0:i]), versionIETFFrames)
 				Expect(err).To(HaveOccurred())
 			}
 		})
@@ -47,7 +47,7 @@ var _ = Describe("STREAM_BLOCKED frame", func() {
 			f := &StreamBlockedFrame{
 				StreamID: 0xdecafbad,
 			}
-			err := f.Write(b, versionMaxDataFrame)
+			err := f.Write(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(b.Bytes()).To(Equal([]byte{0x9,
 				0xde, 0xca, 0xfb, 0xad, // stream id

--- a/internal/wire/stream_blocked_frame_test.go
+++ b/internal/wire/stream_blocked_frame_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -12,9 +13,9 @@ import (
 var _ = Describe("STREAM_BLOCKED frame", func() {
 	Context("parsing", func() {
 		It("accepts sample frame", func() {
-			b := bytes.NewReader([]byte{0x9,
-				0xde, 0xad, 0xbe, 0xef, // stream id
-			})
+			data := []byte{0x9}
+			data = append(data, encodeVarInt(0xdeadbeef)...)
+			b := bytes.NewReader(data)
 			frame, err := ParseStreamBlockedFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
@@ -22,9 +23,8 @@ var _ = Describe("STREAM_BLOCKED frame", func() {
 		})
 
 		It("errors on EOFs", func() {
-			data := []byte{0x9,
-				0xef, 0xbe, 0xad, 0xde, // stream id
-			}
+			data := []byte{0x9}
+			data = append(data, encodeVarInt(0xdeadbeef)...)
 			_, err := ParseStreamBlockedFrame(bytes.NewReader(data), versionIETFFrames)
 			Expect(err).NotTo(HaveOccurred())
 			for i := range data {
@@ -39,7 +39,7 @@ var _ = Describe("STREAM_BLOCKED frame", func() {
 			f := &StreamBlockedFrame{
 				StreamID: 0x1337,
 			}
-			Expect(f.MinLength(0)).To(Equal(protocol.ByteCount(5)))
+			Expect(f.MinLength(0)).To(Equal(1 + utils.VarIntLen(0x1337)))
 		})
 
 		It("writes a sample frame", func() {
@@ -49,9 +49,9 @@ var _ = Describe("STREAM_BLOCKED frame", func() {
 			}
 			err := f.Write(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(b.Bytes()).To(Equal([]byte{0x9,
-				0xde, 0xca, 0xfb, 0xad, // stream id
-			}))
+			expected := []byte{0x9}
+			expected = append(expected, encodeVarInt(uint64(f.StreamID))...)
+			Expect(b.Bytes()).To(Equal(expected))
 		})
 	})
 })

--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -19,13 +19,12 @@ type StreamFrame struct {
 	Data           []byte
 }
 
-var (
-	errInvalidStreamIDLen = errors.New("StreamFrame: Invalid StreamID length")
-	errInvalidOffsetLen   = errors.New("StreamFrame: Invalid offset length")
-)
-
-// ParseStreamFrame reads a stream frame. The type byte must not have been read yet.
+// ParseStreamFrame reads a STREAM frame
 func ParseStreamFrame(r *bytes.Reader, version protocol.VersionNumber) (*StreamFrame, error) {
+	if !version.UsesIETFFrameFormat() {
+		return parseLegacyStreamFrame(r, version)
+	}
+
 	frame := &StreamFrame{}
 
 	typeByte, err := r.ReadByte()
@@ -33,44 +32,39 @@ func ParseStreamFrame(r *bytes.Reader, version protocol.VersionNumber) (*StreamF
 		return nil, err
 	}
 
-	frame.FinBit = typeByte&0x40 > 0
-	frame.DataLenPresent = typeByte&0x20 > 0
-	offsetLen := typeByte & 0x1c >> 2
-	if offsetLen != 0 {
-		offsetLen++
-	}
-	streamIDLen := typeByte&0x3 + 1
+	frame.FinBit = typeByte&0x1 > 0
+	frame.DataLenPresent = typeByte&0x2 > 0
+	hasOffset := typeByte&0x4 > 0
 
-	sid, err := utils.GetByteOrder(version).ReadUintN(r, streamIDLen)
+	streamID, err := utils.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
-	frame.StreamID = protocol.StreamID(sid)
-
-	offset, err := utils.GetByteOrder(version).ReadUintN(r, offsetLen)
-	if err != nil {
-		return nil, err
-	}
-	frame.Offset = protocol.ByteCount(offset)
-
-	var dataLen uint16
-	if frame.DataLenPresent {
-		dataLen, err = utils.GetByteOrder(version).ReadUint16(r)
+	frame.StreamID = protocol.StreamID(streamID)
+	if hasOffset {
+		offset, err := utils.ReadVarInt(r)
 		if err != nil {
 			return nil, err
 		}
+		frame.Offset = protocol.ByteCount(offset)
 	}
 
-	// shortcut to prevent the unneccessary allocation of dataLen bytes
-	// if the dataLen is larger than the remaining length of the packet
-	// reading the packet contents would result in EOF when attempting to READ
-	if int(dataLen) > r.Len() {
-		return nil, io.EOF
-	}
-
-	if !frame.DataLenPresent {
+	var dataLen uint64
+	if frame.DataLenPresent {
+		var err error
+		dataLen, err = utils.ReadVarInt(r)
+		if err != nil {
+			return nil, err
+		}
+		// shortcut to prevent the unneccessary allocation of dataLen bytes
+		// if the dataLen is larger than the remaining length of the packet
+		// reading the packet contents would result in EOF when attempting to READ
+		if dataLen > uint64(r.Len()) {
+			return nil, io.EOF
+		}
+	} else {
 		// The rest of the packet is data
-		dataLen = uint16(r.Len())
+		dataLen = uint64(r.Len())
 	}
 	if dataLen != 0 {
 		frame.Data = make([]byte, dataLen)
@@ -79,8 +73,7 @@ func ParseStreamFrame(r *bytes.Reader, version protocol.VersionNumber) (*StreamF
 			return nil, err
 		}
 	}
-
-	if frame.Offset+frame.DataLen() < frame.Offset {
+	if frame.Offset+frame.DataLen() > protocol.MaxByteCount {
 		return nil, qerr.Error(qerr.InvalidStreamData, "data overflows maximum offset")
 	}
 	if !frame.FinBit && frame.DataLen() == 0 {
@@ -89,118 +82,51 @@ func ParseStreamFrame(r *bytes.Reader, version protocol.VersionNumber) (*StreamF
 	return frame, nil
 }
 
-// WriteStreamFrame writes a stream frame.
+// Write writes a STREAM frame
 func (f *StreamFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+	if !version.UsesIETFFrameFormat() {
+		return f.writeLegacy(b, version)
+	}
+
 	if len(f.Data) == 0 && !f.FinBit {
 		return errors.New("StreamFrame: attempting to write empty frame without FIN")
 	}
 
-	typeByte := uint8(0x80) // sets the leftmost bit to 1
+	typeByte := byte(0x10)
 	if f.FinBit {
-		typeByte ^= 0x40
+		typeByte ^= 0x1
 	}
+	hasOffset := f.Offset != 0
 	if f.DataLenPresent {
-		typeByte ^= 0x20
+		typeByte ^= 0x2
 	}
-
-	offsetLength := f.getOffsetLength()
-	if offsetLength > 0 {
-		typeByte ^= (uint8(offsetLength) - 1) << 2
+	if hasOffset {
+		typeByte ^= 0x4
 	}
-
-	streamIDLen := f.calculateStreamIDLength()
-	typeByte ^= streamIDLen - 1
-
 	b.WriteByte(typeByte)
-
-	switch streamIDLen {
-	case 1:
-		b.WriteByte(uint8(f.StreamID))
-	case 2:
-		utils.GetByteOrder(version).WriteUint16(b, uint16(f.StreamID))
-	case 3:
-		utils.GetByteOrder(version).WriteUint24(b, uint32(f.StreamID))
-	case 4:
-		utils.GetByteOrder(version).WriteUint32(b, uint32(f.StreamID))
-	default:
-		return errInvalidStreamIDLen
+	utils.WriteVarInt(b, uint64(f.StreamID))
+	if hasOffset {
+		utils.WriteVarInt(b, uint64(f.Offset))
 	}
-
-	switch offsetLength {
-	case 0:
-	case 2:
-		utils.GetByteOrder(version).WriteUint16(b, uint16(f.Offset))
-	case 3:
-		utils.GetByteOrder(version).WriteUint24(b, uint32(f.Offset))
-	case 4:
-		utils.GetByteOrder(version).WriteUint32(b, uint32(f.Offset))
-	case 5:
-		utils.GetByteOrder(version).WriteUint40(b, uint64(f.Offset))
-	case 6:
-		utils.GetByteOrder(version).WriteUint48(b, uint64(f.Offset))
-	case 7:
-		utils.GetByteOrder(version).WriteUint56(b, uint64(f.Offset))
-	case 8:
-		utils.GetByteOrder(version).WriteUint64(b, uint64(f.Offset))
-	default:
-		return errInvalidOffsetLen
-	}
-
 	if f.DataLenPresent {
-		utils.GetByteOrder(version).WriteUint16(b, uint16(len(f.Data)))
+		utils.WriteVarInt(b, uint64(f.DataLen()))
 	}
-
 	b.Write(f.Data)
 	return nil
 }
 
-func (f *StreamFrame) calculateStreamIDLength() uint8 {
-	if f.StreamID < (1 << 8) {
-		return 1
-	} else if f.StreamID < (1 << 16) {
-		return 2
-	} else if f.StreamID < (1 << 24) {
-		return 3
-	}
-	return 4
-}
-
-func (f *StreamFrame) getOffsetLength() protocol.ByteCount {
-	if f.Offset == 0 {
-		return 0
-	}
-	if f.Offset < (1 << 16) {
-		return 2
-	}
-	if f.Offset < (1 << 24) {
-		return 3
-	}
-	if f.Offset < (1 << 32) {
-		return 4
-	}
-	if f.Offset < (1 << 40) {
-		return 5
-	}
-	if f.Offset < (1 << 48) {
-		return 6
-	}
-	if f.Offset < (1 << 56) {
-		return 7
-	}
-	return 8
-}
-
 // MinLength returns the length of the header of a StreamFrame
-// the total length of the StreamFrame is frame.MinLength() + frame.DataLen()
-func (f *StreamFrame) MinLength(protocol.VersionNumber) (protocol.ByteCount, error) {
-	length := protocol.ByteCount(1) + protocol.ByteCount(f.calculateStreamIDLength()) + f.getOffsetLength()
+// the total length of the frame is frame.MinLength() + frame.DataLen()
+func (f *StreamFrame) MinLength(version protocol.VersionNumber) (protocol.ByteCount, error) {
+	if !version.UsesIETFFrameFormat() {
+		return f.minLengthLegacy(version)
+	}
+	length := 1 + utils.VarIntLen(uint64(f.StreamID))
+	if f.Offset != 0 {
+		length += utils.VarIntLen(uint64(f.Offset))
+	}
 	if f.DataLenPresent {
-		length += 2
+		length += utils.VarIntLen(uint64(f.DataLen()))
 	}
 	return length, nil
-}
-
-// DataLen gives the length of data in bytes
-func (f *StreamFrame) DataLen() protocol.ByteCount {
-	return protocol.ByteCount(len(f.Data))
 }

--- a/internal/wire/stream_frame_legacy.go
+++ b/internal/wire/stream_frame_legacy.go
@@ -1,0 +1,197 @@
+package wire
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/qerr"
+)
+
+var (
+	errInvalidStreamIDLen = errors.New("StreamFrame: Invalid StreamID length")
+	errInvalidOffsetLen   = errors.New("StreamFrame: Invalid offset length")
+)
+
+// parseLegacyStreamFrame reads a stream frame. The type byte must not have been read yet.
+func parseLegacyStreamFrame(r *bytes.Reader, version protocol.VersionNumber) (*StreamFrame, error) {
+	frame := &StreamFrame{}
+
+	typeByte, err := r.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+
+	frame.FinBit = typeByte&0x40 > 0
+	frame.DataLenPresent = typeByte&0x20 > 0
+	offsetLen := typeByte & 0x1c >> 2
+	if offsetLen != 0 {
+		offsetLen++
+	}
+	streamIDLen := typeByte&0x3 + 1
+
+	sid, err := utils.GetByteOrder(version).ReadUintN(r, streamIDLen)
+	if err != nil {
+		return nil, err
+	}
+	frame.StreamID = protocol.StreamID(sid)
+
+	offset, err := utils.GetByteOrder(version).ReadUintN(r, offsetLen)
+	if err != nil {
+		return nil, err
+	}
+	frame.Offset = protocol.ByteCount(offset)
+
+	var dataLen uint16
+	if frame.DataLenPresent {
+		dataLen, err = utils.GetByteOrder(version).ReadUint16(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// shortcut to prevent the unneccessary allocation of dataLen bytes
+	// if the dataLen is larger than the remaining length of the packet
+	// reading the packet contents would result in EOF when attempting to READ
+	if int(dataLen) > r.Len() {
+		return nil, io.EOF
+	}
+
+	if !frame.DataLenPresent {
+		// The rest of the packet is data
+		dataLen = uint16(r.Len())
+	}
+	if dataLen != 0 {
+		frame.Data = make([]byte, dataLen)
+		if _, err := io.ReadFull(r, frame.Data); err != nil {
+			// this should never happen, since we already checked the dataLen earlier
+			return nil, err
+		}
+	}
+
+	// MaxByteCount is the highest value that can be encoded with the IETF QUIC variable integer encoding (2^62-1).
+	// Note that this value is smaller than the maximum value that could be encoded in the gQUIC STREAM frame (2^64-1).
+	if frame.Offset+frame.DataLen() > protocol.MaxByteCount {
+		return nil, qerr.Error(qerr.InvalidStreamData, "data overflows maximum offset")
+	}
+	if !frame.FinBit && frame.DataLen() == 0 {
+		return nil, qerr.EmptyStreamFrameNoFin
+	}
+	return frame, nil
+}
+
+// writeLegacy writes a stream frame.
+func (f *StreamFrame) writeLegacy(b *bytes.Buffer, version protocol.VersionNumber) error {
+	if len(f.Data) == 0 && !f.FinBit {
+		return errors.New("StreamFrame: attempting to write empty frame without FIN")
+	}
+
+	typeByte := uint8(0x80) // sets the leftmost bit to 1
+	if f.FinBit {
+		typeByte ^= 0x40
+	}
+	if f.DataLenPresent {
+		typeByte ^= 0x20
+	}
+
+	offsetLength := f.getOffsetLength()
+	if offsetLength > 0 {
+		typeByte ^= (uint8(offsetLength) - 1) << 2
+	}
+
+	streamIDLen := f.calculateStreamIDLength()
+	typeByte ^= streamIDLen - 1
+
+	b.WriteByte(typeByte)
+
+	switch streamIDLen {
+	case 1:
+		b.WriteByte(uint8(f.StreamID))
+	case 2:
+		utils.GetByteOrder(version).WriteUint16(b, uint16(f.StreamID))
+	case 3:
+		utils.GetByteOrder(version).WriteUint24(b, uint32(f.StreamID))
+	case 4:
+		utils.GetByteOrder(version).WriteUint32(b, uint32(f.StreamID))
+	default:
+		return errInvalidStreamIDLen
+	}
+
+	switch offsetLength {
+	case 0:
+	case 2:
+		utils.GetByteOrder(version).WriteUint16(b, uint16(f.Offset))
+	case 3:
+		utils.GetByteOrder(version).WriteUint24(b, uint32(f.Offset))
+	case 4:
+		utils.GetByteOrder(version).WriteUint32(b, uint32(f.Offset))
+	case 5:
+		utils.GetByteOrder(version).WriteUint40(b, uint64(f.Offset))
+	case 6:
+		utils.GetByteOrder(version).WriteUint48(b, uint64(f.Offset))
+	case 7:
+		utils.GetByteOrder(version).WriteUint56(b, uint64(f.Offset))
+	case 8:
+		utils.GetByteOrder(version).WriteUint64(b, uint64(f.Offset))
+	default:
+		return errInvalidOffsetLen
+	}
+
+	if f.DataLenPresent {
+		utils.GetByteOrder(version).WriteUint16(b, uint16(len(f.Data)))
+	}
+
+	b.Write(f.Data)
+	return nil
+}
+
+func (f *StreamFrame) calculateStreamIDLength() uint8 {
+	if f.StreamID < (1 << 8) {
+		return 1
+	} else if f.StreamID < (1 << 16) {
+		return 2
+	} else if f.StreamID < (1 << 24) {
+		return 3
+	}
+	return 4
+}
+
+func (f *StreamFrame) getOffsetLength() protocol.ByteCount {
+	if f.Offset == 0 {
+		return 0
+	}
+	if f.Offset < (1 << 16) {
+		return 2
+	}
+	if f.Offset < (1 << 24) {
+		return 3
+	}
+	if f.Offset < (1 << 32) {
+		return 4
+	}
+	if f.Offset < (1 << 40) {
+		return 5
+	}
+	if f.Offset < (1 << 48) {
+		return 6
+	}
+	if f.Offset < (1 << 56) {
+		return 7
+	}
+	return 8
+}
+
+func (f *StreamFrame) minLengthLegacy(protocol.VersionNumber) (protocol.ByteCount, error) {
+	length := protocol.ByteCount(1) + protocol.ByteCount(f.calculateStreamIDLength()) + f.getOffsetLength()
+	if f.DataLenPresent {
+		length += 2
+	}
+	return length, nil
+}
+
+// DataLen gives the length of data in bytes
+func (f *StreamFrame) DataLen() protocol.ByteCount {
+	return protocol.ByteCount(len(f.Data))
+}

--- a/internal/wire/stream_frame_legacy_test.go
+++ b/internal/wire/stream_frame_legacy_test.go
@@ -1,0 +1,483 @@
+package wire
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/qerr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("STREAM frame (for gQUIC)", func() {
+	Context("when parsing", func() {
+		It("accepts a sample frame", func() {
+			// a STREAM frame, plus 3 additional bytes, not belonging to this frame
+			b := bytes.NewReader([]byte{0x80 ^ 0x20,
+				0x1,      // stream id
+				0x0, 0x6, // data length
+				'f', 'o', 'o', 'b', 'a', 'r',
+				'f', 'o', 'o', // additional bytes
+			})
+			frame, err := ParseStreamFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.FinBit).To(BeFalse())
+			Expect(frame.StreamID).To(Equal(protocol.StreamID(1)))
+			Expect(frame.Offset).To(BeZero())
+			Expect(frame.DataLenPresent).To(BeTrue())
+			Expect(frame.Data).To(Equal([]byte("foobar")))
+			Expect(b.Len()).To(Equal(3))
+		})
+
+		It("accepts frames with offsets", func() {
+			b := bytes.NewReader([]byte{0x80 ^ 0x20 /* 2 byte offset */ ^ 0x4,
+				0x1,       // stream id
+				0x0, 0x42, // offset
+				0x0, 0x6, // data length
+				'f', 'o', 'o', 'b', 'a', 'r',
+			})
+			frame, err := ParseStreamFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.FinBit).To(BeFalse())
+			Expect(frame.StreamID).To(Equal(protocol.StreamID(1)))
+			Expect(frame.Offset).To(Equal(protocol.ByteCount(0x42)))
+			Expect(frame.DataLenPresent).To(BeTrue())
+			Expect(frame.Data).To(Equal([]byte("foobar")))
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("errors on EOFs", func() {
+			data := []byte{0x80 ^ 0x20 ^ 0x4,
+				0x1,       // stream id
+				0x0, 0x2a, // offset
+				0x0, 0x6, // data length,
+				'f', 'o', 'o', 'b', 'a', 'r',
+			}
+			_, err := ParseStreamFrame(bytes.NewReader(data), versionBigEndian)
+			Expect(err).NotTo(HaveOccurred())
+			for i := range data {
+				_, err := ParseStreamFrame(bytes.NewReader(data[0:i]), versionBigEndian)
+				Expect(err).To(HaveOccurred())
+			}
+		})
+
+		It("accepts frame without data length", func() {
+			b := bytes.NewReader([]byte{0x80,
+				0x1, // stream id
+				'f', 'o', 'o', 'b', 'a', 'r',
+			})
+			frame, err := ParseStreamFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.FinBit).To(BeFalse())
+			Expect(frame.StreamID).To(Equal(protocol.StreamID(1)))
+			Expect(frame.Offset).To(BeZero())
+			Expect(frame.DataLenPresent).To(BeFalse())
+			Expect(frame.Data).To(Equal([]byte("foobar")))
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("accepts an empty frame with FinBit set, with data length set", func() {
+			// the STREAM frame, plus 3 additional bytes, not belonging to this frame
+			b := bytes.NewReader([]byte{0x80 ^ 0x40 ^ 0x20,
+				0x1,  // stream id
+				0, 0, // data length
+				'f', 'o', 'o', // additional bytes
+			})
+			frame, err := ParseStreamFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.FinBit).To(BeTrue())
+			Expect(frame.DataLenPresent).To(BeTrue())
+			Expect(frame.Data).To(BeEmpty())
+			Expect(b.Len()).To(Equal(3))
+		})
+
+		It("accepts an empty frame with the FinBit set", func() {
+			b := bytes.NewReader([]byte{0x80 ^ 0x40,
+				0x1, // stream id
+				'f', 'o', 'o', 'b', 'a', 'r',
+			})
+			frame, err := ParseStreamFrame(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.FinBit).To(BeTrue())
+			Expect(frame.DataLenPresent).To(BeFalse())
+			Expect(frame.Data).To(Equal([]byte("foobar")))
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("errors on empty stream frames that don't have the FinBit set", func() {
+			b := bytes.NewReader([]byte{0x80 ^ 0x20,
+				0x1,  // stream id
+				0, 0, // data length
+			})
+			_, err := ParseStreamFrame(b, versionBigEndian)
+			Expect(err).To(MatchError(qerr.EmptyStreamFrameNoFin))
+		})
+
+		It("rejects frames to too large dataLen", func() {
+			b := bytes.NewReader([]byte{0xa0, 0x1, 0xff, 0xff})
+			_, err := ParseStreamFrame(b, versionBigEndian)
+			Expect(err).To(MatchError(io.EOF))
+		})
+
+		It("rejects frames that overflow the offset", func() {
+			// Offset + len(Data) overflows MaxByteCount
+			f := &StreamFrame{
+				StreamID: 1,
+				Offset:   protocol.MaxByteCount,
+				Data:     []byte{'f'},
+			}
+			b := &bytes.Buffer{}
+			err := f.Write(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = ParseStreamFrame(bytes.NewReader(b.Bytes()), versionBigEndian)
+			Expect(err).To(MatchError(qerr.Error(qerr.InvalidStreamData, "data overflows maximum offset")))
+		})
+	})
+
+	Context("when writing", func() {
+		Context("in big endian", func() {
+			It("writes sample frame", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID:       1,
+					Data:           []byte("foobar"),
+					DataLenPresent: true,
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()).To(Equal([]byte{0x80 ^ 0x20,
+					0x1,      // stream id
+					0x0, 0x6, // data length
+					'f', 'o', 'o', 'b', 'a', 'r',
+				}))
+			})
+		})
+
+		It("sets the FinBit", func() {
+			b := &bytes.Buffer{}
+			err := (&StreamFrame{
+				StreamID: 1,
+				Data:     []byte("foobar"),
+				FinBit:   true,
+			}).Write(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(b.Bytes()[0] & 0x40).To(Equal(byte(0x40)))
+		})
+
+		It("errors when length is zero and FIN is not set", func() {
+			b := &bytes.Buffer{}
+			err := (&StreamFrame{
+				StreamID: 1,
+			}).Write(b, versionBigEndian)
+			Expect(err).To(MatchError("StreamFrame: attempting to write empty frame without FIN"))
+		})
+
+		It("has proper min length for a short StreamID and a short offset", func() {
+			b := &bytes.Buffer{}
+			f := &StreamFrame{
+				StreamID: 1,
+				Data:     []byte{},
+				Offset:   0,
+				FinBit:   true,
+			}
+			err := f.Write(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.MinLength(0)).To(Equal(protocol.ByteCount(b.Len())))
+		})
+
+		It("has proper min length for a long StreamID and a big offset", func() {
+			b := &bytes.Buffer{}
+			f := &StreamFrame{
+				StreamID: 0xdecafbad,
+				Data:     []byte{},
+				Offset:   0xdeadbeefcafe,
+				FinBit:   true,
+			}
+			err := f.Write(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.MinLength(versionBigEndian)).To(Equal(protocol.ByteCount(b.Len())))
+		})
+
+		Context("data length field", func() {
+			It("writes the data length", func() {
+				dataLen := 0x1337
+				b := &bytes.Buffer{}
+				f := &StreamFrame{
+					StreamID:       1,
+					Data:           bytes.Repeat([]byte{'f'}, dataLen),
+					DataLenPresent: true,
+					Offset:         0,
+				}
+				err := f.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				minLength, _ := f.MinLength(0)
+				Expect(b.Bytes()[0] & 0x20).To(Equal(uint8(0x20)))
+				Expect(b.Bytes()[minLength-2 : minLength]).To(Equal([]byte{0x13, 0x37}))
+			})
+		})
+
+		It("omits the data length field", func() {
+			dataLen := 0x1337
+			b := &bytes.Buffer{}
+			f := &StreamFrame{
+				StreamID:       1,
+				Data:           bytes.Repeat([]byte{'f'}, dataLen),
+				DataLenPresent: false,
+				Offset:         0,
+			}
+			err := f.Write(b, versionBigEndian)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(b.Bytes()[0] & 0x20).To(Equal(uint8(0)))
+			Expect(b.Bytes()[1 : b.Len()-dataLen]).ToNot(ContainSubstring(string([]byte{0x37, 0x13})))
+			minLength, _ := f.MinLength(versionBigEndian)
+			f.DataLenPresent = true
+			minLengthWithoutDataLen, _ := f.MinLength(versionBigEndian)
+			Expect(minLength).To(Equal(minLengthWithoutDataLen - 2))
+		})
+
+		It("calculates the correct min-length", func() {
+			f := &StreamFrame{
+				StreamID:       0xcafe,
+				Data:           []byte("foobar"),
+				DataLenPresent: false,
+				Offset:         0xdeadbeef,
+			}
+			minLengthWithoutDataLen, _ := f.MinLength(versionBigEndian)
+			f.DataLenPresent = true
+			Expect(f.MinLength(versionBigEndian)).To(Equal(minLengthWithoutDataLen + 2))
+		})
+
+		Context("offset lengths", func() {
+			It("does not write an offset if the offset is 0", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 1,
+					Data:     []byte("foobar"),
+					Offset:   0,
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x1c).To(Equal(uint8(0x0)))
+			})
+
+			It("writes a 2-byte offset if the offset is larger than 0", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 1,
+					Data:     []byte("foobar"),
+					Offset:   0x1337,
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x1c).To(Equal(uint8(0x1 << 2)))
+				Expect(b.Bytes()[2:4]).To(Equal([]byte{0x13, 0x37}))
+			})
+
+			It("writes a 3-byte offset if the offset", func() {
+				b := &bytes.Buffer{}
+				(&StreamFrame{
+					StreamID: 1,
+					Data:     []byte("foobar"),
+					Offset:   0x13cafe,
+				}).Write(b, versionBigEndian)
+				Expect(b.Bytes()[0] & 0x1c).To(Equal(uint8(0x2 << 2)))
+				Expect(b.Bytes()[2:5]).To(Equal([]byte{0x13, 0xca, 0xfe}))
+			})
+
+			It("writes a 4-byte offset if the offset", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 1,
+					Data:     []byte("foobar"),
+					Offset:   0xdeadbeef,
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x1c).To(Equal(uint8(0x3 << 2)))
+				Expect(b.Bytes()[2:6]).To(Equal([]byte{0xde, 0xad, 0xbe, 0xef}))
+			})
+
+			It("writes a 5-byte offset if the offset", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 1,
+					Data:     []byte("foobar"),
+					Offset:   0x13deadbeef,
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x1c).To(Equal(uint8(0x4 << 2)))
+				Expect(b.Bytes()[2:7]).To(Equal([]byte{0x13, 0xde, 0xad, 0xbe, 0xef}))
+			})
+
+			It("writes a 6-byte offset if the offset", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 1,
+					Data:     []byte("foobar"),
+					Offset:   0xdeadbeefcafe,
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x1c).To(Equal(uint8(0x5 << 2)))
+				Expect(b.Bytes()[2:8]).To(Equal([]byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe}))
+			})
+
+			It("writes a 7-byte offset if the offset", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 1,
+					Data:     []byte("foobar"),
+					Offset:   0x13deadbeefcafe,
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x1c).To(Equal(uint8(0x6 << 2)))
+				Expect(b.Bytes()[2:9]).To(Equal([]byte{0x13, 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe}))
+			})
+
+			It("writes a 8-byte offset if the offset", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 1,
+					Data:     []byte("foobar"),
+					Offset:   0x1337deadbeefcafe,
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x1c).To(Equal(uint8(0x7 << 2)))
+				Expect(b.Bytes()[2:10]).To(Equal([]byte{0x13, 0x37, 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe}))
+			})
+		})
+
+		Context("lengths of StreamIDs", func() {
+			It("writes a 1 byte StreamID", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 13,
+					Data:     []byte("foobar"),
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x3).To(Equal(uint8(0x0)))
+				Expect(b.Bytes()[1]).To(Equal(uint8(13)))
+			})
+
+			It("writes a 2 byte StreamID", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 0xcafe,
+					Data:     []byte("foobar"),
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x3).To(Equal(uint8(0x1)))
+				Expect(b.Bytes()[1:3]).To(Equal([]byte{0xca, 0xfe}))
+			})
+
+			It("writes a 3 byte StreamID", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 0x13beef,
+					Data:     []byte("foobar"),
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x3).To(Equal(uint8(0x2)))
+				Expect(b.Bytes()[1:4]).To(Equal([]byte{0x13, 0xbe, 0xef}))
+			})
+
+			It("writes a 4 byte StreamID", func() {
+				b := &bytes.Buffer{}
+				err := (&StreamFrame{
+					StreamID: 0xdecafbad,
+					Data:     []byte("foobar"),
+				}).Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x3).To(Equal(uint8(0x3)))
+				Expect(b.Bytes()[1:5]).To(Equal([]byte{0xde, 0xca, 0xfb, 0xad}))
+			})
+
+			It("writes a multiple byte StreamID, after the Stream length was already determined by MinLenght()", func() {
+				b := &bytes.Buffer{}
+				frame := &StreamFrame{
+					StreamID: 0xdecafbad,
+					Data:     []byte("foobar"),
+				}
+				frame.MinLength(0)
+				err := frame.Write(b, versionBigEndian)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(b.Bytes()[0] & 0x3).To(Equal(uint8(0x3)))
+				Expect(b.Bytes()[1:5]).To(Equal([]byte{0xde, 0xca, 0xfb, 0xad}))
+			})
+		})
+	})
+
+	Context("shortening of StreamIDs", func() {
+		It("determines the length of a 1 byte StreamID", func() {
+			f := &StreamFrame{StreamID: 0xFF}
+			Expect(f.calculateStreamIDLength()).To(Equal(uint8(1)))
+		})
+
+		It("determines the length of a 2 byte StreamID", func() {
+			f := &StreamFrame{StreamID: 0xFFFF}
+			Expect(f.calculateStreamIDLength()).To(Equal(uint8(2)))
+		})
+
+		It("determines the length of a 3 byte StreamID", func() {
+			f := &StreamFrame{StreamID: 0xFFFFFF}
+			Expect(f.calculateStreamIDLength()).To(Equal(uint8(3)))
+		})
+
+		It("determines the length of a 4 byte StreamID", func() {
+			f := &StreamFrame{StreamID: 0xFFFFFFFF}
+			Expect(f.calculateStreamIDLength()).To(Equal(uint8(4)))
+		})
+	})
+
+	Context("shortening of Offsets", func() {
+		It("determines length 0 of offset 0", func() {
+			f := &StreamFrame{Offset: 0}
+			Expect(f.getOffsetLength()).To(Equal(protocol.ByteCount(0)))
+		})
+
+		It("determines the length of a 2 byte offset", func() {
+			f := &StreamFrame{Offset: 0xFFFF}
+			Expect(f.getOffsetLength()).To(Equal(protocol.ByteCount(2)))
+		})
+
+		It("determines the length of a 2 byte offset, even if it would fit into 1 byte", func() {
+			f := &StreamFrame{Offset: 0x1}
+			Expect(f.getOffsetLength()).To(Equal(protocol.ByteCount(2)))
+		})
+
+		It("determines the length of a 3 byte offset", func() {
+			f := &StreamFrame{Offset: 0xFFFFFF}
+			Expect(f.getOffsetLength()).To(Equal(protocol.ByteCount(3)))
+		})
+
+		It("determines the length of a 4 byte offset", func() {
+			f := &StreamFrame{Offset: 0xFFFFFFFF}
+			Expect(f.getOffsetLength()).To(Equal(protocol.ByteCount(4)))
+		})
+
+		It("determines the length of a 5 byte offset", func() {
+			f := &StreamFrame{Offset: 0xFFFFFFFFFF}
+			Expect(f.getOffsetLength()).To(Equal(protocol.ByteCount(5)))
+		})
+
+		It("determines the length of a 6 byte offset", func() {
+			f := &StreamFrame{Offset: 0xFFFFFFFFFFFF}
+			Expect(f.getOffsetLength()).To(Equal(protocol.ByteCount(6)))
+		})
+
+		It("determines the length of a 7 byte offset", func() {
+			f := &StreamFrame{Offset: 0xFFFFFFFFFFFFFF}
+			Expect(f.getOffsetLength()).To(Equal(protocol.ByteCount(7)))
+		})
+
+		It("determines the length of an 8 byte offset", func() {
+			f := &StreamFrame{Offset: 0xFFFFFFFFFFFFFFFF}
+			Expect(f.getOffsetLength()).To(Equal(protocol.ByteCount(8)))
+		})
+	})
+
+	Context("DataLen", func() {
+		It("determines the length of the data", func() {
+			frame := StreamFrame{
+				Data: []byte("foobar"),
+			}
+			Expect(frame.DataLen()).To(Equal(protocol.ByteCount(6)))
+		})
+	})
+})

--- a/internal/wire/wire_suite_test.go
+++ b/internal/wire/wire_suite_test.go
@@ -1,6 +1,8 @@
 package wire
 
 import (
+	"bytes"
+
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	. "github.com/onsi/ginkgo"
@@ -20,6 +22,12 @@ const (
 	// a QUIC version that uses the IETF frame types
 	versionIETFFrames = protocol.VersionTLS
 )
+
+func encodeVarInt(i uint64) []byte {
+	b := &bytes.Buffer{}
+	utils.WriteVarInt(b, i)
+	return b.Bytes()
+}
 
 var _ = BeforeSuite(func() {
 	Expect(utils.GetByteOrder(versionBigEndian)).To(Equal(utils.BigEndian))

--- a/internal/wire/wire_suite_test.go
+++ b/internal/wire/wire_suite_test.go
@@ -17,13 +17,13 @@ func TestCrypto(t *testing.T) {
 const (
 	// a QUIC version that uses big endian encoding
 	versionBigEndian = protocol.Version39
-	// a QUIC version that uses the MAX_DATA / MAX_STREAM_DATA and BLOCKED / STREAM_BLOCKED frames
-	versionMaxDataFrame = protocol.VersionTLS
+	// a QUIC version that uses the IETF frame types
+	versionIETFFrames = protocol.VersionTLS
 )
 
 var _ = BeforeSuite(func() {
 	Expect(utils.GetByteOrder(versionBigEndian)).To(Equal(utils.BigEndian))
-	Expect(utils.GetByteOrder(versionMaxDataFrame)).To(Equal(utils.BigEndian))
-	Expect(versionBigEndian.UsesMaxDataFrame()).To(BeFalse())
-	Expect(versionMaxDataFrame.UsesMaxDataFrame()).To(BeTrue())
+	Expect(utils.GetByteOrder(versionIETFFrames)).To(Equal(utils.BigEndian))
+	Expect(versionBigEndian.UsesIETFFrameFormat()).To(BeFalse())
+	Expect(versionIETFFrames.UsesIETFFrameFormat()).To(BeTrue())
 })

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -311,7 +311,8 @@ var _ = Describe("Packet packer", func() {
 	It("packs many control frames into 1 packets", func() {
 		f := &wire.AckFrame{LargestAcked: 1}
 		b := &bytes.Buffer{}
-		f.Write(b, protocol.VersionWhatever)
+		err := f.Write(b, packer.version)
+		Expect(err).ToNot(HaveOccurred())
 		maxFramesPerPacket := int(maxFrameSize) / b.Len()
 		var controlFrames []wire.Frame
 		for i := 0; i < maxFramesPerPacket; i++ {

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -77,8 +77,7 @@ func (u *packetUnpacker) parseFrame(r *bytes.Reader, typeByte byte, hdr *wire.He
 func (u *packetUnpacker) parseIETFFrame(r *bytes.Reader, typeByte byte, hdr *wire.Header) (wire.Frame, error) {
 	var frame wire.Frame
 	var err error
-	// TODO: implement the IETF STREAM frame
-	if typeByte&0x80 == 0x80 {
+	if typeByte&0xf8 == 0x10 {
 		frame, err = wire.ParseStreamFrame(r, u.version)
 		if err != nil {
 			err = qerr.Error(qerr.InvalidStreamData, err.Error())

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -83,12 +83,6 @@ func (u *packetUnpacker) parseIETFFrame(r *bytes.Reader, typeByte byte, hdr *wir
 			err = qerr.Error(qerr.InvalidStreamData, err.Error())
 		}
 		return frame, err
-	} else if typeByte&0xc0 == 0x40 { // TODO: implement the IETF ACK frame
-		frame, err = wire.ParseAckFrame(r, u.version)
-		if err != nil {
-			err = qerr.Error(qerr.InvalidAckData, err.Error())
-		}
-		return frame, err
 	}
 	// TODO: implement all IETF QUIC frame types
 	switch typeByte {
@@ -127,6 +121,11 @@ func (u *packetUnpacker) parseIETFFrame(r *bytes.Reader, typeByte byte, hdr *wir
 		frame, err = wire.ParseStreamBlockedFrame(r, u.version)
 		if err != nil {
 			err = qerr.Error(qerr.InvalidBlockedData, err.Error())
+		}
+	case 0xe:
+		frame, err = wire.ParseAckFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidAckData, err.Error())
 		}
 	default:
 		err = qerr.Error(qerr.InvalidFrameData, fmt.Sprintf("unknown type byte 0x%x", typeByte))

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -47,76 +47,14 @@ func (u *packetUnpacker) Unpack(headerBinary []byte, hdr *wire.Header, data []by
 		}
 		r.UnreadByte()
 
-		var frame wire.Frame
-		if typeByte&0x80 == 0x80 {
-			frame, err = wire.ParseStreamFrame(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidStreamData, err.Error())
-			} else {
-				streamID := frame.(*wire.StreamFrame).StreamID
-				if streamID != u.version.CryptoStreamID() && encryptionLevel <= protocol.EncryptionUnencrypted {
-					err = qerr.Error(qerr.UnencryptedStreamData, fmt.Sprintf("received unencrypted stream data on stream %d", streamID))
-				}
-			}
-		} else if typeByte&0xc0 == 0x40 {
-			frame, err = wire.ParseAckFrame(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidAckData, err.Error())
-			}
-		} else if typeByte == 0x01 {
-			frame, err = wire.ParseRstStreamFrame(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidRstStreamData, err.Error())
-			}
-		} else if typeByte == 0x02 {
-			frame, err = wire.ParseConnectionCloseFrame(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidConnectionCloseData, err.Error())
-			}
-		} else if typeByte == 0x3 {
-			frame, err = wire.ParseGoawayFrame(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidGoawayData, err.Error())
-			}
-		} else if u.version.UsesMaxDataFrame() && typeByte == 0x4 { // in IETF QUIC, 0x4 is a MAX_DATA frame
-			frame, err = wire.ParseMaxDataFrame(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidWindowUpdateData, err.Error())
-			}
-		} else if typeByte == 0x4 { // in gQUIC, 0x4 is a WINDOW_UPDATE frame
-			frame, err = wire.ParseWindowUpdateFrame(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidWindowUpdateData, err.Error())
-			}
-		} else if u.version.UsesMaxDataFrame() && typeByte == 0x5 { // in IETF QUIC, 0x5 is a MAX_STREAM_DATA frame
-			frame, err = wire.ParseMaxStreamDataFrame(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidWindowUpdateData, err.Error())
-			}
-		} else if typeByte == 0x5 { // in gQUIC, 0x5  is a BLOCKED frame
-			frame, err = wire.ParseBlockedFrameLegacy(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidBlockedData, err.Error())
-			}
-		} else if typeByte == 0x6 {
-			frame, err = wire.ParseStopWaitingFrame(r, hdr.PacketNumber, hdr.PacketNumberLen, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidStopWaitingData, err.Error())
-			}
-		} else if typeByte == 0x7 {
-			frame, err = wire.ParsePingFrame(r, u.version)
-		} else if u.version.UsesMaxDataFrame() && typeByte == 0x8 { // in IETF QUIC, 0x4 is a BLOCKED frame
-			frame, err = wire.ParseBlockedFrame(r, u.version)
-		} else if u.version.UsesMaxDataFrame() && typeByte == 0x9 { // in IETF QUIC, 0x4 is a STREAM_BLOCKED frame
-			frame, err = wire.ParseBlockedFrameLegacy(r, u.version)
-			if err != nil {
-				err = qerr.Error(qerr.InvalidBlockedData, err.Error())
-			}
-		} else {
-			err = qerr.Error(qerr.InvalidFrameData, fmt.Sprintf("unknown type byte 0x%x", typeByte))
-		}
+		frame, err := u.parseFrame(r, typeByte, hdr)
 		if err != nil {
 			return nil, err
+		}
+		if sf, ok := frame.(*wire.StreamFrame); ok {
+			if sf.StreamID != u.version.CryptoStreamID() && encryptionLevel <= protocol.EncryptionUnencrypted {
+				return nil, qerr.Error(qerr.UnencryptedStreamData, fmt.Sprintf("received unencrypted stream data on stream %d", sf.StreamID))
+			}
 		}
 		if frame != nil {
 			fs = append(fs, frame)
@@ -127,4 +65,127 @@ func (u *packetUnpacker) Unpack(headerBinary []byte, hdr *wire.Header, data []by
 		encryptionLevel: encryptionLevel,
 		frames:          fs,
 	}, nil
+}
+
+func (u *packetUnpacker) parseFrame(r *bytes.Reader, typeByte byte, hdr *wire.Header) (wire.Frame, error) {
+	if u.version.UsesIETFFrameFormat() {
+		return u.parseIETFFrame(r, typeByte, hdr)
+	}
+	return u.parseGQUICFrame(r, typeByte, hdr)
+}
+
+func (u *packetUnpacker) parseIETFFrame(r *bytes.Reader, typeByte byte, hdr *wire.Header) (wire.Frame, error) {
+	var frame wire.Frame
+	var err error
+	// TODO: implement the IETF STREAM frame
+	if typeByte&0x80 == 0x80 {
+		frame, err = wire.ParseStreamFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidStreamData, err.Error())
+		}
+		return frame, err
+	} else if typeByte&0xc0 == 0x40 { // TODO: implement the IETF ACK frame
+		frame, err = wire.ParseAckFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidAckData, err.Error())
+		}
+		return frame, err
+	}
+	// TODO: implement all IETF QUIC frame types
+	switch typeByte {
+	case 0x1:
+		frame, err = wire.ParseRstStreamFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidRstStreamData, err.Error())
+		}
+	case 0x2:
+		frame, err = wire.ParseConnectionCloseFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidConnectionCloseData, err.Error())
+		}
+	case 0x4:
+		frame, err = wire.ParseMaxDataFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidWindowUpdateData, err.Error())
+		}
+	case 0x5:
+		frame, err = wire.ParseMaxStreamDataFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidWindowUpdateData, err.Error())
+		}
+	case 0x6:
+		// TODO(#964): remove STOP_WAITING frames
+		// TODO(#878): implement the MAX_STREAM_ID frame
+		frame, err = wire.ParseStopWaitingFrame(r, hdr.PacketNumber, hdr.PacketNumberLen, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidStopWaitingData, err.Error())
+		}
+	case 0x7:
+		frame, err = wire.ParsePingFrame(r, u.version)
+	case 0x8:
+		frame, err = wire.ParseBlockedFrame(r, u.version)
+	case 0x9:
+		frame, err = wire.ParseBlockedFrameLegacy(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidBlockedData, err.Error())
+		}
+	default:
+		err = qerr.Error(qerr.InvalidFrameData, fmt.Sprintf("unknown type byte 0x%x", typeByte))
+	}
+	return frame, err
+}
+
+func (u *packetUnpacker) parseGQUICFrame(r *bytes.Reader, typeByte byte, hdr *wire.Header) (wire.Frame, error) {
+	var frame wire.Frame
+	var err error
+	if typeByte&0x80 == 0x80 {
+		frame, err = wire.ParseStreamFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidStreamData, err.Error())
+		}
+		return frame, err
+	} else if typeByte&0xc0 == 0x40 {
+		frame, err = wire.ParseAckFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidAckData, err.Error())
+		}
+		return frame, err
+	}
+	switch typeByte {
+	case 0x1:
+		frame, err = wire.ParseRstStreamFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidRstStreamData, err.Error())
+		}
+	case 0x2:
+		frame, err = wire.ParseConnectionCloseFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidConnectionCloseData, err.Error())
+		}
+	case 0x3:
+		frame, err = wire.ParseGoawayFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidGoawayData, err.Error())
+		}
+	case 0x4:
+		frame, err = wire.ParseWindowUpdateFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidWindowUpdateData, err.Error())
+		}
+	case 0x5:
+		frame, err = wire.ParseBlockedFrameLegacy(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidBlockedData, err.Error())
+		}
+	case 0x6:
+		frame, err = wire.ParseStopWaitingFrame(r, hdr.PacketNumber, hdr.PacketNumberLen, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidStopWaitingData, err.Error())
+		}
+	case 0x7:
+		frame, err = wire.ParsePingFrame(r, u.version)
+	default:
+		err = qerr.Error(qerr.InvalidFrameData, fmt.Sprintf("unknown type byte 0x%x", typeByte))
+	}
+	return frame, err
 }

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -125,7 +125,7 @@ func (u *packetUnpacker) parseIETFFrame(r *bytes.Reader, typeByte byte, hdr *wir
 	case 0x8:
 		frame, err = wire.ParseBlockedFrame(r, u.version)
 	case 0x9:
-		frame, err = wire.ParseBlockedFrameLegacy(r, u.version)
+		frame, err = wire.ParseStreamBlockedFrame(r, u.version)
 		if err != nil {
 			err = qerr.Error(qerr.InvalidBlockedData, err.Error())
 		}

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -54,19 +54,16 @@ var _ = Describe("Packet unpacker", func() {
 		data, _ = unpacker.aead.(*mockAEAD).Seal(nil, p, 0, hdrBin)
 	}
 
-	It("does not read read a private flag for QUIC Version >= 34", func() {
-		f := &wire.ConnectionCloseFrame{ReasonPhrase: "foo"}
-		err := f.Write(buf, 0)
-		Expect(err).ToNot(HaveOccurred())
-		setData(buf.Bytes())
-		packet, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.frames).To(Equal([]wire.Frame{f}))
+	It("errors if the packet doesn't contain any payload", func() {
+		setData(nil)
+		_, err := unpacker.Unpack(hdrBin, hdr, data)
+		Expect(err).To(MatchError(qerr.MissingPayload))
 	})
 
 	It("saves the encryption level", func() {
+		unpacker.version = versionGQUICFrames
 		f := &wire.ConnectionCloseFrame{ReasonPhrase: "foo"}
-		err := f.Write(buf, 0)
+		err := f.Write(buf, versionGQUICFrames)
 		Expect(err).ToNot(HaveOccurred())
 		setData(buf.Bytes())
 		unpacker.aead.(*mockAEAD).encLevelOpen = protocol.EncryptionSecure
@@ -75,85 +72,247 @@ var _ = Describe("Packet unpacker", func() {
 		Expect(packet.encryptionLevel).To(Equal(protocol.EncryptionSecure))
 	})
 
-	It("unpacks ACK frames", func() {
-		unpacker.version = protocol.VersionWhatever
-		f := &wire.AckFrame{
-			LargestAcked: 0x13,
-			LowestAcked:  1,
-		}
-		err := f.Write(buf, protocol.VersionWhatever)
-		Expect(err).ToNot(HaveOccurred())
-		setData(buf.Bytes())
-		packet, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.frames).To(HaveLen(1))
-		readFrame := packet.frames[0].(*wire.AckFrame)
-		Expect(readFrame).ToNot(BeNil())
-		Expect(readFrame.LargestAcked).To(Equal(protocol.PacketNumber(0x13)))
-	})
-
-	It("handles PADDING frames", func() {
-		setData([]byte{0, 0, 0}) // 3 bytes PADDING
-		packet, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.frames).To(BeEmpty())
-	})
-
-	It("handles PADDING between two other frames", func() {
-		f := &wire.PingFrame{}
-		err := f.Write(buf, protocol.VersionWhatever)
-		Expect(err).ToNot(HaveOccurred())
-		_, err = buf.Write(bytes.Repeat([]byte{0}, 10)) // 10 bytes PADDING
-		Expect(err).ToNot(HaveOccurred())
-		err = f.Write(buf, protocol.VersionWhatever)
-		Expect(err).ToNot(HaveOccurred())
-		setData(buf.Bytes())
-		packet, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.frames).To(HaveLen(2))
-	})
-
-	It("unpacks RST_STREAM frames", func() {
-		f := &wire.RstStreamFrame{
-			StreamID:   0xdeadbeef,
-			ByteOffset: 0xdecafbad11223344,
-			ErrorCode:  0x13371234,
-		}
-		err := f.Write(buf, protocol.VersionWhatever)
-		Expect(err).ToNot(HaveOccurred())
-		setData(buf.Bytes())
-		packet, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.frames).To(Equal([]wire.Frame{f}))
-	})
-
-	It("unpacks CONNECTION_CLOSE frames", func() {
-		f := &wire.ConnectionCloseFrame{ReasonPhrase: "foo"}
-		err := f.Write(buf, protocol.VersionWhatever)
-		Expect(err).ToNot(HaveOccurred())
-		setData(buf.Bytes())
-		packet, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.frames).To(Equal([]wire.Frame{f}))
-	})
-
-	It("unpacks GOAWAY frames", func() {
-		f := &wire.GoawayFrame{
-			ErrorCode:      1,
-			LastGoodStream: 2,
-			ReasonPhrase:   "foo",
-		}
-		err := f.Write(buf, 0)
-		Expect(err).ToNot(HaveOccurred())
-		setData(buf.Bytes())
-		packet, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.frames).To(Equal([]wire.Frame{f}))
-	})
-
-	Context("flow control frames, when the crypto stream is stream 0", func() {
+	Context("for gQUIC frames", func() {
 		BeforeEach(func() {
-			unpacker.version = versionCryptoStream0
+			unpacker.version = versionGQUICFrames
+		})
+
+		It("handles PADDING frames", func() {
+			setData([]byte{0, 0, 0}) // 3 bytes PADDING
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(BeEmpty())
+		})
+
+		It("handles PADDING between two other frames", func() {
+			f := &wire.PingFrame{}
+			err := f.Write(buf, versionGQUICFrames)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = buf.Write(bytes.Repeat([]byte{0}, 10)) // 10 bytes PADDING
+			Expect(err).ToNot(HaveOccurred())
+			err = f.Write(buf, versionGQUICFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(HaveLen(2))
+		})
+
+		It("unpacks RST_STREAM frames", func() {
+			f := &wire.RstStreamFrame{
+				StreamID:   0xdeadbeef,
+				ByteOffset: 0xdecafbad11223344,
+				ErrorCode:  0x13371234,
+			}
+			err := f.Write(buf, versionGQUICFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
+		It("unpacks CONNECTION_CLOSE frames", func() {
+			f := &wire.ConnectionCloseFrame{ReasonPhrase: "foo"}
+			err := f.Write(buf, versionGQUICFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
+		It("unpacks GOAWAY frames", func() {
+			f := &wire.GoawayFrame{
+				ErrorCode:      1,
+				LastGoodStream: 2,
+				ReasonPhrase:   "foo",
+			}
+			err := f.Write(buf, 0)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
+		It("unpacks a stream-level WINDOW_UPDATE frame", func() {
+			f := &wire.MaxStreamDataFrame{
+				StreamID:   0xdeadbeef,
+				ByteOffset: 0xcafe000000001337,
+			}
+			buf := &bytes.Buffer{}
+			err := f.Write(buf, versionGQUICFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
+		It("unpacks a connection-level WINDOW_UPDATE frame", func() {
+			f := &wire.MaxDataFrame{
+				ByteOffset: 0xcafe000000001337,
+			}
+			buf := &bytes.Buffer{}
+			err := f.Write(buf, versionGQUICFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
+		It("unpacks connection-level BLOCKED frames", func() {
+			f := &wire.BlockedFrame{}
+			buf := &bytes.Buffer{}
+			err := f.Write(buf, versionGQUICFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
+		It("unpacks stream-level BLOCKED frames", func() {
+			f := &wire.StreamBlockedFrame{StreamID: 0xdeadbeef}
+			buf := &bytes.Buffer{}
+			err := f.Write(buf, versionGQUICFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
+		It("unpacks STOP_WAITING frames", func() {
+			setData([]byte{0x06, 0x03})
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{
+				&wire.StopWaitingFrame{LeastUnacked: 7},
+			}))
+		})
+
+		It("unpacks PING frames", func() {
+			setData([]byte{0x07})
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{
+				&wire.PingFrame{},
+			}))
+		})
+
+		It("errors on invalid type", func() {
+			setData([]byte{0xf})
+			_, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).To(MatchError("InvalidFrameData: unknown type byte 0xf"))
+		})
+
+		It("errors on invalid frames", func() {
+			for b, e := range map[byte]qerr.ErrorCode{
+				0x80: qerr.InvalidStreamData,
+				0x40: qerr.InvalidAckData,
+				0x01: qerr.InvalidRstStreamData,
+				0x02: qerr.InvalidConnectionCloseData,
+				0x03: qerr.InvalidGoawayData,
+				0x04: qerr.InvalidWindowUpdateData,
+				0x05: qerr.InvalidBlockedData,
+				0x06: qerr.InvalidStopWaitingData,
+			} {
+				setData([]byte{b})
+				_, err := unpacker.Unpack(hdrBin, hdr, data)
+				Expect(err.(*qerr.QuicError).ErrorCode).To(Equal(e))
+			}
+		})
+
+		It("unpacks ACK frames", func() {
+			f := &wire.AckFrame{
+				LargestAcked: 0x13,
+				LowestAcked:  1,
+			}
+			err := f.Write(buf, versionGQUICFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(HaveLen(1))
+			readFrame := packet.frames[0].(*wire.AckFrame)
+			Expect(readFrame).ToNot(BeNil())
+			Expect(readFrame.LargestAcked).To(Equal(protocol.PacketNumber(0x13)))
+		})
+
+		Context("unpacking STREAM frames", func() {
+			It("unpacks unencrypted STREAM frames on the crypto stream", func() {
+				unpacker.aead.(*mockAEAD).encLevelOpen = protocol.EncryptionUnencrypted
+				f := &wire.StreamFrame{
+					StreamID: versionGQUICFrames.CryptoStreamID(),
+					Data:     []byte("foobar"),
+				}
+				err := f.Write(buf, versionGQUICFrames)
+				Expect(err).ToNot(HaveOccurred())
+				setData(buf.Bytes())
+				packet, err := unpacker.Unpack(hdrBin, hdr, data)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(packet.frames).To(Equal([]wire.Frame{f}))
+			})
+
+			It("unpacks encrypted STREAM frames on the crypto stream", func() {
+				unpacker.aead.(*mockAEAD).encLevelOpen = protocol.EncryptionSecure
+				f := &wire.StreamFrame{
+					StreamID: versionGQUICFrames.CryptoStreamID(),
+					Data:     []byte("foobar"),
+				}
+				err := f.Write(buf, versionGQUICFrames)
+				Expect(err).ToNot(HaveOccurred())
+				setData(buf.Bytes())
+				packet, err := unpacker.Unpack(hdrBin, hdr, data)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(packet.frames).To(Equal([]wire.Frame{f}))
+			})
+
+			It("does not unpack unencrypted STREAM frames on higher streams", func() {
+				unpacker.aead.(*mockAEAD).encLevelOpen = protocol.EncryptionUnencrypted
+				f := &wire.StreamFrame{
+					StreamID: 3,
+					Data:     []byte("foobar"),
+				}
+				err := f.Write(buf, versionGQUICFrames)
+				Expect(err).ToNot(HaveOccurred())
+				setData(buf.Bytes())
+				_, err = unpacker.Unpack(hdrBin, hdr, data)
+				Expect(err).To(MatchError(qerr.Error(qerr.UnencryptedStreamData, "received unencrypted stream data on stream 3")))
+			})
+		})
+	})
+
+	Context("for IETF draft frames", func() {
+		BeforeEach(func() {
+			unpacker.version = versionIETFFrames
+		})
+
+		It("unpacks RST_STREAM frames", func() {
+			f := &wire.RstStreamFrame{
+				StreamID:   0xdeadbeef,
+				ByteOffset: 0xdecafbad11223344,
+				ErrorCode:  0x13371234,
+			}
+			err := f.Write(buf, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
+		It("unpacks CONNECTION_CLOSE frames", func() {
+			f := &wire.ConnectionCloseFrame{ReasonPhrase: "foo"}
+			err := f.Write(buf, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
 		})
 
 		It("unpacks MAX_DATA frames", func() {
@@ -161,7 +320,7 @@ var _ = Describe("Packet unpacker", func() {
 				ByteOffset: 0xcafe000000001337,
 			}
 			buf := &bytes.Buffer{}
-			err := f.Write(buf, versionCryptoStream0)
+			err := f.Write(buf, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			setData(buf.Bytes())
 			packet, err := unpacker.Unpack(hdrBin, hdr, data)
@@ -175,7 +334,7 @@ var _ = Describe("Packet unpacker", func() {
 				ByteOffset: 0xcafe000000001337,
 			}
 			buf := &bytes.Buffer{}
-			err := f.Write(buf, versionCryptoStream0)
+			err := f.Write(buf, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			setData(buf.Bytes())
 			packet, err := unpacker.Unpack(hdrBin, hdr, data)
@@ -186,7 +345,7 @@ var _ = Describe("Packet unpacker", func() {
 		It("unpacks connection-level BLOCKED frames", func() {
 			f := &wire.BlockedFrame{}
 			buf := &bytes.Buffer{}
-			err := f.Write(buf, versionCryptoStream0)
+			err := f.Write(buf, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			setData(buf.Bytes())
 			packet, err := unpacker.Unpack(hdrBin, hdr, data)
@@ -197,7 +356,7 @@ var _ = Describe("Packet unpacker", func() {
 		It("unpacks stream-level BLOCKED frames", func() {
 			f := &wire.StreamBlockedFrame{StreamID: 0xdeadbeef}
 			buf := &bytes.Buffer{}
-			err := f.Write(buf, versionCryptoStream0)
+			err := f.Write(buf, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			setData(buf.Bytes())
 			packet, err := unpacker.Unpack(hdrBin, hdr, data)
@@ -205,8 +364,16 @@ var _ = Describe("Packet unpacker", func() {
 			Expect(packet.frames).To(Equal([]wire.Frame{f}))
 		})
 
+		It("errors on invalid type", func() {
+			setData([]byte{0xf})
+			_, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).To(MatchError("InvalidFrameData: unknown type byte 0xf"))
+		})
+
 		It("errors on invalid frames", func() {
 			for b, e := range map[byte]qerr.ErrorCode{
+				0x01: qerr.InvalidRstStreamData,
+				0x02: qerr.InvalidConnectionCloseData,
 				0x04: qerr.InvalidWindowUpdateData,
 				0x05: qerr.InvalidWindowUpdateData,
 				0x09: qerr.InvalidBlockedData,
@@ -215,154 +382,6 @@ var _ = Describe("Packet unpacker", func() {
 				_, err := unpacker.Unpack(hdrBin, hdr, data)
 				Expect(err.(*qerr.QuicError).ErrorCode).To(Equal(e))
 			}
-		})
-	})
-
-	Context("flow control frames, when the crypto stream is stream 1", func() {
-		BeforeEach(func() {
-			unpacker.version = versionCryptoStream1
-		})
-
-		It("unpacks a stream-level WINDOW_UPDATE frame", func() {
-			f := &wire.MaxStreamDataFrame{
-				StreamID:   0xdeadbeef,
-				ByteOffset: 0xcafe000000001337,
-			}
-			buf := &bytes.Buffer{}
-			err := f.Write(buf, versionCryptoStream1)
-			Expect(err).ToNot(HaveOccurred())
-			setData(buf.Bytes())
-			packet, err := unpacker.Unpack(hdrBin, hdr, data)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(packet.frames).To(Equal([]wire.Frame{f}))
-		})
-
-		It("unpacks a connection-level WINDOW_UPDATE frame", func() {
-			f := &wire.MaxDataFrame{
-				ByteOffset: 0xcafe000000001337,
-			}
-			buf := &bytes.Buffer{}
-			err := f.Write(buf, versionCryptoStream1)
-			Expect(err).ToNot(HaveOccurred())
-			setData(buf.Bytes())
-			packet, err := unpacker.Unpack(hdrBin, hdr, data)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(packet.frames).To(Equal([]wire.Frame{f}))
-		})
-
-		It("unpacks connection-level BLOCKED frames", func() {
-			f := &wire.BlockedFrame{}
-			buf := &bytes.Buffer{}
-			err := f.Write(buf, versionCryptoStream1)
-			Expect(err).ToNot(HaveOccurred())
-			setData(buf.Bytes())
-			packet, err := unpacker.Unpack(hdrBin, hdr, data)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(packet.frames).To(Equal([]wire.Frame{f}))
-		})
-
-		It("unpacks stream-level BLOCKED frames", func() {
-			f := &wire.StreamBlockedFrame{StreamID: 0xdeadbeef}
-			buf := &bytes.Buffer{}
-			err := f.Write(buf, versionCryptoStream1)
-			Expect(err).ToNot(HaveOccurred())
-			setData(buf.Bytes())
-			packet, err := unpacker.Unpack(hdrBin, hdr, data)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(packet.frames).To(Equal([]wire.Frame{f}))
-		})
-
-		It("errors on invalid frames", func() {
-			for b, e := range map[byte]qerr.ErrorCode{
-				0x04: qerr.InvalidWindowUpdateData,
-				0x05: qerr.InvalidBlockedData,
-			} {
-				setData([]byte{b})
-				_, err := unpacker.Unpack(hdrBin, hdr, data)
-				Expect(err.(*qerr.QuicError).ErrorCode).To(Equal(e))
-			}
-		})
-	})
-
-	It("unpacks STOP_WAITING frames", func() {
-		setData([]byte{0x06, 0x03})
-		packet, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.frames).To(Equal([]wire.Frame{
-			&wire.StopWaitingFrame{LeastUnacked: 7},
-		}))
-	})
-
-	It("unpacks PING frames", func() {
-		setData([]byte{0x07})
-		packet, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.frames).To(Equal([]wire.Frame{
-			&wire.PingFrame{},
-		}))
-	})
-
-	It("errors on invalid type", func() {
-		setData([]byte{0xf})
-		_, err := unpacker.Unpack(hdrBin, hdr, data)
-		Expect(err).To(MatchError("InvalidFrameData: unknown type byte 0xf"))
-	})
-
-	It("errors on invalid frames", func() {
-		for b, e := range map[byte]qerr.ErrorCode{
-			0x80: qerr.InvalidStreamData,
-			0x40: qerr.InvalidAckData,
-			0x01: qerr.InvalidRstStreamData,
-			0x02: qerr.InvalidConnectionCloseData,
-			0x03: qerr.InvalidGoawayData,
-			0x06: qerr.InvalidStopWaitingData,
-		} {
-			setData([]byte{b})
-			_, err := unpacker.Unpack(hdrBin, hdr, data)
-			Expect(err.(*qerr.QuicError).ErrorCode).To(Equal(e))
-		}
-	})
-
-	Context("unpacking STREAM frames", func() {
-		It("unpacks unencrypted STREAM frames on the crypto stream", func() {
-			unpacker.aead.(*mockAEAD).encLevelOpen = protocol.EncryptionUnencrypted
-			f := &wire.StreamFrame{
-				StreamID: unpacker.version.CryptoStreamID(),
-				Data:     []byte("foobar"),
-			}
-			err := f.Write(buf, 0)
-			Expect(err).ToNot(HaveOccurred())
-			setData(buf.Bytes())
-			packet, err := unpacker.Unpack(hdrBin, hdr, data)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(packet.frames).To(Equal([]wire.Frame{f}))
-		})
-
-		It("unpacks encrypted STREAM frames on the crypto stream", func() {
-			unpacker.aead.(*mockAEAD).encLevelOpen = protocol.EncryptionSecure
-			f := &wire.StreamFrame{
-				StreamID: unpacker.version.CryptoStreamID(),
-				Data:     []byte("foobar"),
-			}
-			err := f.Write(buf, 0)
-			Expect(err).ToNot(HaveOccurred())
-			setData(buf.Bytes())
-			packet, err := unpacker.Unpack(hdrBin, hdr, data)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(packet.frames).To(Equal([]wire.Frame{f}))
-		})
-
-		It("does not unpack unencrypted STREAM frames on higher streams", func() {
-			unpacker.aead.(*mockAEAD).encLevelOpen = protocol.EncryptionUnencrypted
-			f := &wire.StreamFrame{
-				StreamID: 3,
-				Data:     []byte("foobar"),
-			}
-			err := f.Write(buf, 0)
-			Expect(err).ToNot(HaveOccurred())
-			setData(buf.Bytes())
-			_, err = unpacker.Unpack(hdrBin, hdr, data)
-			Expect(err).To(MatchError(qerr.Error(qerr.UnencryptedStreamData, "received unencrypted stream data on stream 3")))
 		})
 	})
 })

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -294,8 +294,8 @@ var _ = Describe("Packet unpacker", func() {
 		It("unpacks RST_STREAM frames", func() {
 			f := &wire.RstStreamFrame{
 				StreamID:   0xdeadbeef,
-				ByteOffset: 0xdecafbad11223344,
-				ErrorCode:  0x13371234,
+				ByteOffset: 0xdecafbad1234,
+				ErrorCode:  0x1337,
 			}
 			err := f.Write(buf, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
@@ -317,7 +317,7 @@ var _ = Describe("Packet unpacker", func() {
 
 		It("unpacks MAX_DATA frames", func() {
 			f := &wire.MaxDataFrame{
-				ByteOffset: 0xcafe000000001337,
+				ByteOffset: 0xcafe,
 			}
 			buf := &bytes.Buffer{}
 			err := f.Write(buf, versionIETFFrames)
@@ -331,7 +331,7 @@ var _ = Describe("Packet unpacker", func() {
 		It("unpacks MAX_STREAM_DATA frames", func() {
 			f := &wire.MaxStreamDataFrame{
 				StreamID:   0xdeadbeef,
-				ByteOffset: 0xcafe000000001337,
+				ByteOffset: 0xdecafbad,
 			}
 			buf := &bytes.Buffer{}
 			err := f.Write(buf, versionIETFFrames)

--- a/quic_suite_test.go
+++ b/quic_suite_test.go
@@ -15,15 +15,17 @@ func TestQuicGo(t *testing.T) {
 }
 
 const (
-	versionCryptoStream1 = protocol.Version39
-	versionCryptoStream0 = protocol.VersionTLS
+	versionGQUICFrames = protocol.Version39
+	versionIETFFrames  = protocol.VersionTLS
 )
 
 var mockCtrl *gomock.Controller
 
 var _ = BeforeSuite(func() {
-	Expect(versionCryptoStream0.CryptoStreamID()).To(Equal(protocol.StreamID(0)))
-	Expect(versionCryptoStream1.CryptoStreamID()).To(Equal(protocol.StreamID(1)))
+	Expect(versionGQUICFrames.CryptoStreamID()).To(Equal(protocol.StreamID(1)))
+	Expect(versionGQUICFrames.UsesIETFFrameFormat()).To(BeFalse())
+	Expect(versionIETFFrames.CryptoStreamID()).To(Equal(protocol.StreamID(0)))
+	Expect(versionIETFFrames.UsesIETFFrameFormat()).To(BeTrue())
 })
 
 var _ = BeforeEach(func() {

--- a/session.go
+++ b/session.go
@@ -320,7 +320,7 @@ func (s *session) postSetup(initialPacketNumber protocol.PacketNumber) error {
 	s.receivedPacketHandler = ackhandler.NewReceivedPacketHandler(s.version)
 
 	s.streamsMap = newStreamsMap(s.newStream, s.perspective, s.version)
-	s.streamFramer = newStreamFramer(s.cryptoStream, s.streamsMap, s.connFlowController)
+	s.streamFramer = newStreamFramer(s.cryptoStream, s.streamsMap, s.connFlowController, s.version)
 
 	s.packer = newPacketPacker(s.connectionID,
 		initialPacketNumber,

--- a/stream_framer_test.go
+++ b/stream_framer_test.go
@@ -41,12 +41,12 @@ var _ = Describe("Stream Framer", func() {
 		stream2 = mocks.NewMockStreamI(mockCtrl)
 		stream2.EXPECT().StreamID().Return(protocol.StreamID(6)).AnyTimes()
 
-		streamsMap = newStreamsMap(nil, protocol.PerspectiveServer, protocol.VersionWhatever)
+		streamsMap = newStreamsMap(nil, protocol.PerspectiveServer, versionGQUICFrames)
 		streamsMap.putStream(stream1)
 		streamsMap.putStream(stream2)
 
 		connFC = mocks.NewMockConnectionFlowController(mockCtrl)
-		framer = newStreamFramer(nil, streamsMap, connFC)
+		framer = newStreamFramer(nil, streamsMap, connFC, versionGQUICFrames)
 	})
 
 	setNoData := func(str *mocks.MockStreamI) {
@@ -227,7 +227,7 @@ var _ = Describe("Stream Framer", func() {
 				origlen := retransmittedFrame2.DataLen()
 				fs := framer.PopStreamFrames(6)
 				Expect(fs).To(HaveLen(1))
-				minLength, _ := fs[0].MinLength(0)
+				minLength, _ := fs[0].MinLength(framer.version)
 				Expect(minLength + fs[0].DataLen()).To(Equal(protocol.ByteCount(6)))
 				Expect(framer.retransmissionQueue[0].Data).To(HaveLen(int(origlen - fs[0].DataLen())))
 				Expect(framer.retransmissionQueue[0].Offset).To(Equal(fs[0].DataLen()))

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Streams Map", func() {
 	Context("getting and creating streams", func() {
 		Context("as a server", func() {
 			BeforeEach(func() {
-				setNewStreamsMap(protocol.PerspectiveServer, versionCryptoStream1)
+				setNewStreamsMap(protocol.PerspectiveServer, versionGQUICFrames)
 			})
 
 			Context("client-side streams", func() {
@@ -281,7 +281,7 @@ var _ = Describe("Streams Map", func() {
 				})
 
 				It("starts with stream 1, if the crypto stream is stream 0", func() {
-					setNewStreamsMap(protocol.PerspectiveServer, versionCryptoStream0)
+					setNewStreamsMap(protocol.PerspectiveServer, versionIETFFrames)
 					var str streamI
 					go func() {
 						defer GinkgoRecover()
@@ -414,7 +414,7 @@ var _ = Describe("Streams Map", func() {
 
 		Context("as a client", func() {
 			BeforeEach(func() {
-				setNewStreamsMap(protocol.PerspectiveClient, versionCryptoStream1)
+				setNewStreamsMap(protocol.PerspectiveClient, versionGQUICFrames)
 				m.UpdateMaxStreamLimit(100)
 			})
 
@@ -463,7 +463,7 @@ var _ = Describe("Streams Map", func() {
 
 			Context("client-side streams", func() {
 				It("starts with stream 1, if the crypto stream is stream 0", func() {
-					setNewStreamsMap(protocol.PerspectiveClient, versionCryptoStream0)
+					setNewStreamsMap(protocol.PerspectiveClient, versionIETFFrames)
 					m.UpdateMaxStreamLimit(100)
 					s, err := m.OpenStream()
 					Expect(err).ToNot(HaveOccurred())
@@ -521,7 +521,7 @@ var _ = Describe("Streams Map", func() {
 
 	Context("DoS mitigation, iterating and deleting", func() {
 		BeforeEach(func() {
-			setNewStreamsMap(protocol.PerspectiveServer, versionCryptoStream1)
+			setNewStreamsMap(protocol.PerspectiveServer, versionGQUICFrames)
 		})
 
 		closeStream := func(id protocol.StreamID) {
@@ -615,7 +615,7 @@ var _ = Describe("Streams Map", func() {
 
 			Context("as a client", func() {
 				BeforeEach(func() {
-					setNewStreamsMap(protocol.PerspectiveClient, versionCryptoStream1)
+					setNewStreamsMap(protocol.PerspectiveClient, versionGQUICFrames)
 					m.UpdateMaxStreamLimit(100)
 					for i := 1; i <= 5; i++ {
 						if i%2 == 0 {


### PR DESCRIPTION
This PR implements the variable integer length frame types for the IETF draft, for all frame types that have so far been implemented.

There's still one TODO for the ACK frame: Since the ACK ranges are also varint encoded, and their number is not limited any more, it might overflow the maximum packet size. I'm not a fan of the current code for the ACK frame, so maybe @lucas-clemente has an idea for an elegant solution here.
I think we can merge this PR without resolving this TODO for now, but I'd still be happy to know what you think about this.