### PR TITLE
don't send a window update after the final offset was received

### DIFF
--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -116,6 +116,11 @@ func (c *streamFlowController) GetWindowUpdate() protocol.ByteCount {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
+	// if we already received the final offset for this stream, the peer won't need any additional flow control credit
+	if c.receivedFinalOffset {
+		return 0
+	}
+
 	oldWindowIncrement := c.receiveWindowIncrement
 	offset := c.baseFlowController.getWindowUpdate()
 	if c.receiveWindowIncrement > oldWindowIncrement { // auto-tuning enlarged the window increment

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -193,6 +193,14 @@ var _ = Describe("Stream Flow controller", func() {
 				Expect(controller.receiveWindowIncrement).To(Equal(2 * oldIncrement))
 				Expect(controller.connection.(*connectionFlowController).receiveWindowIncrement).To(Equal(protocol.ByteCount(120))) // unchanged
 			})
+
+			It("doesn't increase the window after a final offset was already received", func() {
+				controller.AddBytesRead(80)
+				err := controller.UpdateHighestReceived(90, true)
+				Expect(err).ToNot(HaveOccurred())
+				offset := controller.GetWindowUpdate()
+				Expect(offset).To(BeZero())
+			})
 		})
 	})
 


### PR DESCRIPTION
Fixes #989.

Receiving a final offset means the peer is done sending on that stream, and there's no need to grant additional flow control credit.