### PR TITLE
don't defer unlocking the mutex when getting window updates

### DIFF
--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -54,13 +54,12 @@ func (c *connectionFlowController) IncrementHighestReceived(increment protocol.B
 
 func (c *connectionFlowController) GetWindowUpdate() protocol.ByteCount {
 	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	oldWindowIncrement := c.receiveWindowIncrement
 	offset := c.baseFlowController.getWindowUpdate()
 	if oldWindowIncrement < c.receiveWindowIncrement {
 		utils.Debugf("Increasing receive flow control window for the connection to %d kB", c.receiveWindowIncrement/(1<<10))
 	}
+	c.mutex.Unlock()
 	return offset
 }
 
@@ -68,10 +67,9 @@ func (c *connectionFlowController) GetWindowUpdate() protocol.ByteCount {
 // it should make sure that the connection-level window is increased when a stream-level window grows
 func (c *connectionFlowController) EnsureMinimumWindowIncrement(inc protocol.ByteCount) {
 	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	if inc > c.receiveWindowIncrement {
 		c.receiveWindowIncrement = utils.MinByteCount(inc, c.maxReceiveWindowIncrement)
 		c.lastWindowUpdateTime = time.Time{} // disables autotuning for the next window update
 	}
+	c.mutex.Unlock()
 }


### PR DESCRIPTION
In the benchmark downloading / uploading concurrently on 100 streams, this brings down the CPU consumption for defer from around 6-7% to 1-2%.