### PR TITLE
allow empty STREAM frames at offset 0

### DIFF
--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -76,7 +76,8 @@ func parseStreamFrame(r *bytes.Reader, version protocol.VersionNumber) (*StreamF
 	if frame.Offset+frame.DataLen() > protocol.MaxByteCount {
 		return nil, qerr.Error(qerr.InvalidStreamData, "data overflows maximum offset")
 	}
-	if !frame.FinBit && frame.DataLen() == 0 {
+	// empty frames are only allowed if they have offset 0 or the FIN bit set
+	if frame.DataLen() == 0 && !frame.FinBit && frame.Offset != 0 {
 		return nil, qerr.EmptyStreamFrameNoFin
 	}
 	return frame, nil

--- a/internal/wire/stream_frame_test.go
+++ b/internal/wire/stream_frame_test.go
@@ -56,9 +56,22 @@ var _ = Describe("STREAM frame (for IETF QUIC)", func() {
 			Expect(r.Len()).To(BeZero())
 		})
 
-		It("rejects empty frames than don't have the FIN bit set", func() {
+		It("allows empty frames at offset 0", func() {
 			data := []byte{0x10}
 			data = append(data, encodeVarInt(0x1337)...) // stream ID
+			r := bytes.NewReader(data)
+			f, err := parseStreamFrame(r, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f.StreamID).To(Equal(protocol.StreamID(0x1337)))
+			Expect(f.Data).To(BeEmpty())
+			Expect(f.Offset).To(BeZero())
+			Expect(f.FinBit).To(BeFalse())
+		})
+
+		It("rejects empty frames than don't have the FIN bit set", func() {
+			data := []byte{0x10 ^ 0x4}
+			data = append(data, encodeVarInt(0x1337)...)     // stream ID
+			data = append(data, encodeVarInt(0xdecafbad)...) // offset
 			r := bytes.NewReader(data)
 			_, err := parseStreamFrame(r, versionIETFFrames)
 			Expect(err).To(MatchError(qerr.EmptyStreamFrameNoFin))


### PR DESCRIPTION
Fixes #1247.

Technically, they're still invalid in gQUIC, but I think we can live with allowing them in both gQUIC and IETF QUIC.