### PR TITLE
schedule sending when queueing a connection-level window update

### DIFF
--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -12,6 +12,8 @@ import (
 type connectionFlowController struct {
 	lastBlockedAt protocol.ByteCount
 	baseFlowController
+
+	queueWindowUpdate func()
 }
 
 var _ ConnectionFlowController = &connectionFlowController{}
@@ -21,6 +23,7 @@ var _ ConnectionFlowController = &connectionFlowController{}
 func NewConnectionFlowController(
 	receiveWindow protocol.ByteCount,
 	maxReceiveWindow protocol.ByteCount,
+	queueWindowUpdate func(),
 	rttStats *congestion.RTTStats,
 	logger utils.Logger,
 ) ConnectionFlowController {
@@ -32,6 +35,7 @@ func NewConnectionFlowController(
 			maxReceiveWindowSize: maxReceiveWindow,
 			logger:               logger,
 		},
+		queueWindowUpdate: queueWindowUpdate,
 	}
 }
 
@@ -60,6 +64,15 @@ func (c *connectionFlowController) IncrementHighestReceived(increment protocol.B
 		return qerr.Error(qerr.FlowControlReceivedTooMuchData, fmt.Sprintf("Received %d bytes for the connection, allowed %d bytes", c.highestReceived, c.receiveWindow))
 	}
 	return nil
+}
+
+func (c *connectionFlowController) MaybeQueueWindowUpdate() {
+	c.mutex.Lock()
+	hasWindowUpdate := c.hasWindowUpdate()
+	c.mutex.Unlock()
+	if hasWindowUpdate {
+		c.queueWindowUpdate()
+	}
 }
 
 func (c *connectionFlowController) GetWindowUpdate() protocol.ByteCount {

--- a/internal/flowcontrol/interface.go
+++ b/internal/flowcontrol/interface.go
@@ -21,8 +21,8 @@ type StreamFlowController interface {
 	// UpdateHighestReceived should be called when a new highest offset is received
 	// final has to be to true if this is the final offset of the stream, as contained in a STREAM frame with FIN bit, and the RST_STREAM frame
 	UpdateHighestReceived(offset protocol.ByteCount, final bool) error
-	// HasWindowUpdate says if it is necessary to update the window
-	HasWindowUpdate() bool
+	// MaybeQueueWindowUpdate queues a window update, if necessary
+	MaybeQueueWindowUpdate()
 }
 
 // The ConnectionFlowController is the flow controller for the connection.

--- a/internal/flowcontrol/interface.go
+++ b/internal/flowcontrol/interface.go
@@ -10,6 +10,7 @@ type flowController interface {
 	// for receiving
 	AddBytesRead(protocol.ByteCount)
 	GetWindowUpdate() protocol.ByteCount // returns 0 if no update is necessary
+	MaybeQueueWindowUpdate()             //  queues a window update, if necessary
 }
 
 // A StreamFlowController is a flow controller for a QUIC stream.
@@ -21,8 +22,6 @@ type StreamFlowController interface {
 	// UpdateHighestReceived should be called when a new highest offset is received
 	// final has to be to true if this is the final offset of the stream, as contained in a STREAM frame with FIN bit, and the RST_STREAM frame
 	UpdateHighestReceived(offset protocol.ByteCount, final bool) error
-	// MaybeQueueWindowUpdate queues a window update, if necessary
-	MaybeQueueWindowUpdate()
 }
 
 // The ConnectionFlowController is the flow controller for the connection.

--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -131,6 +131,9 @@ func (c *streamFlowController) MaybeQueueWindowUpdate() {
 	if hasWindowUpdate {
 		c.queueWindowUpdate()
 	}
+	if c.contributesToConnection {
+		c.connection.MaybeQueueWindowUpdate()
+	}
 }
 
 func (c *streamFlowController) GetWindowUpdate() protocol.ByteCount {

--- a/internal/mocks/connection_flow_controller.go
+++ b/internal/mocks/connection_flow_controller.go
@@ -79,6 +79,16 @@ func (mr *MockConnectionFlowControllerMockRecorder) IsNewlyBlocked() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNewlyBlocked", reflect.TypeOf((*MockConnectionFlowController)(nil).IsNewlyBlocked))
 }
 
+// MaybeQueueWindowUpdate mocks base method
+func (m *MockConnectionFlowController) MaybeQueueWindowUpdate() {
+	m.ctrl.Call(m, "MaybeQueueWindowUpdate")
+}
+
+// MaybeQueueWindowUpdate indicates an expected call of MaybeQueueWindowUpdate
+func (mr *MockConnectionFlowControllerMockRecorder) MaybeQueueWindowUpdate() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeQueueWindowUpdate", reflect.TypeOf((*MockConnectionFlowController)(nil).MaybeQueueWindowUpdate))
+}
+
 // SendWindowSize mocks base method
 func (m *MockConnectionFlowController) SendWindowSize() protocol.ByteCount {
 	ret := m.ctrl.Call(m, "SendWindowSize")

--- a/internal/mocks/stream_flow_controller.go
+++ b/internal/mocks/stream_flow_controller.go
@@ -66,18 +66,6 @@ func (mr *MockStreamFlowControllerMockRecorder) GetWindowUpdate() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWindowUpdate", reflect.TypeOf((*MockStreamFlowController)(nil).GetWindowUpdate))
 }
 
-// HasWindowUpdate mocks base method
-func (m *MockStreamFlowController) HasWindowUpdate() bool {
-	ret := m.ctrl.Call(m, "HasWindowUpdate")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// HasWindowUpdate indicates an expected call of HasWindowUpdate
-func (mr *MockStreamFlowControllerMockRecorder) HasWindowUpdate() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasWindowUpdate", reflect.TypeOf((*MockStreamFlowController)(nil).HasWindowUpdate))
-}
-
 // IsBlocked mocks base method
 func (m *MockStreamFlowController) IsBlocked() (bool, protocol.ByteCount) {
 	ret := m.ctrl.Call(m, "IsBlocked")
@@ -89,6 +77,16 @@ func (m *MockStreamFlowController) IsBlocked() (bool, protocol.ByteCount) {
 // IsBlocked indicates an expected call of IsBlocked
 func (mr *MockStreamFlowControllerMockRecorder) IsBlocked() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBlocked", reflect.TypeOf((*MockStreamFlowController)(nil).IsBlocked))
+}
+
+// MaybeQueueWindowUpdate mocks base method
+func (m *MockStreamFlowController) MaybeQueueWindowUpdate() {
+	m.ctrl.Call(m, "MaybeQueueWindowUpdate")
+}
+
+// MaybeQueueWindowUpdate indicates an expected call of MaybeQueueWindowUpdate
+func (mr *MockStreamFlowControllerMockRecorder) MaybeQueueWindowUpdate() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeQueueWindowUpdate", reflect.TypeOf((*MockStreamFlowController)(nil).MaybeQueueWindowUpdate))
 }
 
 // SendWindowSize mocks base method

--- a/mock_stream_sender_test.go
+++ b/mock_stream_sender_test.go
@@ -45,16 +45,6 @@ func (mr *MockStreamSenderMockRecorder) onHasStreamData(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "onHasStreamData", reflect.TypeOf((*MockStreamSender)(nil).onHasStreamData), arg0)
 }
 
-// onHasWindowUpdate mocks base method
-func (m *MockStreamSender) onHasWindowUpdate(arg0 protocol.StreamID) {
-	m.ctrl.Call(m, "onHasWindowUpdate", arg0)
-}
-
-// onHasWindowUpdate indicates an expected call of onHasWindowUpdate
-func (mr *MockStreamSenderMockRecorder) onHasWindowUpdate(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "onHasWindowUpdate", reflect.TypeOf((*MockStreamSender)(nil).onHasWindowUpdate), arg0)
-}
-
 // onStreamCompleted mocks base method
 func (m *MockStreamSender) onStreamCompleted(arg0 protocol.StreamID) {
 	m.ctrl.Call(m, "onStreamCompleted", arg0)

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -151,10 +151,8 @@ func (s *receiveStream) Read(p []byte) (int, error) {
 		if !s.resetRemotely {
 			s.flowController.AddBytesRead(protocol.ByteCount(m))
 		}
-		// this call triggers the flow controller to increase the flow control window, if necessary
-		if s.flowController.HasWindowUpdate() {
-			s.sender.onHasWindowUpdate(s.streamID)
-		}
+		// increase the flow control window, if necessary
+		s.flowController.MaybeQueueWindowUpdate()
 
 		if s.readPosInFrame >= int(frame.DataLen()) {
 			s.frameQueue.Pop()

--- a/session.go
+++ b/session.go
@@ -1137,6 +1137,7 @@ func (s *session) newFlowController(id protocol.StreamID) flowcontrol.StreamFlow
 		protocol.ReceiveStreamFlowControlWindow,
 		protocol.ByteCount(s.config.MaxReceiveStreamFlowControlWindow),
 		initialSendWindow,
+		s.onHasWindowUpdate,
 		s.rttStats,
 		s.logger,
 	)
@@ -1151,6 +1152,7 @@ func (s *session) newCryptoStream() cryptoStreamI {
 		protocol.ReceiveStreamFlowControlWindow,
 		protocol.ByteCount(s.config.MaxReceiveStreamFlowControlWindow),
 		0,
+		s.onHasWindowUpdate,
 		s.rttStats,
 		s.logger,
 	)

--- a/session.go
+++ b/session.go
@@ -405,6 +405,7 @@ func (s *session) preSetup() {
 	s.connFlowController = flowcontrol.NewConnectionFlowController(
 		protocol.ReceiveConnectionFlowControlWindow,
 		protocol.ByteCount(s.config.MaxReceiveConnectionFlowControlWindow),
+		s.onHasConnectionWindowUpdate,
 		s.rttStats,
 		s.logger,
 	)
@@ -425,7 +426,7 @@ func (s *session) postSetup() error {
 	s.sessionCreationTime = now
 
 	s.receivedPacketHandler = ackhandler.NewReceivedPacketHandler(s.rttStats, s.version)
-	s.windowUpdateQueue = newWindowUpdateQueue(s.streamsMap, s.cryptoStream, s.packer.QueueControlFrame)
+	s.windowUpdateQueue = newWindowUpdateQueue(s.streamsMap, s.cryptoStream, s.connFlowController, s.packer.QueueControlFrame)
 	return nil
 }
 
@@ -1021,9 +1022,6 @@ func (s *session) maybeSendRetransmission() (bool, error) {
 }
 
 func (s *session) sendPacket() (bool, error) {
-	if offset := s.connFlowController.GetWindowUpdate(); offset != 0 {
-		s.packer.QueueControlFrame(&wire.MaxDataFrame{ByteOffset: offset})
-	}
 	if isBlocked, offset := s.connFlowController.IsNewlyBlocked(); isBlocked {
 		s.packer.QueueControlFrame(&wire.BlockedFrame{Offset: offset})
 	}
@@ -1137,7 +1135,7 @@ func (s *session) newFlowController(id protocol.StreamID) flowcontrol.StreamFlow
 		protocol.ReceiveStreamFlowControlWindow,
 		protocol.ByteCount(s.config.MaxReceiveStreamFlowControlWindow),
 		initialSendWindow,
-		s.onHasWindowUpdate,
+		s.onHasStreamWindowUpdate,
 		s.rttStats,
 		s.logger,
 	)
@@ -1152,7 +1150,7 @@ func (s *session) newCryptoStream() cryptoStreamI {
 		protocol.ReceiveStreamFlowControlWindow,
 		protocol.ByteCount(s.config.MaxReceiveStreamFlowControlWindow),
 		0,
-		s.onHasWindowUpdate,
+		s.onHasStreamWindowUpdate,
 		s.rttStats,
 		s.logger,
 	)
@@ -1202,8 +1200,13 @@ func (s *session) queueControlFrame(f wire.Frame) {
 	s.scheduleSending()
 }
 
-func (s *session) onHasWindowUpdate(id protocol.StreamID) {
-	s.windowUpdateQueue.Add(id)
+func (s *session) onHasStreamWindowUpdate(id protocol.StreamID) {
+	s.windowUpdateQueue.AddStream(id)
+	s.scheduleSending()
+}
+
+func (s *session) onHasConnectionWindowUpdate() {
+	s.windowUpdateQueue.AddConnection()
 	s.scheduleSending()
 }
 

--- a/stream.go
+++ b/stream.go
@@ -18,7 +18,6 @@ const (
 // The streamSender is notified by the stream about various events.
 type streamSender interface {
 	queueControlFrame(wire.Frame)
-	onHasWindowUpdate(protocol.StreamID)
 	onHasStreamData(protocol.StreamID)
 	onStreamCompleted(protocol.StreamID)
 }
@@ -32,10 +31,6 @@ type uniStreamSender struct {
 
 func (s *uniStreamSender) queueControlFrame(f wire.Frame) {
 	s.streamSender.queueControlFrame(f)
-}
-
-func (s *uniStreamSender) onHasWindowUpdate(id protocol.StreamID) {
-	s.streamSender.onHasWindowUpdate(id)
 }
 
 func (s *uniStreamSender) onHasStreamData(id protocol.StreamID) {

--- a/window_update_queue.go
+++ b/window_update_queue.go
@@ -3,6 +3,7 @@ package quic
 import (
 	"sync"
 
+	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
@@ -10,29 +11,50 @@ import (
 type windowUpdateQueue struct {
 	mutex sync.Mutex
 
-	queue        map[protocol.StreamID]bool // used as a set
-	callback     func(wire.Frame)
-	cryptoStream cryptoStreamI
-	streamGetter streamGetter
+	queue      map[protocol.StreamID]bool // used as a set
+	queuedConn bool                       // connection-level window update
+
+	cryptoStream       cryptoStreamI
+	streamGetter       streamGetter
+	connFlowController flowcontrol.ConnectionFlowController
+	callback           func(wire.Frame)
 }
 
-func newWindowUpdateQueue(streamGetter streamGetter, cryptoStream cryptoStreamI, cb func(wire.Frame)) *windowUpdateQueue {
+func newWindowUpdateQueue(
+	streamGetter streamGetter,
+	cryptoStream cryptoStreamI,
+	connFC flowcontrol.ConnectionFlowController,
+	cb func(wire.Frame),
+) *windowUpdateQueue {
 	return &windowUpdateQueue{
-		queue:        make(map[protocol.StreamID]bool),
-		streamGetter: streamGetter,
-		cryptoStream: cryptoStream,
-		callback:     cb,
+		queue:              make(map[protocol.StreamID]bool),
+		streamGetter:       streamGetter,
+		cryptoStream:       cryptoStream,
+		connFlowController: connFC,
+		callback:           cb,
 	}
 }
 
-func (q *windowUpdateQueue) Add(id protocol.StreamID) {
+func (q *windowUpdateQueue) AddStream(id protocol.StreamID) {
 	q.mutex.Lock()
 	q.queue[id] = true
 	q.mutex.Unlock()
 }
 
+func (q *windowUpdateQueue) AddConnection() {
+	q.mutex.Lock()
+	q.queuedConn = true
+	q.mutex.Unlock()
+}
+
 func (q *windowUpdateQueue) QueueAll() {
 	q.mutex.Lock()
+	// queue a connection-level window update
+	if q.queuedConn {
+		q.callback(&wire.MaxDataFrame{ByteOffset: q.connFlowController.GetWindowUpdate()})
+		q.queuedConn = false
+	}
+	// queue all stream-level window updates
 	var offset protocol.ByteCount
 	for id := range q.queue {
 		if id == q.cryptoStream.StreamID() {

--- a/window_update_queue_test.go
+++ b/window_update_queue_test.go
@@ -1,6 +1,7 @@
 package quic
 
 import (
+	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 
@@ -12,6 +13,7 @@ var _ = Describe("Window Update Queue", func() {
 	var (
 		q            *windowUpdateQueue
 		streamGetter *MockStreamGetter
+		connFC       *mocks.MockConnectionFlowController
 		queuedFrames []wire.Frame
 		cryptoStream *MockCryptoStream
 	)
@@ -19,9 +21,10 @@ var _ = Describe("Window Update Queue", func() {
 	BeforeEach(func() {
 		streamGetter = NewMockStreamGetter(mockCtrl)
 		cryptoStream = NewMockCryptoStream(mockCtrl)
+		connFC = mocks.NewMockConnectionFlowController(mockCtrl)
 		cryptoStream.EXPECT().StreamID().Return(protocol.StreamID(0)).AnyTimes()
 		queuedFrames = queuedFrames[:0]
-		q = newWindowUpdateQueue(streamGetter, cryptoStream, func(f wire.Frame) {
+		q = newWindowUpdateQueue(streamGetter, cryptoStream, connFC, func(f wire.Frame) {
 			queuedFrames = append(queuedFrames, f)
 		})
 	})
@@ -33,8 +36,8 @@ var _ = Describe("Window Update Queue", func() {
 		stream3.EXPECT().getWindowUpdate().Return(protocol.ByteCount(30))
 		streamGetter.EXPECT().GetOrOpenReceiveStream(protocol.StreamID(3)).Return(stream3, nil)
 		streamGetter.EXPECT().GetOrOpenReceiveStream(protocol.StreamID(1)).Return(stream1, nil)
-		q.Add(3)
-		q.Add(1)
+		q.AddStream(3)
+		q.AddStream(1)
 		q.QueueAll()
 		Expect(queuedFrames).To(ContainElement(&wire.MaxStreamDataFrame{StreamID: 1, ByteOffset: 10}))
 		Expect(queuedFrames).To(ContainElement(&wire.MaxStreamDataFrame{StreamID: 3, ByteOffset: 30}))
@@ -44,7 +47,7 @@ var _ = Describe("Window Update Queue", func() {
 		stream10 := NewMockStreamI(mockCtrl)
 		stream10.EXPECT().getWindowUpdate().Return(protocol.ByteCount(100))
 		streamGetter.EXPECT().GetOrOpenReceiveStream(protocol.StreamID(10)).Return(stream10, nil)
-		q.Add(10)
+		q.AddStream(10)
 		q.QueueAll()
 		Expect(queuedFrames).To(HaveLen(1))
 		q.QueueAll()
@@ -53,7 +56,7 @@ var _ = Describe("Window Update Queue", func() {
 
 	It("doesn't queue a MAX_STREAM_DATA for a closed stream", func() {
 		streamGetter.EXPECT().GetOrOpenReceiveStream(protocol.StreamID(12)).Return(nil, nil)
-		q.Add(12)
+		q.AddStream(12)
 		q.QueueAll()
 		Expect(queuedFrames).To(BeEmpty())
 	})
@@ -62,17 +65,26 @@ var _ = Describe("Window Update Queue", func() {
 		stream5 := NewMockStreamI(mockCtrl)
 		stream5.EXPECT().getWindowUpdate().Return(protocol.ByteCount(0))
 		streamGetter.EXPECT().GetOrOpenReceiveStream(protocol.StreamID(5)).Return(stream5, nil)
-		q.Add(5)
+		q.AddStream(5)
 		q.QueueAll()
 		Expect(queuedFrames).To(BeEmpty())
 	})
 
 	It("adds MAX_STREAM_DATA frames for the crypto stream", func() {
 		cryptoStream.EXPECT().getWindowUpdate().Return(protocol.ByteCount(42))
-		q.Add(0)
+		q.AddStream(0)
 		q.QueueAll()
 		Expect(queuedFrames).To(Equal([]wire.Frame{
 			&wire.MaxStreamDataFrame{StreamID: 0, ByteOffset: 42},
+		}))
+	})
+
+	It("queues MAX_DATA frames", func() {
+		connFC.EXPECT().GetWindowUpdate().Return(protocol.ByteCount(0x1337))
+		q.AddConnection()
+		q.QueueAll()
+		Expect(queuedFrames).To(Equal([]wire.Frame{
+			&wire.MaxDataFrame{ByteOffset: 0x1337},
 		}))
 	})
 
@@ -80,8 +92,8 @@ var _ = Describe("Window Update Queue", func() {
 		stream10 := NewMockStreamI(mockCtrl)
 		stream10.EXPECT().getWindowUpdate().Return(protocol.ByteCount(200))
 		streamGetter.EXPECT().GetOrOpenReceiveStream(protocol.StreamID(10)).Return(stream10, nil)
-		q.Add(10)
-		q.Add(10)
+		q.AddStream(10)
+		q.AddStream(10)
 		q.QueueAll()
 		Expect(queuedFrames).To(Equal([]wire.Frame{
 			&wire.MaxStreamDataFrame{StreamID: 10, ByteOffset: 200},


### PR DESCRIPTION
It is not sufficient to check for connection-level window updates every time a packet is sent. When a connection-level window update needs to be sent, we need to make sure that it gets sent immediately (i.e. call `scheduleSending()` in the session).
Otherwise we might end up in a situation where the connection flow controller knows that a window update needs to be sent, but the session does not. The window update would be sent with the next packet, but the next packet to send might be the CONNECTION_CLOSE after hitting the idle timeout.