### PR TITLE
make the version number a uint32

### DIFF
--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -4,10 +4,11 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"math"
 )
 
 // VersionNumber is a version number as int
-type VersionNumber int32
+type VersionNumber uint32
 
 // gQUIC version range as defined in the wiki: https://github.com/quicwg/base-drafts/wiki/QUIC-Versions
 const (
@@ -20,7 +21,7 @@ const (
 	Version39       VersionNumber = gquicVersion0 + 3*0x100 + 0x9 + iota
 	VersionTLS      VersionNumber = 101
 	VersionWhatever VersionNumber = 0 // for when the version doesn't matter
-	VersionUnknown  VersionNumber = -1
+	VersionUnknown  VersionNumber = math.MaxUint32
 )
 
 // SupportedVersions lists the versions that the server supports


### PR DESCRIPTION
This will allow us to set it to the IETF draft version numbers as listed in https://github.com/quicwg/base-drafts/wiki/QUIC-Versions. Those numbers would overflow a int32.