### PR TITLE
minor change to enable separate listen / main accept&process loop

### DIFF
--- a/h2quic/server.go
+++ b/h2quic/server.go
@@ -107,6 +107,10 @@ func (s *Server) serveImpl(tlsConfig *tls.Config, conn net.PacketConn) error {
 	s.listener = ln
 	s.listenerMutex.Unlock()
 
+	return s.ServeLoop(ln)
+}
+
+func (s *Server) ServeLoop(ln quic.Listener) error {
 	for {
 		sess, err := ln.Accept()
 		if err != nil {


### PR DESCRIPTION
Idea behind this minor change is following. If we have a server that should accept multiple quic/http2 connections at the same time, then we can have a tcp connection by which we would negotiate udp port for quic, and then start quic server on that port. Client, in its turn, gets port and starts quic/http2 communication over that port. However, if listen & accept are in the same method, then there is a race condition, since udp is stateless. In order to avoid that, first we need to create listener, then communicate port back to client and after that start main accept & process loop for quic/http2 server.