### PR TITLE
release 0.8.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.8.0 (unreleased)
+## v0.8.0 (2018-06-26)
 
 - Add support for unidirectional streams (for IETF QUIC).
 - Add a `quic.Config` option for the maximum number of incoming streams.


### PR DESCRIPTION
We should probably try to resolve issue #1353 first, and then release 0.8.0, so Caddy can vendor on the release tag.