### PR TITLE
implement packet send modes to determine what kind of packets are sent

### DIFF
--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -14,11 +14,8 @@ type SentPacketHandler interface {
 	ReceivedAck(ackFrame *wire.AckFrame, withPacketNumber protocol.PacketNumber, encLevel protocol.EncryptionLevel, recvTime time.Time) error
 	SetHandshakeComplete()
 
-	// SendingAllowed says if a packet can be sent.
-	// Sending packets might not be possible because:
-	// * we're congestion limited
-	// * we're tracking the maximum number of sent packets
-	SendingAllowed() bool
+	// The SendMode determines if and what kind of packets can be sent.
+	SendMode() SendMode
 	// TimeUntilSend is the time when the next packet should be sent.
 	// It is used for pacing packets.
 	TimeUntilSend() time.Time

--- a/internal/ackhandler/send_mode.go
+++ b/internal/ackhandler/send_mode.go
@@ -1,0 +1,32 @@
+package ackhandler
+
+import "fmt"
+
+// The SendMode says what kind of packets can be sent.
+type SendMode uint8
+
+const (
+	// SendNone means that no packets should be sent
+	SendNone SendMode = iota
+	// SendAck means an ACK-only packet should be sent
+	SendAck
+	// SendRetransmission means that retransmissions should be sent
+	SendRetransmission
+	// SendAny packet should be sent
+	SendAny
+)
+
+func (s SendMode) String() string {
+	switch s {
+	case SendNone:
+		return "none"
+	case SendAck:
+		return "ack"
+	case SendRetransmission:
+		return "retransmission"
+	case SendAny:
+		return "any"
+	default:
+		return fmt.Sprintf("invalid send mode: %d", s)
+	}
+}

--- a/internal/ackhandler/send_mode_test.go
+++ b/internal/ackhandler/send_mode_test.go
@@ -1,0 +1,16 @@
+package ackhandler
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Send Mode", func() {
+	It("has a string representation", func() {
+		Expect(SendNone.String()).To(Equal("none"))
+		Expect(SendAny.String()).To(Equal("any"))
+		Expect(SendAck.String()).To(Equal("ack"))
+		Expect(SendRetransmission.String()).To(Equal("retransmission"))
+		Expect(SendMode(123).String()).To(Equal("invalid send mode: 123"))
+	})
+})

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -119,16 +119,16 @@ func (mr *MockSentPacketHandlerMockRecorder) ReceivedAck(arg0, arg1, arg2, arg3 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedAck", reflect.TypeOf((*MockSentPacketHandler)(nil).ReceivedAck), arg0, arg1, arg2, arg3)
 }
 
-// SendingAllowed mocks base method
-func (m *MockSentPacketHandler) SendingAllowed() bool {
-	ret := m.ctrl.Call(m, "SendingAllowed")
-	ret0, _ := ret[0].(bool)
+// SendMode mocks base method
+func (m *MockSentPacketHandler) SendMode() ackhandler.SendMode {
+	ret := m.ctrl.Call(m, "SendMode")
+	ret0, _ := ret[0].(ackhandler.SendMode)
 	return ret0
 }
 
-// SendingAllowed indicates an expected call of SendingAllowed
-func (mr *MockSentPacketHandlerMockRecorder) SendingAllowed() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendingAllowed", reflect.TypeOf((*MockSentPacketHandler)(nil).SendingAllowed))
+// SendMode indicates an expected call of SendMode
+func (mr *MockSentPacketHandlerMockRecorder) SendMode() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMode", reflect.TypeOf((*MockSentPacketHandler)(nil).SendMode))
 }
 
 // SentPacket mocks base method

--- a/internal/protocol/server_parameters.go
+++ b/internal/protocol/server_parameters.go
@@ -81,8 +81,15 @@ const MaxTrackedSkippedPackets = 10
 // CookieExpiryTime is the valid time of a cookie
 const CookieExpiryTime = 24 * time.Hour
 
-// MaxTrackedSentPackets is maximum number of sent packets saved for either later retransmission or entropy calculation
-const MaxTrackedSentPackets = 2 * DefaultMaxCongestionWindow
+// MaxOutstandingSentPackets is maximum number of packets saved for retransmission.
+// When reached, it imposes a soft limit on sending new packets:
+// Sending ACKs and retransmission is still allowed, but now new regular packets can be sent.
+const MaxOutstandingSentPackets = 2 * DefaultMaxCongestionWindow
+
+// MaxTrackedSentPackets is maximum number of sent packets saved for retransmission.
+// When reached, no more packets will be sent.
+// This value *must* be larger than MaxOutstandingSentPackets.
+const MaxTrackedSentPackets = MaxOutstandingSentPackets * 5 / 4
 
 // MaxTrackedReceivedAckRanges is the maximum number of ACK ranges tracked
 const MaxTrackedReceivedAckRanges = DefaultMaxCongestionWindow

--- a/session.go
+++ b/session.go
@@ -766,40 +766,56 @@ func (s *session) processTransportParameters(params *handshake.TransportParamete
 
 func (s *session) sendPackets() error {
 	s.pacingDeadline = time.Time{}
-	if !s.sentPacketHandler.SendingAllowed() { // if congestion limited, at least try sending an ACK frame
-		return s.maybeSendAckOnlyPacket()
+
+	sendMode := s.sentPacketHandler.SendMode()
+	if sendMode == ackhandler.SendNone { // shortcut: return immediately if there's nothing to send
+		return nil
 	}
+
 	numPackets := s.sentPacketHandler.ShouldSendNumPackets()
 	var numPacketsSent int
-	// Send retransmissions, until
-	// * we're congestion limited, or
-	// * there are no more retransmissions, or
-	// * the maximum number of packets was reached
-	for ; numPacketsSent < numPackets; numPacketsSent++ {
-		sentPacket, err := s.maybeSendRetransmission()
-		if err != nil {
-			return err
+sendLoop:
+	for {
+		switch sendMode {
+		case ackhandler.SendNone:
+			break sendLoop
+		case ackhandler.SendAck:
+			// We can at most send a single ACK only packet.
+			// There will only be a new ACK after receiving new packets.
+			// SendAck is only returned when we're congestion limited, so we don't need to set the pacingt timer.
+			return s.maybeSendAckOnlyPacket()
+		case ackhandler.SendRetransmission:
+			sentPacket, err := s.maybeSendRetransmission()
+			if err != nil {
+				return err
+			}
+			if sentPacket {
+				numPacketsSent++
+				// This can happen if a retransmission queued, but it wasn't necessary to send it.
+				// e.g. when an Initial is queued, but we already received a packet from the server.
+			}
+		case ackhandler.SendAny:
+			sentPacket, err := s.sendPacket()
+			if err != nil {
+				return err
+			}
+			if !sentPacket {
+				break sendLoop
+			}
+			numPacketsSent++
+		default:
+			return fmt.Errorf("BUG: invalid send mode %d", sendMode)
 		}
-		if !sentPacket { // no more retransmission to send. Proceed to send new data.
+		if numPacketsSent >= numPackets {
 			break
 		}
-		if !s.sentPacketHandler.SendingAllowed() {
-			return nil
-		}
-	}
-	for ; numPacketsSent < numPackets; numPacketsSent++ {
-		sentPacket, err := s.sendPacket()
-		if err != nil {
-			return err
-		}
-		// If no packet was sent, or we're congestion limit, we're done here.
-		if !sentPacket || !s.sentPacketHandler.SendingAllowed() {
-			return nil
-		}
+		sendMode = s.sentPacketHandler.SendMode()
 	}
 	// Only start the pacing timer if we sent as many packets as we were allowed.
 	// There will probably be more to send when calling sendPacket again.
-	s.pacingDeadline = s.sentPacketHandler.TimeUntilSend()
+	if numPacketsSent == numPackets {
+		s.pacingDeadline = s.sentPacketHandler.TimeUntilSend()
+	}
 	return nil
 }
 
@@ -837,7 +853,6 @@ func (s *session) maybeSendRetransmission() (bool, error) {
 		// As soon as we receive one response, we don't need to send any more Initials.
 		if s.receivedFirstPacket && retransmitPacket.PacketType == protocol.PacketTypeInitial {
 			utils.Debugf("Skipping retransmission of packet %d. Already received a response to an Initial.", retransmitPacket.PacketNumber)
-			retransmitPacket = nil
 			continue
 		}
 		break


### PR DESCRIPTION
The `SentPacketHandler` uses different "modes" to communicate to the session what kind of packets can be sent:

* `None`: No packets can be sent. This only happens if we reach the limit of tracked packets.
* `Ack`: ACK-only packets can be sent. This happens if we're congestion limited, or if we're keeping track of too many outstanding packets (note that this is a lower limit than the number of tracked packets, since as soon as we keep track of retransmissions, those will not count towards the outstanding, but the tracked packets).
* `Retransmission`: A retransmission should be sent. This is returned every time the retransmission queue is not empty (and we're not limited by the number of tracked packets).
* `Any`: Any kind of packet can be sent.

This design will make it easy to implement TLPs (#497) by introding a TLP mode (and a method to dequeue the first outstanding packet for retransmission). According to the loss recovery draft, a sender should send new data as a probe packet, and only send a retransmission if no new data is available.