### PR TITLE
add support for QUIC 42

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Add support for unidirectional streams (for IETF QUIC).
 - Add a `quic.Config` option for the maximum number of incoming streams.
+- Add support for QUIC 42.
 
 ## v0.7.0 (2018-02-03)
 

--- a/integrationtests/chrome/chrome_suite_test.go
+++ b/integrationtests/chrome/chrome_suite_test.go
@@ -34,7 +34,6 @@ const (
 var (
 	nFilesUploaded int32 // should be used atomically
 	doneCalled     utils.AtomicBool
-	version        protocol.VersionNumber
 )
 
 func TestChrome(t *testing.T) {
@@ -82,10 +81,6 @@ func init() {
 		doneCalled.Set(true)
 	})
 }
-
-var _ = JustBeforeEach(func() {
-	testserver.StartQuicServer([]protocol.VersionNumber{version})
-})
 
 var _ = AfterEach(func() {
 	testserver.StopQuicServer()

--- a/integrationtests/chrome/chrome_test.go
+++ b/integrationtests/chrome/chrome_test.go
@@ -3,6 +3,7 @@ package chrome_test
 import (
 	"fmt"
 
+	"github.com/lucas-clemente/quic-go/integrationtests/tools/testserver"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 
 	. "github.com/onsi/ginkgo"
@@ -10,9 +11,13 @@ import (
 
 var _ = Describe("Chrome tests", func() {
 	for i := range protocol.SupportedVersions {
-		version = protocol.SupportedVersions[i]
+		version := protocol.SupportedVersions[i]
 
 		Context(fmt.Sprintf("with version %s", version), func() {
+			JustBeforeEach(func() {
+				testserver.StartQuicServer([]protocol.VersionNumber{version})
+			})
+
 			It("downloads a small file", func() {
 				chromeTest(
 					version,

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -18,7 +18,8 @@ const (
 
 // The version numbers, making grepping easier
 const (
-	Version39       VersionNumber = gquicVersion0 + 3*0x100 + 0x9 + iota
+	Version39       VersionNumber = gquicVersion0 + 3*0x100 + 0x9
+	Version42       VersionNumber = gquicVersion0 + 4*0x100 + 0x2
 	VersionTLS      VersionNumber = 101
 	VersionWhatever VersionNumber = 0 // for when the version doesn't matter
 	VersionUnknown  VersionNumber = math.MaxUint32
@@ -27,6 +28,7 @@ const (
 // SupportedVersions lists the versions that the server supports
 // must be in sorted descending order
 var SupportedVersions = []VersionNumber{
+	Version42,
 	Version39,
 }
 
@@ -74,12 +76,12 @@ func (vn VersionNumber) CryptoStreamID() StreamID {
 
 // UsesIETFFrameFormat tells if this version uses the IETF frame format
 func (vn VersionNumber) UsesIETFFrameFormat() bool {
-	return vn != Version39
+	return !vn.isGQUIC()
 }
 
 // UsesStopWaitingFrames tells if this version uses STOP_WAITING frames
 func (vn VersionNumber) UsesStopWaitingFrames() bool {
-	return vn == Version39
+	return vn.isGQUIC()
 }
 
 // StreamContributesToConnectionFlowControl says if a stream contributes to connection-level flow control

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -13,10 +13,12 @@ var _ = Describe("Version", func() {
 	// version numbers taken from the wiki: https://github.com/quicwg/base-drafts/wiki/QUIC-Versions
 	It("has the right gQUIC version number", func() {
 		Expect(Version39).To(BeEquivalentTo(0x51303339))
+		Expect(Version42).To(BeEquivalentTo(0x51303432))
 	})
 
 	It("says if a version is valid", func() {
 		Expect(IsValidVersion(Version39)).To(BeTrue())
+		Expect(IsValidVersion(Version42)).To(BeTrue())
 		Expect(IsValidVersion(VersionTLS)).To(BeTrue())
 		Expect(IsValidVersion(VersionWhatever)).To(BeFalse())
 		Expect(IsValidVersion(VersionUnknown)).To(BeFalse())
@@ -25,11 +27,13 @@ var _ = Describe("Version", func() {
 
 	It("says if a version supports TLS", func() {
 		Expect(Version39.UsesTLS()).To(BeFalse())
+		Expect(Version42.UsesTLS()).To(BeFalse())
 		Expect(VersionTLS.UsesTLS()).To(BeTrue())
 	})
 
 	It("versions don't have reserved version numbers", func() {
 		Expect(isReservedVersion(Version39)).To(BeFalse())
+		Expect(isReservedVersion(Version42)).To(BeFalse())
 		Expect(isReservedVersion(VersionTLS)).To(BeFalse())
 	})
 
@@ -48,6 +52,7 @@ var _ = Describe("Version", func() {
 
 	It("has the right representation for the H2 Alt-Svc tag", func() {
 		Expect(Version39.ToAltSvc()).To(Equal("39"))
+		Expect(Version42.ToAltSvc()).To(Equal("42"))
 		Expect(VersionTLS.ToAltSvc()).To(Equal("101"))
 		// check with unsupported version numbers from the wiki
 		Expect(VersionNumber(0x51303133).ToAltSvc()).To(Equal("13"))
@@ -57,30 +62,37 @@ var _ = Describe("Version", func() {
 
 	It("tells the Stream ID of the crypto stream", func() {
 		Expect(Version39.CryptoStreamID()).To(Equal(StreamID(1)))
+		Expect(Version42.CryptoStreamID()).To(Equal(StreamID(1)))
 		Expect(VersionTLS.CryptoStreamID()).To(Equal(StreamID(0)))
 	})
 
 	It("tells if a version uses the IETF frame types", func() {
 		Expect(Version39.UsesIETFFrameFormat()).To(BeFalse())
+		Expect(Version42.UsesIETFFrameFormat()).To(BeFalse())
 		Expect(VersionTLS.UsesIETFFrameFormat()).To(BeTrue())
 	})
 
 	It("tells if a version uses the IETF frame types", func() {
 		Expect(Version39.UsesIETFFrameFormat()).To(BeFalse())
+		Expect(Version42.UsesIETFFrameFormat()).To(BeFalse())
 		Expect(VersionTLS.UsesIETFFrameFormat()).To(BeTrue())
 	})
 
 	It("tells if a version uses STOP_WAITING frames", func() {
 		Expect(Version39.UsesStopWaitingFrames()).To(BeTrue())
+		Expect(Version42.UsesStopWaitingFrames()).To(BeTrue())
 		Expect(VersionTLS.UsesStopWaitingFrames()).To(BeFalse())
 	})
 
 	It("says if a stream contributes to connection-level flowcontrol, for gQUIC", func() {
-		Expect(Version39.StreamContributesToConnectionFlowControl(1)).To(BeFalse())
-		Expect(Version39.StreamContributesToConnectionFlowControl(2)).To(BeTrue())
-		Expect(Version39.StreamContributesToConnectionFlowControl(3)).To(BeFalse())
-		Expect(Version39.StreamContributesToConnectionFlowControl(4)).To(BeTrue())
-		Expect(Version39.StreamContributesToConnectionFlowControl(5)).To(BeTrue())
+		for _, v := range []VersionNumber{Version39, Version42} {
+			version := v
+			Expect(version.StreamContributesToConnectionFlowControl(1)).To(BeFalse())
+			Expect(version.StreamContributesToConnectionFlowControl(2)).To(BeTrue())
+			Expect(version.StreamContributesToConnectionFlowControl(3)).To(BeFalse())
+			Expect(version.StreamContributesToConnectionFlowControl(4)).To(BeTrue())
+			Expect(version.StreamContributesToConnectionFlowControl(5)).To(BeTrue())
+		}
 	})
 
 	It("says if a stream contributes to connection-level flowcontrol, for TLS", func() {


### PR DESCRIPTION
Fixes #845.

QUIC 42 accepts overlapping stream data. We've been doing this for some time already, so we don't need any additional changes.