### PR TITLE
add a -tls flag to the example client and server

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -7,12 +7,15 @@ import (
 	"net/http"
 	"sync"
 
+	quic "github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/h2quic"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
 func main() {
 	verbose := flag.Bool("v", false, "verbose")
+	tls := flag.Bool("tls", false, "activate support for IETF QUIC (work in progress)")
 	flag.Parse()
 	urls := flag.Args()
 
@@ -23,8 +26,15 @@ func main() {
 	}
 	utils.SetLogTimeFormat("")
 
+	versions := protocol.SupportedVersions
+	if *tls {
+		versions = append([]protocol.VersionNumber{protocol.VersionTLS}, versions...)
+	}
+
 	hclient := &http.Client{
-		Transport: &h2quic.RoundTripper{},
+		Transport: &h2quic.RoundTripper{
+			QuicConfig: &quic.Config{Versions: versions},
+		},
 	}
 
 	var wg sync.WaitGroup

--- a/example/main.go
+++ b/example/main.go
@@ -17,7 +17,9 @@ import (
 
 	_ "net/http/pprof"
 
+	quic "github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/h2quic"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
@@ -121,6 +123,7 @@ func main() {
 	certPath := flag.String("certpath", getBuildDir(), "certificate directory")
 	www := flag.String("www", "/var/www", "www data")
 	tcp := flag.Bool("tcp", false, "also listen on TCP")
+	tls := flag.Bool("tls", false, "activate support for IETF QUIC (work in progress)")
 	flag.Parse()
 
 	if *verbose {
@@ -129,6 +132,11 @@ func main() {
 		utils.SetLogLevel(utils.LogLevelInfo)
 	}
 	utils.SetLogTimeFormat("")
+
+	versions := protocol.SupportedVersions
+	if *tls {
+		versions = append([]protocol.VersionNumber{protocol.VersionTLS}, versions...)
+	}
 
 	certFile := *certPath + "/fullchain.pem"
 	keyFile := *certPath + "/privkey.pem"
@@ -148,7 +156,11 @@ func main() {
 			if *tcp {
 				err = h2quic.ListenAndServe(bCap, certFile, keyFile, nil)
 			} else {
-				err = h2quic.ListenAndServeQUIC(bCap, certFile, keyFile, nil)
+				server := h2quic.Server{
+					Server:     &http.Server{Addr: bCap},
+					QuicConfig: &quic.Config{Versions: versions},
+				}
+				err = server.ListenAndServeTLS(certFile, keyFile)
 			}
 			if err != nil {
 				fmt.Println(err)


### PR DESCRIPTION
This will add the WIP TLS version as the preferred supported version. It is intended for developing and testing of IETF QUIC.