### PR TITLE
Allows using a custom dialer

### DIFF
--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -26,6 +26,11 @@ type roundTripperOpts struct {
 
 var dialAddr = quic.DialAddr
 
+// SetQuicDialer overrides the dialer used for connecting to quic servers
+func SetQuicDialer(qd func(addr string, tlsConf *tls.Config, config *quic.Config) (quic.Session, error)) {
+	dialAddr = qd
+}
+
 // client is a HTTP2 client doing QUIC requests
 type client struct {
 	mutex sync.RWMutex


### PR DESCRIPTION
Use cases:
- listen to specific interface (for example IP6 link local)
- listen to specific port - for example if certain ports are configured with higher NAT timeouts
- customize how the name is resolved