### PR TITLE
remove unused encryptionLevel from client

### DIFF
--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -34,10 +34,9 @@ type client struct {
 	config  *quic.Config
 	opts    *roundTripperOpts
 
-	hostname        string
-	encryptionLevel protocol.EncryptionLevel
-	handshakeErr    error
-	dialOnce        sync.Once
+	hostname     string
+	handshakeErr error
+	dialOnce     sync.Once
 
 	session       quic.Session
 	headerStream  quic.Stream
@@ -67,13 +66,12 @@ func newClient(
 		config = quicConfig
 	}
 	return &client{
-		hostname:        authorityAddr("https", hostname),
-		responses:       make(map[protocol.StreamID]chan *http.Response),
-		encryptionLevel: protocol.EncryptionUnencrypted,
-		tlsConf:         tlsConfig,
-		config:          config,
-		opts:            opts,
-		headerErrored:   make(chan struct{}),
+		hostname:      authorityAddr("https", hostname),
+		responses:     make(map[protocol.StreamID]chan *http.Response),
+		tlsConf:       tlsConfig,
+		config:        config,
+		opts:          opts,
+		headerErrored: make(chan struct{}),
 	}
 }
 

--- a/h2quic/client_test.go
+++ b/h2quic/client_test.go
@@ -151,7 +151,6 @@ var _ = Describe("Client", func() {
 
 		BeforeEach(func() {
 			var err error
-			client.encryptionLevel = protocol.EncryptionForwardSecure
 			dialAddr = func(hostname string, _ *tls.Config, _ *quic.Config) (quic.Session, error) {
 				return session, nil
 			}


### PR DESCRIPTION
The `encryptionLevel` in the h2quic client doesn't seem to be used anywhere.