### PR TITLE
calculate the packet number length in the sent packet handler

### DIFF
--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -32,7 +32,7 @@ type SentPacketHandler interface {
 	GetStopWaitingFrame(force bool) *wire.StopWaitingFrame
 	GetLowestPacketNotConfirmedAcked() protocol.PacketNumber
 	DequeuePacketForRetransmission() (packet *Packet)
-	GetLeastUnacked() protocol.PacketNumber
+	GetPacketNumberLen(protocol.PacketNumber) protocol.PacketNumberLen
 
 	GetAlarmTimeout() time.Time
 	OnAlarm()

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -354,8 +354,8 @@ func (h *sentPacketHandler) DequeuePacketForRetransmission() *Packet {
 	return packet
 }
 
-func (h *sentPacketHandler) GetLeastUnacked() protocol.PacketNumber {
-	return h.lowestUnacked()
+func (h *sentPacketHandler) GetPacketNumberLen(p protocol.PacketNumber) protocol.PacketNumberLen {
+	return protocol.GetPacketNumberLengthForHeader(p, h.lowestUnacked())
 }
 
 func (h *sentPacketHandler) GetStopWaitingFrame(force bool) *wire.StopWaitingFrame {

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -59,9 +59,10 @@ var _ = Describe("SentPacketHandler", func() {
 		return nil
 	}
 
-	It("gets the LeastUnacked packet number", func() {
+	It("determines the packet number length", func() {
 		handler.largestAcked = 0x1337
-		Expect(handler.GetLeastUnacked()).To(Equal(protocol.PacketNumber(0x1337 + 1)))
+		Expect(handler.GetPacketNumberLen(0x1338)).To(Equal(protocol.PacketNumberLen2))
+		Expect(handler.GetPacketNumberLen(0xfffffff)).To(Equal(protocol.PacketNumberLen4))
 	})
 
 	Context("registering sent packets", func() {

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -61,18 +61,6 @@ func (mr *MockSentPacketHandlerMockRecorder) GetAlarmTimeout() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAlarmTimeout", reflect.TypeOf((*MockSentPacketHandler)(nil).GetAlarmTimeout))
 }
 
-// GetLeastUnacked mocks base method
-func (m *MockSentPacketHandler) GetLeastUnacked() protocol.PacketNumber {
-	ret := m.ctrl.Call(m, "GetLeastUnacked")
-	ret0, _ := ret[0].(protocol.PacketNumber)
-	return ret0
-}
-
-// GetLeastUnacked indicates an expected call of GetLeastUnacked
-func (mr *MockSentPacketHandlerMockRecorder) GetLeastUnacked() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLeastUnacked", reflect.TypeOf((*MockSentPacketHandler)(nil).GetLeastUnacked))
-}
-
 // GetLowestPacketNotConfirmedAcked mocks base method
 func (m *MockSentPacketHandler) GetLowestPacketNotConfirmedAcked() protocol.PacketNumber {
 	ret := m.ctrl.Call(m, "GetLowestPacketNotConfirmedAcked")
@@ -83,6 +71,18 @@ func (m *MockSentPacketHandler) GetLowestPacketNotConfirmedAcked() protocol.Pack
 // GetLowestPacketNotConfirmedAcked indicates an expected call of GetLowestPacketNotConfirmedAcked
 func (mr *MockSentPacketHandlerMockRecorder) GetLowestPacketNotConfirmedAcked() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLowestPacketNotConfirmedAcked", reflect.TypeOf((*MockSentPacketHandler)(nil).GetLowestPacketNotConfirmedAcked))
+}
+
+// GetPacketNumberLen mocks base method
+func (m *MockSentPacketHandler) GetPacketNumberLen(arg0 protocol.PacketNumber) protocol.PacketNumberLen {
+	ret := m.ctrl.Call(m, "GetPacketNumberLen", arg0)
+	ret0, _ := ret[0].(protocol.PacketNumberLen)
+	return ret0
+}
+
+// GetPacketNumberLen indicates an expected call of GetPacketNumberLen
+func (mr *MockSentPacketHandlerMockRecorder) GetPacketNumberLen(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPacketNumberLen", reflect.TypeOf((*MockSentPacketHandler)(nil).GetPacketNumberLen), arg0)
 }
 
 // GetStopWaitingFrame mocks base method

--- a/session_test.go
+++ b/session_test.go
@@ -725,7 +725,7 @@ var _ = Describe("Session", func() {
 		It("doesn't retransmit an Initial packet if it already received a response", func() {
 			sess.unpacker = &mockUnpacker{}
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
-			sph.EXPECT().GetLeastUnacked().AnyTimes()
+			sph.EXPECT().GetPacketNumberLen(gomock.Any()).Return(protocol.PacketNumberLen2).AnyTimes()
 			sph.EXPECT().DequeuePacketForRetransmission().Return(&ackhandler.Packet{
 				PacketNumber: 10,
 				PacketType:   protocol.PacketTypeInitial,
@@ -749,7 +749,7 @@ var _ = Describe("Session", func() {
 		It("sends a retransmission and a regular packet in the same run", func() {
 			sess.windowUpdateQueue.callback(&wire.MaxDataFrame{})
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
-			sph.EXPECT().GetLeastUnacked()
+			sph.EXPECT().GetPacketNumberLen(gomock.Any()).Return(protocol.PacketNumberLen2).AnyTimes()
 			sph.EXPECT().DequeuePacketForRetransmission().Return(&ackhandler.Packet{
 				PacketNumber: 10,
 				PacketType:   protocol.PacketTypeHandshake,
@@ -781,7 +781,7 @@ var _ = Describe("Session", func() {
 		BeforeEach(func() {
 			sph = mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetAlarmTimeout().AnyTimes()
-			sph.EXPECT().GetLeastUnacked().AnyTimes()
+			sph.EXPECT().GetPacketNumberLen(gomock.Any()).Return(protocol.PacketNumberLen2).AnyTimes()
 			sph.EXPECT().DequeuePacketForRetransmission().AnyTimes()
 			sess.sentPacketHandler = sph
 			sess.packer.hasSentPacket = true
@@ -894,7 +894,7 @@ var _ = Describe("Session", func() {
 		It("sends ACK only packets", func() {
 			swf := &wire.StopWaitingFrame{LeastUnacked: 10}
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
-			sph.EXPECT().GetLeastUnacked().AnyTimes()
+			sph.EXPECT().GetPacketNumberLen(gomock.Any()).Return(protocol.PacketNumberLen2).AnyTimes()
 			sph.EXPECT().GetAlarmTimeout().AnyTimes()
 			sph.EXPECT().SendingAllowed()
 			sph.EXPECT().GetStopWaitingFrame(false).Return(swf)
@@ -925,7 +925,7 @@ var _ = Describe("Session", func() {
 			sess.version = versionIETFFrames
 			done := make(chan struct{})
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
-			sph.EXPECT().GetLeastUnacked().AnyTimes()
+			sph.EXPECT().GetPacketNumberLen(gomock.Any()).Return(protocol.PacketNumberLen2).AnyTimes()
 			sph.EXPECT().GetAlarmTimeout().AnyTimes()
 			sph.EXPECT().SendingAllowed()
 			sph.EXPECT().TimeUntilSend()
@@ -957,7 +957,7 @@ var _ = Describe("Session", func() {
 			sess.packer.packetNumberGenerator.next = 0x1337 + 10
 			sess.packer.hasSentPacket = true // make sure this is not the first packet the packer sends
 			sph = mockackhandler.NewMockSentPacketHandler(mockCtrl)
-			sph.EXPECT().GetLeastUnacked().AnyTimes()
+			sph.EXPECT().GetPacketNumberLen(gomock.Any()).Return(protocol.PacketNumberLen2).AnyTimes()
 			sess.sentPacketHandler = sph
 			sess.packer.cryptoSetup = &mockCryptoSetup{encLevelSeal: protocol.EncryptionForwardSecure}
 		})
@@ -1114,7 +1114,7 @@ var _ = Describe("Session", func() {
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().SendingAllowed().AnyTimes().Return(true)
 			sph.EXPECT().ShouldSendNumPackets().AnyTimes().Return(1)
-			sph.EXPECT().GetLeastUnacked().AnyTimes()
+			sph.EXPECT().GetPacketNumberLen(gomock.Any()).Return(protocol.PacketNumberLen2).AnyTimes()
 			sph.EXPECT().GetStopWaitingFrame(true).Return(&wire.StopWaitingFrame{LeastUnacked: 10})
 			sph.EXPECT().DequeuePacketForRetransmission().Return(&ackhandler.Packet{
 				PacketNumber:    0x1337,
@@ -1145,7 +1145,6 @@ var _ = Describe("Session", func() {
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
 			sph.EXPECT().GetAlarmTimeout().AnyTimes()
 			sph.EXPECT().SendingAllowed().Return(true).AnyTimes()
-			sph.EXPECT().GetLeastUnacked().Times(2)
 			sph.EXPECT().DequeuePacketForRetransmission()
 			sph.EXPECT().GetStopWaitingFrame(gomock.Any())
 			sph.EXPECT().ShouldSendNumPackets().Return(1)


### PR DESCRIPTION
This seems a bit cleaner than passing the least unacked packet number around.