### PR TITLE
use the timescale factor for flow control tests on CIs

### DIFF
--- a/internal/flowcontrol/base_flow_controller_test.go
+++ b/internal/flowcontrol/base_flow_controller_test.go
@@ -1,6 +1,8 @@
 package flowcontrol
 
 import (
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/lucas-clemente/quic-go/congestion"
@@ -8,6 +10,16 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+// on the CIs, the timing is a lot less precise, so scale every duration by this factor
+func scaleDuration(t time.Duration) time.Duration {
+	scaleFactor := 1
+	if f, err := strconv.Atoi(os.Getenv("TIMESCALE_FACTOR")); err == nil { // parsing "" errors, so this works fine if the env is not set
+		scaleFactor = f
+	}
+	Expect(scaleFactor).ToNot(BeZero())
+	return time.Duration(scaleFactor) * t
+}
 
 var _ = Describe("Base Flow controller", func() {
 	var controller *baseFlowController
@@ -118,7 +130,7 @@ var _ = Describe("Base Flow controller", func() {
 
 			It("increases the window size if read so fast that the window would be consumed in less than 4 RTTs", func() {
 				bytesRead := controller.bytesRead
-				rtt := 200 * time.Millisecond
+				rtt := scaleDuration(20 * time.Millisecond)
 				setRtt(rtt)
 				// consume more than 2/3 of the window...
 				dataRead := receiveWindowSize*2/3 + 1
@@ -139,7 +151,7 @@ var _ = Describe("Base Flow controller", func() {
 				// this test only makes sense if a window update is triggered before half of the window has been consumed
 				Expect(protocol.WindowUpdateThreshold).To(BeNumerically(">", 1/3))
 				bytesRead := controller.bytesRead
-				rtt := 200 * time.Millisecond
+				rtt := scaleDuration(20 * time.Millisecond)
 				setRtt(rtt)
 				// consume more than 2/3 of the window...
 				dataRead := receiveWindowSize*1/3 + 1
@@ -158,7 +170,7 @@ var _ = Describe("Base Flow controller", func() {
 
 			It("doesn't increase the window size if read too slowly", func() {
 				bytesRead := controller.bytesRead
-				rtt := 200 * time.Millisecond
+				rtt := scaleDuration(20 * time.Millisecond)
 				setRtt(rtt)
 				// consume less than 2/3 of the window...
 				dataRead := receiveWindowSize*2/3 - 1
@@ -181,7 +193,7 @@ var _ = Describe("Base Flow controller", func() {
 					controller.epochStartOffset = controller.bytesRead
 					controller.AddBytesRead(controller.receiveWindowSize/2 + 1)
 				}
-				setRtt(200 * time.Millisecond)
+				setRtt(scaleDuration(20 * time.Millisecond))
 				resetEpoch()
 				controller.maybeAdjustWindowSize()
 				Expect(controller.receiveWindowSize).To(Equal(2 * oldWindowSize)) // 2000

--- a/internal/flowcontrol/connection_flow_controller_test.go
+++ b/internal/flowcontrol/connection_flow_controller_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Connection Flow controller", func() {
 			It("autotunes the window", func() {
 				oldOffset := controller.bytesRead
 				oldWindowSize := controller.receiveWindowSize
-				rtt := 200 * time.Millisecond
+				rtt := scaleDuration(20 * time.Millisecond)
 				setRtt(rtt)
 				controller.epochStartTime = time.Now().Add(-time.Millisecond)
 				controller.epochStartOffset = oldOffset

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Stream Flow controller", func() {
 			It("tells the connection flow controller when the window was autotuned", func() {
 				oldOffset := controller.bytesRead
 				controller.contributesToConnection = true
-				setRtt(200 * time.Millisecond)
+				setRtt(scaleDuration(20 * time.Millisecond))
 				controller.epochStartOffset = oldOffset
 				controller.epochStartTime = time.Now().Add(-time.Millisecond)
 				controller.AddBytesRead(55)
@@ -197,7 +197,7 @@ var _ = Describe("Stream Flow controller", func() {
 			It("doesn't tell the connection flow controller if it doesn't contribute", func() {
 				oldOffset := controller.bytesRead
 				controller.contributesToConnection = false
-				setRtt(200 * time.Millisecond)
+				setRtt(scaleDuration(20 * time.Millisecond))
 				controller.epochStartOffset = oldOffset
 				controller.epochStartTime = time.Now().Add(-time.Millisecond)
 				controller.AddBytesRead(55)


### PR DESCRIPTION
Fixes #1099.

We increased the RTT in the flow controller tests from 20 to 200ms in #1075. Apparently this is not enough for AppVeyor. This PR makes use of the TIMESCALE_FACTOR environment variable, which we already use for the stream tests. We set it to 20 on our CIs, so this should result in an RTT of 400ms on the CIs.