### PR TITLE
don't send an ACK when receiving a packet that wouldn't be acked

### DIFF
--- a/internal/ackhandler/received_packet_handler.go
+++ b/internal/ackhandler/received_packet_handler.go
@@ -88,7 +88,7 @@ func (h *receivedPacketHandler) IgnoreBelow(p protocol.PacketNumber) {
 
 // isMissing says if a packet was reported missing in the last ACK.
 func (h *receivedPacketHandler) isMissing(p protocol.PacketNumber) bool {
-	if h.lastAck == nil {
+	if h.lastAck == nil || p < h.ignoreBelow {
 		return false
 	}
 	return p < h.lastAck.LargestAcked() && !h.lastAck.AcksPacket(p)


### PR DESCRIPTION
There's a lower bound which packets get acknowledged in an ACK frame. When receiving a packet smaller than that bound, which was reported missing before, it's not necessary to immediately queue an ACK, since it wouldn't be included in the ACK frame anyway.

This seems to have a small positive effect on the transfer rate on lossy connections.