### PR TITLE
correctly handle completed streams when popping frames

### DIFF
--- a/stream_framer.go
+++ b/stream_framer.go
@@ -113,8 +113,11 @@ func (f *streamFramer) maybePopNormalFrames(maxTotalLen protocol.ByteCount) []*w
 		}
 		id := f.streamQueue[0]
 		f.streamQueue = f.streamQueue[1:]
+		// This should never return an error. Better check it anyway.
+		// The stream will only be in the streamQueue, if it enqueued itself there.
 		str, err := f.streamGetter.GetOrOpenSendStream(id)
-		if err != nil { // can happen if the stream completed after it said it had data
+		// The stream can be nil if it completed after it said it had data.
+		if str == nil || err != nil {
 			delete(f.activeStreams, id)
 			continue
 		}

--- a/stream_framer_test.go
+++ b/stream_framer_test.go
@@ -2,7 +2,6 @@ package quic
 
 import (
 	"bytes"
-	"errors"
 
 	"github.com/golang/mock/gomock"
 
@@ -139,7 +138,7 @@ var _ = Describe("Stream Framer", func() {
 		})
 
 		It("skips a stream that was reported active, but was completed shortly after", func() {
-			streamGetter.EXPECT().GetOrOpenSendStream(id1).Return(nil, errors.New("stream was already deleted"))
+			streamGetter.EXPECT().GetOrOpenSendStream(id1).Return(nil, nil)
 			streamGetter.EXPECT().GetOrOpenSendStream(id2).Return(stream2, nil)
 			f := &wire.StreamFrame{
 				StreamID: id2,


### PR DESCRIPTION
Fixes #1121.

The streamsMap returns a nil stream (and a nil error) when the stream has already completed.