### PR TITLE
make h2quic.Server.ListenAndServe error if it was closed before

### DIFF
--- a/h2quic/server_test.go
+++ b/h2quic/server_test.go
@@ -410,6 +410,13 @@ var _ = Describe("H2 server", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("errors when ListenAndServer is called after Close", func() {
+		serv := &Server{Server: &http.Server{}}
+		Expect(serv.Close()).To(Succeed())
+		err := serv.ListenAndServe()
+		Expect(err).To(MatchError("Server is already closed"))
+	})
+
 	Context("ListenAndServe", func() {
 		BeforeEach(func() {
 			s.Server.Addr = "localhost:0"


### PR DESCRIPTION
This is (part of) what caused the Travis test to be flaky: There are some integration tests that are very fast (https://github.com/lucas-clemente/quic-go/blob/master/integrationtests/gquic/random_rtt_test.go#L22-L51, which we might want to move to the test tools anyway). In those cases, we would start and stop the QUIC test server so quickly, that the `Close` call happens before the `h2quic.Server.Serve` goroutine even spun up.

Note that this PR doesn't solve the problem yet.