### PR TITLE
implement a buffer optimized for writing to preallocated slices

### DIFF
--- a/internal/utils/buffer.go
+++ b/internal/utils/buffer.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"io"
+)
+
+// A ByteWriter combines the io.Writer and io.ByteWriter interface
+type ByteWriter interface {
+	io.ByteWriter
+	io.Writer
+}
+
+// The Buffer implements the ByteWriter interface.
+// It is supposed to be used with pre-allocated slices.
+// It does not grow the underlying slice.
+// Every write that exceeds the capacity will panic.
+type Buffer struct {
+	buf []byte
+}
+
+var _ ByteWriter = &Buffer{}
+
+// NewBuffer creates a new Buffer
+func NewBuffer(buf []byte) *Buffer {
+	return &Buffer{buf}
+}
+
+func (b *Buffer) grow(n int) int {
+	offset := len(b.buf)
+	b.buf = b.buf[:offset+n]
+	return offset
+}
+
+// WriteByte appends the byte c to the buffer.
+// The returned error is always nil.
+// If the write exceeds the buffer's capacity, WriteByte will panic.
+func (b *Buffer) WriteByte(c byte) error {
+	offset := b.grow(1)
+	b.buf[offset] = c
+	return nil
+}
+
+// Write appends the contents of p to the buffer.
+// The return value n is the length of p; err is always nil.
+// If the write exceeds the buffer's capacity, Write will panic with ErrTooLarge.
+func (b *Buffer) Write(p []byte) (int, error) {
+	offset := b.grow(len(p))
+	copy(b.buf[offset:], p)
+	return len(p), nil
+}
+
+// Len returns the length of the buffer.
+func (b *Buffer) Len() int {
+	return len(b.buf)
+}
+
+// Bytes returns a slice of length b.Len() holding the the buffer.
+func (b *Buffer) Bytes() []byte {
+	return b.buf
+}
+
+// String returns the contents of the buffer as a string.
+func (b *Buffer) String() string {
+	return string(b.buf)
+}

--- a/internal/utils/buffer_test.go
+++ b/internal/utils/buffer_test.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Buffer", func() {
+	Context("writing single bytes", func() {
+		It("writes", func() {
+			buf := NewBuffer(make([]byte, 0, 10))
+			buf.WriteByte('b')
+			buf.WriteByte('a')
+			buf.WriteByte('r')
+			Expect(buf.String()).To(Equal("bar"))
+		})
+
+		It("appends to a given slice", func() {
+			data := make([]byte, 3, 6)
+			data[0] = byte('f')
+			data[1] = byte('o')
+			data[2] = byte('o')
+			buf := NewBuffer(data)
+			buf.WriteByte('b')
+			buf.WriteByte('a')
+			buf.WriteByte('r')
+			Expect(buf.String()).To(Equal("foobar"))
+		})
+
+		It("panics when the underlying slice is too short", func() {
+			buf := NewBuffer(make([]byte, 0, 1))
+			buf.WriteByte('a')
+			Expect(func() { buf.WriteByte('b') }).Should(Panic())
+		})
+	})
+
+	Context("writing multiple bytes", func() {
+		It("writes multiple bytes", func() {
+			buf := NewBuffer(make([]byte, 0, 10))
+			buf.Write([]byte{'f', 'o', 'o'})
+			buf.Write([]byte{'b', 'a', 'r'})
+			Expect(buf.String()).To(Equal("foobar"))
+		})
+
+		It("appends to a given slice", func() {
+			data := make([]byte, 3, 6)
+			data[0] = byte('f')
+			data[1] = byte('o')
+			data[2] = byte('o')
+			buf := NewBuffer(data)
+			buf.Write([]byte{'b', 'a', 'r'})
+			Expect(buf.String()).To(Equal("foobar"))
+		})
+
+		It("panics when the underlying slice is too short", func() {
+			buf := NewBuffer(make([]byte, 0, 5))
+			buf.Write([]byte{'f', 'o', 'o'})
+			Expect(func() { buf.Write([]byte{'b', 'a', 'r'}) }).Should(Panic())
+		})
+	})
+
+	Context("length", func() {
+		It("has 0 length in the beginning", func() {
+			buf := NewBuffer(make([]byte, 0, 5))
+			Expect(buf.Len()).To(BeZero())
+		})
+
+		It("returns the length", func() {
+			buf := NewBuffer(make([]byte, 0, 5))
+			buf.Write([]byte{'f', 'o', 'o'})
+			Expect(buf.Len()).To(Equal(3))
+		})
+	})
+})

--- a/internal/utils/byteorder.go
+++ b/internal/utils/byteorder.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"io"
 )
 
@@ -12,14 +11,14 @@ type ByteOrder interface {
 	ReadUint32(io.ByteReader) (uint32, error)
 	ReadUint16(io.ByteReader) (uint16, error)
 
-	WriteUint64(*bytes.Buffer, uint64)
-	WriteUint56(*bytes.Buffer, uint64)
-	WriteUint48(*bytes.Buffer, uint64)
-	WriteUint40(*bytes.Buffer, uint64)
-	WriteUint32(*bytes.Buffer, uint32)
-	WriteUint24(*bytes.Buffer, uint32)
-	WriteUint16(*bytes.Buffer, uint16)
+	WriteUint64(ByteWriter, uint64)
+	WriteUint56(ByteWriter, uint64)
+	WriteUint48(ByteWriter, uint64)
+	WriteUint40(ByteWriter, uint64)
+	WriteUint32(ByteWriter, uint32)
+	WriteUint24(ByteWriter, uint32)
+	WriteUint16(ByteWriter, uint16)
 
 	ReadUfloat16(io.ByteReader) (uint64, error)
-	WriteUfloat16(*bytes.Buffer, uint64)
+	WriteUfloat16(ByteWriter, uint64)
 }

--- a/internal/utils/byteorder_big_endian.go
+++ b/internal/utils/byteorder_big_endian.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 )
@@ -90,7 +89,7 @@ func (bigEndian) ReadUint16(b io.ByteReader) (uint16, error) {
 }
 
 // WriteUint64 writes a uint64
-func (bigEndian) WriteUint64(b *bytes.Buffer, i uint64) {
+func (bigEndian) WriteUint64(b ByteWriter, i uint64) {
 	b.Write([]byte{
 		uint8(i >> 56), uint8(i >> 48), uint8(i >> 40), uint8(i >> 32),
 		uint8(i >> 24), uint8(i >> 16), uint8(i >> 8), uint8(i),
@@ -98,7 +97,7 @@ func (bigEndian) WriteUint64(b *bytes.Buffer, i uint64) {
 }
 
 // WriteUint56 writes 56 bit of a uint64
-func (bigEndian) WriteUint56(b *bytes.Buffer, i uint64) {
+func (bigEndian) WriteUint56(b ByteWriter, i uint64) {
 	if i >= (1 << 56) {
 		panic(fmt.Sprintf("%#x doesn't fit into 56 bits", i))
 	}
@@ -109,7 +108,7 @@ func (bigEndian) WriteUint56(b *bytes.Buffer, i uint64) {
 }
 
 // WriteUint48 writes 48 bit of a uint64
-func (bigEndian) WriteUint48(b *bytes.Buffer, i uint64) {
+func (bigEndian) WriteUint48(b ByteWriter, i uint64) {
 	if i >= (1 << 48) {
 		panic(fmt.Sprintf("%#x doesn't fit into 48 bits", i))
 	}
@@ -120,7 +119,7 @@ func (bigEndian) WriteUint48(b *bytes.Buffer, i uint64) {
 }
 
 // WriteUint40 writes 40 bit of a uint64
-func (bigEndian) WriteUint40(b *bytes.Buffer, i uint64) {
+func (bigEndian) WriteUint40(b ByteWriter, i uint64) {
 	if i >= (1 << 40) {
 		panic(fmt.Sprintf("%#x doesn't fit into 40 bits", i))
 	}
@@ -131,12 +130,12 @@ func (bigEndian) WriteUint40(b *bytes.Buffer, i uint64) {
 }
 
 // WriteUint32 writes a uint32
-func (bigEndian) WriteUint32(b *bytes.Buffer, i uint32) {
+func (bigEndian) WriteUint32(b ByteWriter, i uint32) {
 	b.Write([]byte{uint8(i >> 24), uint8(i >> 16), uint8(i >> 8), uint8(i)})
 }
 
 // WriteUint24 writes 24 bit of a uint32
-func (bigEndian) WriteUint24(b *bytes.Buffer, i uint32) {
+func (bigEndian) WriteUint24(b ByteWriter, i uint32) {
 	if i >= (1 << 24) {
 		panic(fmt.Sprintf("%#x doesn't fit into 24 bits", i))
 	}
@@ -144,7 +143,7 @@ func (bigEndian) WriteUint24(b *bytes.Buffer, i uint32) {
 }
 
 // WriteUint16 writes a uint16
-func (bigEndian) WriteUint16(b *bytes.Buffer, i uint16) {
+func (bigEndian) WriteUint16(b ByteWriter, i uint16) {
 	b.Write([]byte{uint8(i >> 8), uint8(i)})
 }
 
@@ -152,6 +151,6 @@ func (l bigEndian) ReadUfloat16(b io.ByteReader) (uint64, error) {
 	return readUfloat16(b, l)
 }
 
-func (l bigEndian) WriteUfloat16(b *bytes.Buffer, val uint64) {
+func (l bigEndian) WriteUfloat16(b ByteWriter, val uint64) {
 	writeUfloat16(b, l, val)
 }

--- a/internal/utils/byteorder_little_endian.go
+++ b/internal/utils/byteorder_little_endian.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 )
@@ -90,7 +89,7 @@ func (littleEndian) ReadUint16(b io.ByteReader) (uint16, error) {
 }
 
 // WriteUint64 writes a uint64
-func (littleEndian) WriteUint64(b *bytes.Buffer, i uint64) {
+func (littleEndian) WriteUint64(b ByteWriter, i uint64) {
 	b.Write([]byte{
 		uint8(i), uint8(i >> 8), uint8(i >> 16), uint8(i >> 24),
 		uint8(i >> 32), uint8(i >> 40), uint8(i >> 48), uint8(i >> 56),
@@ -98,7 +97,7 @@ func (littleEndian) WriteUint64(b *bytes.Buffer, i uint64) {
 }
 
 // WriteUint56 writes 56 bit of a uint64
-func (littleEndian) WriteUint56(b *bytes.Buffer, i uint64) {
+func (littleEndian) WriteUint56(b ByteWriter, i uint64) {
 	if i >= (1 << 56) {
 		panic(fmt.Sprintf("%#x doesn't fit into 56 bits", i))
 	}
@@ -109,7 +108,7 @@ func (littleEndian) WriteUint56(b *bytes.Buffer, i uint64) {
 }
 
 // WriteUint48 writes 48 bit of a uint64
-func (littleEndian) WriteUint48(b *bytes.Buffer, i uint64) {
+func (littleEndian) WriteUint48(b ByteWriter, i uint64) {
 	if i >= (1 << 48) {
 		panic(fmt.Sprintf("%#x doesn't fit into 48 bits", i))
 	}
@@ -120,7 +119,7 @@ func (littleEndian) WriteUint48(b *bytes.Buffer, i uint64) {
 }
 
 // WriteUint40 writes 40 bit of a uint64
-func (littleEndian) WriteUint40(b *bytes.Buffer, i uint64) {
+func (littleEndian) WriteUint40(b ByteWriter, i uint64) {
 	if i >= (1 << 40) {
 		panic(fmt.Sprintf("%#x doesn't fit into 40 bits", i))
 	}
@@ -131,12 +130,12 @@ func (littleEndian) WriteUint40(b *bytes.Buffer, i uint64) {
 }
 
 // WriteUint32 writes a uint32
-func (littleEndian) WriteUint32(b *bytes.Buffer, i uint32) {
+func (littleEndian) WriteUint32(b ByteWriter, i uint32) {
 	b.Write([]byte{uint8(i), uint8(i >> 8), uint8(i >> 16), uint8(i >> 24)})
 }
 
 // WriteUint24 writes 24 bit of a uint32
-func (littleEndian) WriteUint24(b *bytes.Buffer, i uint32) {
+func (littleEndian) WriteUint24(b ByteWriter, i uint32) {
 	if i >= (1 << 24) {
 		panic(fmt.Sprintf("%#x doesn't fit into 24 bits", i))
 	}
@@ -144,7 +143,7 @@ func (littleEndian) WriteUint24(b *bytes.Buffer, i uint32) {
 }
 
 // WriteUint16 writes a uint16
-func (littleEndian) WriteUint16(b *bytes.Buffer, i uint16) {
+func (littleEndian) WriteUint16(b ByteWriter, i uint16) {
 	b.Write([]byte{uint8(i), uint8(i >> 8)})
 }
 
@@ -152,6 +151,6 @@ func (l littleEndian) ReadUfloat16(b io.ByteReader) (uint64, error) {
 	return readUfloat16(b, l)
 }
 
-func (l littleEndian) WriteUfloat16(b *bytes.Buffer, val uint64) {
+func (l littleEndian) WriteUfloat16(b ByteWriter, val uint64) {
 	writeUfloat16(b, l, val)
 }

--- a/internal/utils/float16.go
+++ b/internal/utils/float16.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"io"
 	"math"
 )
@@ -51,7 +50,7 @@ func readUfloat16(b io.ByteReader, byteOrder ByteOrder) (uint64, error) {
 }
 
 // writeUfloat16 writes a float in the QUIC-float16 format from its uint64 representation
-func writeUfloat16(b *bytes.Buffer, byteOrder ByteOrder, value uint64) {
+func writeUfloat16(b ByteWriter, byteOrder ByteOrder, value uint64) {
 	var result uint16
 	if value < (uint64(1) << uFloat16MantissaEffectiveBits) {
 		// Fast path: either the value is denormalized, or has exponent zero.

--- a/internal/utils/varint.go
+++ b/internal/utils/varint.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
@@ -66,7 +65,7 @@ func ReadVarInt(b io.ByteReader) (uint64, error) {
 }
 
 // WriteVarInt writes a number in the QUIC varint format
-func WriteVarInt(b *bytes.Buffer, i uint64) {
+func WriteVarInt(b ByteWriter, i uint64) {
 	if i <= maxVarInt1 {
 		b.WriteByte(uint8(i))
 	} else if i <= maxVarInt2 {

--- a/internal/wire/ack_frame.go
+++ b/internal/wire/ack_frame.go
@@ -99,7 +99,7 @@ func parseAckFrame(r *bytes.Reader, version protocol.VersionNumber) (*AckFrame, 
 }
 
 // Write writes an ACK frame.
-func (f *AckFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (f *AckFrame) Write(b utils.ByteWriter, version protocol.VersionNumber) error {
 	if !version.UsesIETFFrameFormat() {
 		return f.writeLegacy(b, version)
 	}

--- a/internal/wire/ack_frame_legacy.go
+++ b/internal/wire/ack_frame_legacy.go
@@ -170,7 +170,7 @@ func parseAckFrameLegacy(r *bytes.Reader, _ protocol.VersionNumber) (*AckFrame, 
 	return frame, nil
 }
 
-func (f *AckFrame) writeLegacy(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (f *AckFrame) writeLegacy(b utils.ByteWriter, _ protocol.VersionNumber) error {
 	largestAckedLen := protocol.GetPacketNumberLength(f.LargestAcked)
 
 	typeByte := uint8(0x40)

--- a/internal/wire/blocked_frame.go
+++ b/internal/wire/blocked_frame.go
@@ -26,7 +26,7 @@ func parseBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*BlockedFrame
 	}, nil
 }
 
-func (f *BlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (f *BlockedFrame) Write(b utils.ByteWriter, version protocol.VersionNumber) error {
 	if !version.UsesIETFFrameFormat() {
 		return (&blockedFrameLegacy{}).Write(b, version)
 	}

--- a/internal/wire/blocked_frame_legacy.go
+++ b/internal/wire/blocked_frame_legacy.go
@@ -30,7 +30,7 @@ func parseBlockedFrameLegacy(r *bytes.Reader, _ protocol.VersionNumber) (Frame, 
 }
 
 //Write writes a BLOCKED frame
-func (f *blockedFrameLegacy) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (f *blockedFrameLegacy) Write(b utils.ByteWriter, _ protocol.VersionNumber) error {
 	b.WriteByte(0x05)
 	utils.BigEndian.WriteUint32(b, uint32(f.StreamID))
 	return nil

--- a/internal/wire/connection_close_frame.go
+++ b/internal/wire/connection_close_frame.go
@@ -76,7 +76,7 @@ func (f *ConnectionCloseFrame) Length(version protocol.VersionNumber) protocol.B
 }
 
 // Write writes an CONNECTION_CLOSE frame.
-func (f *ConnectionCloseFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (f *ConnectionCloseFrame) Write(b utils.ByteWriter, version protocol.VersionNumber) error {
 	b.WriteByte(0x02)
 
 	if len(f.ReasonPhrase) > math.MaxUint16 {
@@ -90,7 +90,7 @@ func (f *ConnectionCloseFrame) Write(b *bytes.Buffer, version protocol.VersionNu
 		utils.BigEndian.WriteUint32(b, uint32(f.ErrorCode))
 		utils.BigEndian.WriteUint16(b, uint16(len(f.ReasonPhrase)))
 	}
-	b.WriteString(f.ReasonPhrase)
+	b.Write([]byte(f.ReasonPhrase))
 
 	return nil
 }

--- a/internal/wire/frame.go
+++ b/internal/wire/frame.go
@@ -1,13 +1,12 @@
 package wire
 
 import (
-	"bytes"
-
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
 // A Frame in QUIC
 type Frame interface {
-	Write(b *bytes.Buffer, version protocol.VersionNumber) error
+	Write(b utils.ByteWriter, version protocol.VersionNumber) error
 	Length(version protocol.VersionNumber) protocol.ByteCount
 }

--- a/internal/wire/goaway_frame.go
+++ b/internal/wire/goaway_frame.go
@@ -53,12 +53,12 @@ func parseGoawayFrame(r *bytes.Reader, _ protocol.VersionNumber) (*GoawayFrame, 
 	return frame, nil
 }
 
-func (f *GoawayFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (f *GoawayFrame) Write(b utils.ByteWriter, _ protocol.VersionNumber) error {
 	b.WriteByte(0x03)
 	utils.BigEndian.WriteUint32(b, uint32(f.ErrorCode))
 	utils.BigEndian.WriteUint32(b, uint32(f.LastGoodStream))
 	utils.BigEndian.WriteUint16(b, uint16(len(f.ReasonPhrase)))
-	b.WriteString(f.ReasonPhrase)
+	b.Write([]byte(f.ReasonPhrase))
 	return nil
 }
 

--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -87,7 +87,7 @@ func parsePacketHeader(b *bytes.Reader, sentBy protocol.Perspective, isPublicHea
 }
 
 // Write writes the Header.
-func (h *Header) Write(b *bytes.Buffer, pers protocol.Perspective, version protocol.VersionNumber) error {
+func (h *Header) Write(b utils.ByteWriter, pers protocol.Perspective, version protocol.VersionNumber) error {
 	if !version.UsesTLS() {
 		h.isPublicHeader = true // save that this is a Public Header, so we can log it correctly later
 		return h.writePublicHeader(b, pers, version)

--- a/internal/wire/ietf_header.go
+++ b/internal/wire/ietf_header.go
@@ -110,7 +110,7 @@ func parseShortHeader(b *bytes.Reader, typeByte byte) (*Header, error) {
 }
 
 // writeHeader writes the Header.
-func (h *Header) writeHeader(b *bytes.Buffer) error {
+func (h *Header) writeHeader(b utils.ByteWriter) error {
 	if h.IsLongHeader {
 		return h.writeLongHeader(b)
 	}
@@ -118,7 +118,7 @@ func (h *Header) writeHeader(b *bytes.Buffer) error {
 }
 
 // TODO: add support for the key phase
-func (h *Header) writeLongHeader(b *bytes.Buffer) error {
+func (h *Header) writeLongHeader(b utils.ByteWriter) error {
 	b.WriteByte(byte(0x80 | h.Type))
 	utils.BigEndian.WriteUint64(b, uint64(h.ConnectionID))
 	utils.BigEndian.WriteUint32(b, uint32(h.Version))
@@ -126,7 +126,7 @@ func (h *Header) writeLongHeader(b *bytes.Buffer) error {
 	return nil
 }
 
-func (h *Header) writeShortHeader(b *bytes.Buffer) error {
+func (h *Header) writeShortHeader(b utils.ByteWriter) error {
 	typeByte := byte(0x10)
 	typeByte ^= byte(h.KeyPhase << 5)
 	if h.OmitConnectionID {

--- a/internal/wire/max_data_frame.go
+++ b/internal/wire/max_data_frame.go
@@ -29,7 +29,7 @@ func parseMaxDataFrame(r *bytes.Reader, version protocol.VersionNumber) (*MaxDat
 }
 
 //Write writes a MAX_STREAM_DATA frame
-func (f *MaxDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (f *MaxDataFrame) Write(b utils.ByteWriter, version protocol.VersionNumber) error {
 	if !version.UsesIETFFrameFormat() {
 		// write a gQUIC WINDOW_UPDATE frame (with stream ID 0, which means connection-level there)
 		return (&windowUpdateFrame{

--- a/internal/wire/max_stream_data_frame.go
+++ b/internal/wire/max_stream_data_frame.go
@@ -37,7 +37,7 @@ func parseMaxStreamDataFrame(r *bytes.Reader, version protocol.VersionNumber) (*
 }
 
 // Write writes a MAX_STREAM_DATA frame
-func (f *MaxStreamDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (f *MaxStreamDataFrame) Write(b utils.ByteWriter, version protocol.VersionNumber) error {
 	if !version.UsesIETFFrameFormat() {
 		return (&windowUpdateFrame{
 			StreamID:   f.StreamID,

--- a/internal/wire/max_stream_id_frame.go
+++ b/internal/wire/max_stream_id_frame.go
@@ -25,7 +25,7 @@ func parseMaxStreamIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxStrea
 	return &MaxStreamIDFrame{StreamID: protocol.StreamID(streamID)}, nil
 }
 
-func (f *MaxStreamIDFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (f *MaxStreamIDFrame) Write(b utils.ByteWriter, _ protocol.VersionNumber) error {
 	b.WriteByte(0x6)
 	utils.WriteVarInt(b, uint64(f.StreamID))
 	return nil

--- a/internal/wire/ping_frame.go
+++ b/internal/wire/ping_frame.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
 // A PingFrame is a ping frame
@@ -21,7 +22,7 @@ func parsePingFrame(r *bytes.Reader, version protocol.VersionNumber) (*PingFrame
 	return frame, nil
 }
 
-func (f *PingFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (f *PingFrame) Write(b utils.ByteWriter, version protocol.VersionNumber) error {
 	typeByte := uint8(0x07)
 	b.WriteByte(typeByte)
 	return nil

--- a/internal/wire/public_header.go
+++ b/internal/wire/public_header.go
@@ -19,7 +19,7 @@ var (
 )
 
 // writePublicHeader writes a Public Header.
-func (h *Header) writePublicHeader(b *bytes.Buffer, pers protocol.Perspective, _ protocol.VersionNumber) error {
+func (h *Header) writePublicHeader(b utils.ByteWriter, pers protocol.Perspective, _ protocol.VersionNumber) error {
 	if h.VersionFlag && pers == protocol.PerspectiveServer {
 		return errors.New("PublicHeader: Writing of Version Negotiation Packets not supported")
 	}

--- a/internal/wire/rst_stream_frame.go
+++ b/internal/wire/rst_stream_frame.go
@@ -66,7 +66,7 @@ func parseRstStreamFrame(r *bytes.Reader, version protocol.VersionNumber) (*RstS
 }
 
 //Write writes a RST_STREAM frame
-func (f *RstStreamFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (f *RstStreamFrame) Write(b utils.ByteWriter, version protocol.VersionNumber) error {
 	b.WriteByte(0x01)
 	if version.UsesIETFFrameFormat() {
 		utils.WriteVarInt(b, uint64(f.StreamID))

--- a/internal/wire/stop_sending_frame.go
+++ b/internal/wire/stop_sending_frame.go
@@ -39,7 +39,7 @@ func (f *StopSendingFrame) Length(_ protocol.VersionNumber) protocol.ByteCount {
 	return 1 + utils.VarIntLen(uint64(f.StreamID)) + 2
 }
 
-func (f *StopSendingFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (f *StopSendingFrame) Write(b utils.ByteWriter, _ protocol.VersionNumber) error {
 	b.WriteByte(0x0c)
 	utils.WriteVarInt(b, uint64(f.StreamID))
 	utils.BigEndian.WriteUint16(b, uint16(f.ErrorCode))

--- a/internal/wire/stop_waiting_frame.go
+++ b/internal/wire/stop_waiting_frame.go
@@ -22,7 +22,7 @@ var (
 	errPacketNumberLenNotSet              = errors.New("StopWaitingFrame: PacketNumberLen not set")
 )
 
-func (f *StopWaitingFrame) Write(b *bytes.Buffer, v protocol.VersionNumber) error {
+func (f *StopWaitingFrame) Write(b utils.ByteWriter, v protocol.VersionNumber) error {
 	if v.UsesIETFFrameFormat() {
 		return errors.New("STOP_WAITING not defined in IETF QUIC")
 	}

--- a/internal/wire/stream_blocked_frame.go
+++ b/internal/wire/stream_blocked_frame.go
@@ -33,7 +33,7 @@ func parseStreamBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*Stream
 }
 
 // Write writes a STREAM_BLOCKED frame
-func (f *StreamBlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (f *StreamBlockedFrame) Write(b utils.ByteWriter, version protocol.VersionNumber) error {
 	if !version.UsesIETFFrameFormat() {
 		return (&blockedFrameLegacy{StreamID: f.StreamID}).Write(b, version)
 	}

--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -84,7 +84,7 @@ func parseStreamFrame(r *bytes.Reader, version protocol.VersionNumber) (*StreamF
 }
 
 // Write writes a STREAM frame
-func (f *StreamFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (f *StreamFrame) Write(b utils.ByteWriter, version protocol.VersionNumber) error {
 	if !version.UsesIETFFrameFormat() {
 		return f.writeLegacy(b, version)
 	}

--- a/internal/wire/stream_frame_legacy.go
+++ b/internal/wire/stream_frame_legacy.go
@@ -83,7 +83,7 @@ func parseLegacyStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StreamF
 }
 
 // writeLegacy writes a stream frame.
-func (f *StreamFrame) writeLegacy(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (f *StreamFrame) writeLegacy(b utils.ByteWriter, _ protocol.VersionNumber) error {
 	if len(f.Data) == 0 && !f.FinBit {
 		return errors.New("StreamFrame: attempting to write empty frame without FIN")
 	}

--- a/internal/wire/stream_id_blocked_frame.go
+++ b/internal/wire/stream_id_blocked_frame.go
@@ -24,7 +24,7 @@ func parseStreamIDBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*Stre
 	return &StreamIDBlockedFrame{StreamID: protocol.StreamID(streamID)}, nil
 }
 
-func (f *StreamIDBlockedFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (f *StreamIDBlockedFrame) Write(b utils.ByteWriter, _ protocol.VersionNumber) error {
 	typeByte := uint8(0x0a)
 	b.WriteByte(typeByte)
 	utils.WriteVarInt(b, uint64(f.StreamID))

--- a/internal/wire/window_update_frame.go
+++ b/internal/wire/window_update_frame.go
@@ -37,7 +37,7 @@ func parseWindowUpdateFrame(r *bytes.Reader, _ protocol.VersionNumber) (Frame, e
 	}, nil
 }
 
-func (f *windowUpdateFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (f *windowUpdateFrame) Write(b utils.ByteWriter, _ protocol.VersionNumber) error {
 	b.WriteByte(0x4)
 	utils.BigEndian.WriteUint32(b, uint32(f.StreamID))
 	utils.BigEndian.WriteUint64(b, uint64(f.ByteOffset))

--- a/mint_utils.go
+++ b/mint_utils.go
@@ -148,7 +148,7 @@ func unpackInitialPacket(aead crypto.AEAD, hdr *wire.Header, data []byte, logger
 // It is supposed to be used in the early stages of the handshake, before a session (which owns a packetPacker) is available.
 func packUnencryptedPacket(aead crypto.AEAD, hdr *wire.Header, f wire.Frame, pers protocol.Perspective, logger utils.Logger) ([]byte, error) {
 	raw := *getPacketBuffer()
-	buffer := bytes.NewBuffer(raw[:0])
+	buffer := utils.NewBuffer(raw[:0])
 	if err := hdr.Write(buffer, pers, hdr.Version); err != nil {
 		return nil, err
 	}

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -486,7 +486,7 @@ func (p *packetPacker) writeAndSealPacket(
 	sealer handshake.Sealer,
 ) ([]byte, error) {
 	raw := *getPacketBuffer()
-	buffer := bytes.NewBuffer(raw[:0])
+	buffer := utils.NewBuffer(raw[:0])
 
 	if err := header.Write(buffer, p.perspective, p.version); err != nil {
 		return nil, err


### PR DESCRIPTION
We will need to move away from the `bytes.Buffer` for writing packets when implementing #1302, since it doesn't implement the `io.WriterAt`. We will need to write a specific offset, since in the ACK frame, we **first** write the number of ACK ranges, and **later** we write the ACK ranges. However, we don't know in advance how many ranges we will write, so we will need go back and update the counter.

This can be easily achieved by using our own interface, which combines `io.Writer`, `io.ByteWriter` and `io.WriterAt`. For now, this PR only implements `io.Writer` and `io.ByteWriter`, the `io.WriterAt` will be added in the actual fix for #1302.

The `utils.Buffer` is considerably faster than the `bytes.Buffer`, since it doesn't need to perform any checks if the underlying byte slice needs to be grown (for 1<<15 repetitions).

```
BenchmarkBytesBufferSingleByte-8   	   30000	    106479 ns/op
BenchmarkUtilsBufferSingleByte-8   	  100000	     49962 ns/op
BenchmarkBytesBuffer2Bytes-8       	    5000	    461520 ns/op
BenchmarkUtilsBuffer2Bytes-8       	   10000	    298070 ns/op
BenchmarkBytesBuffer10Bytes-8      	    5000	    521583 ns/op
BenchmarkUtilsBuffer10Bytes-8      	   10000	    343500 ns/op
BenchmarkBytesBuffer50Bytes-8      	    2000	   1545412 ns/op
BenchmarkUtilsBuffer50Bytes-8      	    2000	   1417985 ns/op
BenchmarkBytesBuffer200Bytes-8     	    1000	   2741885 ns/op
BenchmarkUtilsBuffer200Bytes-8     	    1000	   2691521 ns/op
```