### PR TITLE
make the client send a packet when the handshake completes (in gQUIC)

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -1470,6 +1470,22 @@ var _ = Describe("Client Session", func() {
 		newCryptoSetupClient = handshake.NewCryptoSetupClient
 	})
 
+	It("sends a forward-secure packet when the handshake completes", func() {
+		sess.packer.hasSentPacket = true
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			err := sess.run()
+			Expect(err).ToNot(HaveOccurred())
+			close(done)
+		}()
+		close(handshakeChan)
+		Eventually(mconn.written).Should(Receive())
+		//make sure the go routine returns
+		Expect(sess.Close(nil)).To(Succeed())
+		Eventually(done).Should(BeClosed())
+	})
+
 	Context("receiving packets", func() {
 		var hdr *wire.Header
 


### PR DESCRIPTION
In gQUIC, there's no equivalent to the Finished message in TLS. The server knows that the handshake is complete when it receives the first forward-secure packet sent by the client. If the protocol demands that the server sends the first data, this would never happen. We need to make sure that the client actually sends such a packet. Queueing a PING frame is an easy way to do so.

This is the problem that made the [quic-conn](https://github.com/marten-seemann/quic-conn) integration tests fail. Interesting, it only occured if the certificate chain was small (I'm using a self-signed cert there, whereas we use the quic.clemente.io cert for the quic-go integration tests). I don't really understand why, and I don't think it's important to understand.
What happens if we use a larger cert chain is that the client sends an ACK after becoming forward-secure. However, as far as I can see this is not guaranteed.
  