### PR TITLE
parse IETF headers independent of the sender's perspective

### DIFF
--- a/client.go
+++ b/client.go
@@ -346,6 +346,9 @@ func (c *client) handleIETFQUICPacket(hdr *wire.Header, packetData []byte, remot
 		return fmt.Errorf("received a packet with an unexpected connection ID (%s, expected %s)", hdr.DestConnectionID, c.srcConnID)
 	}
 	if hdr.IsLongHeader {
+		if hdr.Type != protocol.PacketTypeRetry && hdr.Type != protocol.PacketTypeHandshake {
+			return fmt.Errorf("Received unsupported packet type: %s", hdr.Type)
+		}
 		c.logger.Debugf("len(packet data): %d, payloadLen: %d", len(packetData), hdr.PayloadLen)
 		if protocol.ByteCount(len(packetData)) < hdr.PayloadLen {
 			return fmt.Errorf("packet payload (%d bytes) is smaller than the expected payload length (%d bytes)", len(packetData), hdr.PayloadLen)

--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -87,7 +87,7 @@ func parsePacketHeader(b *bytes.Reader, sentBy protocol.Perspective, isPublicHea
 		hdr.IsPublicHeader = true // save that this is a Public Header, so we can log it correctly later
 		return hdr, nil
 	}
-	return parseHeader(b, sentBy)
+	return parseHeader(b)
 }
 
 // Write writes the Header.

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -190,6 +190,7 @@ var _ = Describe("Header", func() {
 		It("writes a IETF draft header", func() {
 			buf := &bytes.Buffer{}
 			hdr := &Header{
+				Type:             protocol.PacketTypeHandshake,
 				DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				SrcConnectionID:  protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				PacketNumber:     0x42,
@@ -198,7 +199,7 @@ var _ = Describe("Header", func() {
 			}
 			err := hdr.Write(buf, protocol.PerspectiveServer, versionIETFHeader)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = parseHeader(bytes.NewReader(buf.Bytes()), protocol.PerspectiveServer)
+			_, err = ParseHeaderSentByServer(bytes.NewReader(buf.Bytes()), versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.IsPublicHeader).To(BeFalse())
 		})

--- a/internal/wire/version_negotiation_test.go
+++ b/internal/wire/version_negotiation_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Version Negotiation Packets", func() {
 		data, err := ComposeVersionNegotiation(destConnID, srcConnID, versions)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(data[0] & 0x80).ToNot(BeZero())
-		hdr, err := parseHeader(bytes.NewReader(data), protocol.PerspectiveServer)
+		hdr, err := parseHeader(bytes.NewReader(data))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hdr.IsVersionNegotiation).To(BeTrue())
 		Expect(hdr.DestConnectionID).To(Equal(destConnID))


### PR DESCRIPTION
The IETF header format allows parsing of the header without knowing which peer sent the packet.