### PR TITLE
remove handshake packets from the history when the handshake completes

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -102,6 +102,13 @@ func (h *sentPacketHandler) SetHandshakeComplete() {
 		}
 	}
 	h.retransmissionQueue = queue
+	for el := h.packetHistory.Front(); el != nil; {
+		next := el.Next()
+		if el.Value.EncryptionLevel != protocol.EncryptionForwardSecure {
+			h.packetHistory.Remove(el)
+		}
+		el = next
+	}
 	h.handshakeComplete = true
 }
 


### PR DESCRIPTION
We already remove handshake packets from the retransmission queue, but we should also remove them from the packet history.

This mitigates the bad effects of #1168, since we're removing the Initial packet now once the handshake completes (before it would be retransmitted indefinitely).