### PR TITLE
implement stream ID limits for IETF QUIC

### DIFF
--- a/client.go
+++ b/client.go
@@ -169,9 +169,11 @@ func (c *client) dialTLS() error {
 	params := &handshake.TransportParameters{
 		StreamFlowControlWindow:     protocol.ReceiveStreamFlowControlWindow,
 		ConnectionFlowControlWindow: protocol.ReceiveConnectionFlowControlWindow,
-		MaxStreams:                  protocol.MaxIncomingStreams,
 		IdleTimeout:                 c.config.IdleTimeout,
 		OmitConnectionID:            c.config.RequestConnectionIDOmission,
+		// TODO(#1150): set reasonable limits
+		MaxBidiStreamID: 0xffffffff,
+		MaxUniStreamID:  0xffffffff,
 	}
 	csc := handshake.NewCryptoStreamConn(nil)
 	extHandler := handshake.NewExtensionHandlerClient(params, c.initialVersion, c.config.Versions, c.version)

--- a/client.go
+++ b/client.go
@@ -171,9 +171,9 @@ func (c *client) dialTLS() error {
 		ConnectionFlowControlWindow: protocol.ReceiveConnectionFlowControlWindow,
 		IdleTimeout:                 c.config.IdleTimeout,
 		OmitConnectionID:            c.config.RequestConnectionIDOmission,
-		// TODO(#1150): set reasonable limits
-		MaxBidiStreamID: 0xffffffff,
-		MaxUniStreamID:  0xffffffff,
+		// TODO(#523): make these values configurable
+		MaxBidiStreamID: protocol.MaxBidiStreamID(protocol.MaxIncomingStreams, protocol.PerspectiveClient),
+		MaxUniStreamID:  protocol.MaxUniStreamID(protocol.MaxIncomingStreams, protocol.PerspectiveClient),
 	}
 	csc := handshake.NewCryptoStreamConn(nil)
 	extHandler := handshake.NewExtensionHandlerClient(params, c.initialVersion, c.config.Versions, c.version)

--- a/internal/handshake/tls_extension_handler_server.go
+++ b/internal/handshake/tls_extension_handler_server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 
 	"github.com/lucas-clemente/quic-go/qerr"
 
@@ -105,8 +104,6 @@ func (h *extensionHandlerServer) Receive(hType mint.HandshakeType, el *mint.Exte
 	if err != nil {
 		return err
 	}
-	// TODO(#878): remove this when implementing the MAX_STREAM_ID frame
-	params.MaxStreams = math.MaxUint32
 	h.paramsChan <- *params
 	return nil
 }

--- a/internal/handshake/transport_parameter_test.go
+++ b/internal/handshake/transport_parameter_test.go
@@ -127,6 +127,8 @@ var _ = Describe("Transport Parameters", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(params.StreamFlowControlWindow).To(Equal(protocol.ByteCount(0x11223344)))
 				Expect(params.ConnectionFlowControlWindow).To(Equal(protocol.ByteCount(0x22334455)))
+				Expect(params.MaxBidiStreamID).To(Equal(protocol.StreamID(0x33445566)))
+				Expect(params.MaxUniStreamID).To(Equal(protocol.StreamID(0x44556677)))
 				Expect(params.IdleTimeout).To(Equal(0x1337 * time.Second))
 				Expect(params.OmitConnectionID).To(BeFalse())
 			})
@@ -224,18 +226,20 @@ var _ = Describe("Transport Parameters", func() {
 					StreamFlowControlWindow:     0xdeadbeef,
 					ConnectionFlowControlWindow: 0xdecafbad,
 					IdleTimeout:                 0xcafe * time.Second,
+					MaxBidiStreamID:             0xbadf000d,
+					MaxUniStreamID:              0xface,
 				}
 			})
 
 			It("creates the parameters list", func() {
 				values := paramsListToMap(params.getTransportParameters())
-				Expect(values).To(HaveLen(5))
+				Expect(values).To(HaveLen(6))
 				Expect(values).To(HaveKeyWithValue(initialMaxStreamDataParameterID, []byte{0xde, 0xad, 0xbe, 0xef}))
 				Expect(values).To(HaveKeyWithValue(initialMaxDataParameterID, []byte{0xde, 0xca, 0xfb, 0xad}))
-				Expect(values).To(HaveKeyWithValue(initialMaxStreamIDBiDiParameterID, []byte{0xff, 0xff, 0xff, 0xff}))
+				Expect(values).To(HaveKeyWithValue(initialMaxStreamIDBiDiParameterID, []byte{0xba, 0xdf, 0x00, 0x0d}))
+				Expect(values).To(HaveKeyWithValue(initialMaxStreamIDUniParameterID, []byte{0x0, 0x0, 0xfa, 0xce}))
 				Expect(values).To(HaveKeyWithValue(idleTimeoutParameterID, []byte{0xca, 0xfe}))
 				Expect(values).To(HaveKeyWithValue(maxPacketSizeParameterID, []byte{0x5, 0xac})) // 1452 = 0x5ac
-				Expect(values).ToNot(HaveKey(initialMaxStreamIDUniParameterID))
 			})
 
 			It("request ommision of the connection ID", func() {

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -55,9 +55,6 @@ func (t PacketType) String() string {
 // A ConnectionID in QUIC
 type ConnectionID uint64
 
-// A StreamID in QUIC
-type StreamID uint64
-
 // A ByteCount in QUIC
 type ByteCount uint64
 

--- a/internal/protocol/stream_id.go
+++ b/internal/protocol/stream_id.go
@@ -1,0 +1,36 @@
+package protocol
+
+// A StreamID in QUIC
+type StreamID uint64
+
+// MaxBidiStreamID is the highest stream ID that the peer is allowed to open,
+// when it is allowed to open numStreams bidirectional streams.
+// It is only valid for IETF QUIC.
+func MaxBidiStreamID(numStreams int, pers Perspective) StreamID {
+	if numStreams == 0 {
+		return 0
+	}
+	var first StreamID
+	if pers == PerspectiveClient {
+		first = 1
+	} else {
+		first = 4
+	}
+	return first + 4*StreamID(numStreams-1)
+}
+
+// MaxUniStreamID is the highest stream ID that the peer is allowed to open,
+// when it is allowed to open numStreams unidirectional streams.
+// It is only valid for IETF QUIC.
+func MaxUniStreamID(numStreams int, pers Perspective) StreamID {
+	if numStreams == 0 {
+		return 0
+	}
+	var first StreamID
+	if pers == PerspectiveClient {
+		first = 3
+	} else {
+		first = 2
+	}
+	return first + 4*StreamID(numStreams-1)
+}

--- a/internal/protocol/stream_id_test.go
+++ b/internal/protocol/stream_id_test.go
@@ -1,0 +1,42 @@
+package protocol
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Stream ID", func() {
+	Context("bidirectional streams", func() {
+		It("doesn't allow any", func() {
+			Expect(MaxBidiStreamID(0, PerspectiveClient)).To(Equal(StreamID(0)))
+			Expect(MaxBidiStreamID(0, PerspectiveServer)).To(Equal(StreamID(0)))
+		})
+
+		It("allows one", func() {
+			Expect(MaxBidiStreamID(1, PerspectiveClient)).To(Equal(StreamID(1)))
+			Expect(MaxBidiStreamID(1, PerspectiveServer)).To(Equal(StreamID(4)))
+		})
+
+		It("allows many", func() {
+			Expect(MaxBidiStreamID(100, PerspectiveClient)).To(Equal(StreamID(397)))
+			Expect(MaxBidiStreamID(100, PerspectiveServer)).To(Equal(StreamID(400)))
+		})
+	})
+
+	Context("unidirectional streams", func() {
+		It("doesn't allow any", func() {
+			Expect(MaxUniStreamID(0, PerspectiveClient)).To(Equal(StreamID(0)))
+			Expect(MaxUniStreamID(0, PerspectiveServer)).To(Equal(StreamID(0)))
+		})
+
+		It("allows one", func() {
+			Expect(MaxUniStreamID(1, PerspectiveClient)).To(Equal(StreamID(3)))
+			Expect(MaxUniStreamID(1, PerspectiveServer)).To(Equal(StreamID(2)))
+		})
+
+		It("allows many", func() {
+			Expect(MaxUniStreamID(100, PerspectiveClient)).To(Equal(StreamID(399)))
+			Expect(MaxUniStreamID(100, PerspectiveServer)).To(Equal(StreamID(398)))
+		})
+	})
+})

--- a/mock_stream_manager_test.go
+++ b/mock_stream_manager_test.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	handshake "github.com/lucas-clemente/quic-go/internal/handshake"
 	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
+	wire "github.com/lucas-clemente/quic-go/internal/wire"
 )
 
 // MockStreamManager is a mock of StreamManager interface
@@ -94,6 +95,18 @@ func (m *MockStreamManager) GetOrOpenSendStream(arg0 protocol.StreamID) (sendStr
 // GetOrOpenSendStream indicates an expected call of GetOrOpenSendStream
 func (mr *MockStreamManagerMockRecorder) GetOrOpenSendStream(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrOpenSendStream", reflect.TypeOf((*MockStreamManager)(nil).GetOrOpenSendStream), arg0)
+}
+
+// HandleMaxStreamIDFrame mocks base method
+func (m *MockStreamManager) HandleMaxStreamIDFrame(arg0 *wire.MaxStreamIDFrame) error {
+	ret := m.ctrl.Call(m, "HandleMaxStreamIDFrame", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleMaxStreamIDFrame indicates an expected call of HandleMaxStreamIDFrame
+func (mr *MockStreamManagerMockRecorder) HandleMaxStreamIDFrame(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleMaxStreamIDFrame", reflect.TypeOf((*MockStreamManager)(nil).HandleMaxStreamIDFrame), arg0)
 }
 
 // OpenStream mocks base method

--- a/server_tls.go
+++ b/server_tls.go
@@ -66,8 +66,10 @@ func newServerTLS(
 		params: &handshake.TransportParameters{
 			StreamFlowControlWindow:     protocol.ReceiveStreamFlowControlWindow,
 			ConnectionFlowControlWindow: protocol.ReceiveConnectionFlowControlWindow,
-			MaxStreams:                  protocol.MaxIncomingStreams,
 			IdleTimeout:                 config.IdleTimeout,
+			// TODO(#1150): set reasonable limits
+			MaxBidiStreamID: 0xffffffff,
+			MaxUniStreamID:  0xffffffff,
 		},
 	}
 	s.newMintConn = s.newMintConnImpl

--- a/server_tls.go
+++ b/server_tls.go
@@ -67,9 +67,9 @@ func newServerTLS(
 			StreamFlowControlWindow:     protocol.ReceiveStreamFlowControlWindow,
 			ConnectionFlowControlWindow: protocol.ReceiveConnectionFlowControlWindow,
 			IdleTimeout:                 config.IdleTimeout,
-			// TODO(#1150): set reasonable limits
-			MaxBidiStreamID: 0xffffffff,
-			MaxUniStreamID:  0xffffffff,
+			// TODO(#523): make these values configurable
+			MaxBidiStreamID: protocol.MaxBidiStreamID(protocol.MaxIncomingStreams, protocol.PerspectiveServer),
+			MaxUniStreamID:  protocol.MaxUniStreamID(protocol.MaxIncomingStreams, protocol.PerspectiveServer),
 		},
 	}
 	s.newMintConn = s.newMintConnImpl

--- a/session.go
+++ b/session.go
@@ -37,6 +37,7 @@ type streamManager interface {
 	AcceptStream() (Stream, error)
 	DeleteStream(protocol.StreamID) error
 	UpdateLimits(*handshake.TransportParameters)
+	HandleMaxStreamIDFrame(*wire.MaxStreamIDFrame) error
 	CloseWithError(error)
 }
 
@@ -563,6 +564,8 @@ func (s *session) handleFrames(fs []wire.Frame, encLevel protocol.EncryptionLeve
 			s.handleMaxDataFrame(frame)
 		case *wire.MaxStreamDataFrame:
 			err = s.handleMaxStreamDataFrame(frame)
+		case *wire.MaxStreamIDFrame:
+			err = s.handleMaxStreamIDFrame(frame)
 		case *wire.BlockedFrame:
 		case *wire.StreamBlockedFrame:
 		case *wire.StopSendingFrame:
@@ -632,6 +635,10 @@ func (s *session) handleMaxStreamDataFrame(frame *wire.MaxStreamDataFrame) error
 	}
 	str.handleMaxStreamDataFrame(frame)
 	return nil
+}
+
+func (s *session) handleMaxStreamIDFrame(frame *wire.MaxStreamIDFrame) error {
+	return s.streamsMap.HandleMaxStreamIDFrame(frame)
 }
 
 func (s *session) handleRstStreamFrame(frame *wire.RstStreamFrame) error {

--- a/session_test.go
+++ b/session_test.go
@@ -357,6 +357,23 @@ var _ = Describe("Session", func() {
 			})
 		})
 
+		Context("handling MAX_STREAM_ID frames", func() {
+			It("passes the frame to the streamsMap", func() {
+				f := &wire.MaxStreamIDFrame{StreamID: 10}
+				streamManager.EXPECT().HandleMaxStreamIDFrame(f)
+				err := sess.handleMaxStreamIDFrame(f)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns errors", func() {
+				f := &wire.MaxStreamIDFrame{StreamID: 10}
+				testErr := errors.New("test error")
+				streamManager.EXPECT().HandleMaxStreamIDFrame(f).Return(testErr)
+				err := sess.handleMaxStreamIDFrame(f)
+				Expect(err).To(MatchError(testErr))
+			})
+		})
+
 		Context("handling STOP_SENDING frames", func() {
 			It("passes the frame to the stream", func() {
 				f := &wire.StopSendingFrame{

--- a/streams_map.go
+++ b/streams_map.go
@@ -2,6 +2,7 @@ package quic
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
 	"github.com/lucas-clemente/quic-go/internal/handshake"
@@ -65,9 +66,11 @@ func newStreamsMap(
 		return newReceiveStream(id, m.sender, m.newFlowController(id), version)
 	}
 	m.outgoingBidiStreams = newOutgoingBidiStreamsMap(firstOutgoingBidiStream, newBidiStream)
-	m.incomingBidiStreams = newIncomingBidiStreamsMap(firstIncomingBidiStream, newBidiStream)
+	// TODO(#1150): use a reasonable stream limit
+	m.incomingBidiStreams = newIncomingBidiStreamsMap(firstIncomingBidiStream, protocol.StreamID(math.MaxUint32), newBidiStream)
 	m.outgoingUniStreams = newOutgoingUniStreamsMap(firstOutgoingUniStream, newUniSendStream)
-	m.incomingUniStreams = newIncomingUniStreamsMap(firstIncomingUniStream, newUniReceiveStream)
+	// TODO(#1150): use a reasonable stream limit
+	m.incomingUniStreams = newIncomingUniStreamsMap(firstIncomingUniStream, protocol.StreamID(math.MaxUint32), newUniReceiveStream)
 	return m
 }
 

--- a/streams_map.go
+++ b/streams_map.go
@@ -2,7 +2,6 @@ package quic
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
 	"github.com/lucas-clemente/quic-go/internal/handshake"
@@ -66,11 +65,23 @@ func newStreamsMap(
 		return newReceiveStream(id, m.sender, m.newFlowController(id), version)
 	}
 	m.outgoingBidiStreams = newOutgoingBidiStreamsMap(firstOutgoingBidiStream, newBidiStream)
-	// TODO(#1150): use a reasonable stream limit
-	m.incomingBidiStreams = newIncomingBidiStreamsMap(firstIncomingBidiStream, protocol.StreamID(math.MaxUint32), newBidiStream)
+	// TODO(#523): make these values configurable
+	m.incomingBidiStreams = newIncomingBidiStreamsMap(
+		firstIncomingBidiStream,
+		protocol.MaxBidiStreamID(protocol.MaxIncomingStreams, perspective),
+		protocol.MaxIncomingStreams,
+		sender.queueControlFrame,
+		newBidiStream,
+	)
 	m.outgoingUniStreams = newOutgoingUniStreamsMap(firstOutgoingUniStream, newUniSendStream)
-	// TODO(#1150): use a reasonable stream limit
-	m.incomingUniStreams = newIncomingUniStreamsMap(firstIncomingUniStream, protocol.StreamID(math.MaxUint32), newUniReceiveStream)
+	// TODO(#523): make these values configurable
+	m.incomingUniStreams = newIncomingUniStreamsMap(
+		firstIncomingUniStream,
+		protocol.MaxUniStreamID(protocol.MaxIncomingStreams, perspective),
+		protocol.MaxIncomingStreams,
+		sender.queueControlFrame,
+		newUniReceiveStream,
+	)
 	return m
 }
 

--- a/streams_map_incoming_bidi.go
+++ b/streams_map_incoming_bidi.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
 type incomingBidiStreamsMap struct {
@@ -20,21 +21,28 @@ type incomingBidiStreamsMap struct {
 	nextStream    protocol.StreamID // the next stream that will be returned by AcceptStream()
 	highestStream protocol.StreamID // the highest stream that the peer openend
 	maxStream     protocol.StreamID // the highest stream that the peer is allowed to open
-	newStream     func(protocol.StreamID) streamI
+	maxNumStreams int               // maximum number of streams
+
+	newStream        func(protocol.StreamID) streamI
+	queueMaxStreamID func(*wire.MaxStreamIDFrame)
 
 	closeErr error
 }
 
 func newIncomingBidiStreamsMap(
 	nextStream protocol.StreamID,
-	maxStream protocol.StreamID,
+	initialMaxStreamID protocol.StreamID,
+	maxNumStreams int,
+	queueControlFrame func(wire.Frame),
 	newStream func(protocol.StreamID) streamI,
 ) *incomingBidiStreamsMap {
 	m := &incomingBidiStreamsMap{
-		streams:    make(map[protocol.StreamID]streamI),
-		nextStream: nextStream,
-		maxStream:  maxStream,
-		newStream:  newStream,
+		streams:          make(map[protocol.StreamID]streamI),
+		nextStream:       nextStream,
+		maxStream:        initialMaxStreamID,
+		maxNumStreams:    maxNumStreams,
+		newStream:        newStream,
+		queueMaxStreamID: func(f *wire.MaxStreamIDFrame) { queueControlFrame(f) },
 	}
 	m.cond.L = &m.mutex
 	return m
@@ -99,6 +107,11 @@ func (m *incomingBidiStreamsMap) DeleteStream(id protocol.StreamID) error {
 		return fmt.Errorf("Tried to delete unknown stream %d", id)
 	}
 	delete(m.streams, id)
+	// queue a MAX_STREAM_ID frame, giving the peer the option to open a new stream
+	if numNewStreams := m.maxNumStreams - len(m.streams); numNewStreams > 0 {
+		m.maxStream = m.highestStream + protocol.StreamID(numNewStreams*4)
+		m.queueMaxStreamID(&wire.MaxStreamIDFrame{StreamID: m.maxStream})
+	}
 	return nil
 }
 

--- a/streams_map_incoming_generic.go
+++ b/streams_map_incoming_generic.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
 //go:generate genny -in $GOFILE -out streams_map_incoming_bidi.go gen "item=streamI Item=BidiStream"
@@ -18,21 +19,28 @@ type incomingItemsMap struct {
 	nextStream    protocol.StreamID // the next stream that will be returned by AcceptStream()
 	highestStream protocol.StreamID // the highest stream that the peer openend
 	maxStream     protocol.StreamID // the highest stream that the peer is allowed to open
-	newStream     func(protocol.StreamID) item
+	maxNumStreams int               // maximum number of streams
+
+	newStream        func(protocol.StreamID) item
+	queueMaxStreamID func(*wire.MaxStreamIDFrame)
 
 	closeErr error
 }
 
 func newIncomingItemsMap(
 	nextStream protocol.StreamID,
-	maxStream protocol.StreamID,
+	initialMaxStreamID protocol.StreamID,
+	maxNumStreams int,
+	queueControlFrame func(wire.Frame),
 	newStream func(protocol.StreamID) item,
 ) *incomingItemsMap {
 	m := &incomingItemsMap{
-		streams:    make(map[protocol.StreamID]item),
-		nextStream: nextStream,
-		maxStream:  maxStream,
-		newStream:  newStream,
+		streams:          make(map[protocol.StreamID]item),
+		nextStream:       nextStream,
+		maxStream:        initialMaxStreamID,
+		maxNumStreams:    maxNumStreams,
+		newStream:        newStream,
+		queueMaxStreamID: func(f *wire.MaxStreamIDFrame) { queueControlFrame(f) },
 	}
 	m.cond.L = &m.mutex
 	return m
@@ -97,6 +105,11 @@ func (m *incomingItemsMap) DeleteStream(id protocol.StreamID) error {
 		return fmt.Errorf("Tried to delete unknown stream %d", id)
 	}
 	delete(m.streams, id)
+	// queue a MAX_STREAM_ID frame, giving the peer the option to open a new stream
+	if numNewStreams := m.maxNumStreams - len(m.streams); numNewStreams > 0 {
+		m.maxStream = m.highestStream + protocol.StreamID(numNewStreams*4)
+		m.queueMaxStreamID(&wire.MaxStreamIDFrame{StreamID: m.maxStream})
+	}
 	return nil
 }
 

--- a/streams_map_legacy.go
+++ b/streams_map_legacy.go
@@ -256,3 +256,8 @@ func (m *streamsMapLegacy) UpdateLimits(params *handshake.TransportParameters) {
 	m.mutex.Unlock()
 	m.openStreamOrErrCond.Broadcast()
 }
+
+// should never be called, since MAX_STREAM_ID frames can only be unpacked for IETF QUIC
+func (m *streamsMapLegacy) HandleMaxStreamIDFrame(f *wire.MaxStreamIDFrame) error {
+	return errors.New("gQUIC doesn't have MAX_STREAM_ID frames")
+}

--- a/streams_map_legacy_test.go
+++ b/streams_map_legacy_test.go
@@ -546,4 +546,8 @@ var _ = Describe("Streams Map (for gQUIC)", func() {
 		})
 		m.UpdateLimits(&handshake.TransportParameters{StreamFlowControlWindow: 321})
 	})
+
+	It("doesn't accept MAX_STREAM_ID frames", func() {
+		Expect(m.HandleMaxStreamIDFrame(&wire.MaxStreamIDFrame{})).ToNot(Succeed())
+	})
 })

--- a/streams_map_outgoing_generic_test.go
+++ b/streams_map_outgoing_generic_test.go
@@ -23,56 +23,107 @@ var _ = Describe("Streams Map (outgoing)", func() {
 		m = newOutgoingItemsMap(firstNewStream, newItem)
 	})
 
-	It("opens streams", func() {
-		str, err := m.OpenStream()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(str).To(Equal(firstNewStream))
-		str, err = m.OpenStream()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(str).To(Equal(firstNewStream + 4))
+	Context("no stream ID limit", func() {
+		BeforeEach(func() {
+			m.SetMaxStream(0xffffffff)
+		})
+
+		It("opens streams", func() {
+			str, err := m.OpenStream()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(str).To(Equal(firstNewStream))
+			str, err = m.OpenStream()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(str).To(Equal(firstNewStream + 4))
+		})
+
+		It("doesn't open streams after it has been closed", func() {
+			testErr := errors.New("close")
+			m.CloseWithError(testErr)
+			_, err := m.OpenStream()
+			Expect(err).To(MatchError(testErr))
+		})
+
+		It("gets streams", func() {
+			_, err := m.OpenStream()
+			Expect(err).ToNot(HaveOccurred())
+			str, err := m.GetStream(firstNewStream)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(str).To(Equal(firstNewStream))
+		})
+
+		It("errors when trying to get a stream that has not yet been opened", func() {
+			_, err := m.GetStream(10)
+			Expect(err).To(MatchError(qerr.Error(qerr.InvalidStreamID, "peer attempted to open stream 10")))
+		})
+
+		It("deletes streams", func() {
+			_, err := m.OpenStream() // opens stream 10
+			Expect(err).ToNot(HaveOccurred())
+			err = m.DeleteStream(10)
+			Expect(err).ToNot(HaveOccurred())
+			str, err := m.GetStream(10)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(str).To(BeNil())
+		})
+
+		It("errors when deleting a non-existing stream", func() {
+			err := m.DeleteStream(1337)
+			Expect(err).To(MatchError("Tried to delete unknown stream 1337"))
+		})
+
+		It("errors when deleting a stream twice", func() {
+			_, err := m.OpenStream() // opens stream 10
+			Expect(err).ToNot(HaveOccurred())
+			err = m.DeleteStream(10)
+			Expect(err).ToNot(HaveOccurred())
+			err = m.DeleteStream(10)
+			Expect(err).To(MatchError("Tried to delete unknown stream 10"))
+		})
 	})
 
-	It("doesn't open streams after it has been closed", func() {
-		testErr := errors.New("close")
-		m.CloseWithError(testErr)
-		_, err := m.OpenStream()
-		Expect(err).To(MatchError(testErr))
-	})
+	Context("with stream ID limits", func() {
+		It("errors when no stream can be opened immediately", func() {
+			_, err := m.OpenStream()
+			Expect(err).To(MatchError(qerr.TooManyOpenStreams))
+		})
 
-	It("gets streams", func() {
-		_, err := m.OpenStream()
-		Expect(err).ToNot(HaveOccurred())
-		str, err := m.GetStream(firstNewStream)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(str).To(Equal(firstNewStream))
-	})
+		It("blocks until a stream can be opened synchronously", func() {
+			done := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				str, err := m.OpenStreamSync()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(str).To(Equal(firstNewStream))
+				close(done)
+			}()
 
-	It("errors when trying to get a stream that has not yet been opened", func() {
-		_, err := m.GetStream(10)
-		Expect(err).To(MatchError(qerr.Error(qerr.InvalidStreamID, "peer attempted to open stream 10")))
-	})
+			Consistently(done).ShouldNot(BeClosed())
+			m.SetMaxStream(firstNewStream)
+			Eventually(done).Should(BeClosed())
+		})
 
-	It("deletes streams", func() {
-		_, err := m.OpenStream() // opens stream 10
-		Expect(err).ToNot(HaveOccurred())
-		err = m.DeleteStream(10)
-		Expect(err).ToNot(HaveOccurred())
-		str, err := m.GetStream(10)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(str).To(BeNil())
-	})
+		It("stops opening synchronously when it is closed", func() {
+			testErr := errors.New("test error")
+			done := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				_, err := m.OpenStreamSync()
+				Expect(err).To(MatchError(testErr))
+				close(done)
+			}()
 
-	It("errors when deleting a non-existing stream", func() {
-		err := m.DeleteStream(1337)
-		Expect(err).To(MatchError("Tried to delete unknown stream 1337"))
-	})
+			Consistently(done).ShouldNot(BeClosed())
+			m.CloseWithError(testErr)
+			Eventually(done).Should(BeClosed())
+		})
 
-	It("errors when deleting a stream twice", func() {
-		_, err := m.OpenStream() // opens stream 10
-		Expect(err).ToNot(HaveOccurred())
-		err = m.DeleteStream(10)
-		Expect(err).ToNot(HaveOccurred())
-		err = m.DeleteStream(10)
-		Expect(err).To(MatchError("Tried to delete unknown stream 10"))
+		It("doesn't reduce the stream limit", func() {
+			m.SetMaxStream(firstNewStream)
+			m.SetMaxStream(firstNewStream - 4)
+			str, err := m.OpenStream()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(str).To(Equal(firstNewStream))
+		})
 	})
 })


### PR DESCRIPTION
Fixes #1150. Depends on #1151.

This includes:
- sending the stream limit in the transport parameters during the handshake
- sending MAX_STREAM_ID frames
- receiving MAX_STREAM_ID frames