### PR TITLE
remove old code to send an ACK every 20 packets

### DIFF
--- a/ackhandler/received_packet_handler.go
+++ b/ackhandler/received_packet_handler.go
@@ -77,15 +77,6 @@ func (h *receivedPacketHandler) maybeQueueAck(packetNumber protocol.PacketNumber
 		h.ackQueued = true
 	}
 
-	if h.version < protocol.Version39 {
-		// Always send an ack every 20 packets in order to allow the peer to discard
-		// information from the SentPacketManager and provide an RTT measurement.
-		// From QUIC 39, this is not needed anymore, since the peer will regularly send a retransmittable packet.
-		if h.packetsReceivedSinceLastAck >= protocol.MaxPacketsReceivedBeforeAckSend {
-			h.ackQueued = true
-		}
-	}
-
 	// if the packet number is smaller than the largest acked packet, it must have been reported missing with the last ACK
 	// note that it cannot be a duplicate because they're already filtered out by ReceivedPacket()
 	if h.lastAck != nil && packetNumber < h.lastAck.LargestAcked {

--- a/ackhandler/received_packet_handler_test.go
+++ b/ackhandler/received_packet_handler_test.go
@@ -91,23 +91,10 @@ var _ = Describe("receivedPacketHandler", func() {
 				Expect(handler.GetAlarmTimeout()).To(BeZero())
 			})
 
-			It("only queues one ACK for many non-retransmittable packets", func() {
-				receiveAndAck10Packets()
-				for i := 11; i < 10+protocol.MaxPacketsReceivedBeforeAckSend; i++ {
-					err := handler.ReceivedPacket(protocol.PacketNumber(i), false)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(handler.ackQueued).To(BeFalse())
-				}
-				err := handler.ReceivedPacket(10+protocol.MaxPacketsReceivedBeforeAckSend, false)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.ackQueued).To(BeTrue())
-				Expect(handler.GetAlarmTimeout()).To(BeZero())
-			})
-
-			It("doesn't queue an ACK for non-retransmittable packets, for QUIC >= 39", func() {
+			It("doesn't queue an ACK for non-retransmittable packets", func() {
 				receiveAndAck10Packets()
 				handler.version = protocol.Version39
-				for i := 11; i < 10+10*protocol.MaxPacketsReceivedBeforeAckSend; i++ {
+				for i := 11; i < 1000; i++ {
 					err := handler.ReceivedPacket(protocol.PacketNumber(i), false)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(handler.ackQueued).To(BeFalse())

--- a/internal/protocol/server_parameters.go
+++ b/internal/protocol/server_parameters.go
@@ -87,9 +87,6 @@ const MaxTrackedSentPackets = 2 * DefaultMaxCongestionWindow
 // MaxTrackedReceivedAckRanges is the maximum number of ACK ranges tracked
 const MaxTrackedReceivedAckRanges = DefaultMaxCongestionWindow
 
-// MaxPacketsReceivedBeforeAckSend is the number of packets that can be received before an ACK frame is sent
-const MaxPacketsReceivedBeforeAckSend = 20
-
 // MaxNonRetransmittablePackets is the maximum number of non-retransmittable packets that we send in a row
 const MaxNonRetransmittablePackets = 19
 


### PR DESCRIPTION
This was needed before QUIC 39, and should have been removed when we dropped support for QUIC 38.