### PR TITLE
fix logging of version negotiation packets

### DIFF
--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -271,6 +271,7 @@ var _ = Describe("Header", func() {
 				IsLongHeader:     true,
 				DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				SrcConnectionID:  protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
+				Version:          0x1337,
 			}).Log(logger)
 			Expect(buf.String()).To(ContainSubstring("Long Header"))
 		})

--- a/internal/wire/ietf_header.go
+++ b/internal/wire/ietf_header.go
@@ -45,6 +45,7 @@ func parseLongHeader(b *bytes.Reader, sentBy protocol.Perspective, typeByte byte
 	}
 
 	h := &Header{
+		IsLongHeader:     true,
 		Version:          protocol.VersionNumber(v),
 		DestConnectionID: destConnID,
 		SrcConnectionID:  srcConnID,
@@ -69,7 +70,6 @@ func parseLongHeader(b *bytes.Reader, sentBy protocol.Perspective, typeByte byte
 		return h, nil
 	}
 
-	h.IsLongHeader = true
 	pn, err := utils.BigEndian.ReadUint32(b)
 	if err != nil {
 		return nil, err
@@ -192,7 +192,11 @@ func (h *Header) getHeaderLength() (protocol.ByteCount, error) {
 
 func (h *Header) logHeader(logger utils.Logger) {
 	if h.IsLongHeader {
-		logger.Debugf("   Long Header{Type: %s, DestConnectionID: %s, SrcConnectionID: %s, PacketNumber: %#x, Version: %s}", h.Type, h.DestConnectionID, h.SrcConnectionID, h.PacketNumber, h.Version)
+		if h.Version == 0 {
+			logger.Debugf("    VersionNegotiationPacket{DestConnectionID: %s, SrcConnectionID: %s, SupportedVersions: %s}", h.DestConnectionID, h.SrcConnectionID, h.SupportedVersions)
+		} else {
+			logger.Debugf("   Long Header{Type: %s, DestConnectionID: %s, SrcConnectionID: %s, PacketNumber: %#x, Version: %s}", h.Type, h.DestConnectionID, h.SrcConnectionID, h.PacketNumber, h.Version)
+		}
 	} else {
 		logger.Debugf("   Short Header{DestConnectionID: %s, PacketNumber: %#x, PacketNumberLen: %d, KeyPhase: %d}", h.DestConnectionID, h.PacketNumber, h.PacketNumberLen, h.KeyPhase)
 	}

--- a/internal/wire/ietf_header_test.go
+++ b/internal/wire/ietf_header_test.go
@@ -428,6 +428,19 @@ var _ = Describe("IETF QUIC Header", func() {
 			log.SetOutput(os.Stdout)
 		})
 
+		It("logs version negotiation packets", func() {
+			destConnID := protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37}
+			srcConnID := protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad, 0x013, 0x37, 0x13, 0x37}
+			data, err := ComposeVersionNegotiation(destConnID, srcConnID, []protocol.VersionNumber{0x12345678, 0x87654321})
+			Expect(err).ToNot(HaveOccurred())
+			hdr, err := parseLongHeader(bytes.NewReader(data[1:]), protocol.PerspectiveServer, data[0])
+			Expect(err).ToNot(HaveOccurred())
+			hdr.logHeader(logger)
+			Expect(buf.String()).To(ContainSubstring("VersionNegotiationPacket{DestConnectionID: 0xdeadbeefcafe1337, SrcConnectionID: 0xdecafbad13371337"))
+			Expect(buf.String()).To(ContainSubstring("0x12345678"))
+			Expect(buf.String()).To(ContainSubstring("0x87654321"))
+		})
+
 		It("logs Long Headers", func() {
 			(&Header{
 				IsLongHeader:     true,


### PR DESCRIPTION
We're not using it anywhere, but the wrong logging confused me while debugging.