### PR TITLE
don't reject ACKs with a lower largest ACKed value

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -158,12 +158,7 @@ func (h *sentPacketHandler) ReceivedAck(ackFrame *wire.AckFrame, withPacketNumbe
 		return nil
 	}
 	h.largestReceivedPacketWithAck = withPacketNumber
-
-	// ignore repeated ACK (ACKs that don't have a higher LargestAcked than the last ACK)
-	if ackFrame.LargestAcked < h.lowestUnacked() {
-		return nil
-	}
-	h.largestAcked = ackFrame.LargestAcked
+	h.largestAcked = utils.MaxPacketNumber(h.largestAcked, ackFrame.LargestAcked)
 
 	if h.skippedPacketsAcked(ackFrame) {
 		return qerr.Error(qerr.InvalidAckData, "Received an ACK for a skipped packet number")

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -803,10 +803,11 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.SentPacket(retransmittablePacket(3))
 			Expect(handler.lossTime.IsZero()).To(BeTrue())
 
-			err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 1, LowestAcked: 1}, 1, protocol.EncryptionUnencrypted, time.Now().Add(time.Hour))
+			now := time.Now().Add(time.Hour)
+			err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 1, LowestAcked: 1}, 1, protocol.EncryptionUnencrypted, now)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(handler.lossTime.IsZero()).To(BeTrue())
-			Expect(time.Until(handler.GetAlarmTimeout())).To(BeNumerically("~", handler.computeRTOTimeout(), time.Minute))
+			Expect(handler.GetAlarmTimeout().Sub(now)).To(BeNumerically("~", handler.computeRTOTimeout(), time.Minute))
 
 			// This means RTO, so both packets should be lost
 			handler.OnAlarm()


### PR DESCRIPTION
This is part of my ongoing effort to refactor the `SentPacketHandler`.
We already reject ACKs as soon as we received another ACK in a higher packet, so this check doesn't seem necessary.