### PR TITLE
directly queue RST_STREAM frames on stream.Reset

### DIFF
--- a/session.go
+++ b/session.go
@@ -849,14 +849,6 @@ func (s *session) WaitUntilHandshakeComplete() error {
 	return <-s.handshakeCompleteChan
 }
 
-func (s *session) queueResetStreamFrame(id protocol.StreamID, offset protocol.ByteCount) {
-	s.packer.QueueControlFrame(&wire.RstStreamFrame{
-		StreamID:   id,
-		ByteOffset: offset,
-	})
-	s.scheduleSending()
-}
-
 func (s *session) newStream(id protocol.StreamID) streamI {
 	var initialSendWindow protocol.ByteCount
 	if s.peerParams != nil {
@@ -871,7 +863,7 @@ func (s *session) newStream(id protocol.StreamID) streamI {
 		initialSendWindow,
 		s.rttStats,
 	)
-	return newStream(id, s.scheduleSending, s.queueResetStreamFrame, flowController, s.version)
+	return newStream(id, s.scheduleSending, s.packer.QueueControlFrame, flowController, s.version)
 }
 
 func (s *session) newCryptoStream() cryptoStreamI {

--- a/session_test.go
+++ b/session_test.go
@@ -357,15 +357,6 @@ var _ = Describe("Session", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("queues a RST_STERAM frame", func() {
-				sess.queueResetStreamFrame(5, 0x1337)
-				Expect(sess.packer.controlFrames).To(HaveLen(1))
-				Expect(sess.packer.controlFrames[0].(*wire.RstStreamFrame)).To(Equal(&wire.RstStreamFrame{
-					StreamID:   5,
-					ByteOffset: 0x1337,
-				}))
-			})
-
 			It("returns errors", func() {
 				testErr := errors.New("flow control violation")
 				str, err := sess.GetOrOpenStream(5)


### PR DESCRIPTION
We're currently doing **a lot** wrong when resetting streams. This PR doesn't fix any of those issues, but is a prerequisite for future changes, in 2 ways:

- For gQUIC, we will have to pay attention to the RST_STREAM error code. Sending error code 0 or != 0 has a different effect on the state machine.
- For IETF QUIC, we will need to send STOP_SENDING frames. The new `stream.queueControlFrame` takes any `wire.Frame` as an argument, so we can use this function for that.