### PR TITLE
implement the recent changes to the version negotiation packet

### DIFF
--- a/client.go
+++ b/client.go
@@ -286,10 +286,8 @@ func (c *client) handlePacket(remoteAddr net.Addr, packet []byte) {
 		return
 	}
 
-	isVersionNegotiationPacket := hdr.VersionFlag /* gQUIC Version Negotiation Packet */ || hdr.Type == protocol.PacketTypeVersionNegotiation /* IETF draft style Version Negotiation Packet */
-
 	// handle Version Negotiation Packets
-	if isVersionNegotiationPacket {
+	if hdr.IsVersionNegotiation {
 		// ignore delayed / duplicated version negotiation packets
 		if c.receivedVersionNegotiationPacket || c.versionNegotiated {
 			return

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -28,8 +28,6 @@ const (
 type PacketType uint8
 
 const (
-	// PacketTypeVersionNegotiation is the packet type of a Version Negotiation packet
-	PacketTypeVersionNegotiation PacketType = 1
 	// PacketTypeInitial is the packet type of a Initial packet
 	PacketTypeInitial PacketType = 2
 	// PacketTypeRetry is the packet type of a Retry packet
@@ -42,8 +40,6 @@ const (
 
 func (t PacketType) String() string {
 	switch t {
-	case PacketTypeVersionNegotiation:
-		return "Version Negotiation"
 	case PacketTypeInitial:
 		return "Initial"
 	case PacketTypeRetry:

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -8,7 +8,6 @@ import (
 var _ = Describe("Protocol", func() {
 	Context("Long Header Packet Types", func() {
 		It("has the correct string representation", func() {
-			Expect(PacketTypeVersionNegotiation.String()).To(Equal("Version Negotiation"))
 			Expect(PacketTypeInitial.String()).To(Equal("Initial"))
 			Expect(PacketTypeRetry.String()).To(Equal("Retry"))
 			Expect(PacketTypeHandshake.String()).To(Equal("Handshake"))

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Header", func() {
 				IsLongHeader: true,
 				Type:         protocol.PacketType0RTT,
 				PacketNumber: 0x42,
+				Version:      0x1234,
 			}).writeHeader(buf)
 			Expect(err).ToNot(HaveOccurred())
 			hdr, err := ParseHeaderSentByClient(bytes.NewReader(buf.Bytes()))
@@ -49,6 +50,7 @@ var _ = Describe("Header", func() {
 			Expect(hdr.Type).To(Equal(protocol.PacketType0RTT))
 			Expect(hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x42)))
 			Expect(hdr.isPublicHeader).To(BeFalse())
+			Expect(hdr.Version).To(Equal(protocol.VersionNumber(0x1234)))
 		})
 
 		It("doens't mistake packets with a Short Header for Version Negotiation Packets", func() {
@@ -132,15 +134,14 @@ var _ = Describe("Header", func() {
 
 		It("parses an IETF draft style Version Negotiation Packet", func() {
 			versions := []protocol.VersionNumber{0x13, 0x37}
-			data := ComposeVersionNegotiation(0x42, 0x77, 0x4321, versions)
+			data := ComposeVersionNegotiation(0x42, 0x77, versions)
 			hdr, err := ParseHeaderSentByServer(bytes.NewReader(data), protocol.VersionUnknown)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.isPublicHeader).To(BeFalse())
+			Expect(hdr.IsVersionNegotiation).To(BeTrue())
 			Expect(hdr.ConnectionID).To(Equal(protocol.ConnectionID(0x42)))
 			Expect(hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x77)))
-			Expect(hdr.Version).To(Equal(protocol.VersionNumber(0x4321)))
 			Expect(hdr.SupportedVersions).To(Equal(versions))
-			Expect(hdr.Type).To(Equal(protocol.PacketTypeVersionNegotiation))
 		})
 	})
 

--- a/internal/wire/public_header.go
+++ b/internal/wire/public_header.go
@@ -155,6 +155,7 @@ func parsePublicHeader(b *bytes.Reader, packetSentBy protocol.Perspective) (*Hea
 			if b.Len()%4 != 0 {
 				return nil, qerr.InvalidVersionNegotiationPacket
 			}
+			header.IsVersionNegotiation = true
 			header.SupportedVersions = make([]protocol.VersionNumber, 0)
 			for {
 				var versionTag uint32

--- a/internal/wire/public_header_test.go
+++ b/internal/wire/public_header_test.go
@@ -22,6 +22,7 @@ var _ = Describe("Public Header", func() {
 			hdr, err := parsePublicHeader(b, protocol.PerspectiveClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.VersionFlag).To(BeTrue())
+			Expect(hdr.IsVersionNegotiation).To(BeFalse())
 			Expect(hdr.ResetFlag).To(BeFalse())
 			Expect(hdr.ConnectionID).To(Equal(protocol.ConnectionID(0x4cfa9f9b668619f6)))
 			Expect(hdr.Version).To(Equal(protocol.SupportedVersions[0]))
@@ -65,6 +66,7 @@ var _ = Describe("Public Header", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.ResetFlag).To(BeTrue())
 			Expect(hdr.VersionFlag).To(BeFalse())
+			Expect(hdr.IsVersionNegotiation).To(BeFalse())
 			Expect(hdr.ConnectionID).To(Equal(protocol.ConnectionID(0x0102030405060708)))
 		})
 
@@ -101,6 +103,7 @@ var _ = Describe("Public Header", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hdr.VersionFlag).To(BeTrue())
 				Expect(hdr.Version).To(BeZero()) // unitialized
+				Expect(hdr.IsVersionNegotiation).To(BeTrue())
 				Expect(hdr.SupportedVersions).To(Equal(protocol.SupportedVersions))
 				Expect(b.Len()).To(BeZero())
 			})
@@ -120,6 +123,7 @@ var _ = Describe("Public Header", func() {
 				hdr, err := parsePublicHeader(b, protocol.PerspectiveServer)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hdr.VersionFlag).To(BeTrue())
+				Expect(hdr.IsVersionNegotiation).To(BeTrue())
 				Expect(hdr.SupportedVersions).To(Equal([]protocol.VersionNumber{1, protocol.SupportedVersions[0], 99}))
 				Expect(b.Len()).To(BeZero())
 			})

--- a/internal/wire/version_negotiation.go
+++ b/internal/wire/version_negotiation.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"bytes"
+	"crypto/rand"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
@@ -11,9 +12,10 @@ import (
 func ComposeGQUICVersionNegotiation(connID protocol.ConnectionID, versions []protocol.VersionNumber) []byte {
 	fullReply := &bytes.Buffer{}
 	ph := Header{
-		ConnectionID: connID,
-		PacketNumber: 1,
-		VersionFlag:  true,
+		ConnectionID:         connID,
+		PacketNumber:         1,
+		VersionFlag:          true,
+		IsVersionNegotiation: true,
 	}
 	if err := ph.writePublicHeader(fullReply, protocol.PerspectiveServer, protocol.VersionWhatever); err != nil {
 		utils.Errorf("error composing version negotiation packet: %s", err.Error())
@@ -29,18 +31,20 @@ func ComposeGQUICVersionNegotiation(connID protocol.ConnectionID, versions []pro
 func ComposeVersionNegotiation(
 	connID protocol.ConnectionID,
 	pn protocol.PacketNumber,
-	versionOffered protocol.VersionNumber,
 	versions []protocol.VersionNumber,
 ) []byte {
 	fullReply := &bytes.Buffer{}
-	ph := Header{
-		IsLongHeader: true,
-		Type:         protocol.PacketTypeVersionNegotiation,
-		ConnectionID: connID,
-		PacketNumber: pn,
-		Version:      versionOffered,
+	r := make([]byte, 1)
+	_, _ = rand.Read(r) // ignore the error here. It is not critical to have perfect random here.
+	h := Header{
+		IsLongHeader:         true,
+		Type:                 protocol.PacketType(r[0] | 0x80),
+		ConnectionID:         connID,
+		PacketNumber:         pn,
+		Version:              0,
+		IsVersionNegotiation: true,
 	}
-	if err := ph.writeHeader(fullReply); err != nil {
+	if err := h.writeHeader(fullReply); err != nil {
 		utils.Errorf("error composing version negotiation packet: %s", err.Error())
 		return nil
 	}

--- a/internal/wire/version_negotiation_test.go
+++ b/internal/wire/version_negotiation_test.go
@@ -19,15 +19,14 @@ var _ = Describe("Version Negotiation Packets", func() {
 		Expect(hdr.SupportedVersions).To(Equal(versions))
 	})
 
-	It("writes IETF draft style", func() {
+	It("writes in IETF draft style", func() {
 		versions := []protocol.VersionNumber{1001, 1003}
-		data := ComposeVersionNegotiation(0x1337, 0x42, 0x1234, versions)
+		data := ComposeVersionNegotiation(0x1337, 0x42, versions)
 		hdr, err := parseHeader(bytes.NewReader(data), protocol.PerspectiveServer)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(hdr.Type).To(Equal(protocol.PacketTypeVersionNegotiation))
+		Expect(hdr.IsVersionNegotiation).To(BeTrue())
 		Expect(hdr.ConnectionID).To(Equal(protocol.ConnectionID(0x1337)))
 		Expect(hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x42)))
-		Expect(hdr.Version).To(Equal(protocol.VersionNumber(0x1234)))
 		Expect(hdr.SupportedVersions).To(Equal(versions))
 	})
 })

--- a/server.go
+++ b/server.go
@@ -280,7 +280,7 @@ func (s *server) handlePacket(pconn net.PacketConn, remoteAddr net.Addr, packet 
 	}
 	// send an IETF draft style Version Negotiation Packet, if the client sent an unsupported version with an IETF draft style header
 	if hdr.Type == protocol.PacketTypeInitial && !protocol.IsSupportedVersion(s.config.Versions, hdr.Version) {
-		_, err := pconn.WriteTo(wire.ComposeVersionNegotiation(hdr.ConnectionID, hdr.PacketNumber, hdr.Version, s.config.Versions), remoteAddr)
+		_, err := pconn.WriteTo(wire.ComposeVersionNegotiation(hdr.ConnectionID, hdr.PacketNumber, s.config.Versions), remoteAddr)
 		return err
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -438,6 +438,7 @@ var _ = Describe("Server", func() {
 			IsLongHeader: true,
 			ConnectionID: 0x1337,
 			PacketNumber: 0x55,
+			Version:      0x1234,
 		}
 		hdr.Write(b, protocol.PerspectiveClient, protocol.VersionTLS)
 		b.Write(bytes.Repeat([]byte{0}, protocol.ClientHelloMinimumSize)) // add a fake CHLO
@@ -457,7 +458,7 @@ var _ = Describe("Server", func() {
 		r := bytes.NewReader(conn.dataWritten.Bytes())
 		packet, err := wire.ParseHeaderSentByServer(r, protocol.VersionUnknown)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.Type).To(Equal(protocol.PacketTypeVersionNegotiation))
+		Expect(packet.IsVersionNegotiation).To(BeTrue())
 		Expect(packet.ConnectionID).To(Equal(protocol.ConnectionID(0x1337)))
 		Expect(packet.PacketNumber).To(Equal(protocol.PacketNumber(0x55)))
 		Expect(r.Len()).To(BeZero())


### PR DESCRIPTION
Fixes #972. Should be merged after #961.

Our header parsing is not perfect. Technically, nothing but the connection ID and the version field are an invariant, so technically, we should read the version and stop parsing the header if it's an unsupported version. Practically, the current parsing should work for both gQUIC and IETF QUIC.

