### PR TITLE
temporarily disable running the benchmark tests with race detector

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -10,11 +10,12 @@ fi
 if [ ${TESTMODE} == "integration" ]; then
   # run benchmark tests
   ginkgo -randomizeAllSpecs -randomizeSuites -trace benchmark -- -samples=1
-  # run benchmark tests with the Go race detector
-  # The Go race detector only works on amd64.
-  if [ ${TRAVIS_GOARCH} == 'amd64' ]; then
-    ginkgo -race -randomizeAllSpecs -randomizeSuites -trace benchmark -- -samples=1 -size=10
-  fi
+  # TODO(#1055): reenable this test
+  # # run benchmark tests with the Go race detector
+  # # The Go race detector only works on amd64.
+  # if [ ${TRAVIS_GOARCH} == 'amd64' ]; then
+  #   ginkgo -race -randomizeAllSpecs -randomizeSuites -trace benchmark -- -samples=1 -size=10
+  # fi
   # run integration tests
   ginkgo -r -v -randomizeAllSpecs -randomizeSuites -trace integrationtests
 fi


### PR DESCRIPTION
The test keeps failing because of #1055.