### PR TITLE
don't report blocked streams as active for sending data

### DIFF
--- a/internal/flowcontrol/base_flow_controller.go
+++ b/internal/flowcontrol/base_flow_controller.go
@@ -11,9 +11,8 @@ import (
 
 type baseFlowController struct {
 	// for sending data
-	bytesSent     protocol.ByteCount
-	sendWindow    protocol.ByteCount
-	lastBlockedAt protocol.ByteCount
+	bytesSent  protocol.ByteCount
+	sendWindow protocol.ByteCount
 
 	// for receiving data
 	mutex                sync.RWMutex
@@ -76,17 +75,6 @@ func (c *baseFlowController) getWindowUpdate() protocol.ByteCount {
 	c.maybeAdjustWindowSize()
 	c.receiveWindow = c.bytesRead + c.receiveWindowSize
 	return c.receiveWindow
-}
-
-// IsBlocked says if it is newly blocked by flow control.
-// For every offset, it only returns true once.
-// If it is blocked, the offset is returned.
-func (c *baseFlowController) IsNewlyBlocked() (bool, protocol.ByteCount) {
-	if c.sendWindowSize() != 0 || c.sendWindow == c.lastBlockedAt {
-		return false, 0
-	}
-	c.lastBlockedAt = c.sendWindow
-	return true, c.sendWindow
 }
 
 // maybeAdjustWindowSize increases the receiveWindowSize if we're sending updates too often.

--- a/internal/flowcontrol/base_flow_controller_test.go
+++ b/internal/flowcontrol/base_flow_controller_test.go
@@ -49,29 +49,6 @@ var _ = Describe("Base Flow controller", func() {
 			controller.UpdateSendWindow(10)
 			Expect(controller.sendWindowSize()).To(Equal(protocol.ByteCount(20)))
 		})
-
-		It("says when it's blocked", func() {
-			controller.UpdateSendWindow(100)
-			Expect(controller.IsNewlyBlocked()).To(BeFalse())
-			controller.AddBytesSent(100)
-			blocked, offset := controller.IsNewlyBlocked()
-			Expect(blocked).To(BeTrue())
-			Expect(offset).To(Equal(protocol.ByteCount(100)))
-		})
-
-		It("doesn't say that it's newly blocked multiple times for the same offset", func() {
-			controller.UpdateSendWindow(100)
-			controller.AddBytesSent(100)
-			newlyBlocked, offset := controller.IsNewlyBlocked()
-			Expect(newlyBlocked).To(BeTrue())
-			Expect(offset).To(Equal(protocol.ByteCount(100)))
-			newlyBlocked, _ = controller.IsNewlyBlocked()
-			Expect(newlyBlocked).To(BeFalse())
-			controller.UpdateSendWindow(150)
-			controller.AddBytesSent(150)
-			newlyBlocked, offset = controller.IsNewlyBlocked()
-			Expect(newlyBlocked).To(BeTrue())
-		})
 	})
 
 	Context("receive flow control", func() {

--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -10,6 +10,7 @@ import (
 )
 
 type connectionFlowController struct {
+	lastBlockedAt protocol.ByteCount
 	baseFlowController
 }
 
@@ -34,6 +35,17 @@ func NewConnectionFlowController(
 
 func (c *connectionFlowController) SendWindowSize() protocol.ByteCount {
 	return c.baseFlowController.sendWindowSize()
+}
+
+// IsNewlyBlocked says if it is newly blocked by flow control.
+// For every offset, it only returns true once.
+// If it is blocked, the offset is returned.
+func (c *connectionFlowController) IsNewlyBlocked() (bool, protocol.ByteCount) {
+	if c.sendWindowSize() != 0 || c.sendWindow == c.lastBlockedAt {
+		return false, 0
+	}
+	c.lastBlockedAt = c.sendWindow
+	return true, c.sendWindow
 }
 
 // IncrementHighestReceived adds an increment to the highestReceived value

--- a/internal/flowcontrol/connection_flow_controller_test.go
+++ b/internal/flowcontrol/connection_flow_controller_test.go
@@ -77,6 +77,31 @@ var _ = Describe("Connection Flow controller", func() {
 		})
 	})
 
+	Context("send flow control", func() {
+		It("says when it's blocked", func() {
+			controller.UpdateSendWindow(100)
+			Expect(controller.IsNewlyBlocked()).To(BeFalse())
+			controller.AddBytesSent(100)
+			blocked, offset := controller.IsNewlyBlocked()
+			Expect(blocked).To(BeTrue())
+			Expect(offset).To(Equal(protocol.ByteCount(100)))
+		})
+
+		It("doesn't say that it's newly blocked multiple times for the same offset", func() {
+			controller.UpdateSendWindow(100)
+			controller.AddBytesSent(100)
+			newlyBlocked, offset := controller.IsNewlyBlocked()
+			Expect(newlyBlocked).To(BeTrue())
+			Expect(offset).To(Equal(protocol.ByteCount(100)))
+			newlyBlocked, _ = controller.IsNewlyBlocked()
+			Expect(newlyBlocked).To(BeFalse())
+			controller.UpdateSendWindow(150)
+			controller.AddBytesSent(150)
+			newlyBlocked, offset = controller.IsNewlyBlocked()
+			Expect(newlyBlocked).To(BeTrue())
+		})
+	})
+
 	Context("setting the minimum window size", func() {
 		var (
 			oldWindowSize     protocol.ByteCount

--- a/internal/flowcontrol/interface.go
+++ b/internal/flowcontrol/interface.go
@@ -5,7 +5,6 @@ import "github.com/lucas-clemente/quic-go/internal/protocol"
 type flowController interface {
 	// for sending
 	SendWindowSize() protocol.ByteCount
-	IsNewlyBlocked() (bool, protocol.ByteCount)
 	UpdateSendWindow(protocol.ByteCount)
 	AddBytesSent(protocol.ByteCount)
 	// for receiving
@@ -16,6 +15,8 @@ type flowController interface {
 // A StreamFlowController is a flow controller for a QUIC stream.
 type StreamFlowController interface {
 	flowController
+	// for sending
+	IsBlocked() (bool, protocol.ByteCount)
 	// for receiving
 	// UpdateHighestReceived should be called when a new highest offset is received
 	// final has to be to true if this is the final offset of the stream, as contained in a STREAM frame with FIN bit, and the RST_STREAM frame
@@ -27,6 +28,8 @@ type StreamFlowController interface {
 // The ConnectionFlowController is the flow controller for the connection.
 type ConnectionFlowController interface {
 	flowController
+	// for sending
+	IsNewlyBlocked() (bool, protocol.ByteCount)
 }
 
 type connectionFlowControllerI interface {

--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -109,6 +109,15 @@ func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
 	return window
 }
 
+// IsBlocked says if it is blocked by stream-level flow control.
+// If it is blocked, the offset is returned.
+func (c *streamFlowController) IsBlocked() (bool, protocol.ByteCount) {
+	if c.sendWindowSize() != 0 {
+		return false, 0
+	}
+	return true, c.sendWindow
+}
+
 func (c *streamFlowController) HasWindowUpdate() bool {
 	c.mutex.Lock()
 	hasWindowUpdate := !c.receivedFinalOffset && c.hasWindowUpdate()

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Stream Flow controller", func() {
 			controller.AddBytesSent(50)
 			blocked, _ := controller.connection.IsNewlyBlocked()
 			Expect(blocked).To(BeTrue())
-			Expect(controller.IsNewlyBlocked()).To(BeFalse())
+			Expect(controller.IsBlocked()).To(BeFalse())
 		})
 	})
 })

--- a/internal/mocks/stream_flow_controller.go
+++ b/internal/mocks/stream_flow_controller.go
@@ -78,17 +78,17 @@ func (mr *MockStreamFlowControllerMockRecorder) HasWindowUpdate() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasWindowUpdate", reflect.TypeOf((*MockStreamFlowController)(nil).HasWindowUpdate))
 }
 
-// IsNewlyBlocked mocks base method
-func (m *MockStreamFlowController) IsNewlyBlocked() (bool, protocol.ByteCount) {
-	ret := m.ctrl.Call(m, "IsNewlyBlocked")
+// IsBlocked mocks base method
+func (m *MockStreamFlowController) IsBlocked() (bool, protocol.ByteCount) {
+	ret := m.ctrl.Call(m, "IsBlocked")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(protocol.ByteCount)
 	return ret0, ret1
 }
 
-// IsNewlyBlocked indicates an expected call of IsNewlyBlocked
-func (mr *MockStreamFlowControllerMockRecorder) IsNewlyBlocked() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNewlyBlocked", reflect.TypeOf((*MockStreamFlowController)(nil).IsNewlyBlocked))
+// IsBlocked indicates an expected call of IsBlocked
+func (mr *MockStreamFlowControllerMockRecorder) IsBlocked() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBlocked", reflect.TypeOf((*MockStreamFlowController)(nil).IsBlocked))
 }
 
 // SendWindowSize mocks base method

--- a/stream_test.go
+++ b/stream_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Stream", func() {
 				mockSender.EXPECT().onHasStreamData(streamID).Times(2) // once for the Write, once for the Close
 				mockFC.EXPECT().SendWindowSize().Return(protocol.MaxByteCount).AnyTimes()
 				mockFC.EXPECT().AddBytesSent(protocol.ByteCount(6))
-				mockFC.EXPECT().IsNewlyBlocked()
+				mockFC.EXPECT().IsBlocked()
 				err := str.CancelRead(1234)
 				Expect(err).ToNot(HaveOccurred())
 				writeReturned := make(chan struct{})


### PR DESCRIPTION
Depends on #1069.

When a stream is stream-level flow control blocked, `stream.popStreamFrame` now doesn't report this stream as active. That way, we won't call `popStreamFrame` (which would return `nil` until new flow control credit is granted) every single time when packing a packet.

Note 3 things here:

- When calling `stream.Write` or `stream.Close` after a stream became blocked, we're still reporting it as active. The `streamFramer` will call `stream.popStreamFrame` a single time (which would then report it as having no more data).
- It is only possible to call `stream.Write` exactly once (unless you're setting write deadlines) after a stream became flow control blocked, since `stream.Write` blocks until all the data has been sent out.
- This **only** works for stream-level blocking. If we're connection-level blocked, all streams will stay active, and `stream.popStreamFrame` will be called for every single one of them every time when sending a packet, and return `nil` (assuming the stream contributes to connection-level flow control), until new connection-level flow control credit is granted.