### PR TITLE
remove flow control mutexes for the sending data

### DIFF
--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -34,9 +34,6 @@ func NewConnectionFlowController(
 }
 
 func (c *connectionFlowController) SendWindowSize() protocol.ByteCount {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
 	return c.baseFlowController.sendWindowSize()
 }
 

--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -102,9 +102,6 @@ func (c *streamFlowController) AddBytesSent(n protocol.ByteCount) {
 }
 
 func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	window := c.baseFlowController.sendWindowSize()
 	if c.contributesToConnection {
 		window = utils.MinByteCount(window, c.connection.SendWindowSize())


### PR DESCRIPTION
Receiving MAX_{STREAM}_DATA frames and sending data is all done sequentially, so we don't need a mutex there.

In my benchmark (downloading and uploading on 100 streams concurrently), this reduces the CPU time consumed by `flowcontroller.SendWindowSize()` from 16% to 1.7%.