### PR TITLE
decrease the threshold to send MAX_{STREAM}_DATA frames

### DIFF
--- a/internal/flowcontrol/base_flow_controller.go
+++ b/internal/flowcontrol/base_flow_controller.go
@@ -67,9 +67,9 @@ func (c *baseFlowController) AddBytesRead(n protocol.ByteCount) {
 // getWindowUpdate updates the receive window, if necessary
 // it returns the new offset
 func (c *baseFlowController) getWindowUpdate() protocol.ByteCount {
-	diff := c.receiveWindow - c.bytesRead
-	// update the window when more than half of it was already consumed
-	if diff >= (c.receiveWindowIncrement / 2) {
+	bytesRemaining := c.receiveWindow - c.bytesRead
+	// update the window when more than the threshold was consumed
+	if bytesRemaining >= protocol.ByteCount((float64(c.receiveWindowIncrement) * float64((1 - protocol.WindowUpdateThreshold)))) {
 		return 0
 	}
 
@@ -86,7 +86,8 @@ func (c *baseFlowController) IsBlocked() bool {
 	return c.sendWindowSize() == 0
 }
 
-// maybeAdjustWindowIncrement increases the receiveWindowIncrement if we're sending WindowUpdates too often
+// maybeAdjustWindowIncrement increases the receiveWindowIncrement if we're sending updates too often.
+// For details about auto-tuning, see https://docs.google.com/document/d/1F2YfdDXKpy20WVKJueEf4abn_LVZHhMUMS5gX6Pgjl4/edit#heading=h.hcm2y5x4qmqt.
 func (c *baseFlowController) maybeAdjustWindowIncrement() {
 	if c.lastWindowUpdateTime.IsZero() {
 		return
@@ -98,8 +99,8 @@ func (c *baseFlowController) maybeAdjustWindowIncrement() {
 	}
 
 	timeSinceLastWindowUpdate := time.Since(c.lastWindowUpdateTime)
-	// interval between the window updates is sufficiently large, no need to increase the increment
-	if timeSinceLastWindowUpdate >= 2*rtt {
+	// interval between the updates is sufficiently large, no need to increase the increment
+	if timeSinceLastWindowUpdate >= 4*protocol.WindowUpdateThreshold*rtt {
 		return
 	}
 	c.receiveWindowIncrement = utils.MinByteCount(2*c.receiveWindowIncrement, c.maxReceiveWindowIncrement)

--- a/internal/flowcontrol/connection_flow_controller_test.go
+++ b/internal/flowcontrol/connection_flow_controller_test.go
@@ -58,8 +58,9 @@ var _ = Describe("Connection Flow controller", func() {
 
 			It("autotunes the window", func() {
 				controller.AddBytesRead(80)
-				setRtt(20 * time.Millisecond)
-				controller.lastWindowUpdateTime = time.Now().Add(-35 * time.Millisecond)
+				rtt := 20 * time.Millisecond
+				setRtt(rtt)
+				controller.lastWindowUpdateTime = time.Now().Add(-4*protocol.WindowUpdateThreshold*rtt + time.Millisecond)
 				offset := controller.GetWindowUpdate()
 				Expect(offset).To(Equal(protocol.ByteCount(80 + 2*60)))
 			})

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -175,8 +175,9 @@ var _ = Describe("Stream Flow controller", func() {
 			It("tells the connection flow controller when the window was autotuned", func() {
 				controller.contributesToConnection = true
 				controller.AddBytesRead(75)
-				setRtt(20 * time.Millisecond)
-				controller.lastWindowUpdateTime = time.Now().Add(-35 * time.Millisecond)
+				rtt := 20 * time.Millisecond
+				setRtt(rtt)
+				controller.lastWindowUpdateTime = time.Now().Add(-4*protocol.WindowUpdateThreshold*rtt + time.Millisecond)
 				offset := controller.GetWindowUpdate()
 				Expect(offset).To(Equal(protocol.ByteCount(75 + 2*60)))
 				Expect(controller.receiveWindowIncrement).To(Equal(2 * oldIncrement))
@@ -186,8 +187,9 @@ var _ = Describe("Stream Flow controller", func() {
 			It("doesn't tell the connection flow controller if it doesn't contribute", func() {
 				controller.contributesToConnection = false
 				controller.AddBytesRead(75)
-				setRtt(20 * time.Millisecond)
-				controller.lastWindowUpdateTime = time.Now().Add(-35 * time.Millisecond)
+				rtt := 20 * time.Millisecond
+				setRtt(rtt)
+				controller.lastWindowUpdateTime = time.Now().Add(-4*protocol.WindowUpdateThreshold*rtt + time.Millisecond)
 				offset := controller.GetWindowUpdate()
 				Expect(offset).ToNot(BeZero())
 				Expect(controller.receiveWindowIncrement).To(Equal(2 * oldIncrement))

--- a/internal/protocol/server_parameters.go
+++ b/internal/protocol/server_parameters.go
@@ -56,6 +56,9 @@ const DefaultMaxReceiveConnectionFlowControlWindowClient = 15 * (1 << 20) // 15 
 // This is the value that Chromium is using
 const ConnectionFlowControlMultiplier = 1.5
 
+// WindowUpdateThreshold is the fraction of the receive window that has to be consumed before an higher offset is advertised to the client
+const WindowUpdateThreshold = 0.25
+
 // MaxIncomingStreams is the maximum number of streams that a peer may open
 const MaxIncomingStreams = 100
 

--- a/session.go
+++ b/session.go
@@ -694,8 +694,7 @@ func (s *session) sendPacket() error {
 
 	// Get MAX_DATA and MAX_STREAM_DATA frames
 	// this call triggers the flow controller to increase the flow control windows, if necessary
-	windowUpdates := s.getWindowUpdates()
-	for _, f := range windowUpdates {
+	for _, f := range s.getWindowUpdates() {
 		s.packer.QueueControlFrame(f)
 	}
 
@@ -777,11 +776,6 @@ func (s *session) sendPacket() error {
 			return err
 		}
 
-		// send every window update twice
-		for _, f := range windowUpdates {
-			s.packer.QueueControlFrame(f)
-		}
-		windowUpdates = nil
 		ack = nil
 	}
 }

--- a/session_test.go
+++ b/session_test.go
@@ -830,29 +830,6 @@ var _ = Describe("Session", func() {
 			Expect(sess.sentPacketHandler.(*mockSentPacketHandler).sentPackets[0].Frames).To(ContainElement(&wire.PingFrame{}))
 		})
 
-		It("sends two MAX_STREAM_DATA frames", func() {
-			mockFC := mocks.NewMockStreamFlowController(mockCtrl)
-			mockFC.EXPECT().GetWindowUpdate().Return(protocol.ByteCount(0x1000))
-			mockFC.EXPECT().GetWindowUpdate().Return(protocol.ByteCount(0)).Times(2)
-			str, err := sess.GetOrOpenStream(5)
-			Expect(err).ToNot(HaveOccurred())
-			str.(*stream).flowController = mockFC
-			err = sess.sendPacket()
-			Expect(err).NotTo(HaveOccurred())
-			err = sess.sendPacket()
-			Expect(err).NotTo(HaveOccurred())
-			err = sess.sendPacket()
-			Expect(err).NotTo(HaveOccurred())
-			buf := &bytes.Buffer{}
-			(&wire.MaxStreamDataFrame{
-				StreamID:   5,
-				ByteOffset: 0x1000,
-			}).Write(buf, sess.version)
-			Expect(mconn.written).To(HaveLen(2))
-			Expect(mconn.written).To(Receive(ContainSubstring(string(buf.Bytes()))))
-			Expect(mconn.written).To(Receive(ContainSubstring(string(buf.Bytes()))))
-		})
-
 		It("sends public reset", func() {
 			err := sess.sendPublicReset(1)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This will increase the performance high BDP connections.

The optimization to send every WINDOW_UPDATE twice, which we took from Chrome, was apparently an unintended optimisation there (aka bug), so now that we're sending the updates more often, it should be even safer to remove this.