### PR TITLE
don't do anything when OnAlarm is called, but no packets are outstanding

### DIFF
--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -791,6 +791,11 @@ var _ = Describe("SentPacketHandler", func() {
 		Expect(handler.GetAlarmTimeout()).To(BeZero())
 	})
 
+	It("does nothing on OnAlarm if there are no outstanding packets", func() {
+		Expect(handler.OnAlarm()).To(Succeed())
+		Expect(handler.SendMode()).To(Equal(SendAny))
+	})
+
 	Context("TLPs", func() {
 		It("uses the RTT from RTT stats", func() {
 			rtt := 2 * time.Second


### PR DESCRIPTION
When all outstanding are acknowledged, the alarm is canceled in `updateLossDetectionAlarm`. This doesn't reset the timer in the session though. When OnAlarm is called, we therefore need to make sure that there are actually packets outstanding.