### PR TITLE
remove TODO in Public Header regarding the div nonce bit for clients

### DIFF
--- a/internal/wire/public_header.go
+++ b/internal/wire/public_header.go
@@ -134,10 +134,9 @@ func parsePublicHeader(b *bytes.Reader, packetSentBy protocol.Perspective) (*Hea
 		}
 	}
 
+	// Contrary to what the gQUIC wire spec says, the 0x4 bit only indicates the presence of the diversification nonce for packets sent by the server.
+	// It doesn't have any meaning when sent by the client.
 	if packetSentBy == protocol.PerspectiveServer && publicFlagByte&0x04 > 0 {
-		// TODO: remove the if once the Google servers send the correct value
-		// assume that a packet doesn't contain a diversification nonce if the version flag or the reset flag is set, no matter what the public flag says
-		// see https://github.com/lucas-clemente/quic-go/issues/232
 		if !header.VersionFlag && !header.ResetFlag {
 			header.DiversificationNonce = make([]byte, 32)
 			if _, err := io.ReadFull(b, header.DiversificationNonce); err != nil {

--- a/internal/wire/public_header_test.go
+++ b/internal/wire/public_header_test.go
@@ -81,15 +81,6 @@ var _ = Describe("Public Header", func() {
 			Expect(b.Len()).To(BeZero())
 		})
 
-		PIt("rejects diversification nonces sent by the client", func() {
-			b := bytes.NewReader([]byte{0x0c, 0x4c, 0xfa, 0x9f, 0x9b, 0x66, 0x86, 0x19, 0xf6,
-				0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1,
-				0x01,
-			})
-			_, err := parsePublicHeader(b, protocol.PerspectiveClient)
-			Expect(err).To(MatchError("diversification nonces should only be sent by servers"))
-		})
-
 		Context("version negotiation packets", func() {
 			appendVersion := func(data []byte, v protocol.VersionNumber) []byte {
 				data = append(data, []byte{0, 0, 0, 0}...)


### PR DESCRIPTION
Closes #232.

The Public Header will not change before the switch to IETF QUIC.
We will have to accept the wrong bit in the client Public Header.