### PR TITLE
ignore the delay in an ACK if it results in an RTT less than minRTT

### DIFF
--- a/ackhandler/sent_packet_handler_test.go
+++ b/ackhandler/sent_packet_handler_test.go
@@ -499,8 +499,10 @@ var _ = Describe("SentPacketHandler", func() {
 				Expect(handler.rttStats.LatestRTT()).To(BeNumerically("~", 1*time.Minute, 1*time.Second))
 			})
 
-			It("uses the DelayTime in the ack frame", func() {
+			It("uses the DelayTime in the ACK frame", func() {
 				now := time.Now()
+				// make sure the rttStats have a min RTT, so that the delay is used
+				handler.rttStats.UpdateRTT(5*time.Minute, 0, time.Now())
 				getPacketElement(1).Value.sendTime = now.Add(-10 * time.Minute)
 				err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 1, DelayTime: 5 * time.Minute}, 1, protocol.EncryptionUnencrypted, time.Now())
 				Expect(err).NotTo(HaveOccurred())

--- a/congestion/rtt_stats.go
+++ b/congestion/rtt_stats.go
@@ -98,10 +98,10 @@ func (r *RTTStats) UpdateRTT(sendDelta, ackDelay time.Duration, now time.Time) {
 	r.updateRecentMinRTT(sendDelta, now)
 
 	// Correct for ackDelay if information received from the peer results in a
-	// positive RTT sample. Otherwise, we use the sendDelta as a reasonable
-	// measure for smoothedRTT.
+	// an RTT sample at least as large as minRTT. Otherwise, only use the
+	// sendDelta.
 	sample := sendDelta
-	if sample > ackDelay {
+	if sample-r.minRTT >= ackDelay {
 		sample -= ackDelay
 	}
 	r.latestRTT = sample


### PR DESCRIPTION
Fixes #965.

This is basically just the translation of https://chromium-review.googlesource.com/c/chromium/src/+/873930/1/net/quic/core/congestion_control/rtt_stats_test.cc into Go (while at the same time removing the flag protection).