### PR TITLE
fix the crypto setup so that it works with the recent mint changes

### DIFF
--- a/internal/handshake/crypto_setup_tls.go
+++ b/internal/handshake/crypto_setup_tls.go
@@ -54,6 +54,10 @@ func NewCryptoSetupTLSServer(
 	if err != nil {
 		return nil, err
 	}
+	mintConf.CookieProtector, err = mint.NewDefaultCookieProtector()
+	if err != nil {
+		return nil, err
+	}
 	conn := &fakeConn{
 		stream:     cryptoStream,
 		pers:       protocol.PerspectiveServer,
@@ -128,6 +132,7 @@ func (h *cryptoSetupTLS) HandleCryptoStream() error {
 handshakeLoop:
 	for {
 		switch alert := h.tls.Handshake(); alert {
+		case mint.AlertStatelessRetry:
 		case mint.AlertNoAlert: // handshake complete
 			break handshakeLoop
 		case mint.AlertWouldBlock:


### PR DESCRIPTION
After merging https://github.com/bifurcation/mint/pull/141, mint now supports stateless retries, and requires that the cookie protector is set in the mint.Config and returns a new alert when a retry is performed.