### PR TITLE
enable the no-sandbox mode for Chrome in integration tests

### DIFF
--- a/integrationtests/chrome/chrome_suite_test.go
+++ b/integrationtests/chrome/chrome_suite_test.go
@@ -122,6 +122,7 @@ func chromeTest(version protocol.VersionNumber, url string, blockUntilDone func(
 		"--user-data-dir=" + userDataDir,
 		"--enable-quic=true",
 		"--no-proxy-server=true",
+		"--no-sandbox",
 		"--origin-to-force-quic-on=quic.clemente.io:443",
 		fmt.Sprintf(`--host-resolver-rules=MAP quic.clemente.io:443 127.0.0.1:%s`, testserver.Port()),
 		fmt.Sprintf("--quic-version=QUIC_VERSION_%s", version.ToAltSvc()),


### PR DESCRIPTION
All our Chrome tests started failing as of today. Apparently, we now have to use `--no-sandbox` to make Chrome work on Travis. This flag is not needed (but doesn't hurt) on OSX and in my Ubuntu VM.