### PR TITLE
don't send STOP_WAITING frames (for IETF QUIC)

### DIFF
--- a/internal/wire/stop_waiting_frame.go
+++ b/internal/wire/stop_waiting_frame.go
@@ -22,7 +22,10 @@ var (
 	errPacketNumberLenNotSet              = errors.New("StopWaitingFrame: PacketNumberLen not set")
 )
 
-func (f *StopWaitingFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (f *StopWaitingFrame) Write(b *bytes.Buffer, v protocol.VersionNumber) error {
+	if v.UsesIETFFrameFormat() {
+		return errors.New("STOP_WAITING not defined in IETF QUIC")
+	}
 	// make sure the PacketNumber was set
 	if f.PacketNumber == protocol.PacketNumber(0) {
 		return errPacketNumberNotSet

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -106,13 +106,7 @@ func (u *packetUnpacker) parseIETFFrame(r *bytes.Reader, typeByte byte, hdr *wir
 		if err != nil {
 			err = qerr.Error(qerr.InvalidWindowUpdateData, err.Error())
 		}
-	case 0x6:
-		// TODO(#964): remove STOP_WAITING frames
-		// TODO(#878): implement the MAX_STREAM_ID frame
-		frame, err = wire.ParseStopWaitingFrame(r, hdr.PacketNumber, hdr.PacketNumberLen, u.version)
-		if err != nil {
-			err = qerr.Error(qerr.InvalidStopWaitingData, err.Error())
-		}
+	// TODO(#878): implement the MAX_STREAM_ID frame
 	case 0x7:
 		frame, err = wire.ParsePingFrame(r, u.version)
 	case 0x8:


### PR DESCRIPTION
Fixes #1026. Depends on #1025.