### PR TITLE
close all streams when closing the IETF QUIC streams map

### DIFF
--- a/streams_map_generic_helper.go
+++ b/streams_map_generic_helper.go
@@ -1,0 +1,11 @@
+package quic
+
+import "github.com/cheekybits/genny/generic"
+
+// In the auto-generated streams maps, we need to be able to close the streams.
+// Therefore, extend the generic.Type with the stream close method.
+// This definition must be in a file that Genny doesn't process.
+type item interface {
+	generic.Type
+	closeForShutdown(error)
+}

--- a/streams_map_incoming_bidi.go
+++ b/streams_map_incoming_bidi.go
@@ -123,6 +123,9 @@ func (m *incomingBidiStreamsMap) DeleteStream(id protocol.StreamID) error {
 func (m *incomingBidiStreamsMap) CloseWithError(err error) {
 	m.mutex.Lock()
 	m.closeErr = err
+	for _, str := range m.streams {
+		str.closeForShutdown(err)
+	}
 	m.mutex.Unlock()
 	m.cond.Broadcast()
 }

--- a/streams_map_incoming_generic.go
+++ b/streams_map_incoming_generic.go
@@ -121,6 +121,9 @@ func (m *incomingItemsMap) DeleteStream(id protocol.StreamID) error {
 func (m *incomingItemsMap) CloseWithError(err error) {
 	m.mutex.Lock()
 	m.closeErr = err
+	for _, str := range m.streams {
+		str.closeForShutdown(err)
+	}
 	m.mutex.Unlock()
 	m.cond.Broadcast()
 }

--- a/streams_map_incoming_generic_test.go
+++ b/streams_map_incoming_generic_test.go
@@ -12,7 +12,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Streams Map (outgoing)", func() {
+type mockGenericStream struct {
+	id protocol.StreamID
+
+	closed   bool
+	closeErr error
+}
+
+func (s *mockGenericStream) closeForShutdown(err error) {
+	s.closed = true
+	s.closeErr = err
+}
+
+var _ = Describe("Streams Map (incoming)", func() {
 	const (
 		firstNewStream   protocol.StreamID = 20
 		maxNumStreams    int               = 10
@@ -30,7 +42,7 @@ var _ = Describe("Streams Map (outgoing)", func() {
 		newItemCounter = 0
 		newItem = func(id protocol.StreamID) item {
 			newItemCounter++
-			return id
+			return &mockGenericStream{id: id}
 		}
 		mockSender = NewMockStreamSender(mockCtrl)
 		m = newIncomingItemsMap(firstNewStream, initialMaxStream, maxNumStreams, mockSender.queueControlFrame, newItem)
@@ -57,16 +69,16 @@ var _ = Describe("Streams Map (outgoing)", func() {
 		Expect(err).ToNot(HaveOccurred())
 		str, err := m.AcceptStream()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(str).To(Equal(firstNewStream))
+		Expect(str.(*mockGenericStream).id).To(Equal(firstNewStream))
 		str, err = m.AcceptStream()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(str).To(Equal(firstNewStream + 4))
+		Expect(str.(*mockGenericStream).id).To(Equal(firstNewStream + 4))
 	})
 
 	It("allows opening the maximum stream ID", func() {
 		str, err := m.GetOrOpenStream(initialMaxStream)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(str).To(Equal(initialMaxStream))
+		Expect(str.(*mockGenericStream).id).To(Equal(initialMaxStream))
 	})
 
 	It("errors when trying to get a stream ID higher than the maximum", func() {
@@ -85,8 +97,10 @@ var _ = Describe("Streams Map (outgoing)", func() {
 		Consistently(strChan).ShouldNot(Receive())
 		str, err := m.GetOrOpenStream(firstNewStream)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(str).To(Equal(firstNewStream))
-		Eventually(strChan).Should(Receive(Equal(firstNewStream)))
+		Expect(str.(*mockGenericStream).id).To(Equal(firstNewStream))
+		var acceptedStr item
+		Eventually(strChan).Should(Receive(&acceptedStr))
+		Expect(acceptedStr.(*mockGenericStream).id).To(Equal(firstNewStream))
 	})
 
 	It("unblocks AcceptStream when it is closed", func() {
@@ -108,6 +122,19 @@ var _ = Describe("Streams Map (outgoing)", func() {
 		m.CloseWithError(testErr)
 		_, err := m.AcceptStream()
 		Expect(err).To(MatchError(testErr))
+	})
+
+	It("closes all streams when CloseWithError is called", func() {
+		str1, err := m.GetOrOpenStream(20)
+		Expect(err).ToNot(HaveOccurred())
+		str2, err := m.GetOrOpenStream(20 + 8)
+		Expect(err).ToNot(HaveOccurred())
+		testErr := errors.New("test err")
+		m.CloseWithError(testErr)
+		Expect(str1.(*mockGenericStream).closed).To(BeTrue())
+		Expect(str1.(*mockGenericStream).closeErr).To(MatchError(testErr))
+		Expect(str2.(*mockGenericStream).closed).To(BeTrue())
+		Expect(str2.(*mockGenericStream).closeErr).To(MatchError(testErr))
 	})
 
 	It("deletes streams", func() {

--- a/streams_map_incoming_uni.go
+++ b/streams_map_incoming_uni.go
@@ -123,6 +123,9 @@ func (m *incomingUniStreamsMap) DeleteStream(id protocol.StreamID) error {
 func (m *incomingUniStreamsMap) CloseWithError(err error) {
 	m.mutex.Lock()
 	m.closeErr = err
+	for _, str := range m.streams {
+		str.closeForShutdown(err)
+	}
 	m.mutex.Unlock()
 	m.cond.Broadcast()
 }

--- a/streams_map_outgoing_bidi.go
+++ b/streams_map_outgoing_bidi.go
@@ -118,6 +118,9 @@ func (m *outgoingBidiStreamsMap) SetMaxStream(id protocol.StreamID) {
 func (m *outgoingBidiStreamsMap) CloseWithError(err error) {
 	m.mutex.Lock()
 	m.closeErr = err
+	for _, str := range m.streams {
+		str.closeForShutdown(err)
+	}
 	m.cond.Broadcast()
 	m.mutex.Unlock()
 }

--- a/streams_map_outgoing_generic.go
+++ b/streams_map_outgoing_generic.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cheekybits/genny/generic"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 	"github.com/lucas-clemente/quic-go/qerr"
 )
-
-type item generic.Type
 
 //go:generate genny -in $GOFILE -out streams_map_outgoing_bidi.go gen "item=streamI Item=BidiStream"
 //go:generate genny -in $GOFILE -out streams_map_outgoing_uni.go gen "item=sendStreamI Item=UniStream"
@@ -119,6 +116,9 @@ func (m *outgoingItemsMap) SetMaxStream(id protocol.StreamID) {
 func (m *outgoingItemsMap) CloseWithError(err error) {
 	m.mutex.Lock()
 	m.closeErr = err
+	for _, str := range m.streams {
+		str.closeForShutdown(err)
+	}
 	m.cond.Broadcast()
 	m.mutex.Unlock()
 }

--- a/streams_map_outgoing_uni.go
+++ b/streams_map_outgoing_uni.go
@@ -118,6 +118,9 @@ func (m *outgoingUniStreamsMap) SetMaxStream(id protocol.StreamID) {
 func (m *outgoingUniStreamsMap) CloseWithError(err error) {
 	m.mutex.Lock()
 	m.closeErr = err
+	for _, str := range m.streams {
+		str.closeForShutdown(err)
+	}
 	m.cond.Broadcast()
 	m.mutex.Unlock()
 }


### PR DESCRIPTION
Fixes #1289. Closes #1290.