### PR TITLE
remove the OmitConnectionID field from the Header

### DIFF
--- a/client_multiplexer_test.go
+++ b/client_multiplexer_test.go
@@ -17,7 +17,6 @@ var _ = Describe("Client Multiplexer", func() {
 	getPacket := func(connID protocol.ConnectionID) []byte {
 		buf := &bytes.Buffer{}
 		err := (&wire.Header{
-			SrcConnectionID:  connID,
 			DestConnectionID: connID,
 			PacketNumberLen:  protocol.PacketNumberLen1,
 		}).Write(buf, protocol.PerspectiveServer, protocol.VersionWhatever)

--- a/client_test.go
+++ b/client_test.go
@@ -36,7 +36,6 @@ var _ = Describe("Client", func() {
 		b := &bytes.Buffer{}
 		err := (&wire.Header{
 			DestConnectionID: connID,
-			SrcConnectionID:  connID,
 			PacketNumber:     1,
 			PacketNumberLen:  1,
 		}).Write(b, protocol.PerspectiveServer, protocol.VersionWhatever)
@@ -755,7 +754,6 @@ var _ = Describe("Client", func() {
 				PacketNumber:     1,
 				PacketNumberLen:  protocol.PacketNumberLen2,
 				DestConnectionID: connID,
-				SrcConnectionID:  connID,
 			}
 			b := &bytes.Buffer{}
 			err := ph.Write(b, protocol.PerspectiveServer, cl.version)

--- a/client_test.go
+++ b/client_test.go
@@ -591,11 +591,9 @@ var _ = Describe("Client", func() {
 		cl.session = NewMockQuicSession(mockCtrl) // don't EXPECT any handlePacket calls
 		cl.config = &Config{RequestConnectionIDOmission: false}
 		hdr := &wire.Header{
-			OmitConnectionID: true,
-			SrcConnectionID:  connID,
-			DestConnectionID: connID,
-			PacketNumber:     1,
-			PacketNumberLen:  1,
+			IsPublicHeader:  true,
+			PacketNumber:    1,
+			PacketNumberLen: 1,
 		}
 		err := cl.handlePacketImpl(&receivedPacket{
 			remoteAddr: addr,
@@ -747,6 +745,7 @@ var _ = Describe("Client", func() {
 
 	Context("handling packets", func() {
 		It("handles packets", func() {
+			cl.config = &Config{}
 			sess := NewMockQuicSession(mockCtrl)
 			sess.EXPECT().handlePacket(gomock.Any())
 			cl.session = sess
@@ -786,6 +785,10 @@ var _ = Describe("Client", func() {
 	})
 
 	Context("Public Reset handling", func() {
+		BeforeEach(func() {
+			cl.config = &Config{}
+		})
+
 		It("closes the session when receiving a Public Reset", func() {
 			sess := NewMockQuicSession(mockCtrl)
 			sess.EXPECT().closeRemote(gomock.Any()).Do(func(err error) {

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -27,7 +27,6 @@ var _ = Describe("QUIC Proxy", func() {
 			PacketNumberLen:  protocol.PacketNumberLen6,
 			DestConnectionID: protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0, 0, 0x13, 0x37},
 			SrcConnectionID:  protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0, 0, 0x13, 0x37},
-			OmitConnectionID: false,
 		}
 		hdr.Write(b, protocol.PerspectiveServer, protocol.VersionWhatever)
 		raw := b.Bytes()

--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -18,7 +18,6 @@ type Header struct {
 
 	DestConnectionID protocol.ConnectionID
 	SrcConnectionID  protocol.ConnectionID
-	OmitConnectionID bool
 
 	PacketNumberLen protocol.PacketNumberLen
 	PacketNumber    protocol.PacketNumber

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -81,7 +81,6 @@ var _ = Describe("Header", func() {
 				VersionFlag:      true,
 				Version:          versionPublicHeader,
 				DestConnectionID: connID,
-				SrcConnectionID:  connID,
 				PacketNumber:     0x1337,
 				PacketNumberLen:  protocol.PacketNumberLen4,
 			}).writePublicHeader(buf, protocol.PerspectiveClient, versionPublicHeader)
@@ -89,7 +88,7 @@ var _ = Describe("Header", func() {
 			hdr, err := ParseHeaderSentByClient(bytes.NewReader(buf.Bytes()))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.DestConnectionID).To(Equal(connID))
-			Expect(hdr.SrcConnectionID).To(Equal(connID))
+			Expect(hdr.SrcConnectionID).To(BeEmpty())
 			Expect(hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x1337)))
 			Expect(hdr.Version).To(Equal(versionPublicHeader))
 			Expect(hdr.IsPublicHeader).To(BeTrue())
@@ -100,7 +99,6 @@ var _ = Describe("Header", func() {
 			buf := &bytes.Buffer{}
 			err := (&Header{
 				DestConnectionID:     connID,
-				SrcConnectionID:      connID,
 				PacketNumber:         0x1337,
 				PacketNumberLen:      protocol.PacketNumberLen4,
 				DiversificationNonce: bytes.Repeat([]byte{'f'}, 32),
@@ -109,7 +107,7 @@ var _ = Describe("Header", func() {
 			hdr, err := ParseHeaderSentByServer(bytes.NewReader(buf.Bytes()))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.DestConnectionID).To(Equal(connID))
-			Expect(hdr.SrcConnectionID).To(Equal(connID))
+			Expect(hdr.SrcConnectionID).To(BeEmpty())
 			Expect(hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x1337)))
 			Expect(hdr.DiversificationNonce).To(HaveLen(32))
 			Expect(hdr.IsPublicHeader).To(BeTrue())
@@ -121,7 +119,6 @@ var _ = Describe("Header", func() {
 				VersionFlag:      true,
 				Version:          versionPublicHeader,
 				DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
-				SrcConnectionID:  protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				PacketNumber:     0x1337,
 				PacketNumberLen:  protocol.PacketNumberLen2,
 			}).writePublicHeader(buf, protocol.PerspectiveClient, versionPublicHeader)
@@ -145,7 +142,7 @@ var _ = Describe("Header", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.IsPublicHeader).To(BeTrue())
 			Expect(hdr.DestConnectionID).To(Equal(connID))
-			Expect(hdr.SrcConnectionID).To(Equal(connID))
+			Expect(hdr.SrcConnectionID).To(BeEmpty())
 			// in addition to the versions, the supported versions might contain a reserved version number
 			for _, version := range versions {
 				Expect(hdr.SupportedVersions).To(ContainElement(version))
@@ -177,7 +174,6 @@ var _ = Describe("Header", func() {
 			buf := &bytes.Buffer{}
 			hdr := &Header{
 				DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
-				SrcConnectionID:  protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				PacketNumber:     0x42,
 				PacketNumberLen:  protocol.PacketNumberLen2,
 			}
@@ -211,7 +207,6 @@ var _ = Describe("Header", func() {
 			buf := &bytes.Buffer{}
 			hdr := &Header{
 				DestConnectionID:     protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
-				SrcConnectionID:      protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				PacketNumber:         0x42,
 				PacketNumberLen:      protocol.PacketNumberLen2,
 				DiversificationNonce: bytes.Repeat([]byte{'f'}, 32),

--- a/internal/wire/ietf_header_test.go
+++ b/internal/wire/ietf_header_test.go
@@ -81,7 +81,6 @@ var _ = Describe("IETF QUIC Header", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(h.Type).To(Equal(protocol.PacketTypeInitial))
 				Expect(h.IsLongHeader).To(BeTrue())
-				Expect(h.OmitConnectionID).To(BeFalse())
 				Expect(h.DestConnectionID).To(Equal(protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37}))
 				Expect(h.SrcConnectionID).To(Equal(protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37}))
 				Expect(h.PayloadLen).To(Equal(protocol.ByteCount(0x1337)))
@@ -183,7 +182,6 @@ var _ = Describe("IETF QUIC Header", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(h.IsLongHeader).To(BeFalse())
 				Expect(h.KeyPhase).To(Equal(0))
-				Expect(h.OmitConnectionID).To(BeFalse())
 				Expect(h.DestConnectionID).To(Equal(protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37}))
 				Expect(h.SrcConnectionID).To(BeEmpty())
 				Expect(h.PacketNumber).To(Equal(protocol.PacketNumber(0x42)))
@@ -362,9 +360,8 @@ var _ = Describe("IETF QUIC Header", func() {
 
 			It("writes a header with a 2 byte packet number", func() {
 				err := (&Header{
-					OmitConnectionID: true,
-					PacketNumberLen:  protocol.PacketNumberLen2,
-					PacketNumber:     0x765,
+					PacketNumberLen: protocol.PacketNumberLen2,
+					PacketNumber:    0x765,
 				}).writeHeader(buf)
 				Expect(err).ToNot(HaveOccurred())
 				expected := []byte{0x30}
@@ -374,9 +371,8 @@ var _ = Describe("IETF QUIC Header", func() {
 
 			It("writes a header with a 4 byte packet number", func() {
 				err := (&Header{
-					OmitConnectionID: true,
-					PacketNumberLen:  protocol.PacketNumberLen4,
-					PacketNumber:     0x123456,
+					PacketNumberLen: protocol.PacketNumberLen4,
+					PacketNumber:    0x123456,
 				}).writeHeader(buf)
 				Expect(err).ToNot(HaveOccurred())
 				expected := []byte{0x30}
@@ -386,19 +382,17 @@ var _ = Describe("IETF QUIC Header", func() {
 
 			It("errors when given an invalid packet number length", func() {
 				err := (&Header{
-					OmitConnectionID: true,
-					PacketNumberLen:  3,
-					PacketNumber:     0xdecafbad,
+					PacketNumberLen: 3,
+					PacketNumber:    0xdecafbad,
 				}).writeHeader(buf)
 				Expect(err).To(MatchError("invalid packet number length: 3"))
 			})
 
 			It("writes the Key Phase Bit", func() {
 				err := (&Header{
-					KeyPhase:         1,
-					OmitConnectionID: true,
-					PacketNumberLen:  protocol.PacketNumberLen1,
-					PacketNumber:     0x42,
+					KeyPhase:        1,
+					PacketNumberLen: protocol.PacketNumberLen1,
+					PacketNumber:    0x42,
 				}).writeHeader(buf)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buf.Bytes()).To(Equal([]byte{
@@ -458,10 +452,7 @@ var _ = Describe("IETF QUIC Header", func() {
 		})
 
 		It("has the right length for a short header without a connection ID", func() {
-			h := &Header{
-				OmitConnectionID: true,
-				PacketNumberLen:  protocol.PacketNumberLen1,
-			}
+			h := &Header{PacketNumberLen: protocol.PacketNumberLen1}
 			Expect(h.getHeaderLength()).To(Equal(protocol.ByteCount(1 + 1)))
 			err := h.writeHeader(buf)
 			Expect(err).ToNot(HaveOccurred())
@@ -469,10 +460,7 @@ var _ = Describe("IETF QUIC Header", func() {
 		})
 
 		It("has the right length for a short header with a 2 byte packet number", func() {
-			h := &Header{
-				OmitConnectionID: true,
-				PacketNumberLen:  protocol.PacketNumberLen2,
-			}
+			h := &Header{PacketNumberLen: protocol.PacketNumberLen2}
 			Expect(h.getHeaderLength()).To(Equal(protocol.ByteCount(1 + 2)))
 			err := h.writeHeader(buf)
 			Expect(err).ToNot(HaveOccurred())
@@ -480,10 +468,7 @@ var _ = Describe("IETF QUIC Header", func() {
 		})
 
 		It("has the right length for a short header with a 5 byte packet number", func() {
-			h := &Header{
-				OmitConnectionID: true,
-				PacketNumberLen:  protocol.PacketNumberLen4,
-			}
+			h := &Header{PacketNumberLen: protocol.PacketNumberLen4}
 			Expect(h.getHeaderLength()).To(Equal(protocol.ByteCount(1 + 4)))
 			err := h.writeHeader(buf)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/wire/public_header.go
+++ b/internal/wire/public_header.go
@@ -27,10 +27,10 @@ func (h *Header) writePublicHeader(b *bytes.Buffer, pers protocol.Perspective, _
 	if h.VersionFlag && h.ResetFlag {
 		return errResetAndVersionFlagSet
 	}
-	if !h.DestConnectionID.Equal(h.SrcConnectionID) {
-		return fmt.Errorf("PublicHeader: SrcConnectionID must be equal to DestConnectionID")
+	if h.SrcConnectionID.Len() != 0 {
+		return errors.New("PublicHeader: SrcConnectionID must not be set")
 	}
-	if len(h.DestConnectionID) != 8 {
+	if h.DestConnectionID.Len() != 8 {
 		return fmt.Errorf("PublicHeader: wrong length for Connection ID: %d (expected 8)", len(h.DestConnectionID))
 	}
 
@@ -142,7 +142,6 @@ func parsePublicHeader(b *bytes.Reader, packetSentBy protocol.Perspective) (*Hea
 			return nil, errInvalidConnectionID
 		}
 		header.DestConnectionID = connID
-		header.SrcConnectionID = connID
 	}
 
 	// Contrary to what the gQUIC wire spec says, the 0x4 bit only indicates the presence of the diversification nonce for packets sent by the server.

--- a/internal/wire/public_header.go
+++ b/internal/wire/public_header.go
@@ -13,7 +13,6 @@ import (
 
 var (
 	errResetAndVersionFlagSet            = errors.New("PublicHeader: Reset Flag and Version Flag should not be set at the same time")
-	errReceivedOmittedConnectionID       = qerr.Error(qerr.InvalidPacketHeader, "receiving packets with omitted ConnectionID is not supported")
 	errInvalidConnectionID               = qerr.Error(qerr.InvalidPacketHeader, "connection ID cannot be 0")
 	errGetLengthNotForVersionNegotiation = errors.New("PublicHeader: GetLength cannot be called for VersionNegotiation packets")
 	errInvalidPacketNumberLen6           = errors.New("invalid packet number length: 6 bytes")
@@ -30,7 +29,7 @@ func (h *Header) writePublicHeader(b *bytes.Buffer, pers protocol.Perspective, _
 	if h.SrcConnectionID.Len() != 0 {
 		return errors.New("PublicHeader: SrcConnectionID must not be set")
 	}
-	if h.DestConnectionID.Len() != 8 {
+	if len(h.DestConnectionID) != 0 && len(h.DestConnectionID) != 8 {
 		return fmt.Errorf("PublicHeader: wrong length for Connection ID: %d (expected 8)", len(h.DestConnectionID))
 	}
 
@@ -41,7 +40,7 @@ func (h *Header) writePublicHeader(b *bytes.Buffer, pers protocol.Perspective, _
 	if h.ResetFlag {
 		publicFlagByte |= 0x02
 	}
-	if !h.OmitConnectionID {
+	if h.DestConnectionID.Len() > 0 {
 		publicFlagByte |= 0x08
 	}
 	if len(h.DiversificationNonce) > 0 {
@@ -63,7 +62,7 @@ func (h *Header) writePublicHeader(b *bytes.Buffer, pers protocol.Perspective, _
 	}
 	b.WriteByte(publicFlagByte)
 
-	if !h.OmitConnectionID {
+	if h.DestConnectionID.Len() > 0 {
 		b.Write(h.DestConnectionID)
 	}
 	if h.VersionFlag && pers == protocol.PerspectiveClient {
@@ -112,9 +111,9 @@ func parsePublicHeader(b *bytes.Reader, packetSentBy protocol.Perspective) (*Hea
 	// 	return nil, errors.New("diversification nonces should only be sent by servers")
 	// }
 
-	header.OmitConnectionID = publicFlagByte&0x08 == 0
-	if header.OmitConnectionID && packetSentBy == protocol.PerspectiveClient {
-		return nil, errReceivedOmittedConnectionID
+	hasConnectionID := publicFlagByte&0x08 > 0
+	if !hasConnectionID && packetSentBy == protocol.PerspectiveClient {
+		return nil, qerr.Error(qerr.InvalidPacketHeader, "receiving packets with omitted ConnectionID is not supported")
 	}
 	if header.hasPacketNumber(packetSentBy) {
 		switch publicFlagByte & 0x30 {
@@ -130,12 +129,9 @@ func parsePublicHeader(b *bytes.Reader, packetSentBy protocol.Perspective) (*Hea
 	}
 
 	// Connection ID
-	if !header.OmitConnectionID {
-		connID := make(protocol.ConnectionID, 8)
-		if _, err := io.ReadFull(b, connID); err != nil {
-			if err == io.ErrUnexpectedEOF {
-				err = io.EOF
-			}
+	if hasConnectionID {
+		connID, err := protocol.ReadConnectionID(b, 8)
+		if err != nil {
 			return nil, err
 		}
 		if connID[0] == 0 && connID[1] == 0 && connID[2] == 0 && connID[3] == 0 && connID[4] == 0 && connID[5] == 0 && connID[6] == 0 && connID[7] == 0 {
@@ -218,9 +214,7 @@ func (h *Header) getPublicHeaderLength(pers protocol.Perspective) (protocol.Byte
 		}
 		length += protocol.ByteCount(h.PacketNumberLen)
 	}
-	if !h.OmitConnectionID {
-		length += 8 // 8 bytes for the connection ID
-	}
+	length += protocol.ByteCount(h.DestConnectionID.Len()) // if set, always 8 bytes
 	// Version Number in packets sent by the client
 	if h.VersionFlag {
 		length += 4

--- a/internal/wire/version_negotiation_test.go
+++ b/internal/wire/version_negotiation_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Version Negotiation Packets", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hdr.VersionFlag).To(BeTrue())
 		Expect(hdr.DestConnectionID).To(Equal(connID))
-		Expect(hdr.SrcConnectionID).To(Equal(connID))
+		Expect(hdr.SrcConnectionID).To(BeEmpty())
 		Expect(hdr.SupportedVersions).To(Equal(versions))
 	})
 

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -451,9 +451,8 @@ func (p *packetPacker) getHeader(encLevel protocol.EncryptionLevel) *wire.Header
 	packetNumberLen := p.getPacketNumberLen(pnum)
 
 	header := &wire.Header{
-		DestConnectionID: p.destConnID,
-		PacketNumber:     pnum,
-		PacketNumberLen:  packetNumberLen,
+		PacketNumber:    pnum,
+		PacketNumberLen: packetNumberLen,
 	}
 
 	if p.version.UsesTLS() && encLevel != protocol.EncryptionForwardSecure {
@@ -469,8 +468,8 @@ func (p *packetPacker) getHeader(encLevel protocol.EncryptionLevel) *wire.Header
 		}
 	}
 
-	if p.omitConnectionID && encLevel == protocol.EncryptionForwardSecure {
-		header.OmitConnectionID = true
+	if !p.omitConnectionID || encLevel != protocol.EncryptionForwardSecure {
+		header.DestConnectionID = p.destConnID
 	}
 	if !p.version.UsesTLS() {
 		if p.perspective == protocol.PerspectiveServer && encLevel == protocol.EncryptionSecure {

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -452,13 +452,13 @@ func (p *packetPacker) getHeader(encLevel protocol.EncryptionLevel) *wire.Header
 
 	header := &wire.Header{
 		DestConnectionID: p.destConnID,
-		SrcConnectionID:  p.srcConnID,
 		PacketNumber:     pnum,
 		PacketNumberLen:  packetNumberLen,
 	}
 
 	if p.version.UsesTLS() && encLevel != protocol.EncryptionForwardSecure {
 		header.IsLongHeader = true
+		header.SrcConnectionID = p.srcConnID
 		// Set the payload len to maximum size.
 		// Since it is encoded as a varint, this guarantees us that the header will end up at most as big as GetLength() returns.
 		header.PayloadLen = p.maxPacketSize

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -165,16 +165,16 @@ var _ = Describe("Packet packer", func() {
 
 			It("it omits the connection ID for forward-secure packets", func() {
 				ph := packer.getHeader(protocol.EncryptionForwardSecure)
-				Expect(ph.OmitConnectionID).To(BeFalse())
+				Expect(ph.DestConnectionID.Len()).ToNot(BeZero())
 				packer.SetOmitConnectionID()
 				ph = packer.getHeader(protocol.EncryptionForwardSecure)
-				Expect(ph.OmitConnectionID).To(BeTrue())
+				Expect(ph.DestConnectionID.Len()).To(BeZero())
 			})
 
 			It("doesn't omit the connection ID for non-forward-secure packets", func() {
 				packer.SetOmitConnectionID()
 				ph := packer.getHeader(protocol.EncryptionSecure)
-				Expect(ph.OmitConnectionID).To(BeFalse())
+				Expect(ph.DestConnectionID.Len()).ToNot(BeZero())
 			})
 
 			It("adds the Version Flag to the Public Header before the crypto handshake is finished", func() {
@@ -253,20 +253,6 @@ var _ = Describe("Packet packer", func() {
 				h := packer.getHeader(protocol.EncryptionForwardSecure)
 				Expect(h.IsLongHeader).To(BeFalse())
 				Expect(h.PacketNumberLen).To(BeNumerically(">", 0))
-			})
-
-			It("it omits the connection ID for forward-secure packets", func() {
-				h := packer.getHeader(protocol.EncryptionForwardSecure)
-				Expect(h.OmitConnectionID).To(BeFalse())
-				packer.SetOmitConnectionID()
-				h = packer.getHeader(protocol.EncryptionForwardSecure)
-				Expect(h.OmitConnectionID).To(BeTrue())
-			})
-
-			It("doesn't omit the connection ID for non-forward-secure packets", func() {
-				packer.SetOmitConnectionID()
-				h := packer.getHeader(protocol.EncryptionSecure)
-				Expect(h.OmitConnectionID).To(BeFalse())
 			})
 		})
 	})

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -158,6 +158,11 @@ var _ = Describe("Packet packer", func() {
 				packer.version = versionPublicHeader
 			})
 
+			It("doesn't set the source connection ID", func() {
+				ph := packer.getHeader(protocol.EncryptionForwardSecure)
+				Expect(ph.SrcConnectionID).To(BeEmpty())
+			})
+
 			It("it omits the connection ID for forward-secure packets", func() {
 				ph := packer.getHeader(protocol.EncryptionForwardSecure)
 				Expect(ph.OmitConnectionID).To(BeFalse())

--- a/server.go
+++ b/server.go
@@ -393,7 +393,7 @@ func (s *server) handleGQUICPacket(hdr *wire.Header, packetData []byte, remoteAd
 			return errors.New("dropping small packet with unknown version")
 		}
 		s.logger.Infof("Client offered version %s, sending Version Negotiation Packet", hdr.Version)
-		_, err := s.conn.WriteTo(wire.ComposeGQUICVersionNegotiation(hdr.SrcConnectionID, s.config.Versions), remoteAddr)
+		_, err := s.conn.WriteTo(wire.ComposeGQUICVersionNegotiation(hdr.DestConnectionID, s.config.Versions), remoteAddr)
 		return err
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -371,11 +371,10 @@ var _ = Describe("Server", func() {
 			hdr := wire.Header{
 				VersionFlag:      true,
 				DestConnectionID: connID,
-				SrcConnectionID:  connID,
 				PacketNumber:     1,
 				PacketNumberLen:  protocol.PacketNumberLen2,
 			}
-			hdr.Write(b, protocol.PerspectiveClient, 13 /* not a valid QUIC version */)
+			Expect(hdr.Write(b, protocol.PerspectiveClient, 13 /* not a valid QUIC version */)).To(Succeed())
 			b.Write(bytes.Repeat([]byte{0}, protocol.MinClientHelloSize)) // add a fake CHLO
 			serv.conn = conn
 			sessionHandler.EXPECT().Get(connID)
@@ -389,11 +388,10 @@ var _ = Describe("Server", func() {
 			hdr := wire.Header{
 				VersionFlag:      true,
 				DestConnectionID: connID,
-				SrcConnectionID:  connID,
 				PacketNumber:     1,
 				PacketNumberLen:  protocol.PacketNumberLen2,
 			}
-			hdr.Write(b, protocol.PerspectiveClient, 13 /* not a valid QUIC version */)
+			Expect(hdr.Write(b, protocol.PerspectiveClient, 13 /* not a valid QUIC version */)).To(Succeed())
 			b.Write(bytes.Repeat([]byte{0}, protocol.MinClientHelloSize-1)) // this packet is 1 byte too small
 			serv.conn = conn
 			sessionHandler.EXPECT().Get(connID)
@@ -468,11 +466,10 @@ var _ = Describe("Server", func() {
 		hdr := wire.Header{
 			VersionFlag:      true,
 			DestConnectionID: connID,
-			SrcConnectionID:  connID,
 			PacketNumber:     1,
 			PacketNumberLen:  protocol.PacketNumberLen2,
 		}
-		hdr.Write(b, protocol.PerspectiveClient, 13 /* not a valid QUIC version */)
+		Expect(hdr.Write(b, protocol.PerspectiveClient, 13 /* not a valid QUIC version */)).To(Succeed())
 		b.Write(bytes.Repeat([]byte{0}, protocol.MinClientHelloSize)) // add a fake CHLO
 		conn.dataToRead <- b.Bytes()
 		conn.dataReadFrom = udpAddr
@@ -485,7 +482,6 @@ var _ = Describe("Server", func() {
 			ln.Accept()
 			close(done)
 		}()
-
 		Eventually(func() int { return conn.dataWritten.Len() }).ShouldNot(BeZero())
 		Expect(conn.dataWrittenTo).To(Equal(udpAddr))
 		r := bytes.NewReader(conn.dataWritten.Bytes())
@@ -493,7 +489,6 @@ var _ = Describe("Server", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(packet.VersionFlag).To(BeTrue())
 		Expect(packet.DestConnectionID).To(Equal(connID))
-		Expect(packet.SrcConnectionID).To(Equal(connID))
 		Expect(r.Len()).To(BeZero())
 		Consistently(done).ShouldNot(BeClosed())
 		// make the go routine return

--- a/session.go
+++ b/session.go
@@ -205,7 +205,7 @@ func newSession(
 	s.streamFramer = newStreamFramer(s.cryptoStream, s.streamsMap, s.version)
 	s.packer = newPacketPacker(
 		connectionID,
-		connectionID,
+		nil, // no src connection ID
 		1,
 		s.sentPacketHandler.GetPacketNumberLen,
 		s.RemoteAddr(),
@@ -275,7 +275,7 @@ var newClientSession = func(
 	s.streamFramer = newStreamFramer(s.cryptoStream, s.streamsMap, s.version)
 	s.packer = newPacketPacker(
 		connectionID,
-		connectionID,
+		nil, // no src connection ID
 		1,
 		s.sentPacketHandler.GetPacketNumberLen,
 		s.RemoteAddr(),
@@ -643,7 +643,7 @@ func (s *session) handlePacketImpl(p *receivedPacket) error {
 	}
 
 	// The server can change the source connection ID with the first Handshake packet.
-	if s.perspective == protocol.PerspectiveClient && !s.receivedFirstPacket && !hdr.SrcConnectionID.Equal(s.destConnID) {
+	if s.perspective == protocol.PerspectiveClient && !s.receivedFirstPacket && hdr.IsLongHeader && !hdr.SrcConnectionID.Equal(s.destConnID) {
 		s.logger.Debugf("Received first packet. Switching destination connection ID to: %s", hdr.SrcConnectionID)
 		s.destConnID = hdr.SrcConnectionID
 		s.packer.ChangeDestConnectionID(s.destConnID)

--- a/session_test.go
+++ b/session_test.go
@@ -1124,6 +1124,7 @@ var _ = Describe("Session", func() {
 			It("retransmits an unencrypted packet, and doesn't add a STOP_WAITING frame (for IETF QUIC)", func() {
 				sess.version = versionIETFFrames
 				sess.packer.version = versionIETFFrames
+				sess.packer.srcConnID = sess.destConnID
 				sf := &wire.StreamFrame{StreamID: 1, Data: []byte("foobar")}
 				sph.EXPECT().DequeuePacketForRetransmission().Return(&ackhandler.Packet{
 					PacketNumber:    1337,
@@ -1799,6 +1800,7 @@ var _ = Describe("Client Session", func() {
 	It("changes the connection ID when receiving the first packet from the server", func() {
 		sess.version = protocol.VersionTLS
 		sess.packer.version = protocol.VersionTLS
+		sess.packer.srcConnID = sess.destConnID
 		unpacker := NewMockUnpacker(mockCtrl)
 		unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any(), gomock.Any()).Return(&unpackedPacket{}, nil)
 		sess.unpacker = unpacker
@@ -1808,6 +1810,7 @@ var _ = Describe("Client Session", func() {
 		}()
 		err := sess.handlePacketImpl(&receivedPacket{
 			header: &wire.Header{
+				IsLongHeader:     true,
 				Type:             protocol.PacketTypeHandshake,
 				SrcConnectionID:  protocol.ConnectionID{1, 3, 3, 7, 1, 3, 3, 7},
 				DestConnectionID: sess.srcConnID,


### PR DESCRIPTION
This will be very helpful both for the refactoring of the header parsing needed for #561 and for implementing QUIC 44 (#1394).