### PR TITLE
allow packet number 0

### DIFF
--- a/ackhandler/interfaces.go
+++ b/ackhandler/interfaces.go
@@ -27,7 +27,7 @@ type SentPacketHandler interface {
 // ReceivedPacketHandler handles ACKs needed to send for incoming packets
 type ReceivedPacketHandler interface {
 	ReceivedPacket(packetNumber protocol.PacketNumber, shouldInstigateAck bool) error
-	SetLowerLimit(protocol.PacketNumber)
+	IgnoreBelow(protocol.PacketNumber)
 
 	GetAlarmTimeout() time.Time
 	GetAckFrame() *wire.AckFrame

--- a/ackhandler/received_packet_handler.go
+++ b/ackhandler/received_packet_handler.go
@@ -12,7 +12,7 @@ var errInvalidPacketNumber = errors.New("ReceivedPacketHandler: Invalid packet n
 
 type receivedPacketHandler struct {
 	largestObserved             protocol.PacketNumber
-	lowerLimit                  protocol.PacketNumber
+	ignoreBelow                 protocol.PacketNumber
 	largestObservedReceivedTime time.Time
 
 	packetHistory *receivedPacketHistory
@@ -47,7 +47,7 @@ func (h *receivedPacketHandler) ReceivedPacket(packetNumber protocol.PacketNumbe
 		h.largestObservedReceivedTime = time.Now()
 	}
 
-	if packetNumber <= h.lowerLimit {
+	if packetNumber < h.ignoreBelow {
 		return nil
 	}
 
@@ -58,11 +58,11 @@ func (h *receivedPacketHandler) ReceivedPacket(packetNumber protocol.PacketNumbe
 	return nil
 }
 
-// SetLowerLimit sets a lower limit for acking packets.
-// Packets with packet numbers smaller or equal than p will not be acked.
-func (h *receivedPacketHandler) SetLowerLimit(p protocol.PacketNumber) {
-	h.lowerLimit = p
-	h.packetHistory.DeleteUpTo(p)
+// IgnoreBelow sets a lower limit for acking packets.
+// Packets with packet numbers smaller than p will not be acked.
+func (h *receivedPacketHandler) IgnoreBelow(p protocol.PacketNumber) {
+	h.ignoreBelow = p
+	h.packetHistory.DeleteBelow(p)
 }
 
 func (h *receivedPacketHandler) maybeQueueAck(packetNumber protocol.PacketNumber, shouldInstigateAck bool) {

--- a/ackhandler/received_packet_handler.go
+++ b/ackhandler/received_packet_handler.go
@@ -1,14 +1,11 @@
 package ackhandler
 
 import (
-	"errors"
 	"time"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
-
-var errInvalidPacketNumber = errors.New("ReceivedPacketHandler: Invalid packet number")
 
 type receivedPacketHandler struct {
 	largestObserved             protocol.PacketNumber
@@ -38,10 +35,6 @@ func NewReceivedPacketHandler(version protocol.VersionNumber) ReceivedPacketHand
 }
 
 func (h *receivedPacketHandler) ReceivedPacket(packetNumber protocol.PacketNumber, shouldInstigateAck bool) error {
-	if packetNumber == 0 {
-		return errInvalidPacketNumber
-	}
-
 	if packetNumber > h.largestObserved {
 		h.largestObserved = packetNumber
 		h.largestObservedReceivedTime = time.Now()

--- a/ackhandler/received_packet_handler_test.go
+++ b/ackhandler/received_packet_handler_test.go
@@ -202,13 +202,13 @@ var _ = Describe("receivedPacketHandler", func() {
 			})
 
 			It("accepts packets below the lower limit", func() {
-				handler.SetLowerLimit(5)
+				handler.IgnoreBelow(6)
 				err := handler.ReceivedPacket(2, true)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("doesn't add delayed packets to the packetHistory", func() {
-				handler.SetLowerLimit(6)
+				handler.IgnoreBelow(7)
 				err := handler.ReceivedPacket(4, true)
 				Expect(err).ToNot(HaveOccurred())
 				err = handler.ReceivedPacket(10, true)
@@ -224,7 +224,7 @@ var _ = Describe("receivedPacketHandler", func() {
 					err := handler.ReceivedPacket(protocol.PacketNumber(i), true)
 					Expect(err).ToNot(HaveOccurred())
 				}
-				handler.SetLowerLimit(6)
+				handler.IgnoreBelow(7)
 				// check that the packets were deleted from the receivedPacketHistory by checking the values in an ACK frame
 				ack := handler.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
@@ -235,7 +235,7 @@ var _ = Describe("receivedPacketHandler", func() {
 
 			// TODO: remove this test when dropping support for STOP_WAITINGs
 			It("handles a lower limit of 0", func() {
-				handler.SetLowerLimit(0)
+				handler.IgnoreBelow(0)
 				err := handler.ReceivedPacket(1337, true)
 				Expect(err).ToNot(HaveOccurred())
 				ack := handler.GetAckFrame()

--- a/ackhandler/received_packet_history.go
+++ b/ackhandler/received_packet_history.go
@@ -74,17 +74,17 @@ func (h *receivedPacketHistory) ReceivedPacket(p protocol.PacketNumber) error {
 	return nil
 }
 
-// DeleteUpTo deletes all entries up to (and including) p
-func (h *receivedPacketHistory) DeleteUpTo(p protocol.PacketNumber) {
-	h.lowestInReceivedPacketNumbers = utils.MaxPacketNumber(h.lowestInReceivedPacketNumbers, p+1)
+// DeleteBelow deletes all entries below (but not including) p
+func (h *receivedPacketHistory) DeleteBelow(p protocol.PacketNumber) {
+	h.lowestInReceivedPacketNumbers = utils.MaxPacketNumber(h.lowestInReceivedPacketNumbers, p)
 
 	nextEl := h.ranges.Front()
 	for el := h.ranges.Front(); nextEl != nil; el = nextEl {
 		nextEl = el.Next()
 
-		if p >= el.Value.Start && p < el.Value.End {
-			el.Value.Start = p + 1
-		} else if el.Value.End <= p { // delete a whole range
+		if p > el.Value.Start && p <= el.Value.End {
+			el.Value.Start = p
+		} else if el.Value.End < p { // delete a whole range
 			h.ranges.Remove(el)
 		} else { // no ranges affected. Nothing to do
 			return

--- a/ackhandler/received_packet_history_test.go
+++ b/ackhandler/received_packet_history_test.go
@@ -124,7 +124,7 @@ var _ = Describe("receivedPacketHistory", func() {
 
 	Context("deleting", func() {
 		It("does nothing when the history is empty", func() {
-			hist.DeleteUpTo(5)
+			hist.DeleteBelow(5)
 			Expect(hist.ranges.Len()).To(BeZero())
 		})
 
@@ -132,7 +132,7 @@ var _ = Describe("receivedPacketHistory", func() {
 			hist.ReceivedPacket(4)
 			hist.ReceivedPacket(5)
 			hist.ReceivedPacket(10)
-			hist.DeleteUpTo(5)
+			hist.DeleteBelow(6)
 			Expect(hist.ranges.Len()).To(Equal(1))
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 10, End: 10}))
 		})
@@ -141,7 +141,7 @@ var _ = Describe("receivedPacketHistory", func() {
 			hist.ReceivedPacket(1)
 			hist.ReceivedPacket(5)
 			hist.ReceivedPacket(10)
-			hist.DeleteUpTo(8)
+			hist.DeleteBelow(8)
 			Expect(hist.ranges.Len()).To(Equal(1))
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 10, End: 10}))
 		})
@@ -152,7 +152,7 @@ var _ = Describe("receivedPacketHistory", func() {
 			hist.ReceivedPacket(5)
 			hist.ReceivedPacket(6)
 			hist.ReceivedPacket(7)
-			hist.DeleteUpTo(4)
+			hist.DeleteBelow(5)
 			Expect(hist.ranges.Len()).To(Equal(1))
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 5, End: 7}))
 		})
@@ -161,7 +161,7 @@ var _ = Describe("receivedPacketHistory", func() {
 			hist.ReceivedPacket(4)
 			hist.ReceivedPacket(5)
 			hist.ReceivedPacket(10)
-			hist.DeleteUpTo(4)
+			hist.DeleteBelow(5)
 			Expect(hist.ranges.Len()).To(Equal(2))
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 5, End: 5}))
 			Expect(hist.ranges.Back().Value).To(Equal(utils.PacketInterval{Start: 10, End: 10}))
@@ -169,7 +169,7 @@ var _ = Describe("receivedPacketHistory", func() {
 
 		It("keeps a one-packet range, if deleting up to the packet directly below", func() {
 			hist.ReceivedPacket(4)
-			hist.DeleteUpTo(3)
+			hist.DeleteBelow(4)
 			Expect(hist.ranges.Len()).To(Equal(1))
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 4, End: 4}))
 		})
@@ -191,7 +191,7 @@ var _ = Describe("receivedPacketHistory", func() {
 				}
 				err := hist.ReceivedPacket(2*protocol.MaxTrackedReceivedAckRanges + 2)
 				Expect(err).To(MatchError(errTooManyOutstandingReceivedAckRanges))
-				hist.DeleteUpTo(protocol.MaxTrackedReceivedAckRanges) // deletes about half of the ranges
+				hist.DeleteBelow(protocol.MaxTrackedReceivedAckRanges) // deletes about half of the ranges
 				err = hist.ReceivedPacket(2*protocol.MaxTrackedReceivedAckRanges + 4)
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/ackhandler/sent_packet_handler.go
+++ b/ackhandler/sent_packet_handler.go
@@ -99,10 +99,6 @@ func (h *sentPacketHandler) SetHandshakeComplete() {
 }
 
 func (h *sentPacketHandler) SentPacket(packet *Packet) error {
-	if packet.PacketNumber <= h.lastSentPacketNumber {
-		return errors.New("Already sent a packet with a higher packet number")
-	}
-
 	if protocol.PacketNumber(len(h.retransmissionQueue)+h.packetHistory.Len()+1) > protocol.MaxTrackedSentPackets {
 		return errors.New("Too many outstanding non-acked and non-retransmitted packets")
 	}

--- a/ackhandler/sent_packet_handler_test.go
+++ b/ackhandler/sent_packet_handler_test.go
@@ -124,31 +124,6 @@ var _ = Describe("SentPacketHandler", func() {
 			Expect(handler.skippedPackets).To(BeEmpty())
 		})
 
-		It("rejects packets with the same packet number", func() {
-			packet1 := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1}
-			packet2 := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 2}
-			err := handler.SentPacket(&packet1)
-			Expect(err).ToNot(HaveOccurred())
-			err = handler.SentPacket(&packet2)
-			Expect(err).To(MatchError("Already sent a packet with a higher packet number"))
-			Expect(handler.lastSentPacketNumber).To(Equal(protocol.PacketNumber(1)))
-			Expect(handler.packetHistory.Front().Value.PacketNumber).To(Equal(protocol.PacketNumber(1)))
-			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(1)))
-			Expect(handler.skippedPackets).To(BeEmpty())
-		})
-
-		It("rejects packets with decreasing packet number", func() {
-			packet1 := Packet{PacketNumber: 2, Frames: []wire.Frame{&streamFrame}, Length: 1}
-			packet2 := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 2}
-			err := handler.SentPacket(&packet1)
-			Expect(err).ToNot(HaveOccurred())
-			err = handler.SentPacket(&packet2)
-			Expect(err).To(MatchError("Already sent a packet with a higher packet number"))
-			Expect(handler.lastSentPacketNumber).To(Equal(protocol.PacketNumber(2)))
-			Expect(handler.packetHistory.Front().Value.PacketNumber).To(Equal(protocol.PacketNumber(2)))
-			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(1)))
-		})
-
 		It("stores the sent time", func() {
 			packet := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1}
 			err := handler.SentPacket(&packet)

--- a/internal/wire/ack_frame.go
+++ b/internal/wire/ack_frame.go
@@ -89,7 +89,7 @@ func ParseAckFrame(r *bytes.Reader, version protocol.VersionNumber) (*AckFrame, 
 		return nil, ErrInvalidFirstAckRange
 	}
 
-	if ackBlockLength > largestAcked {
+	if ackBlockLength > largestAcked+1 {
 		return nil, ErrInvalidAckRanges
 	}
 

--- a/internal/wire/stop_waiting_frame.go
+++ b/internal/wire/stop_waiting_frame.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
-	"github.com/lucas-clemente/quic-go/qerr"
 )
 
 // A StopWaitingFrame in QUIC
@@ -73,8 +72,8 @@ func ParseStopWaitingFrame(r *bytes.Reader, packetNumber protocol.PacketNumber, 
 	if err != nil {
 		return nil, err
 	}
-	if leastUnackedDelta >= uint64(packetNumber) {
-		return nil, qerr.Error(qerr.InvalidStopWaitingData, "invalid LeastUnackedDelta")
+	if leastUnackedDelta > uint64(packetNumber) {
+		return nil, errors.New("invalid LeastUnackedDelta")
 	}
 	frame.LeastUnacked = protocol.PacketNumber(uint64(packetNumber) - leastUnackedDelta)
 	return frame, nil

--- a/session.go
+++ b/session.go
@@ -478,9 +478,7 @@ func (s *session) handleFrames(fs []wire.Frame, encLevel protocol.EncryptionLeve
 		case *wire.GoawayFrame:
 			err = errors.New("unimplemented: handling GOAWAY frames")
 		case *wire.StopWaitingFrame:
-			// LeastUnacked is guaranteed to have LeastUnacked > 0
-			// therefore this will never underflow
-			s.receivedPacketHandler.SetLowerLimit(frame.LeastUnacked - 1)
+			s.receivedPacketHandler.IgnoreBelow(frame.LeastUnacked)
 		case *wire.RstStreamFrame:
 			err = s.handleRstStreamFrame(frame)
 		case *wire.MaxDataFrame:

--- a/session_test.go
+++ b/session_test.go
@@ -130,7 +130,7 @@ func (m *mockReceivedPacketHandler) GetAckFrame() *wire.AckFrame {
 func (m *mockReceivedPacketHandler) ReceivedPacket(packetNumber protocol.PacketNumber, shouldInstigateAck bool) error {
 	panic("not implemented")
 }
-func (m *mockReceivedPacketHandler) SetLowerLimit(protocol.PacketNumber) {
+func (m *mockReceivedPacketHandler) IgnoreBelow(protocol.PacketNumber) {
 	panic("not implemented")
 }
 func (m *mockReceivedPacketHandler) GetAlarmTimeout() time.Time { return m.ackAlarm }


### PR DESCRIPTION
Fixes #872.

Since https://github.com/quicwg/base-drafts/issues/832 was recently closed, and 0 is a valid packet number (which will be chosen with a probability around 2^-32), we need to accept it.

We don't have a good way to integration test this, but I manually went to the `packetNumberGenerator` and set the initial packet number to 0, and everything works as expected.