### PR TITLE
make golint happier

### DIFF
--- a/h2quic/request_writer.go
+++ b/h2quic/request_writer.go
@@ -76,9 +76,8 @@ func (w *requestWriter) encodeHeaders(req *http.Request, addGzipHeader bool, tra
 			if !validPseudoPath(path) {
 				if req.URL.Opaque != "" {
 					return nil, fmt.Errorf("invalid request :path %q from URL.Opaque = %q", orig, req.URL.Opaque)
-				} else {
-					return nil, fmt.Errorf("invalid request :path %q", orig)
 				}
+				return nil, fmt.Errorf("invalid request :path %q", orig)
 			}
 		}
 	}

--- a/h2quic/response.go
+++ b/h2quic/response.go
@@ -3,7 +3,6 @@ package h2quic
 import (
 	"bytes"
 	"errors"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/textproto"
@@ -16,7 +15,7 @@ import (
 // copied from net/http2/transport.go
 
 var errResponseHeaderListSize = errors.New("http2: response header list larger than advertised limit")
-var noBody io.ReadCloser = ioutil.NopCloser(bytes.NewReader(nil))
+var noBody = ioutil.NopCloser(bytes.NewReader(nil))
 
 // from the handleResponse function
 func responseFromHeaders(f *http2.MetaHeadersFrame) (*http.Response, error) {

--- a/integrationtests/tools/proxy/proxy.go
+++ b/integrationtests/tools/proxy/proxy.go
@@ -44,6 +44,8 @@ func (d Direction) String() string {
 	}
 }
 
+// Is says if one direction matches another direction.
+// For example, incoming matches both incoming and both, but not outgoing.
 func (d Direction) Is(dir Direction) bool {
 	if d == DirectionBoth || dir == DirectionBoth {
 		return true

--- a/integrationtests/tools/testserver/server.go
+++ b/integrationtests/tools/testserver/server.go
@@ -22,7 +22,9 @@ const (
 )
 
 var (
-	PRData     = GeneratePRData(dataLen)
+	// PRData contains dataLen bytes of pseudo-random data.
+	PRData = GeneratePRData(dataLen)
+	// PRDataLong contains dataLenLong bytes of pseudo-random data.
 	PRDataLong = GeneratePRData(dataLenLong)
 
 	server         *h2quic.Server
@@ -105,11 +107,13 @@ func StartQuicServer(versions []protocol.VersionNumber) {
 	}()
 }
 
+// StopQuicServer stops the h2quic.Server.
 func StopQuicServer() {
 	Expect(server.Close()).NotTo(HaveOccurred())
 	Eventually(stoppedServing).Should(BeClosed())
 }
 
+// Port returns the UDP port of the QUIC server.
 func Port() string {
 	return port
 }

--- a/internal/crypto/cert_chain.go
+++ b/internal/crypto/cert_chain.go
@@ -55,28 +55,28 @@ func (c *certChain) GetLeafCert(sni string) ([]byte, error) {
 	return cert.Certificate[0], nil
 }
 
-func (cc *certChain) getCertForSNI(sni string) (*tls.Certificate, error) {
-	c := cc.config
-	c, err := maybeGetConfigForClient(c, sni)
+func (c *certChain) getCertForSNI(sni string) (*tls.Certificate, error) {
+	conf := c.config
+	conf, err := maybeGetConfigForClient(conf, sni)
 	if err != nil {
 		return nil, err
 	}
 	// The rest of this function is mostly copied from crypto/tls.getCertificate
 
-	if c.GetCertificate != nil {
-		cert, err := c.GetCertificate(&tls.ClientHelloInfo{ServerName: sni})
+	if conf.GetCertificate != nil {
+		cert, err := conf.GetCertificate(&tls.ClientHelloInfo{ServerName: sni})
 		if cert != nil || err != nil {
 			return cert, err
 		}
 	}
 
-	if len(c.Certificates) == 0 {
+	if len(conf.Certificates) == 0 {
 		return nil, errNoMatchingCertificate
 	}
 
-	if len(c.Certificates) == 1 || c.NameToCertificate == nil {
+	if len(conf.Certificates) == 1 || conf.NameToCertificate == nil {
 		// There's only one choice, so no point doing any work.
-		return &c.Certificates[0], nil
+		return &conf.Certificates[0], nil
 	}
 
 	name := strings.ToLower(sni)
@@ -84,7 +84,7 @@ func (cc *certChain) getCertForSNI(sni string) (*tls.Certificate, error) {
 		name = name[:len(name)-1]
 	}
 
-	if cert, ok := c.NameToCertificate[name]; ok {
+	if cert, ok := conf.NameToCertificate[name]; ok {
 		return cert, nil
 	}
 
@@ -94,13 +94,13 @@ func (cc *certChain) getCertForSNI(sni string) (*tls.Certificate, error) {
 	for i := range labels {
 		labels[i] = "*"
 		candidate := strings.Join(labels, ".")
-		if cert, ok := c.NameToCertificate[candidate]; ok {
+		if cert, ok := conf.NameToCertificate[candidate]; ok {
 			return cert, nil
 		}
 	}
 
 	// If nothing matches, return the first certificate.
-	return &c.Certificates[0], nil
+	return &conf.Certificates[0], nil
 }
 
 func maybeGetConfigForClient(c *tls.Config, sni string) (*tls.Config, error) {

--- a/internal/handshake/cookie_handler.go
+++ b/internal/handshake/cookie_handler.go
@@ -7,6 +7,9 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
+// A CookieHandler generates and validates cookies.
+// The cookie is sent in the TLS Retry.
+// By including the cookie in its ClientHello, a client can proof ownership of its source address.
 type CookieHandler struct {
 	callback func(net.Addr, *Cookie) bool
 
@@ -15,6 +18,7 @@ type CookieHandler struct {
 
 var _ mint.CookieHandler = &CookieHandler{}
 
+// NewCookieHandler creates a new CookieHandler.
 func NewCookieHandler(callback func(net.Addr, *Cookie) bool) (*CookieHandler, error) {
 	cookieGenerator, err := NewCookieGenerator()
 	if err != nil {
@@ -26,6 +30,7 @@ func NewCookieHandler(callback func(net.Addr, *Cookie) bool) (*CookieHandler, er
 	}, nil
 }
 
+// Generate a new cookie for a mint connection.
 func (h *CookieHandler) Generate(conn *mint.Conn) ([]byte, error) {
 	if h.callback(conn.RemoteAddr(), nil) {
 		return nil, nil
@@ -33,6 +38,7 @@ func (h *CookieHandler) Generate(conn *mint.Conn) ([]byte, error) {
 	return h.cookieGenerator.NewToken(conn.RemoteAddr())
 }
 
+// Validate a cookie.
 func (h *CookieHandler) Validate(conn *mint.Conn, token []byte) bool {
 	data, err := h.cookieGenerator.DecodeToken(token)
 	if err != nil {

--- a/internal/handshake/server_config_client.go
+++ b/internal/handshake/server_config_client.go
@@ -102,38 +102,37 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 		return qerr.Error(qerr.CryptoMessageParameterNotFound, "PUBS")
 	}
 
-	var pubs_kexs []struct {
+	var pubsKexs []struct {
 		Length uint32
 		Value  []byte
 	}
-	var last_len uint32
-
-	for i := 0; i < len(pubs)-3; i += int(last_len) + 3 {
+	var lastLen uint32
+	for i := 0; i < len(pubs)-3; i += int(lastLen) + 3 {
 		// the PUBS value is always prepended by 3 byte little endian length field
 
-		err := binary.Read(bytes.NewReader([]byte{pubs[i], pubs[i+1], pubs[i+2], 0x00}), binary.LittleEndian, &last_len)
+		err := binary.Read(bytes.NewReader([]byte{pubs[i], pubs[i+1], pubs[i+2], 0x00}), binary.LittleEndian, &lastLen)
 		if err != nil {
 			return qerr.Error(qerr.CryptoInvalidValueLength, "PUBS not decodable")
 		}
-		if last_len == 0 {
+		if lastLen == 0 {
 			return qerr.Error(qerr.CryptoInvalidValueLength, "PUBS")
 		}
 
-		if i+3+int(last_len) > len(pubs) {
+		if i+3+int(lastLen) > len(pubs) {
 			return qerr.Error(qerr.CryptoInvalidValueLength, "PUBS")
 		}
 
-		pubs_kexs = append(pubs_kexs, struct {
+		pubsKexs = append(pubsKexs, struct {
 			Length uint32
 			Value  []byte
-		}{last_len, pubs[i+3 : i+3+int(last_len)]})
+		}{lastLen, pubs[i+3 : i+3+int(lastLen)]})
 	}
 
-	if c255Foundat >= len(pubs_kexs) {
+	if c255Foundat >= len(pubsKexs) {
 		return qerr.Error(qerr.CryptoMessageParameterNotFound, "KEXS not in PUBS")
 	}
 
-	if pubs_kexs[c255Foundat].Length != 32 {
+	if pubsKexs[c255Foundat].Length != 32 {
 		return qerr.Error(qerr.CryptoInvalidValueLength, "PUBS")
 	}
 
@@ -143,7 +142,7 @@ func (s *serverConfigClient) parseValues(tagMap map[Tag][]byte) error {
 		return err
 	}
 
-	s.sharedSecret, err = s.kex.CalculateSharedKey(pubs_kexs[c255Foundat].Value)
+	s.sharedSecret, err = s.kex.CalculateSharedKey(pubsKexs[c255Foundat].Value)
 	if err != nil {
 		return err
 	}

--- a/qerr/quic_error.go
+++ b/qerr/quic_error.go
@@ -31,6 +31,7 @@ func (e *QuicError) Error() string {
 	return fmt.Sprintf("%s: %s", e.ErrorCode.String(), e.ErrorMessage)
 }
 
+// Timeout says if this error is a timeout.
 func (e *QuicError) Timeout() bool {
 	switch e.ErrorCode {
 	case NetworkIdleTimeout,


### PR DESCRIPTION
This should bring us a good step closer to resolving #1181.

The only things that golint is still complaining about are the dot import in the testing tools, e.g. 
> integrationtests/tools/testserver/server.go:15:2:` should not use dot imports

and the stuttering of `handshake.HandshakeMessage`.

I don't intend to fix these, so if awesome-go doesn't like those, I'm fine with not being included in their list.