### PR TITLE
optimize deleting packets from the packet history

### DIFF
--- a/ackhandler/received_packet_history.go
+++ b/ackhandler/received_packet_history.go
@@ -76,7 +76,10 @@ func (h *receivedPacketHistory) ReceivedPacket(p protocol.PacketNumber) error {
 
 // DeleteBelow deletes all entries below (but not including) p
 func (h *receivedPacketHistory) DeleteBelow(p protocol.PacketNumber) {
-	h.lowestInReceivedPacketNumbers = utils.MaxPacketNumber(h.lowestInReceivedPacketNumbers, p)
+	if p <= h.lowestInReceivedPacketNumbers {
+		return
+	}
+	h.lowestInReceivedPacketNumbers = p
 
 	nextEl := h.ranges.Front()
 	for el := h.ranges.Front(); nextEl != nil; el = nextEl {


### PR DESCRIPTION
`DeleteBelow` is often called with the same value, so we can improve the performance by introducing a short path for this case.