### PR TITLE
rename the constants for the max stream ids in the transport parameters

### DIFF
--- a/internal/handshake/tls_extension.go
+++ b/internal/handshake/tls_extension.go
@@ -11,11 +11,11 @@ const quicTLSExtensionType = 26
 const (
 	initialMaxStreamDataParameterID  transportParameterID = 0x0
 	initialMaxDataParameterID        transportParameterID = 0x1
-	initialMaxStreamsBiDiParameterID transportParameterID = 0x2
+	initialMaxBidiStreamsParameterID transportParameterID = 0x2
 	idleTimeoutParameterID           transportParameterID = 0x3
 	maxPacketSizeParameterID         transportParameterID = 0x5
 	statelessResetTokenParameterID   transportParameterID = 0x6
-	initialMaxStreamsUniParameterID  transportParameterID = 0x8
+	initialMaxUniStreamsParameterID  transportParameterID = 0x8
 )
 
 type transportParameter struct {

--- a/internal/handshake/tls_extension_handler_client_test.go
+++ b/internal/handshake/tls_extension_handler_client_test.go
@@ -69,7 +69,7 @@ var _ = Describe("TLS Extension Handler, for the client", func() {
 			parameters = map[transportParameterID][]byte{
 				initialMaxStreamDataParameterID:  {0x11, 0x22, 0x33, 0x44},
 				initialMaxDataParameterID:        {0x22, 0x33, 0x44, 0x55},
-				initialMaxStreamsBiDiParameterID: {0x33, 0x44},
+				initialMaxBidiStreamsParameterID: {0x33, 0x44},
 				idleTimeoutParameterID:           {0x13, 0x37},
 				statelessResetTokenParameterID:   bytes.Repeat([]byte{0}, 16),
 			}

--- a/internal/handshake/tls_extension_handler_server_test.go
+++ b/internal/handshake/tls_extension_handler_server_test.go
@@ -80,7 +80,7 @@ var _ = Describe("TLS Extension Handler, for the server", func() {
 			parameters = map[transportParameterID][]byte{
 				initialMaxStreamDataParameterID:  {0x11, 0x22, 0x33, 0x44},
 				initialMaxDataParameterID:        {0x22, 0x33, 0x44, 0x55},
-				initialMaxStreamsBiDiParameterID: {0x33, 0x44},
+				initialMaxBidiStreamsParameterID: {0x33, 0x44},
 				idleTimeoutParameterID:           {0x13, 0x37},
 			}
 		})

--- a/internal/handshake/transport_parameter_test.go
+++ b/internal/handshake/transport_parameter_test.go
@@ -128,8 +128,8 @@ var _ = Describe("Transport Parameters", func() {
 				parameters = map[transportParameterID][]byte{
 					initialMaxStreamDataParameterID:  {0x11, 0x22, 0x33, 0x44},
 					initialMaxDataParameterID:        {0x22, 0x33, 0x44, 0x55},
-					initialMaxStreamsBiDiParameterID: {0x33, 0x44},
-					initialMaxStreamsUniParameterID:  {0x44, 0x55},
+					initialMaxBidiStreamsParameterID: {0x33, 0x44},
+					initialMaxUniStreamsParameterID:  {0x44, 0x55},
 					idleTimeoutParameterID:           {0x13, 0x37},
 					maxPacketSizeParameterID:         {0x73, 0x31},
 				}
@@ -186,13 +186,13 @@ var _ = Describe("Transport Parameters", func() {
 			})
 
 			It("rejects the parameters if the initial_max_stream_id_bidi has the wrong length", func() {
-				parameters[initialMaxStreamsBiDiParameterID] = []byte{0x11, 0x22, 0x33} // should be 2 bytes
+				parameters[initialMaxBidiStreamsParameterID] = []byte{0x11, 0x22, 0x33} // should be 2 bytes
 				_, err := readTransportParameters(paramsMapToList(parameters))
 				Expect(err).To(MatchError("wrong length for initial_max_stream_id_bidi: 3 (expected 2)"))
 			})
 
 			It("rejects the parameters if the initial_max_stream_id_bidi has the wrong length", func() {
-				parameters[initialMaxStreamsUniParameterID] = []byte{0x11, 0x22, 0x33} // should be 2 bytes
+				parameters[initialMaxUniStreamsParameterID] = []byte{0x11, 0x22, 0x33} // should be 2 bytes
 				_, err := readTransportParameters(paramsMapToList(parameters))
 				Expect(err).To(MatchError("wrong length for initial_max_stream_id_uni: 3 (expected 2)"))
 			})
@@ -248,8 +248,8 @@ var _ = Describe("Transport Parameters", func() {
 				Expect(values).To(HaveLen(6))
 				Expect(values).To(HaveKeyWithValue(initialMaxStreamDataParameterID, []byte{0xde, 0xad, 0xbe, 0xef}))
 				Expect(values).To(HaveKeyWithValue(initialMaxDataParameterID, []byte{0xde, 0xca, 0xfb, 0xad}))
-				Expect(values).To(HaveKeyWithValue(initialMaxStreamsBiDiParameterID, []byte{0x12, 0x34}))
-				Expect(values).To(HaveKeyWithValue(initialMaxStreamsUniParameterID, []byte{0x43, 0x21}))
+				Expect(values).To(HaveKeyWithValue(initialMaxBidiStreamsParameterID, []byte{0x12, 0x34}))
+				Expect(values).To(HaveKeyWithValue(initialMaxUniStreamsParameterID, []byte{0x43, 0x21}))
 				Expect(values).To(HaveKeyWithValue(idleTimeoutParameterID, []byte{0xca, 0xfe}))
 				Expect(values).To(HaveKeyWithValue(maxPacketSizeParameterID, []byte{0x5, 0xac})) // 1452 = 0x5ac
 			})

--- a/internal/handshake/transport_parameters.go
+++ b/internal/handshake/transport_parameters.go
@@ -116,12 +116,12 @@ func readTransportParameters(paramsList []transportParameter) (*TransportParamet
 				return nil, fmt.Errorf("wrong length for initial_max_data: %d (expected 4)", len(p.Value))
 			}
 			params.ConnectionFlowControlWindow = protocol.ByteCount(binary.BigEndian.Uint32(p.Value))
-		case initialMaxStreamsBiDiParameterID:
+		case initialMaxBidiStreamsParameterID:
 			if len(p.Value) != 2 {
 				return nil, fmt.Errorf("wrong length for initial_max_stream_id_bidi: %d (expected 2)", len(p.Value))
 			}
 			params.MaxBidiStreams = binary.BigEndian.Uint16(p.Value)
-		case initialMaxStreamsUniParameterID:
+		case initialMaxUniStreamsParameterID:
 			if len(p.Value) != 2 {
 				return nil, fmt.Errorf("wrong length for initial_max_stream_id_uni: %d (expected 2)", len(p.Value))
 			}
@@ -168,8 +168,8 @@ func (p *TransportParameters) getTransportParameters() []transportParameter {
 	params := []transportParameter{
 		{initialMaxStreamDataParameterID, initialMaxStreamData},
 		{initialMaxDataParameterID, initialMaxData},
-		{initialMaxStreamsBiDiParameterID, initialMaxBidiStreamID},
-		{initialMaxStreamsUniParameterID, initialMaxUniStreamID},
+		{initialMaxBidiStreamsParameterID, initialMaxBidiStreamID},
+		{initialMaxUniStreamsParameterID, initialMaxUniStreamID},
 		{idleTimeoutParameterID, idleTimeout},
 		{maxPacketSizeParameterID, maxPacketSize},
 	}


### PR DESCRIPTION
These parameters were recently renamed in the draft: https://github.com/quicwg/base-drafts/pull/1310.

No functional change expected.