### PR TITLE
queue stream window updates directly from stream.Read

### DIFF
--- a/mock_stream_sender_test.go
+++ b/mock_stream_sender_test.go
@@ -5,6 +5,7 @@ package quic
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
 	wire "github.com/lucas-clemente/quic-go/internal/wire"
 	reflect "reflect"
 )
@@ -30,6 +31,16 @@ func NewMockStreamSender(ctrl *gomock.Controller) *MockStreamSender {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (_m *MockStreamSender) EXPECT() *MockStreamSenderMockRecorder {
 	return _m.recorder
+}
+
+// onHasWindowUpdate mocks base method
+func (_m *MockStreamSender) onHasWindowUpdate(_param0 protocol.StreamID, _param1 protocol.ByteCount) {
+	_m.ctrl.Call(_m, "onHasWindowUpdate", _param0, _param1)
+}
+
+// onHasWindowUpdate indicates an expected call of onHasWindowUpdate
+func (_mr *MockStreamSenderMockRecorder) onHasWindowUpdate(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "onHasWindowUpdate", reflect.TypeOf((*MockStreamSender)(nil).onHasWindowUpdate), arg0, arg1)
 }
 
 // queueControlFrame mocks base method

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -139,7 +139,10 @@ func (s *receiveStream) Read(p []byte) (int, error) {
 		if !s.resetRemotely {
 			s.flowController.AddBytesRead(protocol.ByteCount(m))
 		}
-		s.sender.scheduleSending() // so that a possible WINDOW_UPDATE is sent
+		// this call triggers the flow controller to increase the flow control window, if necessary
+		if offset := s.flowController.GetWindowUpdate(); offset != 0 {
+			s.sender.onHasWindowUpdate(s.streamID, offset)
+		}
 
 		if s.readPosInFrame >= int(frame.DataLen()) {
 			s.frameQueue.Pop()

--- a/stream.go
+++ b/stream.go
@@ -18,6 +18,7 @@ const (
 type streamSender interface {
 	scheduleSending()
 	queueControlFrame(wire.Frame)
+	onHasWindowUpdate(protocol.StreamID, protocol.ByteCount)
 }
 
 type streamI interface {

--- a/window_update_queue.go
+++ b/window_update_queue.go
@@ -1,0 +1,40 @@
+package quic
+
+import (
+	"sync"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/wire"
+)
+
+type windowUpdateQueue struct {
+	mutex sync.Mutex
+
+	queue    map[protocol.StreamID]protocol.ByteCount
+	callback func(wire.Frame)
+}
+
+func newWindowUpdateQueue(cb func(wire.Frame)) *windowUpdateQueue {
+	return &windowUpdateQueue{
+		queue:    make(map[protocol.StreamID]protocol.ByteCount),
+		callback: cb,
+	}
+}
+
+func (q *windowUpdateQueue) Add(stream protocol.StreamID, offset protocol.ByteCount) {
+	q.mutex.Lock()
+	q.queue[stream] = offset
+	q.mutex.Unlock()
+}
+
+func (q *windowUpdateQueue) QueueAll() {
+	q.mutex.Lock()
+	for stream, offset := range q.queue {
+		q.callback(&wire.MaxStreamDataFrame{
+			StreamID:   stream,
+			ByteOffset: offset,
+		})
+		delete(q.queue, stream)
+	}
+	q.mutex.Unlock()
+}

--- a/window_update_queue_test.go
+++ b/window_update_queue_test.go
@@ -1,0 +1,49 @@
+package quic
+
+import (
+	"github.com/lucas-clemente/quic-go/internal/wire"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Window Update Queue", func() {
+	var (
+		q            *windowUpdateQueue
+		queuedFrames []wire.Frame
+	)
+
+	BeforeEach(func() {
+		queuedFrames = queuedFrames[:0]
+		q = newWindowUpdateQueue(func(f wire.Frame) {
+			queuedFrames = append(queuedFrames, f)
+		})
+	})
+
+	It("adds stream offsets and gets MAX_STREAM_DATA frames", func() {
+		q.Add(1, 10)
+		q.Add(2, 20)
+		q.Add(3, 30)
+		q.QueueAll()
+		Expect(queuedFrames).To(ContainElement(&wire.MaxStreamDataFrame{StreamID: 1, ByteOffset: 10}))
+		Expect(queuedFrames).To(ContainElement(&wire.MaxStreamDataFrame{StreamID: 2, ByteOffset: 20}))
+		Expect(queuedFrames).To(ContainElement(&wire.MaxStreamDataFrame{StreamID: 3, ByteOffset: 30}))
+	})
+
+	It("deletes the entry after getting the MAX_STREAM_DATA frame", func() {
+		q.Add(10, 100)
+		q.QueueAll()
+		Expect(queuedFrames).To(HaveLen(1))
+		q.QueueAll()
+		Expect(queuedFrames).To(HaveLen(1))
+	})
+
+	It("replaces old entries", func() {
+		q.Add(10, 100)
+		q.Add(10, 200)
+		q.QueueAll()
+		Expect(queuedFrames).To(Equal([]wire.Frame{
+			&wire.MaxStreamDataFrame{StreamID: 10, ByteOffset: 200},
+		}))
+	})
+})


### PR DESCRIPTION
Closes #1004. Should be merged after #1048.

By queueing receive window updates directly from `stream.Read`, it is no longer necessary to ask every stream for window updates when sending a packet.