### PR TITLE
remove the Range method in the streamsMap

### DIFF
--- a/session.go
+++ b/session.go
@@ -688,18 +688,13 @@ func (s *session) handleCloseError(closeErr closeError) error {
 
 func (s *session) processTransportParameters(params *handshake.TransportParameters) {
 	s.peerParams = params
-	s.streamsMap.UpdateMaxStreamLimit(params.MaxStreams)
+	s.streamsMap.UpdateLimits(params)
 	if params.OmitConnectionID {
 		s.packer.SetOmitConnectionID()
 	}
 	s.connFlowController.UpdateSendWindow(params.ConnectionFlowControlWindow)
-	// increase the flow control windows of all streams by sending them a fake MAX_STREAM_DATA frame
-	s.streamsMap.Range(func(str streamI) {
-		str.handleMaxStreamDataFrame(&wire.MaxStreamDataFrame{
-			StreamID:   str.StreamID(),
-			ByteOffset: params.StreamFlowControlWindow,
-		})
-	})
+	// the crypto stream is the only open stream at this moment
+	// so we don't need to update stream flow control windows
 }
 
 func (s *session) sendPacket() error {

--- a/session_test.go
+++ b/session_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Session", func() {
 
 		Context("handling STREAM frames", func() {
 			BeforeEach(func() {
-				sess.streamsMap.UpdateMaxStreamLimit(100)
+				sess.streamsMap.UpdateLimits(&handshake.TransportParameters{MaxStreams: 10000})
 			})
 
 			It("makes new streams", func() {
@@ -494,9 +494,9 @@ var _ = Describe("Session", func() {
 			}()
 			_, err := sess.GetOrOpenStream(5)
 			Expect(err).ToNot(HaveOccurred())
-			sess.streamsMap.Range(func(s streamI) {
+			for _, s := range sess.streamsMap.streams {
 				s.(*MockStreamI).EXPECT().closeForShutdown(gomock.Any())
-			})
+			}
 			err = sess.handleFrames([]wire.Frame{&wire.ConnectionCloseFrame{ErrorCode: qerr.ProofInvalid, ReasonPhrase: "foobar"}}, protocol.EncryptionUnspecified)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess.Context().Done()).Should(BeClosed())


### PR DESCRIPTION
`streamsMap.Range` was only used to pass the stream flow control window to all open streams after receiving the peer's transport parameters.

We still need to pass the stream flow control limits to the streams map, since 0-RTT, the client sends an unencrypted packet containing the full CHLO (including all transport parameters), and immediately sends an encrypted packet potentially containing stream data. Since the crypto stream is handled by a separate go routine, the transport parameters are not guaranteed to be processed before the second packet. Note that we can get rid of this when we support stateless connection establishment for gQUIC (#952).