### PR TITLE
Enable travis latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: trusty
+group: travis_latest
 
 addons:
   hosts:


### PR DESCRIPTION
As described on https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images.

I'm not seeing any differences between the two builds now, but it probably won't hurt to use the latest image. What I'm hoping for is that we'll get Chrome updates faster.