### PR TITLE
implement a Dial function for the h2quic.RoundTripper

### DIFF
--- a/h2quic/roundtrip_test.go
+++ b/h2quic/roundtrip_test.go
@@ -103,6 +103,17 @@ var _ = Describe("RoundTripper", func() {
 			Expect(receivedConfig).To(Equal(config))
 		})
 
+		It("uses the custom dialer, if provided", func() {
+			var dialed bool
+			dialer := func(_, _ string, tlsCfgP *tls.Config, cfg *quic.Config) (quic.Session, error) {
+				dialed = true
+				return nil, errors.New("err")
+			}
+			rt.Dial = dialer
+			rt.RoundTrip(req1)
+			Expect(dialed).To(BeTrue())
+		})
+
 		It("reuses existing clients", func() {
 			req, err := http.NewRequest("GET", "https://quic.clemente.io/file1.html", nil)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fixes #747.

If `Dial` is set, it will be used for dialing new QUIC connections. If it is nil, `quic.DialAddr` will be used.

Contrary to what we discussed in #747, I think that returning a `quic.Session` is the right thing to do. Only then can the application use the full flexibilty that `quic.Dial` provides (using a custom `net.PacketConn` **and** taking care of the resolution of the remote `net.Addr`).
In fact, the standard library (kind of) does the same in the `http2.Transport` [here](https://godoc.org/golang.org/x/net/http2#Transport), where the returned `net.Conn` for `DialTLS` has to implement some of the methods a `tls.Conn`.

@lucas-clemente: I still need to fix the tests, but before doing that, I'd like to come to an agreement on the right signature.
I'd also like to hear what @costinm thinks about this, since this is the more idiomatic way of #1093.