### PR TITLE
update CIs to Go 1.10 and Go 1.9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ addons:
 language: go
 
 go:
-  - 1.9.3
-  - 1.10rc1
+  - "1.9.4"
+  - "1.10"
 
 # first part of the GOARCH workaround
 # setting the GOARCH directly doesn't work, since the value will be overwritten later

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ clone_folder: c:\gopath\src\github.com\lucas-clemente\quic-go
 
 install:
   - rmdir c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.9.3.windows-amd64.zip
-  - 7z x go1.9.3.windows-amd64.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.10.windows-amd64.zip
+  - 7z x go1.10.windows-amd64.zip -y -oC:\ > NUL
   - set PATH=%PATH%;%GOPATH%\bin\windows_%GOARCH%;%GOPATH%\bin
   - echo %PATH%
   - echo %GOPATH%


### PR DESCRIPTION
The version numbers in the travis config are strings, not numbers.
See https://github.com/travis-ci/gimme/issues/132.