### PR TITLE
Refactor streamFramer in preparation for priorities

### DIFF
--- a/stream_framer.go
+++ b/stream_framer.go
@@ -7,6 +7,45 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
+// Implementations do not have to be thread safe, the caller is expected to handle locking.
+type StreamScheduler interface {
+	// Invoked when a stream is has data available.
+	AddActiveStream(id protocol.StreamID)
+	// Invoked when a stream is has no more data available.
+	// This method is likely called immediately after a call to NextActiveStream.
+	RemoveActiveStream(id protocol.StreamID)
+	// Returns the next stream to send data from.
+	NextActiveStream() protocol.StreamID
+}
+
+type roundRobbinStreamScheduler struct {
+	streamQueue []protocol.StreamID
+}
+
+func (ss *roundRobbinStreamScheduler) AddActiveStream(id protocol.StreamID) {
+	ss.streamQueue = append(ss.streamQueue, id)
+}
+
+func (ss *roundRobbinStreamScheduler) RemoveActiveStream(id protocol.StreamID) {
+	// Check the end of the array first since this is likely called immediately after NextActiveStream
+	if ss.streamQueue[len(ss.streamQueue)-1] == id {
+		ss.streamQueue = ss.streamQueue[:len(ss.streamQueue)-1]
+	}
+	for i := 0; i < len(ss.streamQueue)-1; i++ {
+		if ss.streamQueue[i] == id {
+			ss.streamQueue = append(ss.streamQueue[:i], ss.streamQueue[i+1:]...)
+			break
+		}
+	}
+}
+
+func (ss *roundRobbinStreamScheduler) NextActiveStream() protocol.StreamID {
+	id := ss.streamQueue[0]
+	ss.streamQueue = ss.streamQueue[1:]
+	ss.streamQueue = append(ss.streamQueue, id)
+	return id
+}
+
 type streamFramer struct {
 	streamGetter streamGetter
 	cryptoStream cryptoStreamI
@@ -14,7 +53,7 @@ type streamFramer struct {
 
 	streamQueueMutex    sync.Mutex
 	activeStreams       map[protocol.StreamID]struct{}
-	streamQueue         []protocol.StreamID
+	streamScheduler     StreamScheduler
 	hasCryptoStreamData bool
 }
 
@@ -24,10 +63,11 @@ func newStreamFramer(
 	v protocol.VersionNumber,
 ) *streamFramer {
 	return &streamFramer{
-		streamGetter:  streamGetter,
-		cryptoStream:  cryptoStream,
-		activeStreams: make(map[protocol.StreamID]struct{}),
-		version:       v,
+		streamGetter:    streamGetter,
+		cryptoStream:    cryptoStream,
+		activeStreams:   make(map[protocol.StreamID]struct{}),
+		streamScheduler: &roundRobbinStreamScheduler{},
+		version:         v,
 	}
 }
 
@@ -40,7 +80,7 @@ func (f *streamFramer) AddActiveStream(id protocol.StreamID) {
 	}
 	f.streamQueueMutex.Lock()
 	if _, ok := f.activeStreams[id]; !ok {
-		f.streamQueue = append(f.streamQueue, id)
+		f.streamScheduler.AddActiveStream(id)
 		f.activeStreams[id] = struct{}{}
 	}
 	f.streamQueueMutex.Unlock()
@@ -65,27 +105,26 @@ func (f *streamFramer) PopStreamFrames(maxTotalLen protocol.ByteCount) []*wire.S
 	var currentLen protocol.ByteCount
 	var frames []*wire.StreamFrame
 	f.streamQueueMutex.Lock()
-	// pop STREAM frames, until less than MinStreamFrameSize bytes are left in the packet
-	numActiveStreams := len(f.streamQueue)
+	// pop STREAM frames, until less than MinStreamFrameSize bytes are left in the packet or there are no more active streams
+	numActiveStreams := len(f.activeStreams)
 	for i := 0; i < numActiveStreams; i++ {
 		if maxTotalLen-currentLen < protocol.MinStreamFrameSize {
 			break
 		}
-		id := f.streamQueue[0]
-		f.streamQueue = f.streamQueue[1:]
+		id := f.streamScheduler.NextActiveStream()
 		// This should never return an error. Better check it anyway.
 		// The stream will only be in the streamQueue, if it enqueued itself there.
 		str, err := f.streamGetter.GetOrOpenSendStream(id)
 		// The stream can be nil if it completed after it said it had data.
 		if str == nil || err != nil {
 			delete(f.activeStreams, id)
+			f.streamScheduler.RemoveActiveStream(id)
 			continue
 		}
 		frame, hasMoreData := str.popStreamFrame(maxTotalLen - currentLen)
-		if hasMoreData { // put the stream back in the queue (at the end)
-			f.streamQueue = append(f.streamQueue, id)
-		} else { // no more data to send. Stream is not active any more
+		if !hasMoreData { // no more data to send. Stream is not active any more
 			delete(f.activeStreams, id)
+			f.streamScheduler.RemoveActiveStream(id)
 		}
 		if frame == nil { // can happen if the receiveStream was canceled after it said it had data
 			continue


### PR DESCRIPTION
First in a series of changes addressing https://github.com/lucas-clemente/quic-go/issues/437.

Steps to address:

1. Introduce a `StreamScheduler` interface, similar to the h2 [WriteScheduler](https://github.com/golang/net/blob/master/http2/writesched.go) and make the streamFramer use this (this PR addresses this step).
2. Add `SetPriority(weight uint8)` to `Stream` interface and `StreamScheduler` interfaces, passing values through.
3. Create a priority queue based implementation and add the ability to specify a desired `StreamScheduler` for a particular `Session`.

