### PR TITLE
Fix KEX test on windows

### DIFF
--- a/internal/handshake/ephermal_cache.go
+++ b/internal/handshake/ephermal_cache.go
@@ -35,7 +35,7 @@ func getEphermalKEX() (crypto.KeyExchange, error) {
 	kexMutex.Lock()
 	defer kexMutex.Unlock()
 	// Check if still unfulfilled
-	if kexCurrent == nil || time.Since(kexCurrentTime) > kexLifetime {
+	if kexCurrent == nil || time.Since(kexCurrentTime) >= kexLifetime {
 		kex, err := crypto.NewCurve25519KEX()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This makes the code rotate the key if `time.Since(kexCurrentTime) == kexLifetime`, which prevents an issue with low-resolution clocks (e.g. in our appveyor tests).