### PR TITLE
don't reduce the bytes in flight for RTO probe packets

### DIFF
--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -20,6 +20,7 @@ type Packet struct {
 	sendTime     time.Time
 
 	queuedForRetransmission bool
+	includedInBytesInFlight bool
 	retransmittedAs         []protocol.PacketNumber
 	isRetransmission        bool // we need a separate bool here because 0 is a valid packet number
 	retransmissionOf        protocol.PacketNumber


### PR DESCRIPTION
We should **only** reduce the `bytes_in_flight` when declaring a packet lost (or of course when receiving an ACK).

Packets that we retransmit as RTO probe packets still count towards the `bytes_in_flight` until:
* we receive an ACK for the original packet (i.e. we detect a spurious RTO, see #687)
* we receive an ACK for the probe packet (i.e. we detect a non-spurious RTO), and we declare all packets below the probe packet lost