### PR TITLE
force clients to set tls.Config.InsecureSkipVerify when using mint

### DIFF
--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -79,7 +79,8 @@ var _ = Describe("Handshake tests", func() {
 	})
 
 	Context("Certifiate validation", func() {
-		for _, v := range []protocol.VersionNumber{protocol.Version39, protocol.VersionTLS} {
+		// no need to run these tests with TLS. mint doesn't do certificate verification
+		for _, v := range protocol.SupportedVersions {
 			version := v
 
 			Context(fmt.Sprintf("using %s", version), func() {

--- a/server_tls_test.go
+++ b/server_tls_test.go
@@ -36,7 +36,8 @@ var _ = Describe("Stateless TLS handling", func() {
 			Versions: []protocol.VersionNumber{protocol.VersionTLS},
 		}
 		var err error
-		server, sessionChan, err = newServerTLS(conn, config, nil, testdata.GetTLSConfig())
+		tlsConf := testdata.GetTLSConfig()
+		server, sessionChan, err = newServerTLS(conn, config, nil, tlsConf)
 		Expect(err).ToNot(HaveOccurred())
 		server.newMintConn = func(bc *handshake.CryptoStreamConn, v protocol.VersionNumber) (handshake.MintTLS, <-chan handshake.TransportParameters, error) {
 			mintReply = bc


### PR DESCRIPTION
mint doesn't verify the certificate chain. This change forces users of quic-go to acknowledge mint's insecure behavior by explicitly setting InsecureSkipVerify.