### PR TITLE
implement the MAX_STREAM_ID and STREAM_ID_BLOCKED frames

### DIFF
--- a/internal/wire/max_stream_id_frame.go
+++ b/internal/wire/max_stream_id_frame.go
@@ -1,0 +1,37 @@
+package wire
+
+import (
+	"bytes"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+)
+
+// A MaxStreamIDFrame is a MAX_STREAM_ID frame
+type MaxStreamIDFrame struct {
+	StreamID protocol.StreamID
+}
+
+// ParseMaxStreamIDFrame parses a MAX_STREAM_ID frame
+func ParseMaxStreamIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxStreamIDFrame, error) {
+	// read the Type byte
+	if _, err := r.ReadByte(); err != nil {
+		return nil, err
+	}
+	streamID, err := utils.ReadVarInt(r)
+	if err != nil {
+		return nil, err
+	}
+	return &MaxStreamIDFrame{StreamID: protocol.StreamID(streamID)}, nil
+}
+
+func (f *MaxStreamIDFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
+	b.WriteByte(0x6)
+	utils.WriteVarInt(b, uint64(f.StreamID))
+	return nil
+}
+
+// MinLength of a written frame
+func (f *MaxStreamIDFrame) MinLength(protocol.VersionNumber) protocol.ByteCount {
+	return 1 + utils.VarIntLen(uint64(f.StreamID))
+}

--- a/internal/wire/max_stream_id_frame_test.go
+++ b/internal/wire/max_stream_id_frame_test.go
@@ -1,0 +1,51 @@
+package wire
+
+import (
+	"bytes"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MAX_STREAM_ID frame", func() {
+	Context("parsing", func() {
+		It("accepts sample frame", func() {
+			data := []byte{0x6}
+			data = append(data, encodeVarInt(0xdecafbad)...)
+			b := bytes.NewReader(data)
+			f, err := ParseMaxStreamIDFrame(b, protocol.VersionWhatever)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.StreamID).To(Equal(protocol.StreamID(0xdecafbad)))
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("errors on EOFs", func() {
+			data := []byte{0x06}
+			data = append(data, encodeVarInt(0xdeadbeefcafe13)...)
+			_, err := ParseMaxStreamIDFrame(bytes.NewReader(data), protocol.VersionWhatever)
+			Expect(err).NotTo(HaveOccurred())
+			for i := range data {
+				_, err := ParseMaxStreamIDFrame(bytes.NewReader(data[0:i]), protocol.VersionWhatever)
+				Expect(err).To(HaveOccurred())
+			}
+		})
+	})
+
+	Context("writing", func() {
+		It("writes a sample frame", func() {
+			b := &bytes.Buffer{}
+			frame := MaxStreamIDFrame{StreamID: 0x12345678}
+			frame.Write(b, protocol.VersionWhatever)
+			expected := []byte{0x6}
+			expected = append(expected, encodeVarInt(0x12345678)...)
+			Expect(b.Bytes()).To(Equal(expected))
+		})
+
+		It("has the correct min length", func() {
+			frame := MaxStreamIDFrame{StreamID: 0x1337}
+			Expect(frame.MinLength(protocol.VersionWhatever)).To(Equal(1 + utils.VarIntLen(0x1337)))
+		})
+	})
+})

--- a/internal/wire/stream_id_blocked_frame.go
+++ b/internal/wire/stream_id_blocked_frame.go
@@ -1,0 +1,37 @@
+package wire
+
+import (
+	"bytes"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+)
+
+// A StreamIDBlockedFrame is a STREAM_ID_BLOCKED frame
+type StreamIDBlockedFrame struct {
+	StreamID protocol.StreamID
+}
+
+// ParseStreamIDBlockedFrame parses a STREAM_ID_BLOCKED frame
+func ParseStreamIDBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StreamIDBlockedFrame, error) {
+	if _, err := r.ReadByte(); err != nil {
+		return nil, err
+	}
+	streamID, err := utils.ReadVarInt(r)
+	if err != nil {
+		return nil, err
+	}
+	return &StreamIDBlockedFrame{StreamID: protocol.StreamID(streamID)}, nil
+}
+
+func (f *StreamIDBlockedFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
+	typeByte := uint8(0x0a)
+	b.WriteByte(typeByte)
+	utils.WriteVarInt(b, uint64(f.StreamID))
+	return nil
+}
+
+// MinLength of a written frame
+func (f *StreamIDBlockedFrame) MinLength(_ protocol.VersionNumber) protocol.ByteCount {
+	return 1 + utils.VarIntLen(uint64(f.StreamID))
+}

--- a/internal/wire/stream_id_blocked_frame_test.go
+++ b/internal/wire/stream_id_blocked_frame_test.go
@@ -1,0 +1,53 @@
+package wire
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("STREAM_ID_BLOCKED frame", func() {
+	Context("parsing", func() {
+		It("accepts sample frame", func() {
+			expected := []byte{0xa}
+			expected = append(expected, encodeVarInt(0xdecafbad)...)
+			b := bytes.NewReader(expected)
+			frame, err := ParseStreamIDBlockedFrame(b, protocol.VersionWhatever)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdecafbad)))
+			Expect(b.Len()).To(BeZero())
+		})
+
+		It("errors on EOFs", func() {
+			data := []byte{0xa}
+			data = append(data, encodeVarInt(0x12345678)...)
+			_, err := ParseStreamIDBlockedFrame(bytes.NewReader(data), versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			for i := range data {
+				_, err := ParseStreamIDBlockedFrame(bytes.NewReader(data[:i]), versionIETFFrames)
+				Expect(err).To(MatchError(io.EOF))
+			}
+		})
+	})
+
+	Context("writing", func() {
+		It("writes a sample frame", func() {
+			b := &bytes.Buffer{}
+			frame := StreamIDBlockedFrame{StreamID: 0xdeadbeefcafe}
+			err := frame.Write(b, protocol.VersionWhatever)
+			Expect(err).ToNot(HaveOccurred())
+			expected := []byte{0xa}
+			expected = append(expected, encodeVarInt(0xdeadbeefcafe)...)
+			Expect(b.Bytes()).To(Equal(expected))
+		})
+
+		It("has the correct min length", func() {
+			frame := StreamIDBlockedFrame{StreamID: 0x123456}
+			Expect(frame.MinLength(0)).To(Equal(protocol.ByteCount(1) + utils.VarIntLen(0x123456)))
+		})
+	})
+})

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -106,7 +106,11 @@ func (u *packetUnpacker) parseIETFFrame(r *bytes.Reader, typeByte byte, hdr *wir
 		if err != nil {
 			err = qerr.Error(qerr.InvalidWindowUpdateData, err.Error())
 		}
-	// TODO(#878): implement the MAX_STREAM_ID frame
+	case 0x6:
+		frame, err = wire.ParseMaxStreamIDFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidFrameData, err.Error())
+		}
 	case 0x7:
 		frame, err = wire.ParsePingFrame(r, u.version)
 	case 0x8:

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -123,6 +123,11 @@ func (u *packetUnpacker) parseIETFFrame(r *bytes.Reader, typeByte byte, hdr *wir
 		if err != nil {
 			err = qerr.Error(qerr.InvalidBlockedData, err.Error())
 		}
+	case 0xa:
+		frame, err = wire.ParseStreamIDBlockedFrame(r, u.version)
+		if err != nil {
+			err = qerr.Error(qerr.InvalidFrameData, err.Error())
+		}
 	case 0xc:
 		frame, err = wire.ParseStopSendingFrame(r, u.version)
 		if err != nil {

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -378,6 +378,17 @@ var _ = Describe("Packet unpacker", func() {
 			Expect(packet.frames).To(Equal([]wire.Frame{f}))
 		})
 
+		It("unpacks STREAM_ID_BLOCKED frames", func() {
+			f := &wire.StreamIDBlockedFrame{StreamID: 0x1234567}
+			buf := &bytes.Buffer{}
+			err := f.Write(buf, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
 		It("unpacks STOP_SENDING frames", func() {
 			f := &wire.StopSendingFrame{StreamID: 0x42}
 			buf := &bytes.Buffer{}
@@ -420,6 +431,7 @@ var _ = Describe("Packet unpacker", func() {
 				0x06: qerr.InvalidFrameData,
 				0x08: qerr.InvalidBlockedData,
 				0x09: qerr.InvalidBlockedData,
+				0x0a: qerr.InvalidFrameData,
 				0x0c: qerr.InvalidFrameData,
 				0x0e: qerr.InvalidAckData,
 				0x10: qerr.InvalidStreamData,

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -342,6 +342,17 @@ var _ = Describe("Packet unpacker", func() {
 			Expect(packet.frames).To(Equal([]wire.Frame{f}))
 		})
 
+		It("unpacks MAX_STREAM_ID frames", func() {
+			f := &wire.MaxStreamIDFrame{StreamID: 0x1337}
+			buf := &bytes.Buffer{}
+			err := f.Write(buf, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			setData(buf.Bytes())
+			packet, err := unpacker.Unpack(hdrBin, hdr, data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packet.frames).To(Equal([]wire.Frame{f}))
+		})
+
 		It("unpacks connection-level BLOCKED frames", func() {
 			f := &wire.BlockedFrame{Offset: 0x1234}
 			buf := &bytes.Buffer{}
@@ -406,6 +417,7 @@ var _ = Describe("Packet unpacker", func() {
 				0x02: qerr.InvalidConnectionCloseData,
 				0x04: qerr.InvalidWindowUpdateData,
 				0x05: qerr.InvalidWindowUpdateData,
+				0x06: qerr.InvalidFrameData,
 				0x08: qerr.InvalidBlockedData,
 				0x09: qerr.InvalidBlockedData,
 				0x0c: qerr.InvalidFrameData,


### PR DESCRIPTION
Fixes #878.

They can be parsed and written, and unpacked, but they're not handled yet.
Will be needed for unidirectional streams (#996).
  