### PR TITLE
keep track of retransmissions

### DIFF
--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -11,6 +11,7 @@ import (
 type SentPacketHandler interface {
 	// SentPacket may modify the packet
 	SentPacket(packet *Packet)
+	SentPacketsAsRetransmission(packets []*Packet, retransmissionOf protocol.PacketNumber)
 	ReceivedAck(ackFrame *wire.AckFrame, withPacketNumber protocol.PacketNumber, encLevel protocol.EncryptionLevel, recvTime time.Time) error
 	SetHandshakeComplete()
 

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -33,7 +33,7 @@ type SentPacketHandler interface {
 	GetPacketNumberLen(protocol.PacketNumber) protocol.PacketNumberLen
 
 	GetAlarmTimeout() time.Time
-	OnAlarm()
+	OnAlarm() error
 }
 
 // ReceivedPacketHandler handles ACKs needed to send for incoming packets

--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -18,6 +18,11 @@ type Packet struct {
 
 	largestAcked protocol.PacketNumber // if the packet contains an ACK, the LargestAcked value of that ACK
 	sendTime     time.Time
+
+	queuedForRetransmission bool
+	retransmittedAs         []protocol.PacketNumber
+	isRetransmission        bool // we need a separate bool here because 0 is a valid packet number
+	retransmissionOf        protocol.PacketNumber
 }
 
 // GetFramesForRetransmission gets all the frames for retransmission

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -150,6 +150,12 @@ func (h *sentPacketHandler) SentPacket(packet *Packet) {
 	h.updateLossDetectionAlarm(now)
 }
 
+func (h *sentPacketHandler) SentPacketsAsRetransmission(packets []*Packet, retransmissionOf protocol.PacketNumber) {
+	for _, packet := range packets {
+		h.SentPacket(packet)
+	}
+}
+
 func (h *sentPacketHandler) ReceivedAck(ackFrame *wire.AckFrame, withPacketNumber protocol.PacketNumber, encLevel protocol.EncryptionLevel, rcvTime time.Time) error {
 	if ackFrame.LargestAcked > h.lastSentPacketNumber {
 		return qerr.Error(qerr.InvalidAckData, "Received ACK for an unsent package")

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -41,7 +41,7 @@ type sentPacketHandler struct {
 	// once we receive an ACK from the peer for packet 20, the lowestPacketNotConfirmedAcked is 101
 	lowestPacketNotConfirmedAcked protocol.PacketNumber
 
-	packetHistory      *PacketList
+	packetHistory      *sentPacketHistory
 	stopWaitingManager stopWaitingManager
 
 	retransmissionQueue []*Packet
@@ -76,7 +76,7 @@ func NewSentPacketHandler(rttStats *congestion.RTTStats) SentPacketHandler {
 	)
 
 	return &sentPacketHandler{
-		packetHistory:      NewPacketList(),
+		packetHistory:      newSentPacketHistory(),
 		stopWaitingManager: stopWaitingManager{},
 		rttStats:           rttStats,
 		congestion:         congestion,
@@ -84,8 +84,8 @@ func NewSentPacketHandler(rttStats *congestion.RTTStats) SentPacketHandler {
 }
 
 func (h *sentPacketHandler) lowestUnacked() protocol.PacketNumber {
-	if f := h.packetHistory.Front(); f != nil {
-		return f.Value.PacketNumber
+	if p := h.packetHistory.Front(); p != nil {
+		return p.PacketNumber
 	}
 	return h.largestAcked + 1
 }
@@ -97,12 +97,15 @@ func (h *sentPacketHandler) SetHandshakeComplete() {
 			queue = append(queue, packet)
 		}
 	}
-	for el := h.packetHistory.Front(); el != nil; {
-		next := el.Next()
-		if el.Value.EncryptionLevel != protocol.EncryptionForwardSecure {
-			h.packetHistory.Remove(el)
+	var handshakePackets []*Packet
+	h.packetHistory.Iterate(func(p *Packet) (bool, error) {
+		if p.EncryptionLevel != protocol.EncryptionForwardSecure {
+			handshakePackets = append(handshakePackets, p)
 		}
-		el = next
+		return true, nil
+	})
+	for _, p := range handshakePackets {
+		h.packetHistory.Remove(p.PacketNumber)
 	}
 	h.retransmissionQueue = queue
 	h.handshakeComplete = true
@@ -133,7 +136,7 @@ func (h *sentPacketHandler) SentPacket(packet *Packet) {
 		packet.sendTime = now
 		packet.largestAcked = largestAcked
 		h.bytesInFlight += packet.Length
-		h.packetHistory.PushBack(*packet)
+		h.packetHistory.SentPacket(packet)
 	}
 	h.congestion.OnPacketSent(
 		now,
@@ -164,9 +167,7 @@ func (h *sentPacketHandler) ReceivedAck(ackFrame *wire.AckFrame, withPacketNumbe
 		return qerr.Error(qerr.InvalidAckData, "Received an ACK for a skipped packet number")
 	}
 
-	rttUpdated := h.maybeUpdateRTT(ackFrame.LargestAcked, ackFrame.DelayTime, rcvTime)
-
-	if rttUpdated {
+	if rttUpdated := h.maybeUpdateRTT(ackFrame.LargestAcked, ackFrame.DelayTime, rcvTime); rttUpdated {
 		h.congestion.MaybeExitSlowStart()
 	}
 
@@ -175,20 +176,18 @@ func (h *sentPacketHandler) ReceivedAck(ackFrame *wire.AckFrame, withPacketNumbe
 		return err
 	}
 
-	if len(ackedPackets) > 0 {
-		for _, p := range ackedPackets {
-			if encLevel < p.Value.EncryptionLevel {
-				return fmt.Errorf("Received ACK with encryption level %s that acks a packet %d (encryption level %s)", encLevel, p.Value.PacketNumber, p.Value.EncryptionLevel)
-			}
-			// largestAcked == 0 either means that the packet didn't contain an ACK, or it just acked packet 0
-			// It is safe to ignore the corner case of packets that just acked packet 0, because
-			// the lowestPacketNotConfirmedAcked is only used to limit the number of ACK ranges we will send.
-			if p.Value.largestAcked != 0 {
-				h.lowestPacketNotConfirmedAcked = utils.MaxPacketNumber(h.lowestPacketNotConfirmedAcked, p.Value.largestAcked+1)
-			}
-			h.onPacketAcked(p)
-			h.congestion.OnPacketAcked(p.Value.PacketNumber, p.Value.Length, h.bytesInFlight)
+	for _, p := range ackedPackets {
+		if encLevel < p.EncryptionLevel {
+			return fmt.Errorf("Received ACK with encryption level %s that acks a packet %d (encryption level %s)", encLevel, p.PacketNumber, p.EncryptionLevel)
 		}
+		// largestAcked == 0 either means that the packet didn't contain an ACK, or it just acked packet 0
+		// It is safe to ignore the corner case of packets that just acked packet 0, because
+		// the lowestPacketNotConfirmedAcked is only used to limit the number of ACK ranges we will send.
+		if p.largestAcked != 0 {
+			h.lowestPacketNotConfirmedAcked = utils.MaxPacketNumber(h.lowestPacketNotConfirmedAcked, p.largestAcked+1)
+		}
+		h.onPacketAcked(p)
+		h.congestion.OnPacketAcked(p.PacketNumber, p.Length, h.bytesInFlight)
 	}
 
 	h.detectLostPackets(rcvTime)
@@ -204,56 +203,56 @@ func (h *sentPacketHandler) GetLowestPacketNotConfirmedAcked() protocol.PacketNu
 	return h.lowestPacketNotConfirmedAcked
 }
 
-func (h *sentPacketHandler) determineNewlyAckedPackets(ackFrame *wire.AckFrame) ([]*PacketElement, error) {
-	var ackedPackets []*PacketElement
+func (h *sentPacketHandler) determineNewlyAckedPackets(ackFrame *wire.AckFrame) ([]*Packet, error) {
+	var ackedPackets []*Packet
 	ackRangeIndex := 0
-	for el := h.packetHistory.Front(); el != nil; el = el.Next() {
-		packet := el.Value
-		packetNumber := packet.PacketNumber
-
+	err := h.packetHistory.Iterate(func(p *Packet) (bool, error) {
 		// Ignore packets below the LowestAcked
-		if packetNumber < ackFrame.LowestAcked {
-			continue
+		if p.PacketNumber < ackFrame.LowestAcked {
+			return true, nil
 		}
 		// Break after LargestAcked is reached
-		if packetNumber > ackFrame.LargestAcked {
-			break
+		if p.PacketNumber > ackFrame.LargestAcked {
+			return false, nil
 		}
 
 		if ackFrame.HasMissingRanges() {
 			ackRange := ackFrame.AckRanges[len(ackFrame.AckRanges)-1-ackRangeIndex]
 
-			for packetNumber > ackRange.Last && ackRangeIndex < len(ackFrame.AckRanges)-1 {
+			for p.PacketNumber > ackRange.Last && ackRangeIndex < len(ackFrame.AckRanges)-1 {
 				ackRangeIndex++
 				ackRange = ackFrame.AckRanges[len(ackFrame.AckRanges)-1-ackRangeIndex]
 			}
 
-			if packetNumber >= ackRange.First { // packet i contained in ACK range
-				if packetNumber > ackRange.Last {
-					return nil, fmt.Errorf("BUG: ackhandler would have acked wrong packet 0x%x, while evaluating range 0x%x -> 0x%x", packetNumber, ackRange.First, ackRange.Last)
+			if p.PacketNumber >= ackRange.First { // packet i contained in ACK range
+				if p.PacketNumber > ackRange.Last {
+					return false, fmt.Errorf("BUG: ackhandler would have acked wrong packet 0x%x, while evaluating range 0x%x -> 0x%x", p.PacketNumber, ackRange.First, ackRange.Last)
 				}
-				ackedPackets = append(ackedPackets, el)
+				ackedPackets = append(ackedPackets, p)
 			}
 		} else {
-			ackedPackets = append(ackedPackets, el)
+			ackedPackets = append(ackedPackets, p)
 		}
-	}
-	return ackedPackets, nil
+		return true, nil
+	})
+	return ackedPackets, err
 }
 
 func (h *sentPacketHandler) maybeUpdateRTT(largestAcked protocol.PacketNumber, ackDelay time.Duration, rcvTime time.Time) bool {
-	for el := h.packetHistory.Front(); el != nil; el = el.Next() {
-		packet := el.Value
-		if packet.PacketNumber == largestAcked {
-			h.rttStats.UpdateRTT(rcvTime.Sub(packet.sendTime), ackDelay, rcvTime)
-			return true
+	var rttUpdated bool
+	h.packetHistory.Iterate(func(p *Packet) (bool, error) {
+		if p.PacketNumber == largestAcked {
+			h.rttStats.UpdateRTT(rcvTime.Sub(p.sendTime), ackDelay, rcvTime)
+			rttUpdated = true
+			return false, nil
 		}
 		// Packets are sorted by number, so we can stop searching
-		if packet.PacketNumber > largestAcked {
-			break
+		if p.PacketNumber > largestAcked {
+			return false, nil
 		}
-	}
-	return false
+		return true, nil
+	})
+	return rttUpdated
 }
 
 func (h *sentPacketHandler) updateLossDetectionAlarm(now time.Time) {
@@ -281,28 +280,25 @@ func (h *sentPacketHandler) detectLostPackets(now time.Time) {
 	maxRTT := float64(utils.MaxDuration(h.rttStats.LatestRTT(), h.rttStats.SmoothedRTT()))
 	delayUntilLost := time.Duration((1.0 + timeReorderingFraction) * maxRTT)
 
-	var lostPackets []*PacketElement
-	for el := h.packetHistory.Front(); el != nil; el = el.Next() {
-		packet := el.Value
-
+	var lostPackets []*Packet
+	h.packetHistory.Iterate(func(packet *Packet) (bool, error) {
 		if packet.PacketNumber > h.largestAcked {
-			break
+			return false, nil
 		}
 
 		timeSinceSent := now.Sub(packet.sendTime)
 		if timeSinceSent > delayUntilLost {
-			lostPackets = append(lostPackets, el)
+			lostPackets = append(lostPackets, packet)
 		} else if h.lossTime.IsZero() {
 			// Note: This conditional is only entered once per call
 			h.lossTime = now.Add(delayUntilLost - timeSinceSent)
 		}
-	}
+		return true, nil
+	})
 
-	if len(lostPackets) > 0 {
-		for _, p := range lostPackets {
-			h.queuePacketForRetransmission(p)
-			h.congestion.OnPacketLost(p.Value.PacketNumber, p.Value.Length, h.bytesInFlight)
-		}
+	for _, p := range lostPackets {
+		h.queuePacketForRetransmission(p)
+		h.congestion.OnPacketLost(p.PacketNumber, p.Length, h.bytesInFlight)
 	}
 }
 
@@ -329,12 +325,12 @@ func (h *sentPacketHandler) GetAlarmTimeout() time.Time {
 	return h.alarm
 }
 
-func (h *sentPacketHandler) onPacketAcked(packetElement *PacketElement) {
-	h.bytesInFlight -= packetElement.Value.Length
+func (h *sentPacketHandler) onPacketAcked(p *Packet) {
+	h.bytesInFlight -= p.Length
 	h.rtoCount = 0
 	h.handshakeCount = 0
 	// TODO(#497): h.tlpCount = 0
-	h.packetHistory.Remove(packetElement)
+	h.packetHistory.Remove(p.PacketNumber)
 }
 
 func (h *sentPacketHandler) DequeuePacketForRetransmission() *Packet {
@@ -405,36 +401,31 @@ func (h *sentPacketHandler) retransmitOldestTwoPackets() {
 	}
 }
 
-func (h *sentPacketHandler) queueRTO(el *PacketElement) {
-	packet := &el.Value
-	utils.Debugf(
-		"\tQueueing packet 0x%x for retransmission (RTO), %d outstanding",
-		packet.PacketNumber,
-		h.packetHistory.Len(),
-	)
-	h.queuePacketForRetransmission(el)
-	h.congestion.OnPacketLost(packet.PacketNumber, packet.Length, h.bytesInFlight)
+func (h *sentPacketHandler) queueRTO(p *Packet) {
+	utils.Debugf("\tQueueing packet 0x%x for retransmission (RTO), %d outstanding", p.PacketNumber, h.packetHistory.Len())
+	h.queuePacketForRetransmission(p)
+	h.congestion.OnPacketLost(p.PacketNumber, p.Length, h.bytesInFlight)
 	h.congestion.OnRetransmissionTimeout(true)
 }
 
 func (h *sentPacketHandler) queueHandshakePacketsForRetransmission() {
-	var handshakePackets []*PacketElement
-	for el := h.packetHistory.Front(); el != nil; el = el.Next() {
-		if el.Value.EncryptionLevel < protocol.EncryptionForwardSecure {
-			handshakePackets = append(handshakePackets, el)
+	var handshakePackets []*Packet
+	h.packetHistory.Iterate(func(p *Packet) (bool, error) {
+		if p.EncryptionLevel < protocol.EncryptionForwardSecure {
+			handshakePackets = append(handshakePackets, p)
 		}
-	}
-	for _, el := range handshakePackets {
-		h.queuePacketForRetransmission(el)
+		return true, nil
+	})
+	for _, p := range handshakePackets {
+		h.queuePacketForRetransmission(p)
 	}
 }
 
-func (h *sentPacketHandler) queuePacketForRetransmission(packetElement *PacketElement) {
-	packet := &packetElement.Value
-	h.bytesInFlight -= packet.Length
-	h.retransmissionQueue = append(h.retransmissionQueue, packet)
-	h.packetHistory.Remove(packetElement)
-	h.stopWaitingManager.QueuedRetransmissionForPacketNumber(packet.PacketNumber)
+func (h *sentPacketHandler) queuePacketForRetransmission(p *Packet) {
+	h.bytesInFlight -= p.Length
+	h.retransmissionQueue = append(h.retransmissionQueue, p)
+	h.packetHistory.Remove(p.PacketNumber)
+	h.stopWaitingManager.QueuedRetransmissionForPacketNumber(p.PacketNumber)
 }
 
 func (h *sentPacketHandler) computeHandshakeTimeout() time.Duration {

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -1,6 +1,7 @@
 package ackhandler
 
 import (
+	"sort"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -32,6 +33,20 @@ func handshakePacket(num protocol.PacketNumber) *Packet {
 		Frames:          []wire.Frame{&wire.PingFrame{}},
 		EncryptionLevel: protocol.EncryptionUnencrypted,
 	}
+}
+
+func createAck(ranges []wire.AckRange) *wire.AckFrame {
+	sort.Slice(ranges, func(i, j int) bool {
+		return ranges[i].First > ranges[j].First
+	})
+	ack := &wire.AckFrame{
+		LowestAcked:  ranges[len(ranges)-1].First,
+		LargestAcked: ranges[0].Last,
+	}
+	if len(ranges) > 1 {
+		ack.AckRanges = ranges
+	}
+	return ack
 }
 
 var _ = Describe("SentPacketHandler", func() {
@@ -72,76 +87,65 @@ var _ = Describe("SentPacketHandler", func() {
 
 	Context("registering sent packets", func() {
 		It("accepts two consecutive packets", func() {
-			packet1 := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1}
-			packet2 := Packet{PacketNumber: 2, Frames: []wire.Frame{&streamFrame}, Length: 2}
-			handler.SentPacket(&packet1)
-			handler.SentPacket(&packet2)
+			handler.SentPacket(retransmittablePacket(1))
+			handler.SentPacket(retransmittablePacket(2))
 			Expect(handler.lastSentPacketNumber).To(Equal(protocol.PacketNumber(2)))
 			expectInPacketHistory([]protocol.PacketNumber{1, 2})
-			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(3)))
+			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
 			Expect(handler.skippedPackets).To(BeEmpty())
 		})
 
 		It("accepts packet number 0", func() {
-			packet1 := Packet{PacketNumber: 0, Frames: []wire.Frame{&streamFrame}, Length: 1}
-			packet2 := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 2}
-			handler.SentPacket(&packet1)
+			handler.SentPacket(retransmittablePacket(0))
 			Expect(handler.lastSentPacketNumber).To(BeZero())
-			handler.SentPacket(&packet2)
+			handler.SentPacket(retransmittablePacket(1))
 			Expect(handler.lastSentPacketNumber).To(Equal(protocol.PacketNumber(1)))
 			expectInPacketHistory([]protocol.PacketNumber{0, 1})
-			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(3)))
+			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
 			Expect(handler.skippedPackets).To(BeEmpty())
 		})
 
 		It("stores the sent time", func() {
-			packet := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1}
-			handler.SentPacket(&packet)
+			handler.SentPacket(retransmittablePacket(1))
 			Expect(getPacket(1).sendTime.Unix()).To(BeNumerically("~", time.Now().Unix(), 1))
 		})
 
 		It("does not store non-retransmittable packets", func() {
-			handler.SentPacket(&Packet{PacketNumber: 1, Length: 1})
+			handler.SentPacket(nonRetransmittablePacket(1))
 			Expect(handler.packetHistory.Len()).To(BeZero())
 		})
 
 		Context("skipped packet numbers", func() {
 			It("works with non-consecutive packet numbers", func() {
-				packet1 := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1}
-				packet2 := Packet{PacketNumber: 3, Frames: []wire.Frame{&streamFrame}, Length: 2}
-				handler.SentPacket(&packet1)
-				handler.SentPacket(&packet2)
+				handler.SentPacket(retransmittablePacket(1))
+				handler.SentPacket(retransmittablePacket(3))
 				Expect(handler.lastSentPacketNumber).To(Equal(protocol.PacketNumber(3)))
 				expectInPacketHistory([]protocol.PacketNumber{1, 3})
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(3)))
-				Expect(handler.skippedPackets).To(HaveLen(1))
-				Expect(handler.skippedPackets[0]).To(Equal(protocol.PacketNumber(2)))
+				Expect(handler.skippedPackets).To(Equal([]protocol.PacketNumber{2}))
+			})
+
+			It("works with non-retransmittable packets", func() {
+				handler.SentPacket(nonRetransmittablePacket(1))
+				handler.SentPacket(nonRetransmittablePacket(3))
+				Expect(handler.skippedPackets).To(Equal([]protocol.PacketNumber{2}))
 			})
 
 			It("recognizes multiple skipped packets", func() {
-				packet1 := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1}
-				packet2 := Packet{PacketNumber: 3, Frames: []wire.Frame{&streamFrame}, Length: 2}
-				packet3 := Packet{PacketNumber: 5, Frames: []wire.Frame{&streamFrame}, Length: 2}
-				handler.SentPacket(&packet1)
-				handler.SentPacket(&packet2)
-				handler.SentPacket(&packet3)
-				Expect(handler.skippedPackets).To(HaveLen(2))
+				handler.SentPacket(retransmittablePacket(1))
+				handler.SentPacket(retransmittablePacket(3))
+				handler.SentPacket(retransmittablePacket(5))
 				Expect(handler.skippedPackets).To(Equal([]protocol.PacketNumber{2, 4}))
 			})
 
 			It("recognizes multiple consecutive skipped packets", func() {
-				packet1 := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1}
-				packet2 := Packet{PacketNumber: 4, Frames: []wire.Frame{&streamFrame}, Length: 2}
-				handler.SentPacket(&packet1)
-				handler.SentPacket(&packet2)
-				Expect(handler.skippedPackets).To(HaveLen(2))
+				handler.SentPacket(retransmittablePacket(1))
+				handler.SentPacket(retransmittablePacket(4))
 				Expect(handler.skippedPackets).To(Equal([]protocol.PacketNumber{2, 3}))
 			})
 
 			It("limits the lengths of the skipped packet slice", func() {
 				for i := 0; i < protocol.MaxTrackedSkippedPackets+5; i++ {
-					packet := Packet{PacketNumber: protocol.PacketNumber(2*i + 1), Frames: []wire.Frame{&streamFrame}, Length: 1}
-					handler.SentPacket(&packet)
+					handler.SentPacket(retransmittablePacket(protocol.PacketNumber(2*i + 1)))
 				}
 				Expect(handler.skippedPackets).To(HaveLen(protocol.MaxUndecryptablePackets))
 				Expect(handler.skippedPackets[0]).To(Equal(protocol.PacketNumber(10)))
@@ -170,284 +174,176 @@ var _ = Describe("SentPacketHandler", func() {
 					Expect(handler.skippedPackets).To(BeEmpty())
 				})
 			})
+
+			Context("ACK handling", func() {
+				BeforeEach(func() {
+					handler.SentPacket(retransmittablePacket(10))
+					handler.SentPacket(retransmittablePacket(12))
+				})
+
+				It("rejects ACKs for skipped packets", func() {
+					ack := createAck([]wire.AckRange{{First: 10, Last: 12}})
+					err := handler.ReceivedAck(ack, 1337, protocol.EncryptionForwardSecure, time.Now())
+					Expect(err).To(MatchError("InvalidAckData: Received an ACK for a skipped packet number"))
+				})
+
+				It("accepts an ACK that correctly nacks a skipped packet", func() {
+					ack := createAck([]wire.AckRange{{First: 10, Last: 10}, {First: 12, Last: 12}})
+					err := handler.ReceivedAck(ack, 1337, protocol.EncryptionForwardSecure, time.Now())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(handler.largestAcked).ToNot(BeZero())
+				})
+			})
 		})
 	})
 
 	Context("ACK processing", func() {
-		var packets []*Packet
-
 		BeforeEach(func() {
-			packets = []*Packet{
-				{PacketNumber: 0, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 2, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 3, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 4, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 5, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 6, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 7, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 8, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 9, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 10, Frames: []wire.Frame{&streamFrame}, Length: 1},
-				{PacketNumber: 12, Frames: []wire.Frame{&streamFrame}, Length: 1},
-			}
-			for _, packet := range packets {
-				handler.SentPacket(packet)
+			for i := protocol.PacketNumber(0); i < 10; i++ {
+				handler.SentPacket(retransmittablePacket(i))
 			}
 			// Increase RTT, because the tests would be flaky otherwise
 			handler.rttStats.UpdateRTT(time.Hour, 0, time.Now())
-			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets))))
+			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(10)))
 		})
 
 		Context("ACK validation", func() {
 			It("accepts ACKs sent in packet 0", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 5,
-					LowestAcked:  1,
-				}
-				err := handler.ReceivedAck(&ack, 0, protocol.EncryptionUnencrypted, time.Now())
+				ack := createAck([]wire.AckRange{{First: 0, Last: 5}})
+				err := handler.ReceivedAck(ack, 0, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(5)))
 			})
 
 			It("rejects duplicate ACKs", func() {
-				ack1 := wire.AckFrame{LargestAcked: 3}
-				ack2 := wire.AckFrame{LargestAcked: 4}
-				err := handler.ReceivedAck(&ack1, 1337, protocol.EncryptionUnencrypted, time.Now())
+				ack1 := createAck([]wire.AckRange{{First: 0, Last: 3}})
+				ack2 := createAck([]wire.AckRange{{First: 0, Last: 4}})
+				err := handler.ReceivedAck(ack1, 1337, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(3)))
 				// this wouldn't happen in practice
 				// for testing purposes, we pretend send a different ACK frame in a duplicated packet, to be able to verify that it actually doesn't get processed
-				err = handler.ReceivedAck(&ack2, 1337, protocol.EncryptionUnencrypted, time.Now())
+				err = handler.ReceivedAck(ack2, 1337, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(3)))
 			})
 
 			It("rejects out of order ACKs", func() {
 				// acks packets 0, 1, 2, 3
-				ack1 := wire.AckFrame{LargestAcked: 3}
-				ack2 := wire.AckFrame{LargestAcked: 4}
-				err := handler.ReceivedAck(&ack1, 1337, protocol.EncryptionUnencrypted, time.Now())
+				ack1 := createAck([]wire.AckRange{{First: 0, Last: 3}})
+				ack2 := createAck([]wire.AckRange{{First: 0, Last: 4}})
+				err := handler.ReceivedAck(ack1, 1337, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				// this wouldn't happen in practive
 				// a receiver wouldn't send an ACK for a lower largest acked in a packet sent later
-				err = handler.ReceivedAck(&ack2, 1337-1, protocol.EncryptionUnencrypted, time.Now())
+				err = handler.ReceivedAck(ack2, 1337-1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(3)))
 			})
 
 			It("rejects ACKs with a too high LargestAcked packet number", func() {
-				ack := wire.AckFrame{
-					LargestAcked: packets[len(packets)-1].PacketNumber + 1337,
-				}
-				err := handler.ReceivedAck(&ack, 1, protocol.EncryptionUnencrypted, time.Now())
+				ack := createAck([]wire.AckRange{{First: 0, Last: 9999}})
+				err := handler.ReceivedAck(ack, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).To(MatchError("InvalidAckData: Received ACK for an unsent package"))
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets))))
+				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(10)))
 			})
 
 			It("ignores repeated ACKs", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 3,
-					LowestAcked:  1,
-				}
-				err := handler.ReceivedAck(&ack, 1337, protocol.EncryptionUnencrypted, time.Now())
+				ack := createAck([]wire.AckRange{{First: 1, Last: 3}})
+				err := handler.ReceivedAck(ack, 1337, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets) - 3)))
-				err = handler.ReceivedAck(&ack, 1337+1, protocol.EncryptionUnencrypted, time.Now())
+				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(7)))
+				err = handler.ReceivedAck(ack, 1337+1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(3)))
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets) - 3)))
-			})
-
-			It("rejects ACKs for skipped packets", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 12,
-					LowestAcked:  5,
-				}
-				err := handler.ReceivedAck(&ack, 1337, protocol.EncryptionUnencrypted, time.Now())
-				Expect(err).To(MatchError("InvalidAckData: Received an ACK for a skipped packet number"))
-			})
-
-			It("accepts an ACK that correctly nacks a skipped packet", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 12,
-					LowestAcked:  5,
-					AckRanges: []wire.AckRange{
-						{First: 12, Last: 12},
-						{First: 5, Last: 10},
-					},
-				}
-				err := handler.ReceivedAck(&ack, 1337, protocol.EncryptionUnencrypted, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.largestAcked).ToNot(BeZero())
+				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(7)))
 			})
 		})
 
 		Context("acks and nacks the right packets", func() {
 			It("adjusts the LargestAcked", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 5,
-					LowestAcked:  0,
-				}
-				err := handler.ReceivedAck(&ack, 1, protocol.EncryptionUnencrypted, time.Now())
+				ack := createAck([]wire.AckRange{{First: 0, Last: 5}})
+				err := handler.ReceivedAck(ack, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(5)))
-				Expect(handler.packetHistory.Len()).To(Equal(6)) // 6, 7, 8, 9, 10, 12
-				for i := protocol.PacketNumber(6); i <= 10; i++ {
-					Expect(getPacket(i)).ToNot(BeNil())
-				}
-				Expect(getPacket(12)).ToNot(BeNil())
-			})
-
-			It("rejects an ACK that acks packets with a higher encryption level", func() {
-				handler.SentPacket(&Packet{
-					PacketNumber:    13,
-					EncryptionLevel: protocol.EncryptionForwardSecure,
-					Frames:          []wire.Frame{&streamFrame},
-					Length:          1,
-				})
-				ack := wire.AckFrame{
-					LargestAcked: 13,
-					LowestAcked:  13,
-				}
-				err := handler.ReceivedAck(&ack, 1, protocol.EncryptionSecure, time.Now())
-				Expect(err).To(MatchError("Received ACK with encryption level encrypted (not forward-secure) that acks a packet 13 (encryption level forward-secure)"))
-			})
-
-			It("acks all packets for an ACK frame with no missing packets", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 8,
-					LowestAcked:  1,
-				}
-				err := handler.ReceivedAck(&ack, 1, protocol.EncryptionUnencrypted, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.packetHistory.Len()).To(Equal(4)) // 0, 9, 10, 12
-				Expect(getPacket(0)).ToNot(BeNil())
-				Expect(getPacket(9)).ToNot(BeNil())
-				Expect(getPacket(10)).ToNot(BeNil())
-				Expect(getPacket(12)).ToNot(BeNil())
+				expectInPacketHistory([]protocol.PacketNumber{6, 7, 8, 9})
 			})
 
 			It("acks packet 0", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 0,
-					LowestAcked:  0,
-				}
-				err := handler.ReceivedAck(&ack, 1, protocol.EncryptionUnencrypted, time.Now())
+				ack := createAck([]wire.AckRange{{First: 0, Last: 0}})
+				err := handler.ReceivedAck(ack, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(getPacket(0)).To(BeNil())
-				Expect(handler.packetHistory.Len()).To(Equal(11)) // 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12
+				expectInPacketHistory([]protocol.PacketNumber{1, 2, 3, 4, 5, 6, 7, 8, 9})
 			})
 
 			It("handles an ACK frame with one missing packet range", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 9,
-					LowestAcked:  1,
-					AckRanges: []wire.AckRange{ // packets 4 and 5 were lost
-						{First: 6, Last: 9},
-						{First: 1, Last: 3},
-					},
-				}
-				err := handler.ReceivedAck(&ack, 1, protocol.EncryptionUnencrypted, time.Now())
+				ack := createAck([]wire.AckRange{{First: 1, Last: 3}, {First: 6, Last: 9}}) // lose 4 and 5
+				err := handler.ReceivedAck(ack, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 4, 5, 10, 12})
+				expectInPacketHistory([]protocol.PacketNumber{0, 4, 5})
 			})
 
 			It("does not ack packets below the LowestAcked", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 8,
-					LowestAcked:  3,
-				}
-				err := handler.ReceivedAck(&ack, 1, protocol.EncryptionUnencrypted, time.Now())
+				ack := createAck([]wire.AckRange{{First: 3, Last: 8}})
+				err := handler.ReceivedAck(ack, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 1, 2, 9, 10, 12})
+				expectInPacketHistory([]protocol.PacketNumber{0, 1, 2, 9})
 			})
 
 			It("handles an ACK with multiple missing packet ranges", func() {
-				ack := wire.AckFrame{
-					LargestAcked: 9,
-					LowestAcked:  1,
-					AckRanges: []wire.AckRange{ // packets 2, 4 and 5, and 8 were lost
-						{First: 9, Last: 9},
-						{First: 6, Last: 7},
-						{First: 3, Last: 3},
-						{First: 1, Last: 1},
-					},
-				}
-				err := handler.ReceivedAck(&ack, 1, protocol.EncryptionUnencrypted, time.Now())
+				ack := createAck([]wire.AckRange{ // packets 2, 4 and 5, and 8 were lost
+					{First: 9, Last: 9},
+					{First: 6, Last: 7},
+					{First: 3, Last: 3},
+					{First: 1, Last: 1},
+				})
+				err := handler.ReceivedAck(ack, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 2, 4, 5, 8, 10, 12})
+				expectInPacketHistory([]protocol.PacketNumber{0, 2, 4, 5, 8})
 			})
 
 			It("processes an ACK frame that would be sent after a late arrival of a packet", func() {
-				largestObserved := 6
-				ack1 := wire.AckFrame{
-					LargestAcked: protocol.PacketNumber(largestObserved),
-					LowestAcked:  1,
-					AckRanges: []wire.AckRange{
-						{First: 4, Last: protocol.PacketNumber(largestObserved)},
-						{First: 1, Last: 2},
-					},
-				}
-				err := handler.ReceivedAck(&ack1, 1, protocol.EncryptionUnencrypted, time.Now())
+				ack1 := createAck([]wire.AckRange{{First: 1, Last: 2}, {First: 4, Last: 6}}) // 3 lost
+				err := handler.ReceivedAck(ack1, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets) - 5)))
-				expectInPacketHistory([]protocol.PacketNumber{0, 3, 7, 8, 9, 10, 12})
-				ack2 := wire.AckFrame{
-					LargestAcked: protocol.PacketNumber(largestObserved),
-					LowestAcked:  1,
-				}
-				err = handler.ReceivedAck(&ack2, 2, protocol.EncryptionUnencrypted, time.Now())
+				expectInPacketHistory([]protocol.PacketNumber{0, 3, 7, 8, 9})
+				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(5)))
+				ack2 := createAck([]wire.AckRange{{First: 1, Last: 6}}) // now ack 3
+				err = handler.ReceivedAck(ack2, 2, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets) - 6)))
-				expectInPacketHistory([]protocol.PacketNumber{0, 7, 8, 9, 10, 12})
+				expectInPacketHistory([]protocol.PacketNumber{0, 7, 8, 9})
+				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(4)))
 			})
 
 			It("processes an ACK frame that would be sent after a late arrival of a packet and another packet", func() {
-				ack1 := wire.AckFrame{
-					LargestAcked: 6,
-					LowestAcked:  0,
-					AckRanges: []wire.AckRange{
-						{First: 4, Last: 6},
-						{First: 0, Last: 2},
-					},
-				}
-				err := handler.ReceivedAck(&ack1, 1, protocol.EncryptionUnencrypted, time.Now())
+				ack1 := createAck([]wire.AckRange{{First: 0, Last: 2}, {First: 4, Last: 6}})
+				err := handler.ReceivedAck(ack1, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets) - 6)))
-				expectInPacketHistory([]protocol.PacketNumber{3, 7, 8, 9, 10, 12})
-				ack2 := wire.AckFrame{
-					LargestAcked: 7,
-					LowestAcked:  1,
-				}
-				err = handler.ReceivedAck(&ack2, 2, protocol.EncryptionUnencrypted, time.Now())
+				expectInPacketHistory([]protocol.PacketNumber{3, 7, 8, 9})
+				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(4)))
+				ack2 := createAck([]wire.AckRange{{First: 1, Last: 7}})
+				err = handler.ReceivedAck(ack2, 2, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets) - 8)))
-				expectInPacketHistory([]protocol.PacketNumber{8, 9, 10, 12})
+				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
+				expectInPacketHistory([]protocol.PacketNumber{8, 9})
 			})
 
 			It("processes an ACK that contains old ACK ranges", func() {
-				ack1 := wire.AckFrame{
-					LargestAcked: 6,
-					LowestAcked:  1,
-				}
-				err := handler.ReceivedAck(&ack1, 1, protocol.EncryptionUnencrypted, time.Now())
+				ack1 := createAck([]wire.AckRange{{First: 1, Last: 6}})
+				err := handler.ReceivedAck(ack1, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 7, 8, 9, 10, 12})
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets) - 6)))
-				ack2 := wire.AckFrame{
-					LargestAcked: 10,
-					LowestAcked:  1,
-					AckRanges: []wire.AckRange{
-						{First: 8, Last: 10},
-						{First: 3, Last: 3},
-						{First: 1, Last: 1},
-					},
-				}
-				err = handler.ReceivedAck(&ack2, 2, protocol.EncryptionUnencrypted, time.Now())
+				expectInPacketHistory([]protocol.PacketNumber{0, 7, 8, 9})
+				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(4)))
+				ack2 := createAck([]wire.AckRange{
+					{First: 1, Last: 1},
+					{First: 3, Last: 3},
+					{First: 8, Last: 8},
+				})
+				err = handler.ReceivedAck(ack2, 2, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(len(packets) - 6 - 3)))
-				expectInPacketHistory([]protocol.PacketNumber{0, 7, 12})
+				expectInPacketHistory([]protocol.PacketNumber{0, 7, 9})
+				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(3)))
 			})
 		})
 
@@ -459,13 +355,13 @@ var _ = Describe("SentPacketHandler", func() {
 				getPacket(2).sendTime = now.Add(-5 * time.Minute)
 				getPacket(6).sendTime = now.Add(-1 * time.Minute)
 				// Now, check that the proper times are used when calculating the deltas
-				err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 1}, 1, protocol.EncryptionUnencrypted, time.Now())
+				err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 1}, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(handler.rttStats.LatestRTT()).To(BeNumerically("~", 10*time.Minute, 1*time.Second))
-				err = handler.ReceivedAck(&wire.AckFrame{LargestAcked: 2}, 2, protocol.EncryptionUnencrypted, time.Now())
+				err = handler.ReceivedAck(&wire.AckFrame{LargestAcked: 2}, 2, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(handler.rttStats.LatestRTT()).To(BeNumerically("~", 5*time.Minute, 1*time.Second))
-				err = handler.ReceivedAck(&wire.AckFrame{LargestAcked: 6}, 3, protocol.EncryptionUnencrypted, time.Now())
+				err = handler.ReceivedAck(&wire.AckFrame{LargestAcked: 6}, 3, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(handler.rttStats.LatestRTT()).To(BeNumerically("~", 1*time.Minute, 1*time.Second))
 			})
@@ -475,7 +371,7 @@ var _ = Describe("SentPacketHandler", func() {
 				// make sure the rttStats have a min RTT, so that the delay is used
 				handler.rttStats.UpdateRTT(5*time.Minute, 0, time.Now())
 				getPacket(1).sendTime = now.Add(-10 * time.Minute)
-				err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 1, DelayTime: 5 * time.Minute}, 1, protocol.EncryptionUnencrypted, time.Now())
+				err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 1, DelayTime: 5 * time.Minute}, 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(handler.rttStats.LatestRTT()).To(BeNumerically("~", 5*time.Minute, 1*time.Second))
 			})
@@ -494,25 +390,25 @@ var _ = Describe("SentPacketHandler", func() {
 			})
 
 			It("determines which ACK we have received an ACK for", func() {
-				err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 15, LowestAcked: 12}, 1, protocol.EncryptionUnencrypted, time.Now())
+				err := handler.ReceivedAck(createAck([]wire.AckRange{{First: 13, Last: 15}}), 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(201)))
 			})
 
 			It("doesn't do anything when the acked packet didn't contain an ACK", func() {
-				err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 13, LowestAcked: 13}, 1, protocol.EncryptionUnencrypted, time.Now())
+				err := handler.ReceivedAck(createAck([]wire.AckRange{{First: 13, Last: 13}}), 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(101)))
-				err = handler.ReceivedAck(&wire.AckFrame{LargestAcked: 15, LowestAcked: 15}, 2, protocol.EncryptionUnencrypted, time.Now())
+				err = handler.ReceivedAck(createAck([]wire.AckRange{{First: 15, Last: 15}}), 2, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(101)))
 			})
 
 			It("doesn't decrease the value", func() {
-				err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 14, LowestAcked: 14}, 1, protocol.EncryptionUnencrypted, time.Now())
+				err := handler.ReceivedAck(createAck([]wire.AckRange{{First: 14, Last: 14}}), 1, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(201)))
-				err = handler.ReceivedAck(&wire.AckFrame{LargestAcked: 13, LowestAcked: 13}, 2, protocol.EncryptionUnencrypted, time.Now())
+				err = handler.ReceivedAck(createAck([]wire.AckRange{{First: 13, Last: 13}}), 2, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(201)))
 			})
@@ -520,105 +416,28 @@ var _ = Describe("SentPacketHandler", func() {
 	})
 
 	Context("Retransmission handling", func() {
-		var packets []*Packet
-
-		BeforeEach(func() {
-			packets = []*Packet{
-				{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1, EncryptionLevel: protocol.EncryptionUnencrypted},
-				{PacketNumber: 2, Frames: []wire.Frame{&streamFrame}, Length: 1, EncryptionLevel: protocol.EncryptionUnencrypted},
-				{PacketNumber: 3, Frames: []wire.Frame{&streamFrame}, Length: 1, EncryptionLevel: protocol.EncryptionUnencrypted},
-				{PacketNumber: 4, Frames: []wire.Frame{&streamFrame}, Length: 1, EncryptionLevel: protocol.EncryptionSecure},
-				{PacketNumber: 5, Frames: []wire.Frame{&streamFrame}, Length: 1, EncryptionLevel: protocol.EncryptionSecure},
-				{PacketNumber: 6, Frames: []wire.Frame{&streamFrame}, Length: 1, EncryptionLevel: protocol.EncryptionForwardSecure},
-				{PacketNumber: 7, Frames: []wire.Frame{&streamFrame}, Length: 1, EncryptionLevel: protocol.EncryptionForwardSecure},
-			}
-			for _, packet := range packets {
-				handler.SentPacket(packet)
-			}
-			// Increase RTT, because the tests would be flaky otherwise
-			handler.rttStats.UpdateRTT(time.Minute, 0, time.Now())
-			// Ack a single packet so that we have non-RTO timings
-			handler.ReceivedAck(&wire.AckFrame{LargestAcked: 2, LowestAcked: 2}, 1, protocol.EncryptionForwardSecure, time.Now())
-			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(6)))
-		})
-
 		It("does not dequeue a packet if no ack has been received", func() {
-			Expect(handler.DequeuePacketForRetransmission()).To(BeNil())
-		})
-
-		It("dequeues a packet for retransmission", func() {
-			getPacket(1).sendTime = time.Now().Add(-time.Hour)
-			handler.OnAlarm()
-			Expect(getPacket(1)).To(BeNil())
-			Expect(handler.retransmissionQueue).To(HaveLen(1))
-			Expect(handler.retransmissionQueue[0].PacketNumber).To(Equal(protocol.PacketNumber(1)))
-			packet := handler.DequeuePacketForRetransmission()
-			Expect(packet).ToNot(BeNil())
-			Expect(packet.PacketNumber).To(Equal(protocol.PacketNumber(1)))
-			Expect(handler.DequeuePacketForRetransmission()).To(BeNil())
-		})
-
-		It("deletes non forward-secure packets when the handshake completes", func() {
-			for i := protocol.PacketNumber(1); i <= 7; i++ {
-				if i == 2 { // packet 2 was already acked in BeforeEach
-					continue
-				}
-				handler.queuePacketForRetransmission(getPacket(i))
-			}
-			Expect(handler.retransmissionQueue).To(HaveLen(6))
-			handler.SetHandshakeComplete()
-			packet := handler.DequeuePacketForRetransmission()
-			Expect(packet).ToNot(BeNil())
-			Expect(packet.PacketNumber).To(Equal(protocol.PacketNumber(6)))
-			packet = handler.DequeuePacketForRetransmission()
-			Expect(packet).ToNot(BeNil())
-			Expect(packet.PacketNumber).To(Equal(protocol.PacketNumber(7)))
+			handler.SentPacket(retransmittablePacket(1))
 			Expect(handler.DequeuePacketForRetransmission()).To(BeNil())
 		})
 
 		Context("STOP_WAITINGs", func() {
 			It("gets a STOP_WAITING frame", func() {
-				ack := wire.AckFrame{LargestAcked: 5, LowestAcked: 5}
+				handler.SentPacket(retransmittablePacket(1))
+				handler.SentPacket(retransmittablePacket(2))
+				handler.SentPacket(retransmittablePacket(3))
+				ack := wire.AckFrame{LargestAcked: 3, LowestAcked: 3}
 				err := handler.ReceivedAck(&ack, 2, protocol.EncryptionForwardSecure, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.GetStopWaitingFrame(false)).To(Equal(&wire.StopWaitingFrame{LeastUnacked: 6}))
+				Expect(handler.GetStopWaitingFrame(false)).To(Equal(&wire.StopWaitingFrame{LeastUnacked: 4}))
 			})
 
 			It("gets a STOP_WAITING frame after queueing a retransmission", func() {
+				handler.SentPacket(retransmittablePacket(5))
 				handler.queuePacketForRetransmission(getPacket(5))
 				Expect(handler.GetStopWaitingFrame(false)).To(Equal(&wire.StopWaitingFrame{LeastUnacked: 6}))
 			})
 		})
-	})
-
-	It("calculates bytes in flight", func() {
-		packet1 := Packet{PacketNumber: 1, Frames: []wire.Frame{&streamFrame}, Length: 1}
-		packet2 := Packet{PacketNumber: 2, Frames: []wire.Frame{&streamFrame}, Length: 2}
-		packet3 := Packet{PacketNumber: 3, Frames: []wire.Frame{&streamFrame}, Length: 3}
-		handler.SentPacket(&packet1)
-		Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(1)))
-		handler.SentPacket(&packet2)
-		Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(1 + 2)))
-		handler.SentPacket(&packet3)
-		Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(1 + 2 + 3)))
-
-		// Increase RTT, because the tests would be flaky otherwise
-		handler.rttStats.UpdateRTT(time.Minute, 0, time.Now())
-
-		// ACK 1 and 3, NACK 2
-		ack := wire.AckFrame{
-			LargestAcked: 3,
-			LowestAcked:  1,
-			AckRanges: []wire.AckRange{
-				{First: 3, Last: 3},
-				{First: 1, Last: 1},
-			},
-		}
-		handler.ReceivedAck(&ack, 1, protocol.EncryptionUnencrypted, time.Now())
-		Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
-		getPacket(2).sendTime = time.Now().Add(-time.Hour)
-		handler.OnAlarm()
-		Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(0)))
 	})
 
 	Context("congestion", func() {
@@ -743,7 +562,7 @@ var _ = Describe("SentPacketHandler", func() {
 		})
 	})
 
-	Context("calculating RTO", func() {
+	Context("RTOs", func() {
 		It("uses default RTO", func() {
 			Expect(handler.computeRTOTimeout()).To(Equal(defaultRTOTimeout))
 		})
@@ -775,49 +594,70 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.rtoCount = 2
 			Expect(handler.computeRTOTimeout()).To(Equal(4 * defaultRTOTimeout))
 		})
+
+		It("queues two packets if RTO expires", func() {
+			handler.SentPacket(retransmittablePacket(1))
+			handler.SentPacket(retransmittablePacket(2))
+
+			handler.rttStats.UpdateRTT(time.Hour, 0, time.Now())
+			Expect(handler.lossTime.IsZero()).To(BeTrue())
+			Expect(time.Until(handler.GetAlarmTimeout())).To(BeNumerically("~", handler.computeRTOTimeout(), time.Minute))
+
+			handler.OnAlarm()
+			p := handler.DequeuePacketForRetransmission()
+			Expect(p).ToNot(BeNil())
+			Expect(p.PacketNumber).To(Equal(protocol.PacketNumber(1)))
+			p = handler.DequeuePacketForRetransmission()
+			Expect(p).ToNot(BeNil())
+			Expect(p.PacketNumber).To(Equal(protocol.PacketNumber(2)))
+
+			Expect(handler.rtoCount).To(BeEquivalentTo(1))
+		})
 	})
 
 	Context("Delay-based loss detection", func() {
-		It("detects a packet as lost", func() {
+		It("immediately detects old packets as lost when receiving an ACK", func() {
+			now := time.Now()
 			handler.SentPacket(retransmittablePacket(1))
+			getPacket(1).sendTime = now.Add(-time.Hour)
 			handler.SentPacket(retransmittablePacket(2))
+			getPacket(2).sendTime = now.Add(-time.Second)
 			Expect(handler.lossTime.IsZero()).To(BeTrue())
 
-			err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 2, LowestAcked: 2}, 1, protocol.EncryptionForwardSecure, time.Now().Add(time.Hour))
+			err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 2, LowestAcked: 2}, 1, protocol.EncryptionForwardSecure, now)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(handler.lossTime.IsZero()).To(BeFalse())
-
-			// RTT is around 1h now.
-			// The formula is (1+1/8) * RTT, so this should be around that number
-			Expect(time.Until(handler.lossTime)).To(BeNumerically("~", time.Hour*9/8, time.Minute))
-			Expect(time.Until(handler.GetAlarmTimeout())).To(BeNumerically("~", time.Hour*9/8, time.Minute))
-
-			getPacket(1).sendTime = time.Now().Add(-2 * time.Hour)
-			handler.OnAlarm()
-			Expect(handler.DequeuePacketForRetransmission()).NotTo(BeNil())
+			Expect(handler.DequeuePacketForRetransmission()).ToNot(BeNil())
+			// no need to set an alarm, since packet 1 was already declared lost
+			Expect(handler.lossTime.IsZero()).To(BeTrue())
 		})
 
-		It("does not detect packets as lost without ACKs", func() {
-			handler.SentPacket(nonRetransmittablePacket(1))
+		It("sets the early retransmit alarm", func() {
+			now := time.Now()
+			handler.SentPacket(retransmittablePacket(1))
+			getPacket(1).sendTime = now.Add(-2 * time.Second)
 			handler.SentPacket(retransmittablePacket(2))
+			getPacket(2).sendTime = now.Add(-2 * time.Second)
 			handler.SentPacket(retransmittablePacket(3))
+			getPacket(3).sendTime = now.Add(-time.Second)
 			Expect(handler.lossTime.IsZero()).To(BeTrue())
 
-			now := time.Now().Add(time.Hour)
-			err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 1, LowestAcked: 1}, 1, protocol.EncryptionUnencrypted, now)
+			err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 2, LowestAcked: 2}, 1, protocol.EncryptionForwardSecure, now.Add(-time.Second))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(handler.lossTime.IsZero()).To(BeTrue())
-			Expect(handler.GetAlarmTimeout().Sub(now)).To(BeNumerically("~", handler.computeRTOTimeout(), time.Minute))
+			Expect(handler.rttStats.SmoothedRTT()).To(Equal(time.Second))
 
-			// This means RTO, so both packets should be lost
+			// Packet 1 should be considered lost (1+1/8) RTTs after it was sent.
+			Expect(handler.lossTime.IsZero()).To(BeFalse())
+			Expect(handler.lossTime.Sub(getPacket(1).sendTime)).To(Equal(time.Second * 9 / 8))
+			// Expect(time.Until(handler.GetAlarmTimeout())).To(BeNumerically("~", time.Hour*9/8, time.Minute))
+
 			handler.OnAlarm()
-			Expect(handler.DequeuePacketForRetransmission()).ToNot(BeNil())
-			Expect(handler.DequeuePacketForRetransmission()).ToNot(BeNil())
+			Expect(handler.DequeuePacketForRetransmission()).NotTo(BeNil())
+			// make sure this is not an RTO: only packet 1 is retransmissted
 			Expect(handler.DequeuePacketForRetransmission()).To(BeNil())
 		})
 	})
 
-	Context("retransmission for handshake packets", func() {
+	Context("handshake packets", func() {
 		BeforeEach(func() {
 			handler.handshakeComplete = false
 		})
@@ -830,7 +670,7 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.SentPacket(retransmittablePacket(3))
 			handler.SentPacket(handshakePacket(4))
 
-			err := handler.ReceivedAck(&wire.AckFrame{LargestAcked: 1, LowestAcked: 1}, 1, protocol.EncryptionSecure, time.Now())
+			err := handler.ReceivedAck(createAck([]wire.AckRange{{First: 1, Last: 1}}), 1, protocol.EncryptionForwardSecure, time.Now())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(handler.lossTime.IsZero()).To(BeTrue())
 			handshakeTimeout := handler.computeHandshakeTimeout()
@@ -849,26 +689,31 @@ var _ = Describe("SentPacketHandler", func() {
 			// make sure the exponential backoff is used
 			Expect(handler.computeHandshakeTimeout()).To(BeNumerically("~", 2*handshakeTimeout, time.Minute))
 		})
-	})
 
-	Context("RTO retransmission", func() {
-		It("queues two packets if RTO expires", func() {
-			handler.SentPacket(retransmittablePacket(1))
-			handler.SentPacket(retransmittablePacket(2))
+		It("rejects an ACK that acks packets with a higher encryption level", func() {
+			handler.SentPacket(&Packet{
+				PacketNumber:    13,
+				EncryptionLevel: protocol.EncryptionForwardSecure,
+				Frames:          []wire.Frame{&streamFrame},
+				Length:          1,
+			})
+			ack := createAck([]wire.AckRange{{First: 13, Last: 13}})
+			err := handler.ReceivedAck(ack, 1, protocol.EncryptionSecure, time.Now())
+			Expect(err).To(MatchError("Received ACK with encryption level encrypted (not forward-secure) that acks a packet 13 (encryption level forward-secure)"))
+		})
 
-			handler.rttStats.UpdateRTT(time.Hour, 0, time.Now())
-			Expect(handler.lossTime.IsZero()).To(BeTrue())
-			Expect(time.Until(handler.GetAlarmTimeout())).To(BeNumerically("~", handler.computeRTOTimeout(), time.Minute))
-
-			handler.OnAlarm()
-			p := handler.DequeuePacketForRetransmission()
-			Expect(p).ToNot(BeNil())
-			Expect(p.PacketNumber).To(Equal(protocol.PacketNumber(1)))
-			p = handler.DequeuePacketForRetransmission()
-			Expect(p).ToNot(BeNil())
-			Expect(p.PacketNumber).To(Equal(protocol.PacketNumber(2)))
-
-			Expect(handler.rtoCount).To(BeEquivalentTo(1))
+		It("deletes non forward-secure packets when the handshake completes", func() {
+			for i := protocol.PacketNumber(1); i <= 6; i++ {
+				p := retransmittablePacket(i)
+				p.EncryptionLevel = protocol.EncryptionSecure
+				handler.SentPacket(p)
+			}
+			handler.queuePacketForRetransmission(getPacket(1))
+			handler.queuePacketForRetransmission(getPacket(3))
+			handler.SetHandshakeComplete()
+			Expect(handler.packetHistory.Len()).To(BeZero())
+			packet := handler.DequeuePacketForRetransmission()
+			Expect(packet).To(BeNil())
 		})
 	})
 })

--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -1,0 +1,59 @@
+package ackhandler
+
+import (
+	"fmt"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+)
+
+type sentPacketHistory struct {
+	packetList *PacketList
+	packetMap  map[protocol.PacketNumber]*PacketElement
+}
+
+func newSentPacketHistory() *sentPacketHistory {
+	return &sentPacketHistory{
+		packetList: NewPacketList(),
+		packetMap:  make(map[protocol.PacketNumber]*PacketElement),
+	}
+}
+
+func (h *sentPacketHistory) SentPacket(p *Packet) {
+	el := h.packetList.PushBack(*p)
+	h.packetMap[p.PacketNumber] = el
+}
+
+// Iterate iterates through all packets.
+// The callback must not modify the history.
+func (h *sentPacketHistory) Iterate(cb func(*Packet) (cont bool, err error)) error {
+	cont := true
+	for el := h.packetList.Front(); cont && el != nil; el = el.Next() {
+		var err error
+		cont, err = cb(&el.Value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *sentPacketHistory) Front() *Packet {
+	if h.Len() == 0 {
+		return nil
+	}
+	return &h.packetList.Front().Value
+}
+
+func (h *sentPacketHistory) Len() int {
+	return len(h.packetMap)
+}
+
+func (h *sentPacketHistory) Remove(p protocol.PacketNumber) error {
+	el, ok := h.packetMap[p]
+	if !ok {
+		return fmt.Errorf("packet %d not found in sent packet history", p)
+	}
+	h.packetList.Remove(el)
+	delete(h.packetMap, p)
+	return nil
+}

--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -23,6 +23,13 @@ func (h *sentPacketHistory) SentPacket(p *Packet) {
 	h.packetMap[p.PacketNumber] = el
 }
 
+func (h *sentPacketHistory) GetPacket(p protocol.PacketNumber) *Packet {
+	if el, ok := h.packetMap[p]; ok {
+		return &el.Value
+	}
+	return nil
+}
+
 // Iterate iterates through all packets.
 // The callback must not modify the history.
 func (h *sentPacketHistory) Iterate(cb func(*Packet) (cont bool, err error)) error {

--- a/internal/ackhandler/sent_packet_history_test.go
+++ b/internal/ackhandler/sent_packet_history_test.go
@@ -1,0 +1,112 @@
+package ackhandler
+
+import (
+	"errors"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SentPacketHistory", func() {
+	var hist *sentPacketHistory
+
+	expectInHistory := func(packetNumbers []protocol.PacketNumber) {
+		ExpectWithOffset(1, hist.packetMap).To(HaveLen(len(packetNumbers)))
+		ExpectWithOffset(1, hist.packetList.Len()).To(Equal(len(packetNumbers)))
+		i := 0
+		hist.Iterate(func(p *Packet) (bool, error) {
+			pn := packetNumbers[i]
+			ExpectWithOffset(1, p.PacketNumber).To(Equal(pn))
+			ExpectWithOffset(1, hist.packetMap[pn].Value.PacketNumber).To(Equal(pn))
+			i++
+			return true, nil
+		})
+	}
+
+	BeforeEach(func() {
+		hist = newSentPacketHistory()
+	})
+
+	It("saves sent packets", func() {
+		hist.SentPacket(&Packet{PacketNumber: 1})
+		hist.SentPacket(&Packet{PacketNumber: 3})
+		hist.SentPacket(&Packet{PacketNumber: 4})
+		expectInHistory([]protocol.PacketNumber{1, 3, 4})
+	})
+
+	It("gets the length", func() {
+		hist.SentPacket(&Packet{PacketNumber: 1})
+		hist.SentPacket(&Packet{PacketNumber: 10})
+		Expect(hist.Len()).To(Equal(2))
+	})
+
+	It("gets nil, if there's no front packet", func() {
+		Expect(hist.Front()).To(BeNil())
+	})
+
+	It("gets the front packet", func() {
+		hist.SentPacket(&Packet{PacketNumber: 2})
+		hist.SentPacket(&Packet{PacketNumber: 3})
+		front := hist.Front()
+		Expect(front).ToNot(BeNil())
+		Expect(front.PacketNumber).To(Equal(protocol.PacketNumber(2)))
+	})
+
+	It("removes packets", func() {
+		hist.SentPacket(&Packet{PacketNumber: 1})
+		hist.SentPacket(&Packet{PacketNumber: 4})
+		hist.SentPacket(&Packet{PacketNumber: 8})
+		err := hist.Remove(4)
+		Expect(err).ToNot(HaveOccurred())
+		expectInHistory([]protocol.PacketNumber{1, 8})
+	})
+
+	It("errors when trying to remove a non existing packet", func() {
+		hist.SentPacket(&Packet{PacketNumber: 1})
+		err := hist.Remove(2)
+		Expect(err).To(MatchError("packet 2 not found in sent packet history"))
+	})
+
+	Context("iterating", func() {
+		BeforeEach(func() {
+			hist.SentPacket(&Packet{PacketNumber: 10})
+			hist.SentPacket(&Packet{PacketNumber: 14})
+			hist.SentPacket(&Packet{PacketNumber: 18})
+		})
+
+		It("iterates over all packets", func() {
+			var iterations []protocol.PacketNumber
+			err := hist.Iterate(func(p *Packet) (bool, error) {
+				iterations = append(iterations, p.PacketNumber)
+				return true, nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(iterations).To(Equal([]protocol.PacketNumber{10, 14, 18}))
+		})
+
+		It("stops iterating", func() {
+			var iterations []protocol.PacketNumber
+			err := hist.Iterate(func(p *Packet) (bool, error) {
+				iterations = append(iterations, p.PacketNumber)
+				return p.PacketNumber != 14, nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(iterations).To(Equal([]protocol.PacketNumber{10, 14}))
+		})
+
+		It("returns the error", func() {
+			testErr := errors.New("test error")
+			var iterations []protocol.PacketNumber
+			err := hist.Iterate(func(p *Packet) (bool, error) {
+				iterations = append(iterations, p.PacketNumber)
+				if p.PacketNumber == 14 {
+					return false, testErr
+				}
+				return true, nil
+			})
+			Expect(err).To(MatchError(testErr))
+			Expect(iterations).To(Equal([]protocol.PacketNumber{10, 14}))
+		})
+	})
+})

--- a/internal/ackhandler/sent_packet_history_test.go
+++ b/internal/ackhandler/sent_packet_history_test.go
@@ -53,6 +53,16 @@ var _ = Describe("SentPacketHistory", func() {
 		Expect(front.PacketNumber).To(Equal(protocol.PacketNumber(2)))
 	})
 
+	It("gets a packet by packet number", func() {
+		p := &Packet{PacketNumber: 2}
+		hist.SentPacket(p)
+		Expect(hist.GetPacket(2)).To(Equal(p))
+	})
+
+	It("returns nil if the packet doesn't exist", func() {
+		Expect(hist.GetPacket(1337)).To(BeNil())
+	})
+
 	It("removes packets", func() {
 		hist.SentPacket(&Packet{PacketNumber: 1})
 		hist.SentPacket(&Packet{PacketNumber: 4})

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -141,6 +141,16 @@ func (mr *MockSentPacketHandlerMockRecorder) SentPacket(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SentPacket", reflect.TypeOf((*MockSentPacketHandler)(nil).SentPacket), arg0)
 }
 
+// SentPacketsAsRetransmission mocks base method
+func (m *MockSentPacketHandler) SentPacketsAsRetransmission(arg0 []*ackhandler.Packet, arg1 protocol.PacketNumber) {
+	m.ctrl.Call(m, "SentPacketsAsRetransmission", arg0, arg1)
+}
+
+// SentPacketsAsRetransmission indicates an expected call of SentPacketsAsRetransmission
+func (mr *MockSentPacketHandlerMockRecorder) SentPacketsAsRetransmission(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SentPacketsAsRetransmission", reflect.TypeOf((*MockSentPacketHandler)(nil).SentPacketsAsRetransmission), arg0, arg1)
+}
+
 // SetHandshakeComplete mocks base method
 func (m *MockSentPacketHandler) SetHandshakeComplete() {
 	m.ctrl.Call(m, "SetHandshakeComplete")

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -98,8 +98,10 @@ func (mr *MockSentPacketHandlerMockRecorder) GetStopWaitingFrame(arg0 interface{
 }
 
 // OnAlarm mocks base method
-func (m *MockSentPacketHandler) OnAlarm() {
-	m.ctrl.Call(m, "OnAlarm")
+func (m *MockSentPacketHandler) OnAlarm() error {
+	ret := m.ctrl.Call(m, "OnAlarm")
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // OnAlarm indicates an expected call of OnAlarm

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -21,6 +21,16 @@ type packedPacket struct {
 	encryptionLevel protocol.EncryptionLevel
 }
 
+func (p *packedPacket) ToAckHandlerPacket() *ackhandler.Packet {
+	return &ackhandler.Packet{
+		PacketNumber:    p.header.PacketNumber,
+		PacketType:      p.header.Type,
+		Frames:          p.frames,
+		Length:          protocol.ByteCount(len(p.raw)),
+		EncryptionLevel: p.encryptionLevel,
+	}
+}
+
 type streamFrameSource interface {
 	HasCryptoStreamData() bool
 	PopCryptoStreamFrame(protocol.ByteCount) *wire.StreamFrame

--- a/session.go
+++ b/session.go
@@ -418,9 +418,11 @@ runLoop:
 
 		now := time.Now()
 		if timeout := s.sentPacketHandler.GetAlarmTimeout(); !timeout.IsZero() && timeout.Before(now) {
-			// This could cause packets to be retransmitted, so check it before trying
-			// to send packets.
-			s.sentPacketHandler.OnAlarm()
+			// This could cause packets to be retransmitted.
+			// Check it before trying to send packets.
+			if err := s.sentPacketHandler.OnAlarm(); err != nil {
+				s.closeLocal(err)
+			}
 		}
 
 		var pacingDeadline time.Time

--- a/session.go
+++ b/session.go
@@ -838,6 +838,7 @@ func (s *session) maybeSendAckOnlyPacket() error {
 	if err != nil {
 		return err
 	}
+	s.sentPacketHandler.SentPacket(packet.ToAckHandlerPacket())
 	return s.sendPackedPacket(packet)
 }
 
@@ -874,6 +875,11 @@ func (s *session) maybeSendRetransmission() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	ackhandlerPackets := make([]*ackhandler.Packet, len(packets))
+	for i, packet := range packets {
+		ackhandlerPackets[i] = packet.ToAckHandlerPacket()
+	}
+	s.sentPacketHandler.SentPacketsAsRetransmission(ackhandlerPackets, retransmitPacket.PacketNumber)
 	for _, packet := range packets {
 		if err := s.sendPackedPacket(packet); err != nil {
 			return false, err
@@ -904,6 +910,7 @@ func (s *session) sendPacket() (bool, error) {
 	if err != nil || packet == nil {
 		return false, err
 	}
+	s.sentPacketHandler.SentPacket(packet.ToAckHandlerPacket())
 	if err := s.sendPackedPacket(packet); err != nil {
 		return false, err
 	}
@@ -912,13 +919,6 @@ func (s *session) sendPacket() (bool, error) {
 
 func (s *session) sendPackedPacket(packet *packedPacket) error {
 	defer putPacketBuffer(&packet.raw)
-	s.sentPacketHandler.SentPacket(&ackhandler.Packet{
-		PacketNumber:    packet.header.PacketNumber,
-		PacketType:      packet.header.Type,
-		Frames:          packet.frames,
-		Length:          protocol.ByteCount(len(packet.raw)),
-		EncryptionLevel: packet.encryptionLevel,
-	})
 	s.logPacket(packet)
 	return s.conn.Write(packet.raw)
 }


### PR DESCRIPTION
Replaces #1230.

We now keep track which packet was sent as a retransmission of which other packet. When an ACK arrives for the original packet, we can delete the retransmission(s) from the packet history.

I ran some benchmarks with reordered packets, and I don't get a statistically significant improvement in transfer speed here. At this point, I'm not worried about this, since we still have a bunch of loss recovery optimizations outstanding, especially spurious RTO detection (#687) and TLPs (#497).