### PR TITLE
fix flaky key exchange generation test on AppVeyor

### DIFF
--- a/internal/handshake/ephermal_cache_test.go
+++ b/internal/handshake/ephermal_cache_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Ephermal KEX", func() {
 	})
 
 	It("changes KEX", func() {
-		kexLifetime = time.Millisecond
+		kexLifetime = 10 * time.Millisecond
 		defer func() {
 			kexLifetime = protocol.EphermalKeyLifetime
 		}()


### PR DESCRIPTION
Fixes #1317.

I have no idea why this works, and I'm tired of debugging timer issues on Windows. I ran the test 1300 times in my Windows VM, and it didn't fail.