### PR TITLE
update recent mint changes

### DIFF
--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -79,8 +79,7 @@ var _ = Describe("Handshake tests", func() {
 	})
 
 	Context("Certifiate validation", func() {
-		// no need to run these tests with TLS. mint doesn't do certificate verification
-		for _, v := range protocol.SupportedVersions {
+		for _, v := range []protocol.VersionNumber{protocol.Version39, protocol.VersionTLS} {
 			version := v
 
 			Context(fmt.Sprintf("using %s", version), func() {

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -33,7 +33,6 @@ type MintTLS interface {
 	ConnectionState() mint.ConnectionState
 
 	SetCryptoStream(io.ReadWriter)
-	SetExtensionHandler(mint.AppExtensionHandler) error
 }
 
 // CryptoSetup is a crypto setup

--- a/internal/mocks/handshake/mint_tls.go
+++ b/internal/mocks/handshake/mint_tls.go
@@ -94,18 +94,6 @@ func (mr *MockMintTLSMockRecorder) SetCryptoStream(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCryptoStream", reflect.TypeOf((*MockMintTLS)(nil).SetCryptoStream), arg0)
 }
 
-// SetExtensionHandler mocks base method
-func (m *MockMintTLS) SetExtensionHandler(arg0 mint.AppExtensionHandler) error {
-	ret := m.ctrl.Call(m, "SetExtensionHandler", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetExtensionHandler indicates an expected call of SetExtensionHandler
-func (mr *MockMintTLSMockRecorder) SetExtensionHandler(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExtensionHandler", reflect.TypeOf((*MockMintTLS)(nil).SetExtensionHandler), arg0)
-}
-
 // State mocks base method
 func (m *MockMintTLS) State() mint.State {
 	ret := m.ctrl.Call(m, "State")

--- a/mint_utils.go
+++ b/mint_utils.go
@@ -43,7 +43,7 @@ func newMintController(
 }
 
 func (mc *mintController) GetCipherSuite() mint.CipherSuiteParams {
-	return mc.conn.State().CipherSuite
+	return mc.conn.ConnectionState().CipherSuite
 }
 
 func (mc *mintController) ComputeExporter(label string, context []byte, keyLength int) ([]byte, error) {
@@ -55,19 +55,15 @@ func (mc *mintController) Handshake() mint.Alert {
 }
 
 func (mc *mintController) State() mint.State {
-	return mc.conn.State().HandshakeState
+	return mc.conn.ConnectionState().HandshakeState
 }
 
 func (mc *mintController) ConnectionState() mint.ConnectionState {
-	return mc.conn.State()
+	return mc.conn.ConnectionState()
 }
 
 func (mc *mintController) SetCryptoStream(stream io.ReadWriter) {
 	mc.csc.SetStream(stream)
-}
-
-func (mc *mintController) SetExtensionHandler(h mint.AppExtensionHandler) error {
-	return mc.conn.SetExtensionHandler(h)
 }
 
 func tlsToMintConfig(tlsConf *tls.Config, pers protocol.Perspective) (*mint.Config, error) {

--- a/mint_utils.go
+++ b/mint_utils.go
@@ -16,8 +16,6 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
-var errMintIsInsecure = errors.New("mint currently DOES NOT support certificate verification (see https://github.com/bifurcation/mint/issues/161 for details). Set InsecureSkipVerify to acknowledge that no certificate verification will be performed, and the connection will be vulnerable to man-in-the-middle attacks")
-
 type mintController struct {
 	csc  *handshake.CryptoStreamConn
 	conn *mint.Conn
@@ -75,9 +73,6 @@ func tlsToMintConfig(tlsConf *tls.Config, pers protocol.Perspective) (*mint.Conf
 		},
 	}
 	if tlsConf != nil {
-		if pers == protocol.PerspectiveClient && !tlsConf.InsecureSkipVerify {
-			return nil, errMintIsInsecure
-		}
 		mconf.ServerName = tlsConf.ServerName
 		mconf.Certificates = make([]*mint.Certificate, len(tlsConf.Certificates))
 		for i, certChain := range tlsConf.Certificates {

--- a/mint_utils_test.go
+++ b/mint_utils_test.go
@@ -43,10 +43,7 @@ var _ = Describe("Packing and unpacking Initial packets", func() {
 		})
 
 		It("sets the server name", func() {
-			conf := &tls.Config{
-				ServerName:         "www.example.com",
-				InsecureSkipVerify: true,
-			}
+			conf := &tls.Config{ServerName: "www.example.com"}
 			mintConf, err := tlsToMintConfig(conf, protocol.PerspectiveClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mintConf.ServerName).To(Equal("www.example.com"))
@@ -54,40 +51,25 @@ var _ = Describe("Packing and unpacking Initial packets", func() {
 
 		It("sets the certificate chain", func() {
 			tlsConf := testdata.GetTLSConfig()
-			tlsConf.InsecureSkipVerify = true
 			mintConf, err := tlsToMintConfig(tlsConf, protocol.PerspectiveClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mintConf.Certificates).ToNot(BeEmpty())
 			Expect(mintConf.Certificates).To(HaveLen(len(tlsConf.Certificates)))
 		})
 
-		It("forces the application to set InsecureSkipVerify, because mint is INSECURE", func() {
-			conf := &tls.Config{
-				ServerName:         "www.example.com",
-				InsecureSkipVerify: false,
-			}
-			_, err := tlsToMintConfig(conf, protocol.PerspectiveClient)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(errMintIsInsecure))
-		})
-
 		It("requires client authentication", func() {
-			conf := &tls.Config{ServerName: "localhost"} // mint forces us to set a ServerName for a server config, although this field is only used for clients
-			mintConf, err := tlsToMintConfig(conf, protocol.PerspectiveServer)
+			mintConf, err := tlsToMintConfig(nil, protocol.PerspectiveClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mintConf.RequireClientAuth).To(BeFalse())
-			conf = &tls.Config{
-				ServerName: "localhost", // mint forces us to set a ServerName for a server config, although this field is only used for clients
-				ClientAuth: tls.RequireAnyClientCert,
-			}
-			mintConf, err = tlsToMintConfig(conf, protocol.PerspectiveServer)
+			conf := &tls.Config{ClientAuth: tls.RequireAnyClientCert}
+			mintConf, err = tlsToMintConfig(conf, protocol.PerspectiveClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mintConf.RequireClientAuth).To(BeTrue())
 		})
 
 		It("rejects unsupported client auth types", func() {
 			conf := &tls.Config{ClientAuth: tls.RequireAndVerifyClientCert}
-			_, err := tlsToMintConfig(conf, protocol.PerspectiveServer)
+			_, err := tlsToMintConfig(conf, protocol.PerspectiveClient)
 			Expect(err).To(MatchError("mint currently only support ClientAuthType RequireAnyClientCert"))
 		})
 	})

--- a/server_tls.go
+++ b/server_tls.go
@@ -89,14 +89,10 @@ func (s *serverTLS) HandleInitial(remoteAddr net.Addr, hdr *wire.Header, data []
 
 // will be set to s.newMintConn by the constructor
 func (s *serverTLS) newMintConnImpl(bc *handshake.CryptoStreamConn, v protocol.VersionNumber) (handshake.MintTLS, <-chan handshake.TransportParameters, error) {
-	conn := mint.Server(bc, s.mintConf)
 	extHandler := handshake.NewExtensionHandlerServer(s.params, s.config.Versions, v)
-	if err := conn.SetExtensionHandler(extHandler); err != nil {
-		return nil, nil, err
-	}
-	tls := newMintController(bc, s.mintConf, protocol.PerspectiveServer)
-	tls.SetExtensionHandler(extHandler)
-	return tls, extHandler.GetPeerParams(), nil
+	conf := s.mintConf.Clone()
+	conf.ExtensionHandler = extHandler
+	return newMintController(bc, conf, protocol.PerspectiveServer), extHandler.GetPeerParams(), nil
 }
 
 func (s *serverTLS) sendConnectionClose(remoteAddr net.Addr, clientHdr *wire.Header, aead crypto.AEAD, closeErr error) error {

--- a/server_tls_test.go
+++ b/server_tls_test.go
@@ -36,8 +36,7 @@ var _ = Describe("Stateless TLS handling", func() {
 			Versions: []protocol.VersionNumber{protocol.VersionTLS},
 		}
 		var err error
-		tlsConf := testdata.GetTLSConfig()
-		server, sessionChan, err = newServerTLS(conn, config, nil, tlsConf)
+		server, sessionChan, err = newServerTLS(conn, config, nil, testdata.GetTLSConfig())
 		Expect(err).ToNot(HaveOccurred())
 		server.newMintConn = func(bc *handshake.CryptoStreamConn, v protocol.VersionNumber) (handshake.MintTLS, <-chan handshake.TransportParameters, error) {
 			mintReply = bc

--- a/vendor/github.com/bifurcation/mint/client-state-machine.go
+++ b/vendor/github.com/bifurcation/mint/client-state-machine.go
@@ -3,6 +3,7 @@ package mint
 import (
 	"bytes"
 	"crypto"
+	"crypto/x509"
 	"hash"
 	"time"
 )
@@ -50,7 +51,7 @@ import (
 //  CONNECTED					StoreTicket || (RekeyIn; [RekeyOut])
 
 type ClientStateStart struct {
-	Caps   Capabilities
+	Config *Config
 	Opts   ConnectionOptions
 	Params ConnectionParameters
 
@@ -71,9 +72,9 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 	offeredDH := map[NamedGroup][]byte{}
 	ks := KeyShareExtension{
 		HandshakeType: HandshakeTypeClientHello,
-		Shares:        make([]KeyShareEntry, len(state.Caps.Groups)),
+		Shares:        make([]KeyShareEntry, len(state.Config.Groups)),
 	}
-	for i, group := range state.Caps.Groups {
+	for i, group := range state.Config.Groups {
 		pub, priv, err := newKeyShare(group)
 		if err != nil {
 			logf(logTypeHandshake, "[ClientStateStart] Error generating key share [%v]", err)
@@ -90,8 +91,8 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 	// supported_versions, supported_groups, signature_algorithms, server_name
 	sv := SupportedVersionsExtension{HandshakeType: HandshakeTypeClientHello, Versions: []uint16{supportedVersion}}
 	sni := ServerNameExtension(state.Opts.ServerName)
-	sg := SupportedGroupsExtension{Groups: state.Caps.Groups}
-	sa := SignatureAlgorithmsExtension{Algorithms: state.Caps.SignatureSchemes}
+	sg := SupportedGroupsExtension{Groups: state.Config.Groups}
+	sa := SignatureAlgorithmsExtension{Algorithms: state.Config.SignatureSchemes}
 
 	state.Params.ServerName = state.Opts.ServerName
 
@@ -103,7 +104,8 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 
 	// Construct base ClientHello
 	ch := &ClientHelloBody{
-		CipherSuites: state.Caps.CipherSuites,
+		LegacyVersion: wireVersion(state.hsCtx.hIn),
+		CipherSuites:  state.Config.CipherSuites,
 	}
 	_, err := prng.Read(ch.Random[:])
 	if err != nil {
@@ -135,8 +137,8 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 	}
 
 	// Run the external extension handler.
-	if state.Caps.ExtensionHandler != nil {
-		err := state.Caps.ExtensionHandler.Send(HandshakeTypeClientHello, &ch.Extensions)
+	if state.Config.ExtensionHandler != nil {
+		err := state.Config.ExtensionHandler.Send(HandshakeTypeClientHello, &ch.Extensions)
 		if err != nil {
 			logf(logTypeHandshake, "[ClientStateStart] Error running external extension sender [%v]", err)
 			return nil, nil, AlertInternalError
@@ -152,7 +154,7 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 	var earlySecret []byte
 	var clientEarlyTrafficKeys keySet
 	var clientHello *HandshakeMessage
-	if key, ok := state.Caps.PSKs.Get(state.Opts.ServerName); ok {
+	if key, ok := state.Config.PSKs.Get(state.Opts.ServerName); ok {
 		offeredPSK = key
 
 		// Narrow ciphersuites to ones that match PSK hash
@@ -182,11 +184,11 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 		}
 
 		// Signal supported PSK key exchange modes
-		if len(state.Caps.PSKModes) == 0 {
+		if len(state.Config.PSKModes) == 0 {
 			logf(logTypeHandshake, "PSK selected, but no PSKModes")
 			return nil, nil, AlertInternalError
 		}
-		kem := &PSKKeyExchangeModesExtension{KEModes: state.Caps.PSKModes}
+		kem := &PSKKeyExchangeModesExtension{KEModes: state.Config.PSKModes}
 		err = ch.Extensions.Add(kem)
 		if err != nil {
 			logf(logTypeHandshake, "Error adding PSKKeyExchangeModes extension: %v", err)
@@ -267,7 +269,7 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 	logf(logTypeHandshake, "[ClientStateStart] -> [ClientStateWaitSH]")
 	state.hsCtx.SetVersion(tls12Version) // Everything after this should be 1.2.
 	nextState := ClientStateWaitSH{
-		Caps:       state.Caps,
+		Config:     state.Config,
 		Opts:       state.Opts,
 		Params:     state.Params,
 		hsCtx:      state.hsCtx,
@@ -297,7 +299,7 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 }
 
 type ClientStateWaitSH struct {
-	Caps       Capabilities
+	Config     *Config
 	Opts       ConnectionOptions
 	Params     ConnectionParameters
 	hsCtx      HandshakeContext
@@ -360,7 +362,7 @@ func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 	}
 	// 3. Check that the server provided a supported ciphersuite
 	supportedCipherSuite := false
-	for _, suite := range state.Caps.CipherSuites {
+	for _, suite := range state.Config.CipherSuites {
 		supportedCipherSuite = supportedCipherSuite || (suite == sh.CipherSuite)
 	}
 	if !supportedCipherSuite {
@@ -375,11 +377,11 @@ func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 		hrr := sh
 
 		// Narrow the supported ciphersuites to the server-provided one
-		state.Caps.CipherSuites = []CipherSuite{hrr.CipherSuite}
+		state.Config.CipherSuites = []CipherSuite{hrr.CipherSuite}
 
 		// Handle external extensions.
-		if state.Caps.ExtensionHandler != nil {
-			err := state.Caps.ExtensionHandler.Receive(HandshakeTypeHelloRetryRequest, &hrr.Extensions)
+		if state.Config.ExtensionHandler != nil {
+			err := state.Config.ExtensionHandler.Receive(HandshakeTypeHelloRetryRequest, &hrr.Extensions)
 			if err != nil {
 				logf(logTypeHandshake, "[ClientWaitSH] Error running external extension handler [%v]", err)
 				return nil, nil, AlertInternalError
@@ -412,7 +414,7 @@ func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 
 		logf(logTypeHandshake, "[ClientStateWaitSH] -> [ClientStateStart]")
 		return ClientStateStart{
-			Caps:              state.Caps,
+			Config:            state.Config,
 			Opts:              state.Opts,
 			hsCtx:             state.hsCtx,
 			cookie:            serverCookie.Cookie,
@@ -423,8 +425,8 @@ func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 
 	// This is SH.
 	// Handle external extensions.
-	if state.Caps.ExtensionHandler != nil {
-		err := state.Caps.ExtensionHandler.Receive(HandshakeTypeServerHello, &sh.Extensions)
+	if state.Config.ExtensionHandler != nil {
+		err := state.Config.ExtensionHandler.Receive(HandshakeTypeServerHello, &sh.Extensions)
 		if err != nil {
 			logf(logTypeHandshake, "[ClientWaitSH] Error running external extension handler [%v]", err)
 			return nil, nil, AlertInternalError
@@ -516,12 +518,11 @@ func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 
 	logf(logTypeHandshake, "[ClientStateWaitSH] -> [ClientStateWaitEE]")
 	nextState := ClientStateWaitEE{
-		Caps:                         state.Caps,
+		Config:                       state.Config,
 		Params:                       state.Params,
 		hsCtx:                        state.hsCtx,
 		cryptoParams:                 params,
 		handshakeHash:                handshakeHash,
-		certificates:                 state.Caps.Certificates,
 		masterSecret:                 masterSecret,
 		clientHandshakeTrafficSecret: clientHandshakeTrafficSecret,
 		serverHandshakeTrafficSecret: serverHandshakeTrafficSecret,
@@ -533,13 +534,11 @@ func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 }
 
 type ClientStateWaitEE struct {
-	Caps                         Capabilities
-	AuthCertificate              func(chain []CertificateEntry) error
+	Config                       *Config
 	Params                       ConnectionParameters
 	hsCtx                        HandshakeContext
 	cryptoParams                 CipherSuiteParams
 	handshakeHash                hash.Hash
-	certificates                 []*Certificate
 	masterSecret                 []byte
 	clientHandshakeTrafficSecret []byte
 	serverHandshakeTrafficSecret []byte
@@ -568,8 +567,8 @@ func (state ClientStateWaitEE) Next(hr handshakeMessageReader) (HandshakeState, 
 	}
 
 	// Handle external extensions.
-	if state.Caps.ExtensionHandler != nil {
-		err := state.Caps.ExtensionHandler.Receive(HandshakeTypeEncryptedExtensions, &ee.Extensions)
+	if state.Config.ExtensionHandler != nil {
+		err := state.Config.ExtensionHandler.Receive(HandshakeTypeEncryptedExtensions, &ee.Extensions)
 		if err != nil {
 			logf(logTypeHandshake, "[ClientWaitStateEE] Error running external extension handler [%v]", err)
 			return nil, nil, AlertInternalError
@@ -604,7 +603,7 @@ func (state ClientStateWaitEE) Next(hr handshakeMessageReader) (HandshakeState, 
 			hsCtx:                        state.hsCtx,
 			cryptoParams:                 state.cryptoParams,
 			handshakeHash:                state.handshakeHash,
-			certificates:                 state.certificates,
+			certificates:                 state.Config.Certificates,
 			masterSecret:                 state.masterSecret,
 			clientHandshakeTrafficSecret: state.clientHandshakeTrafficSecret,
 			serverHandshakeTrafficSecret: state.serverHandshakeTrafficSecret,
@@ -614,12 +613,11 @@ func (state ClientStateWaitEE) Next(hr handshakeMessageReader) (HandshakeState, 
 
 	logf(logTypeHandshake, "[ClientStateWaitEE] -> [ClientStateWaitCertCR]")
 	nextState := ClientStateWaitCertCR{
-		AuthCertificate:              state.AuthCertificate,
+		Config:                       state.Config,
 		Params:                       state.Params,
 		hsCtx:                        state.hsCtx,
 		cryptoParams:                 state.cryptoParams,
 		handshakeHash:                state.handshakeHash,
-		certificates:                 state.certificates,
 		masterSecret:                 state.masterSecret,
 		clientHandshakeTrafficSecret: state.clientHandshakeTrafficSecret,
 		serverHandshakeTrafficSecret: state.serverHandshakeTrafficSecret,
@@ -628,12 +626,11 @@ func (state ClientStateWaitEE) Next(hr handshakeMessageReader) (HandshakeState, 
 }
 
 type ClientStateWaitCertCR struct {
-	AuthCertificate              func(chain []CertificateEntry) error
+	Config                       *Config
 	Params                       ConnectionParameters
 	hsCtx                        HandshakeContext
 	cryptoParams                 CipherSuiteParams
 	handshakeHash                hash.Hash
-	certificates                 []*Certificate
 	masterSecret                 []byte
 	clientHandshakeTrafficSecret []byte
 	serverHandshakeTrafficSecret []byte
@@ -667,12 +664,11 @@ func (state ClientStateWaitCertCR) Next(hr handshakeMessageReader) (HandshakeSta
 	case *CertificateBody:
 		logf(logTypeHandshake, "[ClientStateWaitCertCR] -> [ClientStateWaitCV]")
 		nextState := ClientStateWaitCV{
-			AuthCertificate:              state.AuthCertificate,
+			Config:                       state.Config,
 			Params:                       state.Params,
 			hsCtx:                        state.hsCtx,
 			cryptoParams:                 state.cryptoParams,
 			handshakeHash:                state.handshakeHash,
-			certificates:                 state.certificates,
 			serverCertificate:            body,
 			masterSecret:                 state.masterSecret,
 			clientHandshakeTrafficSecret: state.clientHandshakeTrafficSecret,
@@ -691,12 +687,11 @@ func (state ClientStateWaitCertCR) Next(hr handshakeMessageReader) (HandshakeSta
 
 		logf(logTypeHandshake, "[ClientStateWaitCertCR] -> [ClientStateWaitCert]")
 		nextState := ClientStateWaitCert{
-			AuthCertificate:              state.AuthCertificate,
+			Config:                       state.Config,
 			Params:                       state.Params,
 			hsCtx:                        state.hsCtx,
 			cryptoParams:                 state.cryptoParams,
 			handshakeHash:                state.handshakeHash,
-			certificates:                 state.certificates,
 			serverCertificateRequest:     body,
 			masterSecret:                 state.masterSecret,
 			clientHandshakeTrafficSecret: state.clientHandshakeTrafficSecret,
@@ -709,13 +704,12 @@ func (state ClientStateWaitCertCR) Next(hr handshakeMessageReader) (HandshakeSta
 }
 
 type ClientStateWaitCert struct {
-	AuthCertificate func(chain []CertificateEntry) error
-	Params          ConnectionParameters
-	hsCtx           HandshakeContext
-	cryptoParams    CipherSuiteParams
-	handshakeHash   hash.Hash
+	Config        *Config
+	Params        ConnectionParameters
+	hsCtx         HandshakeContext
+	cryptoParams  CipherSuiteParams
+	handshakeHash hash.Hash
 
-	certificates             []*Certificate
 	serverCertificateRequest *CertificateRequestBody
 
 	masterSecret                 []byte
@@ -749,12 +743,11 @@ func (state ClientStateWaitCert) Next(hr handshakeMessageReader) (HandshakeState
 
 	logf(logTypeHandshake, "[ClientStateWaitCert] -> [ClientStateWaitCV]")
 	nextState := ClientStateWaitCV{
-		AuthCertificate:              state.AuthCertificate,
+		Config:                       state.Config,
 		Params:                       state.Params,
 		hsCtx:                        state.hsCtx,
 		cryptoParams:                 state.cryptoParams,
 		handshakeHash:                state.handshakeHash,
-		certificates:                 state.certificates,
 		serverCertificate:            cert,
 		serverCertificateRequest:     state.serverCertificateRequest,
 		masterSecret:                 state.masterSecret,
@@ -765,13 +758,12 @@ func (state ClientStateWaitCert) Next(hr handshakeMessageReader) (HandshakeState
 }
 
 type ClientStateWaitCV struct {
-	AuthCertificate func(chain []CertificateEntry) error
-	Params          ConnectionParameters
-	hsCtx           HandshakeContext
-	cryptoParams    CipherSuiteParams
-	handshakeHash   hash.Hash
+	Config        *Config
+	Params        ConnectionParameters
+	hsCtx         HandshakeContext
+	cryptoParams  CipherSuiteParams
+	handshakeHash hash.Hash
 
-	certificates             []*Certificate
 	serverCertificate        *CertificateBody
 	serverCertificateRequest *CertificateRequestBody
 
@@ -811,14 +803,41 @@ func (state ClientStateWaitCV) Next(hr handshakeMessageReader) (HandshakeState, 
 		return nil, nil, AlertHandshakeFailure
 	}
 
-	if state.AuthCertificate != nil {
-		err := state.AuthCertificate(state.serverCertificate.CertificateList)
+	certs := make([]*x509.Certificate, len(state.serverCertificate.CertificateList))
+	rawCerts := make([][]byte, len(state.serverCertificate.CertificateList))
+	for i, certEntry := range state.serverCertificate.CertificateList {
+		certs[i] = certEntry.CertData
+		rawCerts[i] = certEntry.CertData.Raw
+	}
+
+	var verifiedChains [][]*x509.Certificate
+	if !state.Config.InsecureSkipVerify {
+		opts := x509.VerifyOptions{
+			Roots:         state.Config.RootCAs,
+			CurrentTime:   state.Config.time(),
+			DNSName:       state.Config.ServerName,
+			Intermediates: x509.NewCertPool(),
+		}
+
+		for i, cert := range certs {
+			if i == 0 {
+				continue
+			}
+			opts.Intermediates.AddCert(cert)
+		}
+		var err error
+		verifiedChains, err = certs[0].Verify(opts)
 		if err != nil {
-			logf(logTypeHandshake, "[ClientStateWaitCV] Application rejected server certificate")
+			logf(logTypeHandshake, "[ClientStateWaitCV] Certificate verification failed: %s", err)
 			return nil, nil, AlertBadCertificate
 		}
-	} else {
-		logf(logTypeHandshake, "[ClientStateWaitCV] WARNING: No verification of server certificate")
+	}
+
+	if state.Config.VerifyPeerCertificate != nil {
+		if err := state.Config.VerifyPeerCertificate(rawCerts, verifiedChains); err != nil {
+			logf(logTypeHandshake, "[ClientStateWaitCV] Application rejected server certificate: %s", err)
+			return nil, nil, AlertBadCertificate
+		}
 	}
 
 	state.handshakeHash.Write(hm.Marshal())
@@ -829,11 +848,13 @@ func (state ClientStateWaitCV) Next(hr handshakeMessageReader) (HandshakeState, 
 		hsCtx:                        state.hsCtx,
 		cryptoParams:                 state.cryptoParams,
 		handshakeHash:                state.handshakeHash,
-		certificates:                 state.certificates,
+		certificates:                 state.Config.Certificates,
 		serverCertificateRequest:     state.serverCertificateRequest,
 		masterSecret:                 state.masterSecret,
 		clientHandshakeTrafficSecret: state.clientHandshakeTrafficSecret,
 		serverHandshakeTrafficSecret: state.serverHandshakeTrafficSecret,
+		peerCertificates:             certs,
+		verifiedChains:               verifiedChains,
 	}
 	return nextState, nil, AlertNoAlert
 }
@@ -846,6 +867,8 @@ type ClientStateWaitFinished struct {
 
 	certificates             []*Certificate
 	serverCertificateRequest *CertificateRequestBody
+	peerCertificates         []*x509.Certificate
+	verifiedChains           [][]*x509.Certificate
 
 	masterSecret                 []byte
 	clientHandshakeTrafficSecret []byte
@@ -1032,6 +1055,8 @@ func (state ClientStateWaitFinished) Next(hr handshakeMessageReader) (HandshakeS
 		clientTrafficSecret: clientTrafficSecret,
 		serverTrafficSecret: serverTrafficSecret,
 		exporterSecret:      exporterSecret,
+		peerCertificates:    state.peerCertificates,
+		verifiedChains:      state.verifiedChains,
 	}
 	return nextState, toSend, AlertNoAlert
 }

--- a/vendor/github.com/bifurcation/mint/common.go
+++ b/vendor/github.com/bifurcation/mint/common.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	supportedVersion uint16 = 0x7f16 // draft-22
-	tls12Version     uint16 = 0x0303
-	tls10Version     uint16 = 0x0301
+	supportedVersion  uint16 = 0x7f16 // draft-22
+	tls12Version      uint16 = 0x0303
+	tls10Version      uint16 = 0x0301
+	dtls12WireVersion uint16 = 0xfefd
 )
 
 var (

--- a/vendor/github.com/bifurcation/mint/crypto.go
+++ b/vendor/github.com/bifurcation/mint/crypto.go
@@ -11,11 +11,9 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
 	"math/big"
-	"time"
 
 	"golang.org/x/crypto/curve25519"
 
@@ -329,40 +327,6 @@ func newSigningKey(sig SignatureScheme) (crypto.Signer, error) {
 	default:
 		return nil, fmt.Errorf("tls.newsigningkey: Unsupported signature algorithm [%04x]", sig)
 	}
-}
-
-func newSelfSigned(name string, alg SignatureScheme, priv crypto.Signer) (*x509.Certificate, error) {
-	sigAlg, ok := x509AlgMap[alg]
-	if !ok {
-		return nil, fmt.Errorf("tls.selfsigned: Unknown signature algorithm [%04x]", alg)
-	}
-	if len(name) == 0 {
-		return nil, fmt.Errorf("tls.selfsigned: No name provided")
-	}
-
-	serial, err := rand.Int(rand.Reader, big.NewInt(0xA0A0A0A0))
-	if err != nil {
-		return nil, err
-	}
-
-	template := &x509.Certificate{
-		SerialNumber:       serial,
-		NotBefore:          time.Now(),
-		NotAfter:           time.Now().AddDate(0, 0, 1),
-		SignatureAlgorithm: sigAlg,
-		Subject:            pkix.Name{CommonName: name},
-		DNSNames:           []string{name},
-		KeyUsage:           x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	}
-	der, err := x509.CreateCertificate(prng, template, template, priv.Public(), priv)
-	if err != nil {
-		return nil, err
-	}
-
-	// It is safe to ignore the error here because we're parsing known-good data
-	cert, _ := x509.ParseCertificate(der)
-	return cert, nil
 }
 
 // XXX(rlb): Copied from crypto/x509

--- a/vendor/github.com/bifurcation/mint/dtls.go
+++ b/vendor/github.com/bifurcation/mint/dtls.go
@@ -1,7 +1,28 @@
 package mint
 
+import (
+	"fmt"
+)
+
 // This file is a placeholder. DTLS-specific stuff (timer management,
 // ACKs, retransmits, etc. will eventually go here.
 const (
 	initialMtu = 1200
 )
+
+func wireVersion(h *HandshakeLayer) uint16 {
+	if h.datagram {
+		return dtls12WireVersion
+	}
+	return tls12Version
+}
+
+func dtlsConvertVersion(version uint16) uint16 {
+	if version == tls12Version {
+		return dtls12WireVersion
+	}
+	if version == tls10Version {
+		return 0xfeff
+	}
+	panic(fmt.Sprintf("Internal error, unexpected version=%d", version))
+}

--- a/vendor/github.com/bifurcation/mint/handshake-layer.go
+++ b/vendor/github.com/bifurcation/mint/handshake-layer.go
@@ -77,8 +77,6 @@ func (hm HandshakeMessage) ToBody() (HandshakeMessageBody, error) {
 		body = new(ClientHelloBody)
 	case HandshakeTypeServerHello:
 		body = new(ServerHelloBody)
-	case HandshakeTypeHelloRetryRequest:
-		body = new(HelloRetryRequestBody)
 	case HandshakeTypeEncryptedExtensions:
 		body = new(EncryptedExtensionsBody)
 	case HandshakeTypeCertificate:

--- a/vendor/github.com/bifurcation/mint/record-layer.go
+++ b/vendor/github.com/bifurcation/mint/record-layer.go
@@ -119,6 +119,15 @@ func (r *RecordLayer) Rekey(epoch Epoch, factory aeadFactory, key []byte, iv []b
 	return nil
 }
 
+func (c *cipherState) formatSeq(datagram bool) []byte {
+	seq := append([]byte{}, c.seq...)
+	if datagram {
+		seq[0] = byte(c.epoch >> 8)
+		seq[1] = byte(c.epoch & 0xff)
+	}
+	return seq
+}
+
 func (c *cipherState) computeNonce(seq []byte) []byte {
 	nonce := make([]byte, len(c.iv))
 	copy(nonce, c.iv)
@@ -143,9 +152,9 @@ func (c *cipherState) incrementSequenceNumber() {
 	if i < 0 {
 		// Not allowed to let sequence number wrap.
 		// Instead, must renegotiate before it does.
-		// Not likely enough to bothec.
+		// Not likely enough to bother.
 		// TODO(ekr@rtfm.com): Check for DTLS here
-		// because the limit is soonec.
+		// because the limit is sooner.
 		panic("TLS: sequence number wraparound")
 	}
 }
@@ -157,7 +166,8 @@ func (c *cipherState) overhead() int {
 	return c.cipher.Overhead()
 }
 
-func (r *RecordLayer) encrypt(cipher *cipherState, pt *TLSPlaintext, padLen int) *TLSPlaintext {
+func (r *RecordLayer) encrypt(cipher *cipherState, seq []byte, pt *TLSPlaintext, padLen int) *TLSPlaintext {
+	logf(logTypeIO, "Encrypt seq=[%x]", seq)
 	// Expand the fragment to hold contentType, padding, and overhead
 	originalLen := len(pt.fragment)
 	plaintextLen := originalLen + 1 + padLen
@@ -165,6 +175,7 @@ func (r *RecordLayer) encrypt(cipher *cipherState, pt *TLSPlaintext, padLen int)
 
 	// Assemble the revised plaintext
 	out := &TLSPlaintext{
+
 		contentType: RecordTypeApplicationData,
 		fragment:    make([]byte, ciphertextLen),
 	}
@@ -176,11 +187,12 @@ func (r *RecordLayer) encrypt(cipher *cipherState, pt *TLSPlaintext, padLen int)
 
 	// Encrypt the fragment
 	payload := out.fragment[:plaintextLen]
-	cipher.cipher.Seal(payload[:0], cipher.computeNonce(cipher.seq), payload, nil)
+	cipher.cipher.Seal(payload[:0], cipher.computeNonce(seq), payload, nil)
 	return out
 }
 
 func (r *RecordLayer) decrypt(pt *TLSPlaintext, seq []byte) (*TLSPlaintext, int, error) {
+	logf(logTypeIO, "Decrypt seq=[%x]", seq)
 	if len(pt.fragment) < r.cipher.overhead() {
 		msg := fmt.Sprintf("tls.record.decrypt: Record too short [%d] < [%d]", len(pt.fragment), r.cipher.overhead())
 		return nil, 0, DecryptError(msg)
@@ -312,6 +324,8 @@ func (r *RecordLayer) nextRecord() (*TLSPlaintext, error) {
 		if r.datagram {
 			seq = header[3:11]
 		}
+		// TODO(ekr@rtfm.com): Handle the wrong epoch.
+		// TODO(ekr@rtfm.com): Handle duplicates.
 		logf(logTypeIO, "RecordLayer.ReadRecord epoch=[%s] seq=[%x] [%d] ciphertext=[%x]", cipher.epoch.label(), seq, pt.contentType, pt.fragment)
 		pt, _, err = r.decrypt(pt, seq)
 		if err != nil {
@@ -341,9 +355,11 @@ func (r *RecordLayer) WriteRecordWithPadding(pt *TLSPlaintext, padLen int) error
 }
 
 func (r *RecordLayer) writeRecordWithPadding(pt *TLSPlaintext, cipher *cipherState, padLen int) error {
+	seq := cipher.formatSeq(r.datagram)
+
 	if cipher.cipher != nil {
 		logf(logTypeIO, "RecordLayer.WriteRecord epoch=[%s] seq=[%x] [%d] plaintext=[%x]", cipher.epoch.label(), cipher.seq, pt.contentType, pt.fragment)
-		pt = r.encrypt(cipher, pt, padLen)
+		pt = r.encrypt(cipher, seq, pt, padLen)
 	} else if padLen > 0 {
 		return fmt.Errorf("tls.record: Padding can only be done on encrypted records")
 	}
@@ -354,16 +370,17 @@ func (r *RecordLayer) writeRecordWithPadding(pt *TLSPlaintext, cipher *cipherSta
 
 	length := len(pt.fragment)
 	var header []byte
+
 	if !r.datagram {
 		header = []byte{byte(pt.contentType),
 			byte(r.version >> 8), byte(r.version & 0xff),
 			byte(length >> 8), byte(length)}
 	} else {
-		// TODO(ekr@rtfm.com): Double check version
-		seq := cipher.seq
-		header = []byte{byte(pt.contentType), 0xfe, 0xff,
-			0x00, 0x00, // TODO(ekr@rtfm.com): double-check epoch
-			seq[2], seq[3], seq[4], seq[5], seq[6], seq[7],
+		version := dtlsConvertVersion(r.version)
+		header = []byte{byte(pt.contentType),
+			byte(version >> 8), byte(version & 0xff),
+			seq[0], seq[1], seq[2], seq[3],
+			seq[4], seq[5], seq[6], seq[7],
 			byte(length >> 8), byte(length)}
 	}
 	record := append(header, pt.fragment...)

--- a/vendor/github.com/bifurcation/mint/state-machine.go
+++ b/vendor/github.com/bifurcation/mint/state-machine.go
@@ -1,6 +1,7 @@
 package mint
 
 import (
+	"crypto/x509"
 	"time"
 )
 
@@ -42,30 +43,6 @@ type HandshakeState interface {
 type AppExtensionHandler interface {
 	Send(hs HandshakeType, el *ExtensionList) error
 	Receive(hs HandshakeType, el *ExtensionList) error
-}
-
-// Capabilities objects represent the capabilities of a TLS client or server,
-// as an input to TLS negotiation
-type Capabilities struct {
-	// For both client and server
-	CipherSuites     []CipherSuite
-	Groups           []NamedGroup
-	SignatureSchemes []SignatureScheme
-	PSKs             PreSharedKeyCache
-	Certificates     []*Certificate
-	AuthCertificate  func(chain []CertificateEntry) error
-	ExtensionHandler AppExtensionHandler
-	UseDTLS          bool
-	// For client
-	PSKModes []PSKKeyExchangeMode
-
-	// For server
-	NextProtos        []string
-	AllowEarlyData    bool
-	RequireCookie     bool
-	CookieProtector   CookieProtector
-	CookieHandler     CookieHandler
-	RequireClientAuth bool
 }
 
 // ConnectionOptions objects represent per-connection settings for a client
@@ -114,6 +91,8 @@ type StateConnected struct {
 	clientTrafficSecret []byte
 	serverTrafficSecret []byte
 	exporterSecret      []byte
+	peerCertificates    []*x509.Certificate
+	verifiedChains      [][]*x509.Certificate
 }
 
 var _ HandshakeState = &StateConnected{}

--- a/vendor/github.com/bifurcation/mint/tls.go
+++ b/vendor/github.com/bifurcation/mint/tls.go
@@ -93,6 +93,7 @@ func DialWithDialer(dialer *net.Dialer, network, addr string, config *Config) (*
 	if config != nil && config.NonBlocking {
 		return nil, errors.New("dialing not possible in non-blocking mode")
 	}
+
 	// We want the Timeout and Deadline values from dialer to cover the
 	// whole process: TCP connection and TLS handshake. This means that we
 	// also need to start our own timers now.
@@ -127,15 +128,19 @@ func DialWithDialer(dialer *net.Dialer, network, addr string, config *Config) (*
 
 	if config == nil {
 		config = &Config{}
+	} else {
+		config = config.Clone()
 	}
+
 	// If no ServerName is set, infer the ServerName
 	// from the hostname we're connecting to.
 	if config.ServerName == "" {
-		// Make a copy to avoid polluting argument or default.
-		c := config.Clone()
-		c.ServerName = hostname
-		config = c
+		config.ServerName = hostname
+
 	}
+
+	// Set up DTLS as needed.
+	config.UseDTLS = (network == "udp")
 
 	conn := Client(rawConn, config)
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "nxj6lkDUEZ81SO0lP8YUhm+4BAM=",
+			"checksumSHA1": "8nsuzBKJY9oVNM/NPU0kbY/YpDw=",
 			"path": "github.com/bifurcation/mint",
-			"revision": "f699e8d03646cb8e6e15410ced7bff37fcf8dddd",
-			"revisionTime": "2017-12-21T19:05:27Z"
+			"revision": "a00905133cda39e4ac20677ae9332dce13e785eb",
+			"revisionTime": "2018-02-01T00:42:34Z"
 		},
 		{
 			"checksumSHA1": "PZNcjO1c9gV/LZzppwpVRl6+QAY=",


### PR DESCRIPTION
mint now supports certificate verification, so we don't need to force clients to set `InsecureSkipVerify`.