### PR TITLE
don't send greased version numbers for gQUIC

### DIFF
--- a/internal/handshake/crypto_setup_server.go
+++ b/internal/handshake/crypto_setup_server.go
@@ -429,7 +429,7 @@ func (h *cryptoSetupServer) handleCHLO(sni string, data []byte, cryptoData map[T
 	replyMap := h.params.getHelloMap()
 	// add crypto parameters
 	verTag := &bytes.Buffer{}
-	for _, v := range protocol.GetGreasedVersions(h.supportedVersions) {
+	for _, v := range h.supportedVersions {
 		utils.BigEndian.WriteUint32(verTag, uint32(v))
 	}
 	replyMap[TagPUBS] = ephermalKex.PublicKey()

--- a/internal/handshake/crypto_setup_server_test.go
+++ b/internal/handshake/crypto_setup_server_test.go
@@ -317,8 +317,7 @@ var _ = Describe("Server Crypto Setup", func() {
 			Expect(message.Data).To(HaveKeyWithValue(TagPUBS, []byte("ephermal pub")))
 			Expect(message.Data).To(HaveKey(TagSNO))
 			Expect(message.Data).To(HaveKey(TagVER))
-			// the supported versions should include one reserved version number
-			Expect(message.Data[TagVER]).To(HaveLen(4*len(supportedVersions) + 4))
+			Expect(message.Data[TagVER]).To(HaveLen(4 * len(supportedVersions)))
 			for _, v := range supportedVersions {
 				b := &bytes.Buffer{}
 				utils.BigEndian.WriteUint32(b, uint32(v))

--- a/internal/wire/version_negotiation.go
+++ b/internal/wire/version_negotiation.go
@@ -21,7 +21,7 @@ func ComposeGQUICVersionNegotiation(connID protocol.ConnectionID, versions []pro
 		utils.Errorf("error composing version negotiation packet: %s", err.Error())
 		return nil
 	}
-	for _, v := range protocol.GetGreasedVersions(versions) {
+	for _, v := range versions {
 		utils.BigEndian.WriteUint32(buf, uint32(v))
 	}
 	return buf.Bytes()

--- a/internal/wire/version_negotiation_test.go
+++ b/internal/wire/version_negotiation_test.go
@@ -16,11 +16,7 @@ var _ = Describe("Version Negotiation Packets", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hdr.VersionFlag).To(BeTrue())
 		Expect(hdr.ConnectionID).To(Equal(protocol.ConnectionID(0x1337)))
-		// the supported versions should include one reserved version number
-		Expect(hdr.SupportedVersions).To(HaveLen(len(versions) + 1))
-		for _, version := range versions {
-			Expect(hdr.SupportedVersions).To(ContainElement(version))
-		}
+		Expect(hdr.SupportedVersions).To(Equal(versions))
 	})
 
 	It("writes in IETF draft style", func() {


### PR DESCRIPTION
Fixes #1206.

The gQUIC spec says:

> In order to avoid downgrade attacks, the version of the protocol that the client specified in the first packet and the set of versions supported by the server must be included in the crypto handshake data. The client needs to verify that the server’s version list from the handshake matches the list of versions in the Version Negotiation Packet. 

Since we're generating random greased versions, this won't work with the gQUIC handshake. The only reason we didn't notice this earlier is because our integration test was disabled (since there's only one gQUIC version at the moment). I'll make sure to find a better solution for that integration test when fixing #1017.