### PR TITLE
don't retransmit Initial packets after receiving a packet from the server

### DIFF
--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -13,6 +13,7 @@ type SentPacketHandler interface {
 	SentPacket(packet *Packet) error
 	ReceivedAck(ackFrame *wire.AckFrame, withPacketNumber protocol.PacketNumber, encLevel protocol.EncryptionLevel, recvTime time.Time) error
 	SetHandshakeComplete()
+	ReceivedFirstPacket()
 
 	// SendingAllowed says if a packet can be sent.
 	// Sending packets might not be possible because:

--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -11,6 +11,7 @@ import (
 // +gen linkedlist
 type Packet struct {
 	PacketNumber    protocol.PacketNumber
+	PacketType      protocol.PacketType
 	Frames          []wire.Frame
 	Length          protocol.ByteCount
 	EncryptionLevel protocol.EncryptionLevel

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -119,6 +119,16 @@ func (mr *MockSentPacketHandlerMockRecorder) ReceivedAck(arg0, arg1, arg2, arg3 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedAck", reflect.TypeOf((*MockSentPacketHandler)(nil).ReceivedAck), arg0, arg1, arg2, arg3)
 }
 
+// ReceivedFirstPacket mocks base method
+func (m *MockSentPacketHandler) ReceivedFirstPacket() {
+	m.ctrl.Call(m, "ReceivedFirstPacket")
+}
+
+// ReceivedFirstPacket indicates an expected call of ReceivedFirstPacket
+func (mr *MockSentPacketHandlerMockRecorder) ReceivedFirstPacket() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedFirstPacket", reflect.TypeOf((*MockSentPacketHandler)(nil).ReceivedFirstPacket))
+}
+
 // SendingAllowed mocks base method
 func (m *MockSentPacketHandler) SendingAllowed() bool {
 	ret := m.ctrl.Call(m, "SendingAllowed")

--- a/session_test.go
+++ b/session_test.go
@@ -551,6 +551,16 @@ var _ = Describe("Session", func() {
 			hdr = &wire.Header{PacketNumberLen: protocol.PacketNumberLen6}
 		})
 
+		It("informs the SentPacketHandler when receiving a Retry packet", func() {
+			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
+			sess.sentPacketHandler = sph
+			now := time.Now()
+			sph.EXPECT().ReceivedFirstPacket()
+			hdr.PacketNumber = 5
+			err := sess.handlePacketImpl(&receivedPacket{header: hdr, rcvTime: now})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("sets the {last,largest}RcvdPacketNumber", func() {
 			hdr.PacketNumber = 5
 			err := sess.handlePacketImpl(&receivedPacket{header: hdr})

--- a/streams_map_incoming_bidi.go
+++ b/streams_map_incoming_bidi.go
@@ -69,18 +69,20 @@ func (m *incomingBidiStreamsMap) AcceptStream() (streamI, error) {
 }
 
 func (m *incomingBidiStreamsMap) GetOrOpenStream(id protocol.StreamID) (streamI, error) {
+	m.mutex.RLock()
 	if id > m.maxStream {
+		m.mutex.RUnlock()
 		return nil, fmt.Errorf("peer tried to open stream %d (current limit: %d)", id, m.maxStream)
 	}
 	// if the id is smaller than the highest we accepted
 	// * this stream exists in the map, and we can return it, or
 	// * this stream was already closed, then we can return the nil
 	if id <= m.highestStream {
-		m.mutex.RLock()
 		s := m.streams[id]
 		m.mutex.RUnlock()
 		return s, nil
 	}
+	m.mutex.RUnlock()
 
 	m.mutex.Lock()
 	var start protocol.StreamID

--- a/streams_map_incoming_generic.go
+++ b/streams_map_incoming_generic.go
@@ -67,18 +67,20 @@ func (m *incomingItemsMap) AcceptStream() (item, error) {
 }
 
 func (m *incomingItemsMap) GetOrOpenStream(id protocol.StreamID) (item, error) {
+	m.mutex.RLock()
 	if id > m.maxStream {
+		m.mutex.RUnlock()
 		return nil, fmt.Errorf("peer tried to open stream %d (current limit: %d)", id, m.maxStream)
 	}
 	// if the id is smaller than the highest we accepted
 	// * this stream exists in the map, and we can return it, or
 	// * this stream was already closed, then we can return the nil
 	if id <= m.highestStream {
-		m.mutex.RLock()
 		s := m.streams[id]
 		m.mutex.RUnlock()
 		return s, nil
 	}
+	m.mutex.RUnlock()
 
 	m.mutex.Lock()
 	var start protocol.StreamID

--- a/streams_map_incoming_uni.go
+++ b/streams_map_incoming_uni.go
@@ -69,18 +69,20 @@ func (m *incomingUniStreamsMap) AcceptStream() (receiveStreamI, error) {
 }
 
 func (m *incomingUniStreamsMap) GetOrOpenStream(id protocol.StreamID) (receiveStreamI, error) {
+	m.mutex.RLock()
 	if id > m.maxStream {
+		m.mutex.RUnlock()
 		return nil, fmt.Errorf("peer tried to open stream %d (current limit: %d)", id, m.maxStream)
 	}
 	// if the id is smaller than the highest we accepted
 	// * this stream exists in the map, and we can return it, or
 	// * this stream was already closed, then we can return the nil
 	if id <= m.highestStream {
-		m.mutex.RLock()
 		s := m.streams[id]
 		m.mutex.RUnlock()
 		return s, nil
 	}
+	m.mutex.RUnlock()
 
 	m.mutex.Lock()
 	var start protocol.StreamID

--- a/streams_map_outgoing_bidi.go
+++ b/streams_map_outgoing_bidi.go
@@ -85,10 +85,11 @@ func (m *outgoingBidiStreamsMap) openStreamImpl() (streamI, error) {
 }
 
 func (m *outgoingBidiStreamsMap) GetStream(id protocol.StreamID) (streamI, error) {
+	m.mutex.RLock()
 	if id >= m.nextStream {
+		m.mutex.RUnlock()
 		return nil, qerr.Error(qerr.InvalidStreamID, fmt.Sprintf("peer attempted to open stream %d", id))
 	}
-	m.mutex.RLock()
 	s := m.streams[id]
 	m.mutex.RUnlock()
 	return s, nil

--- a/streams_map_outgoing_generic.go
+++ b/streams_map_outgoing_generic.go
@@ -86,10 +86,11 @@ func (m *outgoingItemsMap) openStreamImpl() (item, error) {
 }
 
 func (m *outgoingItemsMap) GetStream(id protocol.StreamID) (item, error) {
+	m.mutex.RLock()
 	if id >= m.nextStream {
+		m.mutex.RUnlock()
 		return nil, qerr.Error(qerr.InvalidStreamID, fmt.Sprintf("peer attempted to open stream %d", id))
 	}
-	m.mutex.RLock()
 	s := m.streams[id]
 	m.mutex.RUnlock()
 	return s, nil

--- a/streams_map_outgoing_uni.go
+++ b/streams_map_outgoing_uni.go
@@ -85,10 +85,11 @@ func (m *outgoingUniStreamsMap) openStreamImpl() (sendStreamI, error) {
 }
 
 func (m *outgoingUniStreamsMap) GetStream(id protocol.StreamID) (sendStreamI, error) {
+	m.mutex.RLock()
 	if id >= m.nextStream {
+		m.mutex.RUnlock()
 		return nil, qerr.Error(qerr.InvalidStreamID, fmt.Sprintf("peer attempted to open stream %d", id))
 	}
-	m.mutex.RLock()
 	s := m.streams[id]
 	m.mutex.RUnlock()
 	return s, nil


### PR DESCRIPTION
Fixes #1168.

This is not a trivial problem to solve. When we retransmit an Initial packet (and we do that quickly, to reduce handshake latency), multiple things can happen:

1.  the first one can actually turn out to be lost
2. the second one can get lost
3. both can arrive and get a reply:

     1. both replies are a Handshake
     2. one reply is a Retry, one is a Handshake

Note that the case where we receive one Retry packet is not a problem, since we're recreating the session (thereby canceling all retransmissions of the first Initial packet).

We need to handle all 3 cases correctly:

1. Is not a problem, normal retransmission logic takes of this.
2. Is more tricky. The server creates a new session when receiving the Initial packet. When the retransmission of second Initial packet arrives, it will just drop it, and we'll never get an ACK for that. That's why I had to introduce the `SentPacketHandler.ReceivedFirstPacket` that cancels *all* Initial retransmissions immediately.
3. i and ii are race conditions in the protocol, see https://github.com/quicwg/base-drafts/issues/1085.

Note that this problem also exists in gQUIC, but doesn't occur, since we're not doing stateless processing.