### PR TITLE
Use http.Request.Host only for authority header and not for dialing

### DIFF
--- a/h2quic/request.go
+++ b/h2quic/request.go
@@ -70,9 +70,6 @@ func requestFromHeaders(headers []hpack.HeaderField) (*http.Request, error) {
 }
 
 func hostnameFromRequest(req *http.Request) string {
-	if len(req.Host) > 0 {
-		return req.Host
-	}
 	if req.URL != nil {
 		return req.URL.Host
 	}

--- a/h2quic/request_test.go
+++ b/h2quic/request_test.go
@@ -101,16 +101,16 @@ var _ = Describe("Request", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("uses req.Host if available", func() {
+		It("uses req.URL.Host", func() {
+			req := &http.Request{URL: url}
+			Expect(hostnameFromRequest(req)).To(Equal("quic.clemente.io:1337"))
+		})
+
+		It("uses req.URL.Host even if req.Host is available", func() {
 			req := &http.Request{
 				Host: "www.example.org",
 				URL:  url,
 			}
-			Expect(hostnameFromRequest(req)).To(Equal("www.example.org"))
-		})
-
-		It("uses req.URL.Host if req.Host is not set", func() {
-			req := &http.Request{URL: url}
 			Expect(hostnameFromRequest(req)).To(Equal("quic.clemente.io:1337"))
 		})
 


### PR DESCRIPTION
As from `net/http` documentation:
```text
    // For client requests Host optionally overrides the Host
    // header to send. If empty, the Request.Write method uses
    // the value of URL.Host.
```

Though `h2quic` uses `http.Request.Host` as the address to connect to. This is wrong as it has to pick the address from the URL. `hostnameFromRequest()` is being used only to get the hostname to dial and there is similar (but correct) logic in `requestWriter.encodeHeaders()`.