### PR TITLE
remove unused functions from the RTT stats

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -17,7 +17,6 @@ const (
 	// In fraction of an RTT.
 	timeReorderingFraction = 1.0 / 8
 	// The default RTT used before an RTT sample is taken.
-	// Note: This constant is also defined in the congestion package.
 	defaultInitialRTT = 100 * time.Millisecond
 	// defaultRTOTimeout is the RTO time on new connections
 	defaultRTOTimeout = 500 * time.Millisecond

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -781,10 +781,6 @@ var _ = Describe("SentPacketHandler", func() {
 	})
 
 	Context("TLPs", func() {
-		It("uses the default RTT", func() {
-			Expect(handler.computeTLPTimeout()).To(Equal(defaultInitialRTT * 3 / 2))
-		})
-
 		It("uses the RTT from RTT stats", func() {
 			rtt := 2 * time.Second
 			updateRTT(rtt)

--- a/internal/congestion/rtt_stats.go
+++ b/internal/congestion/rtt_stats.go
@@ -11,6 +11,8 @@ const (
 	oneMinusAlpha float32 = (1 - rttAlpha)
 	rttBeta       float32 = 0.25
 	oneMinusBeta  float32 = (1 - rttBeta)
+	// The default RTT used before an RTT sample is taken.
+	defaultInitialRTT = 100 * time.Millisecond
 )
 
 // RTTStats provides round-trip statistics
@@ -37,6 +39,15 @@ func (r *RTTStats) LatestRTT() time.Duration { return r.latestRTT }
 // SmoothedRTT returns the EWMA smoothed RTT for the connection.
 // May return Zero if no valid updates have occurred.
 func (r *RTTStats) SmoothedRTT() time.Duration { return r.smoothedRTT }
+
+// SmoothedOrInitialRTT returns the EWMA smoothed RTT for the connection.
+// If no valid updates have occurred, it returns the initial RTT.
+func (r *RTTStats) SmoothedOrInitialRTT() time.Duration {
+	if r.smoothedRTT != 0 {
+		return r.smoothedRTT
+	}
+	return defaultInitialRTT
+}
 
 // MeanDeviation gets the mean deviation
 func (r *RTTStats) MeanDeviation() time.Duration { return r.meanDeviation }

--- a/internal/congestion/rtt_stats.go
+++ b/internal/congestion/rtt_stats.go
@@ -7,49 +7,24 @@ import (
 )
 
 const (
-	// Note: This constant is also defined in the ackhandler package.
-	initialRTTus          = 100 * 1000
 	rttAlpha      float32 = 0.125
 	oneMinusAlpha float32 = (1 - rttAlpha)
 	rttBeta       float32 = 0.25
 	oneMinusBeta  float32 = (1 - rttBeta)
-	halfWindow    float32 = 0.5
-	quarterWindow float32 = 0.25
 )
-
-type rttSample struct {
-	rtt  time.Duration
-	time time.Time
-}
 
 // RTTStats provides round-trip statistics
 type RTTStats struct {
-	initialRTTus int64
-
-	recentMinRTTwindow time.Duration
-	minRTT             time.Duration
-	latestRTT          time.Duration
-	smoothedRTT        time.Duration
-	meanDeviation      time.Duration
-
-	numMinRTTsamplesRemaining uint32
-
-	newMinRTT        rttSample
-	recentMinRTT     rttSample
-	halfWindowRTT    rttSample
-	quarterWindowRTT rttSample
+	minRTT        time.Duration
+	latestRTT     time.Duration
+	smoothedRTT   time.Duration
+	meanDeviation time.Duration
 }
 
 // NewRTTStats makes a properly initialized RTTStats object
 func NewRTTStats() *RTTStats {
-	return &RTTStats{
-		initialRTTus:       initialRTTus,
-		recentMinRTTwindow: utils.InfDuration,
-	}
+	return &RTTStats{}
 }
-
-// InitialRTTus is the initial RTT in us
-func (r *RTTStats) InitialRTTus() int64 { return r.initialRTTus }
 
 // MinRTT Returns the minRTT for the entire connection.
 // May return Zero if no valid updates have occurred.
@@ -59,27 +34,12 @@ func (r *RTTStats) MinRTT() time.Duration { return r.minRTT }
 // May return Zero if no valid updates have occurred.
 func (r *RTTStats) LatestRTT() time.Duration { return r.latestRTT }
 
-// RecentMinRTT the minRTT since SampleNewRecentMinRtt has been called, or the
-// minRTT for the entire connection if SampleNewMinRtt was never called.
-func (r *RTTStats) RecentMinRTT() time.Duration { return r.recentMinRTT.rtt }
-
 // SmoothedRTT returns the EWMA smoothed RTT for the connection.
 // May return Zero if no valid updates have occurred.
 func (r *RTTStats) SmoothedRTT() time.Duration { return r.smoothedRTT }
 
-// GetQuarterWindowRTT gets the quarter window RTT
-func (r *RTTStats) GetQuarterWindowRTT() time.Duration { return r.quarterWindowRTT.rtt }
-
-// GetHalfWindowRTT gets the half window RTT
-func (r *RTTStats) GetHalfWindowRTT() time.Duration { return r.halfWindowRTT.rtt }
-
 // MeanDeviation gets the mean deviation
 func (r *RTTStats) MeanDeviation() time.Duration { return r.meanDeviation }
-
-// SetRecentMinRTTwindow sets how old a recent min rtt sample can be.
-func (r *RTTStats) SetRecentMinRTTwindow(recentMinRTTwindow time.Duration) {
-	r.recentMinRTTwindow = recentMinRTTwindow
-}
 
 // UpdateRTT updates the RTT based on a new sample.
 func (r *RTTStats) UpdateRTT(sendDelta, ackDelay time.Duration, now time.Time) {
@@ -94,7 +54,6 @@ func (r *RTTStats) UpdateRTT(sendDelta, ackDelay time.Duration, now time.Time) {
 	if r.minRTT == 0 || r.minRTT > sendDelta {
 		r.minRTT = sendDelta
 	}
-	r.updateRecentMinRTT(sendDelta, now)
 
 	// Correct for ackDelay if information received from the peer results in a
 	// an RTT sample at least as large as minRTT. Otherwise, only use the
@@ -114,63 +73,12 @@ func (r *RTTStats) UpdateRTT(sendDelta, ackDelay time.Duration, now time.Time) {
 	}
 }
 
-func (r *RTTStats) updateRecentMinRTT(sample time.Duration, now time.Time) { // Recent minRTT update.
-	if r.numMinRTTsamplesRemaining > 0 {
-		r.numMinRTTsamplesRemaining--
-		if r.newMinRTT.rtt == 0 || sample <= r.newMinRTT.rtt {
-			r.newMinRTT = rttSample{rtt: sample, time: now}
-		}
-		if r.numMinRTTsamplesRemaining == 0 {
-			r.recentMinRTT = r.newMinRTT
-			r.halfWindowRTT = r.newMinRTT
-			r.quarterWindowRTT = r.newMinRTT
-		}
-	}
-
-	// Update the three recent rtt samples.
-	if r.recentMinRTT.rtt == 0 || sample <= r.recentMinRTT.rtt {
-		r.recentMinRTT = rttSample{rtt: sample, time: now}
-		r.halfWindowRTT = r.recentMinRTT
-		r.quarterWindowRTT = r.recentMinRTT
-	} else if sample <= r.halfWindowRTT.rtt {
-		r.halfWindowRTT = rttSample{rtt: sample, time: now}
-		r.quarterWindowRTT = r.halfWindowRTT
-	} else if sample <= r.quarterWindowRTT.rtt {
-		r.quarterWindowRTT = rttSample{rtt: sample, time: now}
-	}
-
-	// Expire old min rtt samples.
-	if r.recentMinRTT.time.Before(now.Add(-r.recentMinRTTwindow)) {
-		r.recentMinRTT = r.halfWindowRTT
-		r.halfWindowRTT = r.quarterWindowRTT
-		r.quarterWindowRTT = rttSample{rtt: sample, time: now}
-	} else if r.halfWindowRTT.time.Before(now.Add(-time.Duration(float32(r.recentMinRTTwindow/time.Microsecond)*halfWindow) * time.Microsecond)) {
-		r.halfWindowRTT = r.quarterWindowRTT
-		r.quarterWindowRTT = rttSample{rtt: sample, time: now}
-	} else if r.quarterWindowRTT.time.Before(now.Add(-time.Duration(float32(r.recentMinRTTwindow/time.Microsecond)*quarterWindow) * time.Microsecond)) {
-		r.quarterWindowRTT = rttSample{rtt: sample, time: now}
-	}
-}
-
-// SampleNewRecentMinRTT forces RttStats to sample a new recent min rtt within the next
-// |numSamples| UpdateRTT calls.
-func (r *RTTStats) SampleNewRecentMinRTT(numSamples uint32) {
-	r.numMinRTTsamplesRemaining = numSamples
-	r.newMinRTT = rttSample{}
-}
-
 // OnConnectionMigration is called when connection migrates and rtt measurement needs to be reset.
 func (r *RTTStats) OnConnectionMigration() {
 	r.latestRTT = 0
 	r.minRTT = 0
 	r.smoothedRTT = 0
 	r.meanDeviation = 0
-	r.initialRTTus = initialRTTus
-	r.numMinRTTsamplesRemaining = 0
-	r.recentMinRTTwindow = utils.InfDuration
-	r.recentMinRTT = rttSample{}
-	r.halfWindowRTT = rttSample{}
-	r.quarterWindowRTT = rttSample{}
 }
 
 // ExpireSmoothedMetrics causes the smoothed_rtt to be increased to the latest_rtt if the latest_rtt

--- a/internal/congestion/rtt_stats_test.go
+++ b/internal/congestion/rtt_stats_test.go
@@ -37,6 +37,12 @@ var _ = Describe("RTT stats", func() {
 		Expect(rttStats.SmoothedRTT()).To(Equal((287500 * time.Microsecond)))
 	})
 
+	It("SmoothedOrInitialRTT", func() {
+		Expect(rttStats.SmoothedOrInitialRTT()).To(Equal(defaultInitialRTT))
+		rttStats.UpdateRTT((300 * time.Millisecond), (100 * time.Millisecond), time.Time{})
+		Expect(rttStats.SmoothedOrInitialRTT()).To(Equal((300 * time.Millisecond)))
+	})
+
 	It("MinRTT", func() {
 		rttStats.UpdateRTT((200 * time.Millisecond), 0, time.Time{})
 		Expect(rttStats.MinRTT()).To(Equal((200 * time.Millisecond)))


### PR DESCRIPTION
These functions are not used anywhere, and were removed from Chromium code as well.