### PR TITLE
attempt to fix #765

### DIFF
--- a/h2quic/client.go
+++ b/h2quic/client.go
@@ -237,6 +237,15 @@ func (c *client) RoundTrip(req *http.Request) (*http.Response, error) {
 	return res, nil
 }
 
+func (c *client) isClosed() bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if c.session == nil { // still dialing
+		return false
+	}
+	return c.session.Context().Err() != nil
+}
+
 func (c *client) writeRequestBody(dataStream quic.Stream, body io.ReadCloser) (err error) {
 	defer func() {
 		cerr := body.Close()

--- a/qerr/quic_error.go
+++ b/qerr/quic_error.go
@@ -2,6 +2,7 @@ package qerr
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
@@ -18,6 +19,8 @@ type QuicError struct {
 	ErrorCode    ErrorCode
 	ErrorMessage string
 }
+
+var _ net.Error = &QuicError{}
 
 // Error creates a new QuicError instance
 func Error(errorCode ErrorCode, errorMessage string) *QuicError {
@@ -39,6 +42,10 @@ func (e *QuicError) Timeout() bool {
 		return true
 	}
 	return false
+}
+
+func (e *QuicError) Temporary() bool {
+	return e.Timeout()
 }
 
 // ToQuicError converts an arbitrary error to a QuicError. It leaves QuicErrors


### PR DESCRIPTION
@lucas-clemente: This isn't done yet, but I'd like your feedback on this. It's a bit than we talked yesterday, but it seems like there's no way to make this not racy.

You have to consider the case where two requests are sent at the same time. You don't want the first one to time out after one timeout period, and the second one after two.
On the other hand, there seems to be no way to have a request which is issued right before the timeout occurs (i.e. the server's CONNECTION_CLOSE already being in flight) not timing out immediately.