### PR TITLE
update validation of version negotiation

### DIFF
--- a/internal/handshake/tls_extension.go
+++ b/internal/handshake/tls_extension.go
@@ -24,12 +24,12 @@ type transportParameter struct {
 }
 
 type clientHelloTransportParameters struct {
-	NegotiatedVersion uint32               // actually a protocol.VersionNumber
-	InitialVersion    uint32               // actually a protocol.VersionNumber
-	Parameters        []transportParameter `tls:"head=2"`
+	InitialVersion uint32               // actually a protocol.VersionNumber
+	Parameters     []transportParameter `tls:"head=2"`
 }
 
 type encryptedExtensionsTransportParameters struct {
+	NegotiatedVersion uint32               // actually a protocol.VersionNumber
 	SupportedVersions []uint32             `tls:"head=1"` // actually a protocol.VersionNumber
 	Parameters        []transportParameter `tls:"head=2"`
 }

--- a/internal/handshake/tls_extension_handler_client.go
+++ b/internal/handshake/tls_extension_handler_client.go
@@ -45,9 +45,8 @@ func (h *extensionHandlerClient) Send(hType mint.HandshakeType, el *mint.Extensi
 	}
 
 	data, err := syntax.Marshal(clientHelloTransportParameters{
-		NegotiatedVersion: uint32(h.version),
-		InitialVersion:    uint32(h.initialVersion),
-		Parameters:        h.params.getTransportParameters(),
+		InitialVersion: uint32(h.initialVersion),
+		Parameters:     h.params.getTransportParameters(),
 	})
 	if err != nil {
 		return err
@@ -83,6 +82,10 @@ func (h *extensionHandlerClient) Receive(hType mint.HandshakeType, el *mint.Exte
 	serverSupportedVersions := make([]protocol.VersionNumber, len(eetp.SupportedVersions))
 	for i, v := range eetp.SupportedVersions {
 		serverSupportedVersions[i] = protocol.VersionNumber(v)
+	}
+	// check that the negotiated_version is the current version
+	if protocol.VersionNumber(eetp.NegotiatedVersion) != h.version {
+		return qerr.Error(qerr.VersionNegotiationMismatch, "current version doesn't match negotiated_version")
 	}
 	// check that the current version is included in the supported versions
 	if !protocol.IsSupportedVersion(serverSupportedVersions, h.version) {


### PR DESCRIPTION
Fixes #971.

The negotiated_version parameter was recently moved from the client_hello TLS handshake message to the encrypted_extensions.