### PR TITLE
bundle PING frame with other frames

### DIFF
--- a/session.go
+++ b/session.go
@@ -766,7 +766,7 @@ func (s *session) sendPacket() error {
 		}
 		// add a retransmittable frame
 		if s.sentPacketHandler.ShouldSendRetransmittablePacket() {
-			s.packer.QueueControlFrame(&wire.PingFrame{})
+			s.packer.MakeNextPacketRetransmittable()
 		}
 		packet, err := s.packer.PackPacket()
 		if err != nil || packet == nil {

--- a/session_test.go
+++ b/session_test.go
@@ -824,6 +824,7 @@ var _ = Describe("Session", func() {
 
 		It("sends a retransmittable packet when required by the SentPacketHandler", func() {
 			sess.sentPacketHandler = &mockSentPacketHandler{shouldSendRetransmittablePacket: true}
+			sess.packer.QueueControlFrame(&wire.AckFrame{LargestAcked: 1000})
 			err := sess.sendPacket()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mconn.written).To(HaveLen(1))


### PR DESCRIPTION
Should be merged after #968.

We're sending a retransmittable packet every 20 packets (if there are no other frames to send). To make a packet retransmittable, we add a PING frame. We should bundle this PING with an ACK.

This will be especially important when we remove STOP_WAITING frames (#964). Then we keep track of the largest acked of every retransmittable packet sent to increase the lower bound of packets we include in the ACK frame. That means we need to make sure that a packet containing an ACK actually is a retransmittable packet from time to time.