### PR TITLE
update CIs to Go 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,17 +37,17 @@ defaults: &defaults
 
 version: 2
 jobs:
+  build-go1.11:
+    docker:
+      - image: circleci/golang:1.11rc1-stretch-browsers
+    <<: *defaults
   build-go1.10:
     docker:
       - image: circleci/golang:1.10.3-stretch-browsers
-    <<: *defaults
-  build-go1.9:
-    docker:
-      - image: circleci/golang:1.9.7-stretch-browsers
     <<: *defaults
 workflows:
   version: 2
   build:
     jobs:
-      - build-go1.9
       - build-go1.10
+      - build-go1.11

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -18,6 +18,7 @@
   ],
   "Linters": {
     "vet": "go tool vet -printfuncs=Infof,Debugf,Warningf,Errorf:PATH:LINE:MESSAGE",
-    "misspell": "misspell -i ect:PATH:LINE:COL:MESSAGE"
+    "misspell": "misspell -i ect:PATH:LINE:COL:MESSAGE",
+    "megacheck": "megacheck -ignore github.com/lucas-clemente/quic-go/h2quic/response_writer_closenotifier.go:SA1019:PATH:LINE:COL:MESSAGE"
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ addons:
 language: go
 
 go:
-  - "1.9.7"
   - "1.10.3"
+  - "1.11rc1"
 
 # first part of the GOARCH workaround
 # setting the GOARCH directly doesn't work, since the value will be overwritten later
@@ -23,6 +23,15 @@ env:
     - TRAVIS_GOARCH=amd64 TESTMODE=integration
     - TRAVIS_GOARCH=386 TESTMODE=unit
     - TRAVIS_GOARCH=386 TESTMODE=integration
+
+# Linters might work differently in different Go versions.
+# Only run them in the most recent one.
+matrix:
+  exclude:
+  - go: "1.10.3"
+    env: TRAVIS_GOARCH=amd64 TESTMODE=lint
+  - go: "1.10.3"
+    env: TRAVIS_GOARCH=386 TESTMODE=lint
 
 # second part of the GOARCH workaround
 # now actually set the GOARCH env variable to the value of the temporary variable set earlier

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ clone_folder: c:\gopath\src\github.com\lucas-clemente\quic-go
 
 install:
   - rmdir c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.10.3.windows-amd64.zip
-  - 7z x go1.10.3.windows-amd64.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.11rc1.windows-amd64.zip
+  - 7z x go1.11rc1.windows-amd64.zip -y -oC:\ > NUL
   - set PATH=%PATH%;%GOPATH%\bin\windows_%GOARCH%;%GOPATH%\bin
   - echo %PATH%
   - echo %GOPATH%

--- a/h2quic/response_writer.go
+++ b/h2quic/response_writer.go
@@ -98,9 +98,6 @@ func (w *responseWriter) CloseNotify() <-chan bool { return make(<-chan bool) }
 // test that we implement http.Flusher
 var _ http.Flusher = &responseWriter{}
 
-// test that we implement http.CloseNotifier
-var _ http.CloseNotifier = &responseWriter{}
-
 // copied from http2/http2.go
 // bodyAllowedForStatus reports whether a given response status code
 // permits a body. See RFC 2616, section 4.4.

--- a/h2quic/response_writer_closenotifier.go
+++ b/h2quic/response_writer_closenotifier.go
@@ -1,0 +1,9 @@
+package h2quic
+
+import "net/http"
+
+// The CloseNotifier is a deprecated interface, and staticcheck will report that from Go 1.11.
+// By defining it in a separate file, we can exclude this file from staticcheck.
+
+// test that we implement http.CloseNotifier
+var _ http.CloseNotifier = &responseWriter{}

--- a/integrationtests/gquic/server_test.go
+++ b/integrationtests/gquic/server_test.go
@@ -46,10 +46,10 @@ var _ = Describe("Server tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			templateRoot := &x509.Certificate{
-				SerialNumber: big.NewInt(1),
-				NotBefore:    time.Now().Add(-time.Hour),
-				NotAfter:     time.Now().Add(time.Hour),
-				IsCA:         true,
+				SerialNumber:          big.NewInt(1),
+				NotBefore:             time.Now().Add(-time.Hour),
+				NotAfter:              time.Now().Add(time.Hour),
+				IsCA:                  true,
 				BasicConstraintsValid: true,
 			}
 			certDER, err := x509.CreateCertificate(rand.Reader, templateRoot, templateRoot, &key.PublicKey, key)

--- a/internal/crypto/cert_manager_test.go
+++ b/internal/crypto/cert_manager_test.go
@@ -317,10 +317,10 @@ var _ = Describe("Cert Manager", func() {
 			}
 
 			templateRoot := &x509.Certificate{
-				SerialNumber: big.NewInt(1),
-				NotBefore:    time.Now().Add(-time.Hour),
-				NotAfter:     time.Now().Add(time.Hour),
-				IsCA:         true,
+				SerialNumber:          big.NewInt(1),
+				NotBefore:             time.Now().Add(-time.Hour),
+				NotAfter:              time.Now().Add(time.Hour),
+				IsCA:                  true,
 				BasicConstraintsValid: true,
 			}
 			rootKey, rootCert := getCertificate(templateRoot)

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -39,7 +39,7 @@ func newPacketHandlerMap(conn net.PacketConn, connIDLen int, logger utils.Logger
 		connIDLen:                 connIDLen,
 		handlers:                  make(map[string]packetHandler),
 		deleteClosedSessionsAfter: protocol.ClosedSessionDeleteTimeout,
-		logger: logger,
+		logger:                    logger,
 	}
 	go m.listen()
 	return m


### PR DESCRIPTION
This PR removes Go 1.9.x from the CIs, and runs the jobs on 1.11rc1 instead.

In order to make the linter work, a few modifications were necessary:

- goimports (which checks formatting, among others) works different in Go 1.10 and Go 1.11. Solution: only run the linters in Go 1.11.
- megacheck complains about the `http.CloseNotifier` being deprecated. We implement the interface, but not the functionality. Solution: Move the implementation check to a separate file, and exclude it from linting.

@lucas-clemente: In the README, we say that we're supporting Go 1.9. While this is still true at the moment, we're not running any CI builds on 1.9, so support might break silently at some time. I don't think we'll use any of the new language feature of 1.10 and 1.11, so I think this is ok. wdyt?