### PR TITLE
don't schedule sending when stream.Write is called after the deadline

### DIFF
--- a/send_stream.go
+++ b/send_stream.go
@@ -81,6 +81,9 @@ func (s *sendStream) Write(p []byte) (int, error) {
 	if s.closeForShutdownErr != nil {
 		return 0, s.closeForShutdownErr
 	}
+	if !s.writeDeadline.IsZero() && !time.Now().Before(s.writeDeadline) {
+		return 0, errDeadline
+	}
 	if len(p) == 0 {
 		return 0, nil
 	}

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -208,6 +208,7 @@ var _ = Describe("Send Stream", func() {
 				n, err := strWithTimeout.Write([]byte("foobar"))
 				Expect(err).To(MatchError(errDeadline))
 				Expect(n).To(BeZero())
+				Expect(onDataCalled).To(BeFalse())
 			})
 
 			It("unblocks after the deadline", func() {


### PR DESCRIPTION
Fixes #1045. Should be merged after #1043.