### PR TITLE
use pointer to byte slices in the buffer pool

### DIFF
--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -8,19 +8,20 @@ import (
 
 var bufferPool sync.Pool
 
-func getPacketBuffer() []byte {
-	return bufferPool.Get().([]byte)
+func getPacketBuffer() *[]byte {
+	return bufferPool.Get().(*[]byte)
 }
 
-func putPacketBuffer(buf []byte) {
-	if cap(buf) != int(protocol.MaxReceivePacketSize) {
+func putPacketBuffer(buf *[]byte) {
+	if cap(*buf) != int(protocol.MaxReceivePacketSize) {
 		panic("putPacketBuffer called with packet of wrong size!")
 	}
-	bufferPool.Put(buf[:0])
+	bufferPool.Put(buf)
 }
 
 func init() {
 	bufferPool.New = func() interface{} {
-		return make([]byte, 0, protocol.MaxReceivePacketSize)
+		b := make([]byte, 0, protocol.MaxReceivePacketSize)
+		return &b
 	}
 }

--- a/buffer_pool_test.go
+++ b/buffer_pool_test.go
@@ -8,25 +8,14 @@ import (
 )
 
 var _ = Describe("Buffer Pool", func() {
-	It("returns buffers of correct len and cap", func() {
-		buf := getPacketBuffer()
-		Expect(buf).To(HaveLen(0))
+	It("returns buffers of cap", func() {
+		buf := *getPacketBuffer()
 		Expect(buf).To(HaveCap(int(protocol.MaxReceivePacketSize)))
-	})
-
-	It("zeroes put buffers' length", func() {
-		for i := 0; i < 1000; i++ {
-			buf := getPacketBuffer()
-			putPacketBuffer(buf[0:10])
-			buf = getPacketBuffer()
-			Expect(buf).To(HaveLen(0))
-			Expect(buf).To(HaveCap(int(protocol.MaxReceivePacketSize)))
-		}
 	})
 
 	It("panics if wrong-sized buffers are passed", func() {
 		Expect(func() {
-			putPacketBuffer([]byte{0})
+			putPacketBuffer(&[]byte{0})
 		}).To(Panic())
 	})
 })

--- a/client.go
+++ b/client.go
@@ -245,7 +245,7 @@ func (c *client) listen() {
 	for {
 		var n int
 		var addr net.Addr
-		data := getPacketBuffer()
+		data := *getPacketBuffer()
 		data = data[:protocol.MaxReceivePacketSize]
 		// The packet size should not exceed protocol.MaxReceivePacketSize bytes
 		// If it does, we only read a truncated packet, which will then end up undecryptable

--- a/mint_utils.go
+++ b/mint_utils.go
@@ -139,8 +139,8 @@ func unpackInitialPacket(aead crypto.AEAD, hdr *wire.Header, data []byte, versio
 // packUnencryptedPacket provides a low-overhead way to pack a packet.
 // It is supposed to be used in the early stages of the handshake, before a session (which owns a packetPacker) is available.
 func packUnencryptedPacket(aead crypto.AEAD, hdr *wire.Header, f wire.Frame, pers protocol.Perspective) ([]byte, error) {
-	raw := getPacketBuffer()
-	buffer := bytes.NewBuffer(raw)
+	raw := *getPacketBuffer()
+	buffer := bytes.NewBuffer(raw[:0])
 	if err := hdr.Write(buffer, pers, hdr.Version); err != nil {
 		return nil, err
 	}

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -342,8 +342,8 @@ func (p *packetPacker) writeAndSealPacket(
 	payloadFrames []wire.Frame,
 	sealer handshake.Sealer,
 ) ([]byte, error) {
-	raw := getPacketBuffer()
-	buffer := bytes.NewBuffer(raw)
+	raw := *getPacketBuffer()
+	buffer := bytes.NewBuffer(raw[:0])
 
 	if err := header.Write(buffer, p.perspective, p.version); err != nil {
 		return nil, err

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -24,8 +24,9 @@ type packetUnpacker struct {
 }
 
 func (u *packetUnpacker) Unpack(headerBinary []byte, hdr *wire.Header, data []byte) (*unpackedPacket, error) {
-	buf := getPacketBuffer()
-	defer putPacketBuffer(buf)
+	buf := *getPacketBuffer()
+	buf = buf[:0]
+	defer putPacketBuffer(&buf)
 	decrypted, encryptionLevel, err := u.aead.Open(buf, data, hdr.PacketNumber, headerBinary)
 	if err != nil {
 		// Wrap err in quicError so that public reset is sent by session

--- a/server.go
+++ b/server.go
@@ -213,7 +213,7 @@ func populateServerConfig(config *Config) *Config {
 // serve listens on an existing PacketConn
 func (s *server) serve() {
 	for {
-		data := getPacketBuffer()
+		data := *getPacketBuffer()
 		data = data[:protocol.MaxReceivePacketSize]
 		// The packet size should not exceed protocol.MaxReceivePacketSize bytes
 		// If it does, we only read a truncated packet, which will then end up undecryptable

--- a/session.go
+++ b/session.go
@@ -393,7 +393,7 @@ runLoop:
 			}
 			// This is a bit unclean, but works properly, since the packet always
 			// begins with the public header and we never copy it.
-			putPacketBuffer(p.header.Raw)
+			putPacketBuffer(&p.header.Raw)
 		case p := <-s.paramsChan:
 			s.processTransportParameters(&p)
 		case _, ok := <-handshakeEvent:
@@ -867,7 +867,7 @@ func (s *session) sendPacket() (bool, error) {
 }
 
 func (s *session) sendPackedPacket(packet *packedPacket) error {
-	defer putPacketBuffer(packet.raw)
+	defer putPacketBuffer(&packet.raw)
 	err := s.sentPacketHandler.SentPacket(&ackhandler.Packet{
 		PacketNumber:    packet.header.PacketNumber,
 		Frames:          packet.frames,


### PR DESCRIPTION
https://staticcheck.io/docs/staticcheck#SA6002 suggests to use pointers to objects in the `sync.Pool`. It seems like we can avoid copying the two ints of the slice (for length and capacity) when using a pointer, at the cost of an additional pointer dereference.

I created a [benchmark](https://gist.github.com/marten-seemann/07dd737cd7ed3fb190c8e6833a184d22) for this, but the results are inconclusive. I'm not seeing any reduction in allocations, and the performance seems pretty much the same.