### PR TITLE
adapt TLS state handling to mint changes

### DIFF
--- a/internal/handshake/crypto_setup_tls.go
+++ b/internal/handshake/crypto_setup_tls.go
@@ -215,9 +215,9 @@ func (h *cryptoSetupTLS) determineNextPacketType() error {
 	state := h.tls.State().HandshakeState
 	if h.perspective == protocol.PerspectiveServer {
 		switch state {
-		case "ServerStateStart": // if we're still at ServerStateStart when writing the first packet, that means we've come back to that state by sending a HelloRetryRequest
+		case mint.StateServerStart: // if we're still at ServerStateStart when writing the first packet, that means we've come back to that state by sending a HelloRetryRequest
 			h.nextPacketType = protocol.PacketTypeRetry
-		case "ServerStateWaitFinished":
+		case mint.StateServerWaitFinished:
 			h.nextPacketType = protocol.PacketTypeHandshake
 		default:
 			// TODO: accept 0-RTT data
@@ -226,7 +226,7 @@ func (h *cryptoSetupTLS) determineNextPacketType() error {
 		return nil
 	}
 	// client
-	if state != "ClientStateWaitSH" {
+	if state != mint.StateClientWaitSH {
 		h.nextPacketType = protocol.PacketTypeHandshake
 	}
 	return nil


### PR DESCRIPTION
bifurcation/mint#151 was merged an currently breaks quic-go.
I think it will be eventually fixed by #980, but that seems to be a massive change. For now, it would be nice to just make the minimal changes to let this package compile again.
This PR does exactly that changes and nothing else.