### PR TITLE
print quic.clemente.io certificate expiration date in travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
   - export GOARCH=$TRAVIS_GOARCH
   - go env # for debugging
   - google-chrome --version
+  - "printf \"quic.clemente.io certificate valid until: \" && openssl x509 -in example/fullchain.pem -enddate -noout | cut -d = -f 2"
   - "export DISPLAY=:99.0"
   - "Xvfb $DISPLAY &> /dev/null &"
 


### PR DESCRIPTION
This is how it will look like:
<img width="1140" alt="screen shot 2017-12-20 at 10 38 49" src="https://user-images.githubusercontent.com/1478487/34190314-8bb12002-e572-11e7-99c9-9a42d4e2da5d.png">
