### PR TITLE
delete handshake packets from history when receiving a forward-secure packet

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -101,6 +101,13 @@ func (h *sentPacketHandler) SetHandshakeComplete() {
 			queue = append(queue, packet)
 		}
 	}
+	for el := h.packetHistory.Front(); el != nil; {
+		next := el.Next()
+		if el.Value.EncryptionLevel != protocol.EncryptionForwardSecure {
+			h.packetHistory.Remove(el)
+		}
+		el = next
+	}
 	h.retransmissionQueue = queue
 	h.handshakeComplete = true
 }


### PR DESCRIPTION
Fixes #1174. Depends on #1198.

In TLS 1.3, the client considers the handshake complete as soon as it received the server's Finished message and sent its Finished.

However, this is too early to clean up all handshake packets from the packet history: Packets sent after receiving the server's Finished message (these can be packets carrying the client certificate, the client's Finished message and packets just carrying ACK frames) can get lost and retransmitted.

We have to wait for the first forward-secure packet from the server before deleting all handshake packets from the history.