### PR TITLE
expose the ConnectionState in the Session

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - The lower boundary for packets included in ACKs is now derived, and the value sent in STOP_WAITING frames is ignored.
 - Remove `DialNonFWSecure` and `DialAddrNonFWSecure`.
+- Expose the `ConnectionState` in the `Session` (experimental API).
 
 ## v0.6.0 (2017-12-12)
 

--- a/h2quic/server_test.go
+++ b/h2quic/server_test.go
@@ -70,6 +70,7 @@ func (s *mockSession) RemoteAddr() net.Addr {
 func (s *mockSession) Context() context.Context {
 	return s.ctx
 }
+func (s *mockSession) ConnectionState() quic.ConnectionState { panic("not implemented") }
 
 var _ = Describe("H2 server", func() {
 	var (

--- a/interface.go
+++ b/interface.go
@@ -19,6 +19,9 @@ type VersionNumber = protocol.VersionNumber
 // A Cookie can be used to verify the ownership of the client address.
 type Cookie = handshake.Cookie
 
+// ConnectionState records basic details about the QUIC connection.
+type ConnectionState = handshake.ConnectionState
+
 // An ErrorCode is an application-defined error code.
 type ErrorCode = protocol.ApplicationErrorCode
 
@@ -128,6 +131,9 @@ type Session interface {
 	// The context is cancelled when the session is closed.
 	// Warning: This API should not be considered stable and might change soon.
 	Context() context.Context
+	// ConnectionState returns basic details about the QUIC connection.
+	// Warning: This API should not be considered stable and might change soon.
+	ConnectionState() ConnectionState
 }
 
 // Config contains all configuration data needed for a QUIC server or client.

--- a/internal/crypto/cert_manager.go
+++ b/internal/crypto/cert_manager.go
@@ -18,6 +18,7 @@ type CertManager interface {
 	GetLeafCertHash() (uint64, error)
 	VerifyServerProof(proof, chlo, serverConfigData []byte) bool
 	Verify(hostname string) error
+	GetChain() []*x509.Certificate
 }
 
 type certManager struct {
@@ -52,6 +53,10 @@ func (c *certManager) SetData(data []byte) error {
 
 	c.chain = chain
 	return nil
+}
+
+func (c *certManager) GetChain() []*x509.Certificate {
+	return c.chain
 }
 
 func (c *certManager) GetCommonCertificateHashes() []byte {

--- a/internal/handshake/crypto_setup_client.go
+++ b/internal/handshake/crypto_setup_client.go
@@ -381,6 +381,15 @@ func (h *cryptoSetupClient) SetDiversificationNonce(data []byte) {
 	h.divNonceChan <- data
 }
 
+func (h *cryptoSetupClient) ConnectionState() ConnectionState {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	return ConnectionState{
+		HandshakeComplete: h.forwardSecureAEAD != nil,
+		PeerCertificates:  h.certManager.GetChain(),
+	}
+}
+
 func (h *cryptoSetupClient) sendCHLO() error {
 	h.clientHelloCounter++
 	if h.clientHelloCounter > protocol.MaxClientHellos {

--- a/internal/handshake/crypto_setup_tls.go
+++ b/internal/handshake/crypto_setup_tls.go
@@ -164,3 +164,14 @@ func (h *cryptoSetupTLS) DiversificationNonce() []byte {
 func (h *cryptoSetupTLS) SetDiversificationNonce([]byte) {
 	panic("diversification nonce not needed for TLS")
 }
+
+func (h *cryptoSetupTLS) ConnectionState() ConnectionState {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	mintConnState := h.tls.ConnectionState()
+	return ConnectionState{
+		// TODO: set the ServerName, once mint exports it
+		HandshakeComplete: h.aead != nil,
+		PeerCertificates:  mintConnState.PeerCertificates,
+	}
+}

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -1,6 +1,7 @@
 package handshake
 
 import (
+	"crypto/x509"
 	"io"
 
 	"github.com/bifurcation/mint"
@@ -29,6 +30,7 @@ type MintTLS interface {
 	// additional methods
 	Handshake() mint.Alert
 	State() mint.State
+	ConnectionState() mint.ConnectionState
 
 	SetCryptoStream(io.ReadWriter)
 	SetExtensionHandler(mint.AppExtensionHandler) error
@@ -41,8 +43,17 @@ type CryptoSetup interface {
 	// TODO: clean up this interface
 	DiversificationNonce() []byte   // only needed for cryptoSetupServer
 	SetDiversificationNonce([]byte) // only needed for cryptoSetupClient
+	ConnectionState() ConnectionState
 
 	GetSealer() (protocol.EncryptionLevel, Sealer)
 	GetSealerWithEncryptionLevel(protocol.EncryptionLevel) (Sealer, error)
 	GetSealerForCryptoStream() (protocol.EncryptionLevel, Sealer)
+}
+
+// ConnectionState records basic details about the QUIC connection.
+// Warning: This API should not be considered stable and might change soon.
+type ConnectionState struct {
+	HandshakeComplete bool                // handshake is complete
+	ServerName        string              // server name requested by client, if any (server side only)
+	PeerCertificates  []*x509.Certificate // certificate chain presented by remote peer
 }

--- a/internal/mocks/handshake/mint_tls.go
+++ b/internal/mocks/handshake/mint_tls.go
@@ -48,6 +48,18 @@ func (mr *MockMintTLSMockRecorder) ComputeExporter(arg0, arg1, arg2 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeExporter", reflect.TypeOf((*MockMintTLS)(nil).ComputeExporter), arg0, arg1, arg2)
 }
 
+// ConnectionState mocks base method
+func (m *MockMintTLS) ConnectionState() mint.ConnectionState {
+	ret := m.ctrl.Call(m, "ConnectionState")
+	ret0, _ := ret[0].(mint.ConnectionState)
+	return ret0
+}
+
+// ConnectionState indicates an expected call of ConnectionState
+func (mr *MockMintTLSMockRecorder) ConnectionState() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectionState", reflect.TypeOf((*MockMintTLS)(nil).ConnectionState))
+}
+
 // GetCipherSuite mocks base method
 func (m *MockMintTLS) GetCipherSuite() mint.CipherSuiteParams {
 	ret := m.ctrl.Call(m, "GetCipherSuite")

--- a/mint_utils.go
+++ b/mint_utils.go
@@ -56,6 +56,10 @@ func (mc *mintController) State() mint.State {
 	return mc.conn.State().HandshakeState
 }
 
+func (mc *mintController) ConnectionState() mint.ConnectionState {
+	return mc.conn.State()
+}
+
 func (mc *mintController) SetCryptoStream(stream io.ReadWriter) {
 	mc.csc.SetStream(stream)
 }

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -50,6 +50,7 @@ func (m *mockCryptoSetup) GetSealerWithEncryptionLevel(protocol.EncryptionLevel)
 }
 func (m *mockCryptoSetup) DiversificationNonce() []byte            { return m.divNonce }
 func (m *mockCryptoSetup) SetDiversificationNonce(divNonce []byte) { m.divNonce = divNonce }
+func (m *mockCryptoSetup) ConnectionState() ConnectionState        { panic("not implemented") }
 
 var _ = Describe("Packet packer", func() {
 	var (

--- a/server_test.go
+++ b/server_test.go
@@ -62,6 +62,7 @@ func (s *mockSession) OpenStreamSync() (Stream, error)  { panic("not implemented
 func (s *mockSession) LocalAddr() net.Addr              { panic("not implemented") }
 func (s *mockSession) RemoteAddr() net.Addr             { panic("not implemented") }
 func (*mockSession) Context() context.Context           { panic("not implemented") }
+func (*mockSession) ConnectionState() ConnectionState   { panic("not implemented") }
 func (*mockSession) GetVersion() protocol.VersionNumber { return protocol.VersionWhatever }
 func (s *mockSession) handshakeStatus() <-chan error    { return s.handshakeChan }
 func (*mockSession) getCryptoStream() cryptoStreamI     { panic("not implemented") }

--- a/session.go
+++ b/session.go
@@ -457,6 +457,10 @@ func (s *session) Context() context.Context {
 	return s.ctx
 }
 
+func (s *session) ConnectionState() ConnectionState {
+	return s.cryptoSetup.ConnectionState()
+}
+
 func (s *session) maybeResetTimer() {
 	var deadline time.Time
 	if s.config.KeepAlive && s.handshakeComplete && !s.keepAlivePingSent {


### PR DESCRIPTION
Fixes #746.

This will be needed for the libp2p integration (to access the certificate chain). I created a PR to mint to expose the certificate chain: https://github.com/bifurcation/mint/pull/162.

The ConnectionState contains basic details about the QUIC connection. I noticed that [mint](https://godoc.org/github.com/bifurcation/mint#ConnectionState) as well as [tls-tris](https://godoc.org/github.com/cloudflare/tls-tris#ConnectionState) define their own `ConnectionState` struct, so maybe that's what we can go with in quic-go as well, at least as long as we're not using the TLS 1.3 implementation that will be added to the Go standard library at some point (maybe).
The `ConnectionState` now has a minimal feature set, and we can certainly add more fields there. I marked the API as unstable, so we don't need to assume any responsibility for breaking other people's builds ;).