### PR TITLE
fix incorrect server test

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -357,7 +357,6 @@ var _ = Describe("Server", func() {
 			testErr := errors.New("connection error")
 			conn.readErr = testErr
 			go serv.serve()
-			Eventually(func() Session { return serv.sessions[connID] }).Should(BeNil())
 			Eventually(func() bool { return session.(*mockSession).closed }).Should(BeTrue())
 			Expect(serv.Close()).To(Succeed())
 		})


### PR DESCRIPTION
When a `Read` from the connection fails, we need to close all sessions, but it's not necessary to remove them from the sessions map in the server.