### PR TITLE
reduce the drop rate in the self drop tests from 1/4 to 1/5

### DIFF
--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -175,9 +175,9 @@ var _ = Describe("Handshake drop tests", func() {
 							app.run(version)
 						})
 
-						It(fmt.Sprintf("establishes a connection when 1/4 of the packets are lost in %s direction", d), func() {
+						It(fmt.Sprintf("establishes a connection when 1/5 of the packets are lost in %s direction", d), func() {
 							startListenerAndProxy(func(d quicproxy.Direction, p uint64) bool {
-								return d.Is(direction) && stochasticDropper(4)
+								return d.Is(direction) && stochasticDropper(5)
 							}, version)
 							app.run(version)
 						})


### PR DESCRIPTION
This should help make our integration tests less flaky.
It's the same drop rate we're also using in the gQUIC integration tests.