### PR TITLE
accept ACKs sent in packet number 0

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -157,8 +157,7 @@ func (h *sentPacketHandler) ReceivedAck(ackFrame *wire.AckFrame, withPacketNumbe
 	}
 
 	// duplicate or out-of-order ACK
-	// if withPacketNumber <= h.largestReceivedPacketWithAck && withPacketNumber != 0 {
-	if withPacketNumber <= h.largestReceivedPacketWithAck {
+	if withPacketNumber != 0 && withPacketNumber <= h.largestReceivedPacketWithAck {
 		return ErrDuplicateOrOutOfOrderAck
 	}
 	h.largestReceivedPacketWithAck = withPacketNumber

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -207,6 +207,16 @@ var _ = Describe("SentPacketHandler", func() {
 		}
 
 		Context("ACK validation", func() {
+			It("accepts ACKs sent in packet 0", func() {
+				ack := wire.AckFrame{
+					LargestAcked: 5,
+					LowestAcked:  1,
+				}
+				err := handler.ReceivedAck(&ack, 0, protocol.EncryptionUnencrypted, time.Now())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(5)))
+			})
+
 			It("rejects duplicate ACKs", func() {
 				largestAcked := 3
 				ack := wire.AckFrame{


### PR DESCRIPTION
Packet number 0 **really** sucks. Maybe we should make the packet number a signed int, and initialize it to -1 everywhere in the ackhandler.