### PR TITLE
rename stream.Cancel to stream.CloseForShutdown

### DIFF
--- a/crypto_stream.go
+++ b/crypto_stream.go
@@ -13,7 +13,7 @@ type cryptoStreamI interface {
 	io.Writer
 	HandleStreamFrame(*wire.StreamFrame) error
 	PopStreamFrame(protocol.ByteCount) *wire.StreamFrame
-	Cancel(error)
+	CloseForShutdown(error)
 	HasDataForWriting() bool
 	SetReadOffset(protocol.ByteCount)
 	// methods needed for flow control

--- a/internal/mocks/stream.go
+++ b/internal/mocks/stream.go
@@ -36,16 +36,6 @@ func (_m *MockStreamI) EXPECT() *MockStreamIMockRecorder {
 	return _m.recorder
 }
 
-// Cancel mocks base method
-func (_m *MockStreamI) Cancel(_param0 error) {
-	_m.ctrl.Call(_m, "Cancel", _param0)
-}
-
-// Cancel indicates an expected call of Cancel
-func (_mr *MockStreamIMockRecorder) Cancel(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "Cancel", reflect.TypeOf((*MockStreamI)(nil).Cancel), arg0)
-}
-
 // Close mocks base method
 func (_m *MockStreamI) Close() error {
 	ret := _m.ctrl.Call(_m, "Close")
@@ -56,6 +46,16 @@ func (_m *MockStreamI) Close() error {
 // Close indicates an expected call of Close
 func (_mr *MockStreamIMockRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "Close", reflect.TypeOf((*MockStreamI)(nil).Close))
+}
+
+// CloseForShutdown mocks base method
+func (_m *MockStreamI) CloseForShutdown(_param0 error) {
+	_m.ctrl.Call(_m, "CloseForShutdown", _param0)
+}
+
+// CloseForShutdown indicates an expected call of CloseForShutdown
+func (_mr *MockStreamIMockRecorder) CloseForShutdown(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "CloseForShutdown", reflect.TypeOf((*MockStreamI)(nil).CloseForShutdown), arg0)
 }
 
 // Context mocks base method

--- a/session.go
+++ b/session.go
@@ -656,7 +656,7 @@ func (s *session) handleCloseError(closeErr closeError) error {
 		utils.Errorf("Closing session with error: %s", closeErr.err.Error())
 	}
 
-	s.cryptoStream.Cancel(quicErr)
+	s.cryptoStream.CloseForShutdown(quicErr)
 	s.streamsMap.CloseWithError(quicErr)
 
 	if closeErr.err == errCloseSessionForNewVersion || closeErr.err == handshake.ErrCloseSessionForRetry {

--- a/session_test.go
+++ b/session_test.go
@@ -498,7 +498,7 @@ var _ = Describe("Session", func() {
 			_, err := sess.GetOrOpenStream(5)
 			Expect(err).ToNot(HaveOccurred())
 			sess.streamsMap.Range(func(s streamI) {
-				s.(*mocks.MockStreamI).EXPECT().Cancel(gomock.Any())
+				s.(*mocks.MockStreamI).EXPECT().CloseForShutdown(gomock.Any())
 			})
 			err = sess.handleFrames([]wire.Frame{&wire.ConnectionCloseFrame{ErrorCode: qerr.ProofInvalid, ReasonPhrase: "foobar"}}, protocol.EncryptionUnspecified)
 			Expect(err).NotTo(HaveOccurred())
@@ -1397,7 +1397,7 @@ var _ = Describe("Session", func() {
 			str, err := sess.GetOrOpenStream(9)
 			Expect(err).ToNot(HaveOccurred())
 			str.Close()
-			str.(*stream).Cancel(nil)
+			str.(*stream).CloseForShutdown(nil)
 			Expect(str.(*stream).Finished()).To(BeTrue())
 			err = sess.streamsMap.DeleteClosedStreams()
 			Expect(err).ToNot(HaveOccurred())

--- a/stream_test.go
+++ b/stream_test.go
@@ -457,12 +457,12 @@ var _ = Describe("Stream", func() {
 					close(done)
 				}()
 				Consistently(done).ShouldNot(BeClosed())
-				str.Cancel(testErr)
+				str.CloseForShutdown(testErr)
 				Eventually(done).Should(BeClosed())
 			})
 
 			It("errors for all following reads", func() {
-				str.Cancel(testErr)
+				str.CloseForShutdown(testErr)
 				b := make([]byte, 1)
 				n, err := strWithTimeout.Read(b)
 				Expect(n).To(BeZero())
@@ -471,7 +471,7 @@ var _ = Describe("Stream", func() {
 
 			It("cancels the context", func() {
 				Expect(str.Context().Done()).ToNot(BeClosed())
-				str.Cancel(testErr)
+				str.CloseForShutdown(testErr)
 				Expect(str.Context().Done()).To(BeClosed())
 			})
 		})
@@ -1001,7 +1001,7 @@ var _ = Describe("Stream", func() {
 			})
 
 			It("doesn't allow FIN after an error", func() {
-				str.Cancel(errors.New("test"))
+				str.CloseForShutdown(errors.New("test"))
 				f := str.PopStreamFrame(1000)
 				Expect(f).To(BeNil())
 			})
@@ -1016,11 +1016,11 @@ var _ = Describe("Stream", func() {
 			})
 		})
 
-		Context("cancelling", func() {
+		Context("closing abruptly", func() {
 			testErr := errors.New("test")
 
 			It("returns errors when the stream is cancelled", func() {
-				str.Cancel(testErr)
+				str.CloseForShutdown(testErr)
 				n, err := strWithTimeout.Write([]byte("foo"))
 				Expect(n).To(BeZero())
 				Expect(err).To(MatchError(testErr))
@@ -1037,7 +1037,7 @@ var _ = Describe("Stream", func() {
 					close(done)
 				}()
 				Eventually(func() *wire.StreamFrame { return str.PopStreamFrame(50) }).ShouldNot(BeNil()) // get a STREAM frame containing some data, but not all
-				str.Cancel(testErr)
+				str.CloseForShutdown(testErr)
 				Expect(str.PopStreamFrame(1000)).To(BeNil())
 				Eventually(done).Should(BeClosed())
 			})
@@ -1068,7 +1068,7 @@ var _ = Describe("Stream", func() {
 		}
 
 		It("is finished after it is canceled", func() {
-			str.Cancel(testErr)
+			str.CloseForShutdown(testErr)
 			Expect(str.Finished()).To(BeTrue())
 		})
 

--- a/streams_map.go
+++ b/streams_map.go
@@ -317,7 +317,7 @@ func (m *streamsMap) CloseWithError(err error) {
 	m.nextStreamOrErrCond.Broadcast()
 	m.openStreamOrErrCond.Broadcast()
 	for _, s := range m.openStreams {
-		m.streams[s].Cancel(err)
+		m.streams[s].CloseForShutdown(err)
 	}
 }
 

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Streams Map", func() {
 						testErr := errors.New("test error")
 						openMaxNumStreams()
 						for _, str := range m.streams {
-							str.(*mocks.MockStreamI).EXPECT().Cancel(testErr)
+							str.(*mocks.MockStreamI).EXPECT().CloseForShutdown(testErr)
 						}
 
 						done := make(chan struct{})


### PR DESCRIPTION
No functional changes expected.

`stream.CloseAbruptly` is **only** called when the session is closed.