### PR TITLE
don't accept transport parameters in the NewSessionTicket message

### DIFF
--- a/internal/handshake/tls_extension_handler_client.go
+++ b/internal/handshake/tls_extension_handler_client.go
@@ -63,15 +63,10 @@ func (h *extensionHandlerClient) Receive(hType mint.HandshakeType, el *mint.Exte
 		return err
 	}
 
-	if hType != mint.HandshakeTypeEncryptedExtensions && hType != mint.HandshakeTypeNewSessionTicket {
+	if hType != mint.HandshakeTypeEncryptedExtensions {
 		if found {
 			return fmt.Errorf("Unexpected QUIC extension in handshake message %d", hType)
 		}
-		return nil
-	}
-	if hType == mint.HandshakeTypeNewSessionTicket {
-		// the extension it's optional in the NewSessionTicket message
-		// TODO: handle this
 		return nil
 	}
 

--- a/internal/handshake/tls_extension_handler_client_test.go
+++ b/internal/handshake/tls_extension_handler_client_test.go
@@ -100,14 +100,6 @@ var _ = Describe("TLS Extension Handler, for the client", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		// TODO: fix this when implementing the NewSessionTicket
-		It("ignors the TransportParameters in the NewSessionTicket message", func() {
-			err := el.Add(fakeBody)
-			Expect(err).ToNot(HaveOccurred())
-			err = handler.Receive(mint.HandshakeTypeNewSessionTicket, &el)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
 		It("errors when it can't parse the TransportParameters", func() {
 			err := el.Add(fakeBody)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This was recently removed from the WG draft: https://github.com/quicwg/base-drafts/pull/1058.