### PR TITLE
don't add more STREAM frames to a packet if remaining size is too small

### DIFF
--- a/internal/protocol/server_parameters.go
+++ b/internal/protocol/server_parameters.go
@@ -122,3 +122,9 @@ const ClosedSessionDeleteTimeout = time.Minute
 
 // NumCachedCertificates is the number of cached compressed certificate chains, each taking ~1K space
 const NumCachedCertificates = 128
+
+// MinStreamFrameSize is the minimum size that has to be left in a packet, so that we add another STREAM frame.
+// This avoids splitting up STREAM frames into small pieces, which has 2 advantages:
+// 1. it reduces the framing overhead
+// 2. it reduces the head-of-line blocking, when a packet is lost
+const MinStreamFrameSize ByteCount = 128


### PR DESCRIPTION
This is an optimization, which will become important for a later refactoring of the `stream`. 
Since it's a useful change in itself, I'd like to merge it as a separate PRö