### PR TITLE
close the h2quic.RoundTripper in the example client

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -31,10 +31,12 @@ func main() {
 		versions = append([]protocol.VersionNumber{protocol.VersionTLS}, versions...)
 	}
 
+	roundTripper := &h2quic.RoundTripper{
+		QuicConfig: &quic.Config{Versions: versions},
+	}
+	defer roundTripper.Close()
 	hclient := &http.Client{
-		Transport: &h2quic.RoundTripper{
-			QuicConfig: &quic.Config{Versions: versions},
-		},
+		Transport: roundTripper,
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
While it's not necessary, it's best practice to close the `h2quic.RoundTripper`.
That way, QUIC can do a proper connection shutdown.