### PR TITLE
always allow sending of IETF QUIC Version Negotiation Packets

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -379,6 +379,7 @@ var _ = Describe("Server", func() {
 			DestConnectionID: connID,
 			PacketNumber:     1,
 			PacketNumberLen:  protocol.PacketNumberLen2,
+			Version:          protocol.Version39 - 1,
 		}
 		Expect(hdr.Write(b, protocol.PerspectiveClient, 13 /* not a valid QUIC version */)).To(Succeed())
 		b.Write(bytes.Repeat([]byte{0}, protocol.MinClientHelloSize)) // add a fake CHLO
@@ -411,7 +412,6 @@ var _ = Describe("Server", func() {
 	})
 
 	It("sends an IETF draft style Version Negotaion Packet, if the client sent a IETF draft style header", func() {
-		config.Versions = append(config.Versions, protocol.VersionTLS)
 		ln, err := Listen(conn, testdata.GetTLSConfig(), config)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/server_tls_test.go
+++ b/server_tls_test.go
@@ -41,22 +41,6 @@ var _ = Describe("Stateless TLS handling", func() {
 		return hdr
 	}
 
-	It("sends a Version Negotiation Packet if it doesn't support the version", func() {
-		server.HandleInitial(&receivedPacket{
-			header: &wire.Header{
-				DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
-				SrcConnectionID:  protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
-				PacketNumberLen:  protocol.PacketNumberLen1,
-				Version:          0x1337,
-			},
-			data: bytes.Repeat([]byte{0}, protocol.MinInitialPacketSize),
-		})
-		Expect(conn.dataWritten.Len()).ToNot(BeZero())
-		hdr := parseHeader(conn.dataWritten.Bytes())
-		Expect(hdr.IsVersionNegotiation).To(BeTrue())
-		Expect(sessionChan).ToNot(Receive())
-	})
-
 	It("drops too small packets", func() {
 		server.HandleInitial(&receivedPacket{
 			header: &wire.Header{},


### PR DESCRIPTION
Fixes #1458.

When receiving a packet with an IETF QUIC Header using an unsupported version, we should send a IETF QUIC Version Negotiation Packet, even if none of the supported versions is IETF QUIC.