### PR TITLE
remove incorrect documentation about the listeners

### DIFF
--- a/server.go
+++ b/server.go
@@ -59,7 +59,6 @@ type server struct {
 var _ Listener = &server{}
 
 // ListenAddr creates a QUIC server listening on a given address.
-// The listener is not active until Serve() is called.
 // The tls.Config must not be nil, the quic.Config may be nil.
 func ListenAddr(addr string, tlsConf *tls.Config, config *Config) (Listener, error) {
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
@@ -74,7 +73,6 @@ func ListenAddr(addr string, tlsConf *tls.Config, config *Config) (Listener, err
 }
 
 // Listen listens for QUIC connections on a given net.PacketConn.
-// The listener is not active until Serve() is called.
 // The tls.Config must not be nil, the quic.Config may be nil.
 func Listen(conn net.PacketConn, tlsConf *tls.Config, config *Config) (Listener, error) {
 	certChain := crypto.NewCertChain(tlsConf)


### PR DESCRIPTION
`Listener.Serve()` was removed a very long time ago.