### PR TITLE
remove incorrect error check when sending a packet

### DIFF
--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -10,7 +10,7 @@ import (
 // SentPacketHandler handles ACKs received for outgoing packets
 type SentPacketHandler interface {
 	// SentPacket may modify the packet
-	SentPacket(packet *Packet) error
+	SentPacket(packet *Packet)
 	ReceivedAck(ackFrame *wire.AckFrame, withPacketNumber protocol.PacketNumber, encLevel protocol.EncryptionLevel, recvTime time.Time) error
 	SetHandshakeComplete()
 

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -132,10 +132,8 @@ func (mr *MockSentPacketHandlerMockRecorder) SendingAllowed() *gomock.Call {
 }
 
 // SentPacket mocks base method
-func (m *MockSentPacketHandler) SentPacket(arg0 *ackhandler.Packet) error {
-	ret := m.ctrl.Call(m, "SentPacket", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+func (m *MockSentPacketHandler) SentPacket(arg0 *ackhandler.Packet) {
+	m.ctrl.Call(m, "SentPacket", arg0)
 }
 
 // SentPacket indicates an expected call of SentPacket

--- a/session.go
+++ b/session.go
@@ -877,16 +877,13 @@ func (s *session) sendPacket() (bool, error) {
 
 func (s *session) sendPackedPacket(packet *packedPacket) error {
 	defer putPacketBuffer(&packet.raw)
-	err := s.sentPacketHandler.SentPacket(&ackhandler.Packet{
+	s.sentPacketHandler.SentPacket(&ackhandler.Packet{
 		PacketNumber:    packet.header.PacketNumber,
 		PacketType:      packet.header.Type,
 		Frames:          packet.frames,
 		Length:          protocol.ByteCount(len(packet.raw)),
 		EncryptionLevel: packet.encryptionLevel,
 	})
-	if err != nil {
-		return err
-	}
 	s.logPacket(packet)
 	return s.conn.Write(packet.raw)
 }

--- a/session_test.go
+++ b/session_test.go
@@ -1091,7 +1091,7 @@ var _ = Describe("Session", func() {
 		Expect(sess.rttStats.SmoothedRTT()).To(Equal(rtt)) // make sure it worked
 		sess.packer.packetNumberGenerator.next = n + 1
 		// Now, we send a single packet, and expect that it was retransmitted later
-		err := sess.sentPacketHandler.SentPacket(&ackhandler.Packet{
+		sess.sentPacketHandler.SentPacket(&ackhandler.Packet{
 			PacketNumber: n,
 			Length:       1,
 			Frames: []wire.Frame{&wire.StreamFrame{
@@ -1099,7 +1099,6 @@ var _ = Describe("Session", func() {
 			}},
 			EncryptionLevel: protocol.EncryptionForwardSecure,
 		})
-		Expect(err).NotTo(HaveOccurred())
 		go sess.run()
 		defer sess.Close(nil)
 		sess.scheduleSending()


### PR DESCRIPTION
There's no need for a check if more than `protocol.MaxTrackedSentPackets` packets were sent. There are certain situations where we allow (via `SendingAllowed()`) sending of more packets, and we shouldn't throw an error when the session then actually sends these packets.