### PR TITLE
also run the Travis tests with Go 1.10 beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ language: go
 
 go:
   - 1.9.2
+  - 1.10beta1
 
 # first part of the GOARCH workaround
 # setting the GOARCH directly doesn't work, since the value will be overwritten later


### PR DESCRIPTION
Go 1.10 beta has been out for a while. Now that Travis finally is non-flaky, we should start using it.