### PR TITLE
remove non forward-secure dialing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v0.6.1 (unreleased)
+## v0.7 (unreleased)
 
 - The lower boundary for packets included in ACKs is now derived, and the value sent in STOP_WAITING frames is ignored.
+- Remove `DialNonFWSecure` and `DialAddrNonFWSecure`.
 
 ## v0.6.0 (2017-12-12)
 

--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -2,14 +2,12 @@ package self_test
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net"
 	"time"
 
 	quic "github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/qerr"
 
 	"github.com/lucas-clemente/quic-go/internal/testdata"
@@ -109,18 +107,6 @@ var _ = Describe("Handshake RTT tests", func() {
 		_, err := quic.DialAddr(proxy.LocalAddr().String(), &tls.Config{InsecureSkipVerify: true}, nil)
 		Expect(err).ToNot(HaveOccurred())
 		expectDurationInRTTs(4)
-	})
-
-	// 1 RTT for verifying the source address
-	// 1 RTT to become secure
-	// TODO (marten-seemann): enable this test (see #625)
-	PIt("is secure after 2 RTTs", func() {
-		utils.SetLogLevel(utils.LogLevelDebug)
-		runServerAndProxy()
-		_, err := quic.DialAddrNonFWSecure(proxy.LocalAddr().String(), &tls.Config{InsecureSkipVerify: true}, nil)
-		fmt.Println("#### is non fw secure ###")
-		Expect(err).ToNot(HaveOccurred())
-		expectDurationInRTTs(2)
 	})
 
 	It("is forward-secure after 2 RTTs when the server doesn't require a Cookie", func() {

--- a/interface.go
+++ b/interface.go
@@ -130,13 +130,6 @@ type Session interface {
 	Context() context.Context
 }
 
-// A NonFWSession is a QUIC connection between two peers half-way through the handshake.
-// The communication is encrypted, but not yet forward secure.
-type NonFWSession interface {
-	Session
-	WaitUntilHandshakeComplete() error
-}
-
 // Config contains all configuration data needed for a QUIC server or client.
 type Config struct {
 	// The QUIC versions that can be negotiated.

--- a/session_test.go
+++ b/session_test.go
@@ -78,11 +78,11 @@ func areSessionsRunning() bool {
 
 var _ = Describe("Session", func() {
 	var (
-		sess        *session
-		scfg        *handshake.ServerConfig
-		mconn       *mockConnection
-		cryptoSetup *mockCryptoSetup
-		aeadChanged chan<- protocol.EncryptionLevel
+		sess          *session
+		scfg          *handshake.ServerConfig
+		mconn         *mockConnection
+		cryptoSetup   *mockCryptoSetup
+		handshakeChan chan<- struct{}
 	)
 
 	BeforeEach(func() {
@@ -99,9 +99,9 @@ var _ = Describe("Session", func() {
 			_ []protocol.VersionNumber,
 			_ func(net.Addr, *Cookie) bool,
 			_ chan<- handshake.TransportParameters,
-			aeadChangedP chan<- protocol.EncryptionLevel,
+			handshakeChanP chan<- struct{},
 		) (handshake.CryptoSetup, error) {
-			aeadChanged = aeadChangedP
+			handshakeChan = handshakeChanP
 			return cryptoSetup, nil
 		}
 
@@ -149,7 +149,7 @@ var _ = Describe("Session", func() {
 				_ []protocol.VersionNumber,
 				cookieFunc func(net.Addr, *Cookie) bool,
 				_ chan<- handshake.TransportParameters,
-				_ chan<- protocol.EncryptionLevel,
+				_ chan<- struct{},
 			) (handshake.CryptoSetup, error) {
 				cookieVerify = cookieFunc
 				return cryptoSetup, nil
@@ -514,61 +514,6 @@ var _ = Describe("Session", func() {
 	It("tells its versions", func() {
 		sess.version = 4242
 		Expect(sess.GetVersion()).To(Equal(protocol.VersionNumber(4242)))
-	})
-
-	Context("waiting until the handshake completes", func() {
-		It("waits until the handshake is complete", func() {
-			go func() {
-				defer GinkgoRecover()
-				sess.run()
-			}()
-
-			done := make(chan struct{})
-			go func() {
-				defer GinkgoRecover()
-				err := sess.WaitUntilHandshakeComplete()
-				Expect(err).ToNot(HaveOccurred())
-				close(done)
-			}()
-			aeadChanged <- protocol.EncryptionForwardSecure
-			Consistently(done).ShouldNot(BeClosed())
-			close(aeadChanged)
-			Eventually(done).Should(BeClosed())
-			Expect(sess.Close(nil)).To(Succeed())
-		})
-
-		It("errors if the handshake fails", func(done Done) {
-			testErr := errors.New("crypto error")
-			sess.cryptoSetup = &mockCryptoSetup{handleErr: testErr}
-			go sess.run()
-			err := sess.WaitUntilHandshakeComplete()
-			Expect(err).To(MatchError(testErr))
-			close(done)
-		}, 0.5)
-
-		It("returns when Close is called", func(done Done) {
-			testErr := errors.New("close error")
-			go sess.run()
-			var waitReturned bool
-			go func() {
-				defer GinkgoRecover()
-				err := sess.WaitUntilHandshakeComplete()
-				Expect(err).To(MatchError(testErr))
-				waitReturned = true
-			}()
-			sess.Close(testErr)
-			Eventually(func() bool { return waitReturned }).Should(BeTrue())
-			close(done)
-		})
-
-		It("doesn't wait if the handshake is already completed", func(done Done) {
-			go sess.run()
-			close(aeadChanged)
-			err := sess.WaitUntilHandshakeComplete()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sess.Close(nil)).To(Succeed())
-			close(done)
-		})
 	})
 
 	Context("accepting streams", func() {
@@ -1362,46 +1307,48 @@ var _ = Describe("Session", func() {
 		})
 	})
 
-	It("send a handshake event on the handshakeChan when the AEAD changes to secure", func(done Done) {
-		go sess.run()
-		aeadChanged <- protocol.EncryptionSecure
-		Eventually(sess.handshakeStatus()).Should(Receive(&handshakeEvent{encLevel: protocol.EncryptionSecure}))
+	It("doesn't do anything when the crypto setup says to decrypt undecryptable packets", func() {
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err := sess.run()
+			Expect(err).ToNot(HaveOccurred())
+			close(done)
+		}()
+		handshakeChan <- struct{}{}
+		Consistently(sess.handshakeStatus()).ShouldNot(Receive())
+		// make sure the go routine returns
 		Expect(sess.Close(nil)).To(Succeed())
-		close(done)
+		Eventually(done).Should(BeClosed())
 	})
 
-	It("send a handshake event on the handshakeChan when the AEAD changes to forward-secure", func(done Done) {
-		go sess.run()
-		aeadChanged <- protocol.EncryptionForwardSecure
-		Eventually(sess.handshakeStatus()).Should(Receive(&handshakeEvent{encLevel: protocol.EncryptionForwardSecure}))
-		Expect(sess.Close(nil)).To(Succeed())
-		close(done)
-	})
-
-	It("closes the handshakeChan when the handshake completes", func(done Done) {
-		go sess.run()
-		close(aeadChanged)
+	It("closes the handshakeChan when the handshake completes", func() {
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err := sess.run()
+			Expect(err).ToNot(HaveOccurred())
+			close(done)
+		}()
+		close(handshakeChan)
 		Eventually(sess.handshakeStatus()).Should(BeClosed())
+		// make sure the go routine returns
 		Expect(sess.Close(nil)).To(Succeed())
-		close(done)
+		Eventually(done).Should(BeClosed())
 	})
 
-	It("passes errors to the handshakeChan", func(done Done) {
+	It("passes errors to the handshakeChan", func() {
 		testErr := errors.New("handshake error")
-		go sess.run()
-		Expect(sess.Close(nil)).To(Succeed())
-		Expect(sess.handshakeStatus()).To(Receive(&handshakeEvent{err: testErr}))
-		close(done)
-	})
-
-	It("does not block if an error occurs", func(done Done) {
-		// this test basically tests that the handshakeChan has a capacity of 3
-		// The session needs to run (and close) properly, even if no one is receiving from the handshakeChan
-		go sess.run()
-		aeadChanged <- protocol.EncryptionSecure
-		aeadChanged <- protocol.EncryptionForwardSecure
-		Expect(sess.Close(nil)).To(Succeed())
-		close(done)
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err := sess.run()
+			Expect(err).To(MatchError(testErr))
+			close(done)
+		}()
+		sess.Close(testErr)
+		Expect(sess.handshakeStatus()).To(Receive(Equal(testErr)))
+		Eventually(done).Should(BeClosed())
 	})
 
 	It("process transport parameters received from the peer", func() {
@@ -1503,7 +1450,7 @@ var _ = Describe("Session", func() {
 
 		It("closes the session due to the idle timeout after handshake", func() {
 			sess.config.IdleTimeout = 0
-			close(aeadChanged)
+			close(handshakeChan)
 			errChan := make(chan error)
 			go func() {
 				defer GinkgoRecover()
@@ -1619,9 +1566,9 @@ var _ = Describe("Session", func() {
 
 var _ = Describe("Client Session", func() {
 	var (
-		sess        *session
-		mconn       *mockConnection
-		aeadChanged chan<- protocol.EncryptionLevel
+		sess          *session
+		mconn         *mockConnection
+		handshakeChan chan<- struct{}
 
 		cryptoSetup *mockCryptoSetup
 	)
@@ -1638,11 +1585,11 @@ var _ = Describe("Client Session", func() {
 			_ *tls.Config,
 			_ *handshake.TransportParameters,
 			_ chan<- handshake.TransportParameters,
-			aeadChangedP chan<- protocol.EncryptionLevel,
+			handshakeChanP chan<- struct{},
 			_ protocol.VersionNumber,
 			_ []protocol.VersionNumber,
 		) (handshake.CryptoSetup, error) {
-			aeadChanged = aeadChangedP
+			handshakeChan = handshakeChanP
 			return cryptoSetup, nil
 		}
 
@@ -1674,10 +1621,13 @@ var _ = Describe("Client Session", func() {
 			sess.unpacker = &mockUnpacker{}
 		})
 
-		It("passes the diversification nonce to the cryptoSetup", func() {
+		It("passes the diversification nonce to the crypto setup", func() {
+			done := make(chan struct{})
 			go func() {
 				defer GinkgoRecover()
-				sess.run()
+				err := sess.run()
+				Expect(err).ToNot(HaveOccurred())
+				close(done)
 			}()
 			hdr.PacketNumber = 5
 			hdr.DiversificationNonce = []byte("foobar")
@@ -1685,16 +1635,7 @@ var _ = Describe("Client Session", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() []byte { return cryptoSetup.divNonce }).Should(Equal(hdr.DiversificationNonce))
 			Expect(sess.Close(nil)).To(Succeed())
+			Eventually(done).Should(BeClosed())
 		})
-	})
-
-	It("does not block if an error occurs", func(done Done) {
-		// this test basically tests that the handshakeChan has a capacity of 3
-		// The session needs to run (and close) properly, even if no one is receiving from the handshakeChan
-		go sess.run()
-		aeadChanged <- protocol.EncryptionSecure
-		aeadChanged <- protocol.EncryptionForwardSecure
-		Expect(sess.Close(nil)).To(Succeed())
-		close(done)
 	})
 })


### PR DESCRIPTION
This never actually worked, for multiple reasons:

- We only created the secure AEAD when receiving the SHLO (#625), right before creating the forward-secure AEAD.
- Flow control and max stream limits  in gQUIC are only advertised in the SHLO, and trying to open a stream would block until receiving the SHLO, and even if it didn't the stream wouldn't have any flow control credit and block.

I'm therefore suggesting to remove `DialNonFWSecure` and `DialAddrNonFWSecure`. Note furthermore, that such a thing doesn't exist in IETF QUIC: Data is only sent after receiving the TLS 1.3 Finished message (see https://quicwg.github.io/base-drafts/draft-ietf-quic-tls.html#tls-handshake), unless the client is doing a session resumption or attempting 0-RTT (in which case it has previous knowledge of flow control and stream limits).