### PR TITLE
Make h2quic RoundTripper.RoundTrip(...) return if client timeout expires

### DIFF
--- a/h2quic/response_writer_test.go
+++ b/h2quic/response_writer_test.go
@@ -18,12 +18,13 @@ import (
 )
 
 type mockStream struct {
-	id           protocol.StreamID
-	dataToRead   bytes.Buffer
-	dataWritten  bytes.Buffer
-	reset        bool
-	closed       bool
-	remoteClosed bool
+	id            protocol.StreamID
+	dataToRead    bytes.Buffer
+	dataWritten   bytes.Buffer
+	reset         bool
+	canceledWrite bool
+	closed        bool
+	remoteClosed  bool
 
 	unblockRead chan struct{}
 	ctx         context.Context
@@ -43,7 +44,7 @@ func newMockStream(id protocol.StreamID) *mockStream {
 
 func (s *mockStream) Close() error                          { s.closed = true; s.ctxCancel(); return nil }
 func (s *mockStream) CancelRead(quic.ErrorCode) error       { s.reset = true; return nil }
-func (s *mockStream) CancelWrite(quic.ErrorCode) error      { panic("not implemented") }
+func (s *mockStream) CancelWrite(quic.ErrorCode) error      { s.canceledWrite = true; return nil }
 func (s *mockStream) CloseRemote(offset protocol.ByteCount) { s.remoteClosed = true; s.ctxCancel() }
 func (s mockStream) StreamID() protocol.StreamID            { return s.id }
 func (s *mockStream) Context() context.Context              { return s.ctx }


### PR DESCRIPTION
Currently, the implementation of `h2quic.RoundTripper.RoundTrip(req *http.Request)` ignores the context of `req`. As a result, if the `RoundTripper` is used as transport of an `http.Client` with a timeout value set, that is ignored.

For example, in the following snippet, client.Do(req) does not promptly return if the task takes more than client.Timeout to complete.

```
    client := http.Client{
        Timeout: 50 * time.Millisecond,
        Transport = &h2quic.RoundTripper{}
    }
    req, err := http.NewRequest("GET", "https://www.example.com", nil)
    response, err := client.Do(req)
```

This commit updates `h2quic.client.RoundTrip(req *http.Request)` to return an error if the request is cancelled.

This partially addresses #410 