### PR TITLE
call the scheduleSending callback when stream.Close is called

### DIFF
--- a/send_stream.go
+++ b/send_stream.go
@@ -191,6 +191,7 @@ func (s *sendStream) Close() error {
 		return fmt.Errorf("Close called for canceled stream %d", s.streamID)
 	}
 	s.finishedWriting = true
+	s.sender.scheduleSending()
 	s.ctxCancel()
 	return nil
 }


### PR DESCRIPTION
Fixes #1067.

The stream needs to send the STREAM frame containing the FIN bit.