### PR TITLE
implement (un)marshalling of the transport parameters

### DIFF
--- a/internal/handshake/tls_extension.go
+++ b/internal/handshake/tls_extension.go
@@ -1,7 +1,14 @@
 package handshake
 
 import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
 	"github.com/bifurcation/mint"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
 type transportParameterID uint16
@@ -19,20 +26,81 @@ const (
 	disableMigrationParameterID      transportParameterID = 0x9
 )
 
-type transportParameter struct {
-	Parameter transportParameterID
-	Value     []byte `tls:"head=2"`
+type clientHelloTransportParameters struct {
+	InitialVersion protocol.VersionNumber
+	Parameters     TransportParameters
 }
 
-type clientHelloTransportParameters struct {
-	InitialVersion uint32               // actually a protocol.VersionNumber
-	Parameters     []transportParameter `tls:"head=2"`
+func (p *clientHelloTransportParameters) Marshal() []byte {
+	const lenOffset = 4
+	b := &bytes.Buffer{}
+	utils.BigEndian.WriteUint32(b, uint32(p.InitialVersion))
+	b.Write([]byte{0, 0}) // length. Will be replaced later
+	p.Parameters.marshal(b)
+	data := b.Bytes()
+	binary.BigEndian.PutUint16(data[lenOffset:lenOffset+2], uint16(len(data)-lenOffset-2))
+	return data
+}
+
+func (p *clientHelloTransportParameters) Unmarshal(data []byte) error {
+	if len(data) < 6 {
+		return errors.New("transport parameter data too short")
+	}
+	p.InitialVersion = protocol.VersionNumber(binary.BigEndian.Uint32(data[:4]))
+	paramsLen := int(binary.BigEndian.Uint16(data[4:6]))
+	data = data[6:]
+	if len(data) != paramsLen {
+		return fmt.Errorf("expected transport parameters to be %d bytes long, have %d", paramsLen, len(data))
+	}
+	return p.Parameters.unmarshal(data)
 }
 
 type encryptedExtensionsTransportParameters struct {
-	NegotiatedVersion uint32               // actually a protocol.VersionNumber
-	SupportedVersions []uint32             `tls:"head=1"` // actually a protocol.VersionNumber
-	Parameters        []transportParameter `tls:"head=2"`
+	NegotiatedVersion protocol.VersionNumber
+	SupportedVersions []protocol.VersionNumber
+	Parameters        TransportParameters
+}
+
+func (p *encryptedExtensionsTransportParameters) Marshal() []byte {
+	b := &bytes.Buffer{}
+	utils.BigEndian.WriteUint32(b, uint32(p.NegotiatedVersion))
+	b.WriteByte(uint8(4 * len(p.SupportedVersions)))
+	for _, v := range p.SupportedVersions {
+		utils.BigEndian.WriteUint32(b, uint32(v))
+	}
+	lenOffset := b.Len()
+	b.Write([]byte{0, 0}) // length. Will be replaced later
+	p.Parameters.marshal(b)
+	data := b.Bytes()
+	binary.BigEndian.PutUint16(data[lenOffset:lenOffset+2], uint16(len(data)-lenOffset-2))
+	return data
+}
+
+func (p *encryptedExtensionsTransportParameters) Unmarshal(data []byte) error {
+	if len(data) < 5 {
+		return errors.New("transport parameter data too short")
+	}
+	p.NegotiatedVersion = protocol.VersionNumber(binary.BigEndian.Uint32(data[:4]))
+	numVersions := int(data[4])
+	if numVersions%4 != 0 {
+		return fmt.Errorf("invalid length for version list: %d", numVersions)
+	}
+	numVersions /= 4
+	data = data[5:]
+	if len(data) < 4*numVersions+2 /*length field for the parameter list */ {
+		return errors.New("transport parameter data too short")
+	}
+	p.SupportedVersions = make([]protocol.VersionNumber, numVersions)
+	for i := 0; i < numVersions; i++ {
+		p.SupportedVersions[i] = protocol.VersionNumber(binary.BigEndian.Uint32(data[:4]))
+		data = data[4:]
+	}
+	paramsLen := int(binary.BigEndian.Uint16(data[:2]))
+	data = data[2:]
+	if len(data) != paramsLen {
+		return fmt.Errorf("expected transport parameters to be %d bytes long, have %d", paramsLen, len(data))
+	}
+	return p.Parameters.unmarshal(data)
 }
 
 type tlsExtensionBody struct {

--- a/internal/handshake/tls_extension_handler_client.go
+++ b/internal/handshake/tls_extension_handler_client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/lucas-clemente/quic-go/qerr"
 
 	"github.com/bifurcation/mint"
-	"github.com/bifurcation/mint/syntax"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
@@ -52,16 +51,12 @@ func (h *extensionHandlerClient) Send(hType mint.HandshakeType, el *mint.Extensi
 	if hType != mint.HandshakeTypeClientHello {
 		return nil
 	}
-
 	h.logger.Debugf("Sending Transport Parameters: %s", h.ourParams)
-	data, err := syntax.Marshal(clientHelloTransportParameters{
-		InitialVersion: uint32(h.initialVersion),
-		Parameters:     h.ourParams.getTransportParameters(),
-	})
-	if err != nil {
-		return err
+	chtp := &clientHelloTransportParameters{
+		InitialVersion: h.initialVersion,
+		Parameters:     *h.ourParams,
 	}
-	return el.Add(&tlsExtensionBody{data})
+	return el.Add(&tlsExtensionBody{data: chtp.Marshal()})
 }
 
 func (h *extensionHandlerClient) Receive(hType mint.HandshakeType, el *mint.ExtensionList) error {
@@ -84,38 +79,31 @@ func (h *extensionHandlerClient) Receive(hType mint.HandshakeType, el *mint.Exte
 	}
 
 	eetp := &encryptedExtensionsTransportParameters{}
-	if _, err := syntax.Unmarshal(ext.data, eetp); err != nil {
+	if err := eetp.Unmarshal(ext.data); err != nil {
 		return err
 	}
-	serverSupportedVersions := make([]protocol.VersionNumber, len(eetp.SupportedVersions))
-	for i, v := range eetp.SupportedVersions {
-		serverSupportedVersions[i] = protocol.VersionNumber(v)
-	}
 	// check that the negotiated_version is the current version
-	if protocol.VersionNumber(eetp.NegotiatedVersion) != h.version {
+	if eetp.NegotiatedVersion != h.version {
 		return qerr.Error(qerr.VersionNegotiationMismatch, "current version doesn't match negotiated_version")
 	}
 	// check that the current version is included in the supported versions
-	if !protocol.IsSupportedVersion(serverSupportedVersions, h.version) {
+	if !protocol.IsSupportedVersion(eetp.SupportedVersions, h.version) {
 		return qerr.Error(qerr.VersionNegotiationMismatch, "current version not included in the supported versions")
 	}
 	// if version negotiation was performed, check that we would have selected the current version based on the supported versions sent by the server
 	if h.version != h.initialVersion {
-		negotiatedVersion, ok := protocol.ChooseSupportedVersion(h.supportedVersions, serverSupportedVersions)
+		negotiatedVersion, ok := protocol.ChooseSupportedVersion(h.supportedVersions, eetp.SupportedVersions)
 		if !ok || h.version != negotiatedVersion {
 			return qerr.Error(qerr.VersionNegotiationMismatch, "would have picked a different version")
 		}
 	}
 
-	params, err := readTransportParameters(eetp.Parameters)
-	if err != nil {
-		return err
-	}
-	if len(params.StatelessResetToken) == 0 {
+	// check that the server sent a stateless reset token
+	if len(eetp.Parameters.StatelessResetToken) == 0 {
 		return errors.New("server didn't sent stateless_reset_token")
 	}
-	h.logger.Debugf("Received Transport Parameters: %s", params)
-	h.paramsChan <- *params
+	h.logger.Debugf("Received Transport Parameters: %s", &eetp.Parameters)
+	h.paramsChan <- eetp.Parameters
 	return nil
 }
 

--- a/internal/handshake/tls_extension_handler_client.go
+++ b/internal/handshake/tls_extension_handler_client.go
@@ -107,24 +107,12 @@ func (h *extensionHandlerClient) Receive(hType mint.HandshakeType, el *mint.Exte
 		}
 	}
 
-	// check that the server sent the stateless reset token
-	var foundStatelessResetToken bool
-	for _, p := range eetp.Parameters {
-		if p.Parameter == statelessResetTokenParameterID {
-			if len(p.Value) != 16 {
-				return fmt.Errorf("wrong length for stateless_reset_token: %d (expected 16)", len(p.Value))
-			}
-			foundStatelessResetToken = true
-			// TODO: handle this value
-		}
-	}
-	if !foundStatelessResetToken {
-		// TODO: return the right error here
-		return errors.New("server didn't sent stateless_reset_token")
-	}
 	params, err := readTransportParameters(eetp.Parameters)
 	if err != nil {
 		return err
+	}
+	if len(params.StatelessResetToken) == 0 {
+		return errors.New("server didn't sent stateless_reset_token")
 	}
 	h.logger.Debugf("Received Transport Parameters: %s", params)
 	h.paramsChan <- *params

--- a/internal/handshake/tls_extension_handler_client_test.go
+++ b/internal/handshake/tls_extension_handler_client_test.go
@@ -135,13 +135,6 @@ var _ = Describe("TLS Extension Handler, for the client", func() {
 			Expect(err).To(MatchError("server didn't sent stateless_reset_token"))
 		})
 
-		It("errors if the stateless reset token has the wrong length", func() {
-			parameters[statelessResetTokenParameterID] = bytes.Repeat([]byte{0}, 15) // should be 16
-			addEncryptedExtensionsWithParameters(parameters)
-			err := handler.Receive(mint.HandshakeTypeEncryptedExtensions, &el)
-			Expect(err).To(MatchError("wrong length for stateless_reset_token: 15 (expected 16)"))
-		})
-
 		Context("Version Negotiation", func() {
 			It("accepts a valid version negotiation", func() {
 				done := make(chan struct{})

--- a/internal/handshake/tls_extension_handler_server.go
+++ b/internal/handshake/tls_extension_handler_server.go
@@ -7,7 +7,6 @@ import (
 	"github.com/lucas-clemente/quic-go/qerr"
 
 	"github.com/bifurcation/mint"
-	"github.com/bifurcation/mint/syntax"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
@@ -48,22 +47,13 @@ func (h *extensionHandlerServer) Send(hType mint.HandshakeType, el *mint.Extensi
 	if hType != mint.HandshakeTypeEncryptedExtensions {
 		return nil
 	}
-
-	supportedVersions := protocol.GetGreasedVersions(h.supportedVersions)
-	versions := make([]uint32, len(supportedVersions))
-	for i, v := range supportedVersions {
-		versions[i] = uint32(v)
-	}
 	h.logger.Debugf("Sending Transport Parameters: %s", h.ourParams)
-	data, err := syntax.Marshal(encryptedExtensionsTransportParameters{
-		NegotiatedVersion: uint32(h.version),
-		SupportedVersions: versions,
-		Parameters:        h.ourParams.getTransportParameters(),
-	})
-	if err != nil {
-		return err
+	eetp := &encryptedExtensionsTransportParameters{
+		NegotiatedVersion: h.version,
+		SupportedVersions: protocol.GetGreasedVersions(h.supportedVersions),
+		Parameters:        *h.ourParams,
 	}
-	return el.Add(&tlsExtensionBody{data})
+	return el.Add(&tlsExtensionBody{data: eetp.Marshal()})
 }
 
 func (h *extensionHandlerServer) Receive(hType mint.HandshakeType, el *mint.ExtensionList) error {
@@ -84,28 +74,24 @@ func (h *extensionHandlerServer) Receive(hType mint.HandshakeType, el *mint.Exte
 		return errors.New("ClientHello didn't contain a QUIC extension")
 	}
 	chtp := &clientHelloTransportParameters{}
-	if _, err := syntax.Unmarshal(ext.data, chtp); err != nil {
+	if err := chtp.Unmarshal(ext.data); err != nil {
 		return err
 	}
-	initialVersion := protocol.VersionNumber(chtp.InitialVersion)
 
 	// perform the stateless version negotiation validation:
 	// make sure that we would have sent a Version Negotiation Packet if the client offered the initial version
 	// this is the case if and only if the initial version is not contained in the supported versions
-	if initialVersion != h.version && protocol.IsSupportedVersion(h.supportedVersions, initialVersion) {
+	if chtp.InitialVersion != h.version && protocol.IsSupportedVersion(h.supportedVersions, chtp.InitialVersion) {
 		return qerr.Error(qerr.VersionNegotiationMismatch, "Client should have used the initial version")
 	}
 
-	params, err := readTransportParameters(chtp.Parameters)
-	if err != nil {
-		return err
-	}
-	if len(params.StatelessResetToken) != 0 {
+	// check that the client didn't send a stateless reset token
+	if len(chtp.Parameters.StatelessResetToken) != 0 {
 		// TODO: return the correct error type
 		return errors.New("client sent a stateless reset token")
 	}
-	h.logger.Debugf("Received Transport Parameters: %s", params)
-	h.paramsChan <- *params
+	h.logger.Debugf("Received Transport Parameters: %s", &chtp.Parameters)
+	h.paramsChan <- chtp.Parameters
 	return nil
 }
 

--- a/internal/handshake/tls_extension_handler_server.go
+++ b/internal/handshake/tls_extension_handler_server.go
@@ -96,15 +96,13 @@ func (h *extensionHandlerServer) Receive(hType mint.HandshakeType, el *mint.Exte
 		return qerr.Error(qerr.VersionNegotiationMismatch, "Client should have used the initial version")
 	}
 
-	for _, p := range chtp.Parameters {
-		if p.Parameter == statelessResetTokenParameterID {
-			// TODO: return the correct error type
-			return errors.New("client sent a stateless reset token")
-		}
-	}
 	params, err := readTransportParameters(chtp.Parameters)
 	if err != nil {
 		return err
+	}
+	if len(params.StatelessResetToken) != 0 {
+		// TODO: return the correct error type
+		return errors.New("client sent a stateless reset token")
 	}
 	h.logger.Debugf("Received Transport Parameters: %s", params)
 	h.paramsChan <- *params

--- a/internal/handshake/tls_extension_handler_server.go
+++ b/internal/handshake/tls_extension_handler_server.go
@@ -1,7 +1,6 @@
 package handshake
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 
@@ -50,11 +49,6 @@ func (h *extensionHandlerServer) Send(hType mint.HandshakeType, el *mint.Extensi
 		return nil
 	}
 
-	transportParams := append(
-		h.ourParams.getTransportParameters(),
-		// TODO(#855): generate a real token
-		transportParameter{statelessResetTokenParameterID, bytes.Repeat([]byte{42}, 16)},
-	)
 	supportedVersions := protocol.GetGreasedVersions(h.supportedVersions)
 	versions := make([]uint32, len(supportedVersions))
 	for i, v := range supportedVersions {
@@ -64,7 +58,7 @@ func (h *extensionHandlerServer) Send(hType mint.HandshakeType, el *mint.Extensi
 	data, err := syntax.Marshal(encryptedExtensionsTransportParameters{
 		NegotiatedVersion: uint32(h.version),
 		SupportedVersions: versions,
-		Parameters:        transportParams,
+		Parameters:        h.ourParams.getTransportParameters(),
 	})
 	if err != nil {
 		return err

--- a/internal/handshake/tls_extension_handler_server_test.go
+++ b/internal/handshake/tls_extension_handler_server_test.go
@@ -3,22 +3,15 @@ package handshake
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/bifurcation/mint"
-	"github.com/bifurcation/mint/syntax"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-
-func parameterMapToList(paramMap map[transportParameterID][]byte) []transportParameter {
-	var params []transportParameter
-	for id, val := range paramMap {
-		params = append(params, transportParameter{id, val})
-	}
-	return params
-}
 
 var _ = Describe("TLS Extension Handler, for the server", func() {
 	var (
@@ -54,36 +47,31 @@ var _ = Describe("TLS Extension Handler, for the server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 			eetp := &encryptedExtensionsTransportParameters{}
-			_, err = syntax.Unmarshal(ext.data, eetp)
+			err = eetp.Unmarshal(ext.data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(eetp.NegotiatedVersion).To(BeEquivalentTo(666))
 			// the SupportedVersions will contain one reserved version number
 			Expect(eetp.SupportedVersions).To(HaveLen(len(versions) + 1))
 			for _, version := range versions {
-				Expect(eetp.SupportedVersions).To(ContainElement(uint32(version)))
+				Expect(eetp.SupportedVersions).To(ContainElement(version))
 			}
 		})
 	})
 
 	Context("receiving", func() {
-		var fakeBody *tlsExtensionBody
-		var parameters map[transportParameterID][]byte
+		var (
+			fakeBody   *tlsExtensionBody
+			parameters TransportParameters
+		)
 
-		addClientHelloWithParameters := func(paramMap map[transportParameterID][]byte) {
-			body, err := syntax.Marshal(clientHelloTransportParameters{Parameters: parameterMapToList(paramMap)})
-			Expect(err).ToNot(HaveOccurred())
-			err = el.Add(&tlsExtensionBody{data: body})
-			Expect(err).ToNot(HaveOccurred())
+		addClientHelloWithParameters := func(params TransportParameters) {
+			body := (&clientHelloTransportParameters{Parameters: params}).Marshal()
+			Expect(el.Add(&tlsExtensionBody{data: body})).To(Succeed())
 		}
 
 		BeforeEach(func() {
 			fakeBody = &tlsExtensionBody{data: []byte("foobar foobar")}
-			parameters = map[transportParameterID][]byte{
-				initialMaxStreamDataParameterID:  {0x11, 0x22, 0x33, 0x44},
-				initialMaxDataParameterID:        {0x22, 0x33, 0x44, 0x55},
-				initialMaxBidiStreamsParameterID: {0x33, 0x44},
-				idleTimeoutParameterID:           {0x13, 0x37},
-			}
+			parameters = TransportParameters{IdleTimeout: 0x1337 * time.Second}
 		})
 
 		It("accepts the TransportParameters on the EncryptedExtensions message", func() {
@@ -92,7 +80,7 @@ var _ = Describe("TLS Extension Handler, for the server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			var params TransportParameters
 			Expect(handler.GetPeerParams()).To(Receive(&params))
-			Expect(params.StreamFlowControlWindow).To(BeEquivalentTo(0x11223344))
+			Expect(params.IdleTimeout).To(Equal(0x1337 * time.Second))
 		})
 
 		It("errors if the ClientHello doesn't contain TransportParameters", func() {
@@ -119,7 +107,7 @@ var _ = Describe("TLS Extension Handler, for the server", func() {
 		})
 
 		It("rejects messages that contain a stateless reset token", func() {
-			parameters[statelessResetTokenParameterID] = bytes.Repeat([]byte{0}, 16)
+			parameters.StatelessResetToken = bytes.Repeat([]byte{0}, 16)
 			addClientHelloWithParameters(parameters)
 			err := handler.Receive(mint.HandshakeTypeClientHello, &el)
 			Expect(err).To(MatchError("client sent a stateless reset token"))
@@ -128,12 +116,11 @@ var _ = Describe("TLS Extension Handler, for the server", func() {
 		Context("Version Negotiation", func() {
 			It("accepts a ClientHello, when no version negotiation was performed", func() {
 				handler.version = 42
-				body, err := syntax.Marshal(clientHelloTransportParameters{
+				body := (&clientHelloTransportParameters{
 					InitialVersion: 42,
-					Parameters:     parameterMapToList(parameters),
-				})
-				Expect(err).ToNot(HaveOccurred())
-				err = el.Add(&tlsExtensionBody{data: body})
+					Parameters:     parameters,
+				}).Marshal()
+				err := el.Add(&tlsExtensionBody{data: body})
 				Expect(err).ToNot(HaveOccurred())
 				err = handler.Receive(mint.HandshakeTypeClientHello, &el)
 				Expect(err).ToNot(HaveOccurred())
@@ -142,12 +129,11 @@ var _ = Describe("TLS Extension Handler, for the server", func() {
 			It("accepts a valid version negotiation", func() {
 				handler.version = 42
 				handler.supportedVersions = []protocol.VersionNumber{13, 37, 42}
-				body, err := syntax.Marshal(clientHelloTransportParameters{
+				body := (&clientHelloTransportParameters{
 					InitialVersion: 22, // this must be an unsupported version
-					Parameters:     parameterMapToList(parameters),
-				})
-				Expect(err).ToNot(HaveOccurred())
-				err = el.Add(&tlsExtensionBody{data: body})
+					Parameters:     parameters,
+				}).Marshal()
+				err := el.Add(&tlsExtensionBody{data: body})
 				Expect(err).ToNot(HaveOccurred())
 				err = handler.Receive(mint.HandshakeTypeClientHello, &el)
 				Expect(err).ToNot(HaveOccurred())
@@ -156,11 +142,10 @@ var _ = Describe("TLS Extension Handler, for the server", func() {
 			It("erros when a version negotiation was performed, although we already support the initial version", func() {
 				handler.supportedVersions = []protocol.VersionNumber{11, 12, 13}
 				handler.version = 13
-				body, err := syntax.Marshal(clientHelloTransportParameters{
+				body := (&clientHelloTransportParameters{
 					InitialVersion: 11, // this is an supported version
-				})
-				Expect(err).ToNot(HaveOccurred())
-				err = el.Add(&tlsExtensionBody{data: body})
+				}).Marshal()
+				err := el.Add(&tlsExtensionBody{data: body})
 				Expect(err).ToNot(HaveOccurred())
 				err = handler.Receive(mint.HandshakeTypeClientHello, &el)
 				Expect(err).To(MatchError("VersionNegotiationMismatch: Client should have used the initial version"))

--- a/internal/handshake/tls_extension_handler_server_test.go
+++ b/internal/handshake/tls_extension_handler_server_test.go
@@ -1,6 +1,7 @@
 package handshake
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/bifurcation/mint"
@@ -118,7 +119,7 @@ var _ = Describe("TLS Extension Handler, for the server", func() {
 		})
 
 		It("rejects messages that contain a stateless reset token", func() {
-			parameters[statelessResetTokenParameterID] = []byte("reset")
+			parameters[statelessResetTokenParameterID] = bytes.Repeat([]byte{0}, 16)
 			addClientHelloWithParameters(parameters)
 			err := handler.Receive(mint.HandshakeTypeClientHello, &el)
 			Expect(err).To(MatchError("client sent a stateless reset token"))

--- a/internal/handshake/tls_extension_test.go
+++ b/internal/handshake/tls_extension_test.go
@@ -1,32 +1,95 @@
 package handshake
 
 import (
+	"math/rand"
+	"time"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("TLS extension body", func() {
-	var extBody *tlsExtensionBody
+	Context("Client Hello Transport Parameters", func() {
+		It("marshals and unmarshals", func() {
+			chtp := &clientHelloTransportParameters{
+				InitialVersion: 0x123456,
+				Parameters: TransportParameters{
+					StreamFlowControlWindow: 0x42,
+					IdleTimeout:             0x1337 * time.Second,
+				},
+			}
+			chtp2 := &clientHelloTransportParameters{}
+			Expect(chtp2.Unmarshal(chtp.Marshal())).To(Succeed())
+			Expect(chtp2.InitialVersion).To(Equal(chtp.InitialVersion))
+			Expect(chtp2.Parameters.StreamFlowControlWindow).To(Equal(chtp.Parameters.StreamFlowControlWindow))
+			Expect(chtp2.Parameters.IdleTimeout).To(Equal(chtp.Parameters.IdleTimeout))
+		})
 
-	BeforeEach(func() {
-		extBody = &tlsExtensionBody{}
+		It("fuzzes", func() {
+			rand := rand.New(rand.NewSource(GinkgoRandomSeed()))
+			b := make([]byte, 100)
+			for i := 0; i < 1000; i++ {
+				rand.Read(b)
+				chtp := &clientHelloTransportParameters{}
+				chtp.Unmarshal(b[:int(rand.Int31n(100))])
+			}
+		})
 	})
 
-	It("has the right TLS extension type", func() {
-		Expect(extBody.Type()).To(BeEquivalentTo(quicTLSExtensionType))
+	Context("Encrypted Extensions Transport Parameters", func() {
+		It("marshals and unmarshals", func() {
+			eetp := &encryptedExtensionsTransportParameters{
+				NegotiatedVersion: 0x123456,
+				SupportedVersions: []protocol.VersionNumber{0x42, 0x4242},
+				Parameters: TransportParameters{
+					StreamFlowControlWindow: 0x42,
+					IdleTimeout:             0x1337 * time.Second,
+				},
+			}
+			eetp2 := &encryptedExtensionsTransportParameters{}
+			Expect(eetp2.Unmarshal(eetp.Marshal())).To(Succeed())
+			Expect(eetp2.NegotiatedVersion).To(Equal(eetp.NegotiatedVersion))
+			Expect(eetp2.SupportedVersions).To(Equal(eetp.SupportedVersions))
+			Expect(eetp2.Parameters.StreamFlowControlWindow).To(Equal(eetp.Parameters.StreamFlowControlWindow))
+			Expect(eetp2.Parameters.IdleTimeout).To(Equal(eetp.Parameters.IdleTimeout))
+		})
+
+		It("fuzzes", func() {
+			rand := rand.New(rand.NewSource(GinkgoRandomSeed()))
+			b := make([]byte, 100)
+			for i := 0; i < 1000; i++ {
+				rand.Read(b)
+				chtp := &encryptedExtensionsTransportParameters{}
+				chtp.Unmarshal(b[:int(rand.Int31n(100))])
+			}
+		})
 	})
 
-	It("saves the body when unmarshalling", func() {
-		n, err := extBody.Unmarshal([]byte("foobar"))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(n).To(Equal(6))
-		Expect(extBody.data).To(Equal([]byte("foobar")))
-	})
+	Context("TLS Extension Body", func() {
+		var extBody *tlsExtensionBody
 
-	It("returns the body when marshalling", func() {
-		extBody.data = []byte("foo")
-		data, err := extBody.Marshal()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(data).To(Equal([]byte("foo")))
+		BeforeEach(func() {
+			extBody = &tlsExtensionBody{}
+		})
+
+		It("has the right TLS extension type", func() {
+			Expect(extBody.Type()).To(BeEquivalentTo(quicTLSExtensionType))
+		})
+
+		It("saves the body when unmarshalling", func() {
+			n, err := extBody.Unmarshal([]byte("foobar"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(n).To(Equal(6))
+			Expect(extBody.data).To(Equal([]byte("foobar")))
+		})
+
+		It("returns the body when marshalling", func() {
+			extBody.data = []byte("foo")
+			data, err := extBody.Marshal()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).To(Equal([]byte("foo")))
+		})
 	})
 })

--- a/internal/handshake/transport_parameter_test.go
+++ b/internal/handshake/transport_parameter_test.go
@@ -237,12 +237,13 @@ var _ = Describe("Transport Parameters", func() {
 					MaxBidiStreams:              0x1234,
 					MaxUniStreams:               0x4321,
 					DisableMigration:            true,
+					StatelessResetToken:         []byte("foobar"),
 				}
 			})
 
 			It("creates the parameters list", func() {
 				values := paramsListToMap(params.getTransportParameters())
-				Expect(values).To(HaveLen(7))
+				Expect(values).To(HaveLen(8))
 				Expect(values).To(HaveKeyWithValue(initialMaxStreamDataParameterID, []byte{0xde, 0xad, 0xbe, 0xef}))
 				Expect(values).To(HaveKeyWithValue(initialMaxDataParameterID, []byte{0xde, 0xca, 0xfb, 0xad}))
 				Expect(values).To(HaveKeyWithValue(initialMaxBidiStreamsParameterID, []byte{0x12, 0x34}))
@@ -250,6 +251,7 @@ var _ = Describe("Transport Parameters", func() {
 				Expect(values).To(HaveKeyWithValue(idleTimeoutParameterID, []byte{0xca, 0xfe}))
 				Expect(values).To(HaveKeyWithValue(maxPacketSizeParameterID, []byte{0x5, 0xac})) // 1452 = 0x5ac
 				Expect(values).To(HaveKeyWithValue(disableMigrationParameterID, []byte{}))
+				Expect(values).To(HaveKeyWithValue(statelessResetTokenParameterID, []byte("foobar")))
 			})
 		})
 	})

--- a/internal/handshake/transport_parameter_test.go
+++ b/internal/handshake/transport_parameter_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -103,14 +104,6 @@ var _ = Describe("Transport Parameters", func() {
 	})
 
 	Context("for TLS", func() {
-		paramsMapToList := func(p map[transportParameterID][]byte) []transportParameter {
-			var list []transportParameter
-			for id, val := range p {
-				list = append(list, transportParameter{id, val})
-			}
-			return list
-		}
-
 		It("has a string representation", func() {
 			p := &TransportParameters{
 				StreamFlowControlWindow:     0x1234,
@@ -124,11 +117,23 @@ var _ = Describe("Transport Parameters", func() {
 
 		Context("parsing", func() {
 			var (
+				params              *TransportParameters
 				parameters          map[transportParameterID][]byte
 				statelessResetToken []byte
 			)
 
+			marshal := func(p map[transportParameterID][]byte) []byte {
+				b := &bytes.Buffer{}
+				for id, val := range p {
+					utils.BigEndian.WriteUint16(b, uint16(id))
+					utils.BigEndian.WriteUint16(b, uint16(len(val)))
+					b.Write(val)
+				}
+				return b.Bytes()
+			}
+
 			BeforeEach(func() {
+				params = &TransportParameters{}
 				statelessResetToken = bytes.Repeat([]byte{42}, 16)
 				parameters = map[transportParameterID][]byte{
 					initialMaxStreamDataParameterID:  {0x11, 0x22, 0x33, 0x44},
@@ -142,7 +147,7 @@ var _ = Describe("Transport Parameters", func() {
 				}
 			})
 			It("reads parameters", func() {
-				params, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(params.StreamFlowControlWindow).To(Equal(protocol.ByteCount(0x11223344)))
 				Expect(params.ConnectionFlowControlWindow).To(Equal(protocol.ByteCount(0x22334455)))
@@ -157,7 +162,7 @@ var _ = Describe("Transport Parameters", func() {
 
 			It("rejects the parameters if the idle_timeout is missing", func() {
 				delete(parameters, idleTimeoutParameterID)
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("missing parameter"))
 			})
 
@@ -165,106 +170,95 @@ var _ = Describe("Transport Parameters", func() {
 				t := 2 * time.Second
 				Expect(t).To(BeNumerically("<", protocol.MinRemoteIdleTimeout))
 				parameters[idleTimeoutParameterID] = []byte{0, uint8(t.Seconds())}
-				params, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(params.IdleTimeout).To(Equal(protocol.MinRemoteIdleTimeout))
 			})
 
 			It("rejects the parameters if the initial_max_stream_data has the wrong length", func() {
 				parameters[initialMaxStreamDataParameterID] = []byte{0x11, 0x22, 0x33} // should be 4 bytes
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("wrong length for initial_max_stream_data: 3 (expected 4)"))
 			})
 
 			It("rejects the parameters if the initial_max_data has the wrong length", func() {
 				parameters[initialMaxDataParameterID] = []byte{0x11, 0x22, 0x33} // should be 4 bytes
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("wrong length for initial_max_data: 3 (expected 4)"))
 			})
 
 			It("rejects the parameters if the initial_max_stream_id_bidi has the wrong length", func() {
 				parameters[initialMaxBidiStreamsParameterID] = []byte{0x11, 0x22, 0x33} // should be 2 bytes
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("wrong length for initial_max_stream_id_bidi: 3 (expected 2)"))
 			})
 
 			It("rejects the parameters if the initial_max_stream_id_bidi has the wrong length", func() {
 				parameters[initialMaxUniStreamsParameterID] = []byte{0x11, 0x22, 0x33} // should be 2 bytes
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("wrong length for initial_max_stream_id_uni: 3 (expected 2)"))
 			})
 
 			It("rejects the parameters if the initial_idle_timeout has the wrong length", func() {
 				parameters[idleTimeoutParameterID] = []byte{0x11, 0x22, 0x33} // should be 2 bytes
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("wrong length for idle_timeout: 3 (expected 2)"))
 			})
 
 			It("rejects the parameters if max_packet_size has the wrong length", func() {
 				parameters[maxPacketSizeParameterID] = []byte{0x11} // should be 2 bytes
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("wrong length for max_packet_size: 1 (expected 2)"))
 			})
 
 			It("rejects max_packet_sizes smaller than 1200 bytes", func() {
 				parameters[maxPacketSizeParameterID] = []byte{0x4, 0xaf} // 0x4af = 1199
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("invalid value for max_packet_size: 1199 (minimum 1200)"))
 			})
 
 			It("rejects the parameters if disable_connection_migration has the wrong length", func() {
 				parameters[disableMigrationParameterID] = []byte{0x11} // should empty
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("wrong length for disable_migration: 1 (expected empty)"))
 			})
 
 			It("rejects the parameters if the stateless_reset_token has the wrong length", func() {
 				parameters[statelessResetTokenParameterID] = statelessResetToken[1:]
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).To(MatchError("wrong length for stateless_reset_token: 15 (expected 16)"))
 			})
 
 			It("ignores unknown parameters", func() {
 				parameters[1337] = []byte{42}
-				_, err := readTransportParameters(paramsMapToList(parameters))
+				err := params.unmarshal(marshal(parameters))
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
-		Context("writing", func() {
-			var params *TransportParameters
-
-			paramsListToMap := func(l []transportParameter) map[transportParameterID][]byte {
-				p := make(map[transportParameterID][]byte)
-				for _, v := range l {
-					p[v.Parameter] = v.Value
-				}
-				return p
-			}
-
-			BeforeEach(func() {
-				params = &TransportParameters{
+		Context("marshalling", func() {
+			It("marshals", func() {
+				params := &TransportParameters{
 					StreamFlowControlWindow:     0xdeadbeef,
 					ConnectionFlowControlWindow: 0xdecafbad,
 					IdleTimeout:                 0xcafe * time.Second,
 					MaxBidiStreams:              0x1234,
 					MaxUniStreams:               0x4321,
 					DisableMigration:            true,
-					StatelessResetToken:         []byte("foobar"),
+					StatelessResetToken:         bytes.Repeat([]byte{100}, 16),
 				}
-			})
+				b := &bytes.Buffer{}
+				params.marshal(b)
 
-			It("creates the parameters list", func() {
-				values := paramsListToMap(params.getTransportParameters())
-				Expect(values).To(HaveLen(8))
-				Expect(values).To(HaveKeyWithValue(initialMaxStreamDataParameterID, []byte{0xde, 0xad, 0xbe, 0xef}))
-				Expect(values).To(HaveKeyWithValue(initialMaxDataParameterID, []byte{0xde, 0xca, 0xfb, 0xad}))
-				Expect(values).To(HaveKeyWithValue(initialMaxBidiStreamsParameterID, []byte{0x12, 0x34}))
-				Expect(values).To(HaveKeyWithValue(initialMaxUniStreamsParameterID, []byte{0x43, 0x21}))
-				Expect(values).To(HaveKeyWithValue(idleTimeoutParameterID, []byte{0xca, 0xfe}))
-				Expect(values).To(HaveKeyWithValue(maxPacketSizeParameterID, []byte{0x5, 0xac})) // 1452 = 0x5ac
-				Expect(values).To(HaveKeyWithValue(disableMigrationParameterID, []byte{}))
-				Expect(values).To(HaveKeyWithValue(statelessResetTokenParameterID, []byte("foobar")))
+				p := &TransportParameters{}
+				Expect(p.unmarshal(b.Bytes())).To(Succeed())
+				Expect(p.StreamFlowControlWindow).To(Equal(params.StreamFlowControlWindow))
+				Expect(p.ConnectionFlowControlWindow).To(Equal(params.ConnectionFlowControlWindow))
+				Expect(p.MaxUniStreams).To(Equal(params.MaxUniStreams))
+				Expect(p.MaxBidiStreams).To(Equal(params.MaxBidiStreams))
+				Expect(p.IdleTimeout).To(Equal(params.IdleTimeout))
+				Expect(p.DisableMigration).To(Equal(params.DisableMigration))
+				Expect(p.StatelessResetToken).To(Equal(params.StatelessResetToken))
 			})
 		})
 	})

--- a/internal/handshake/transport_parameters.go
+++ b/internal/handshake/transport_parameters.go
@@ -26,10 +26,10 @@ type TransportParameters struct {
 	MaxBidiStreams uint16 // only used for IETF QUIC
 	MaxStreams     uint32 // only used for gQUIC
 
-	OmitConnectionID bool // only used for gQUIC
-	IdleTimeout      time.Duration
-	DisableMigration bool // only used for IETF QUIC
-
+	OmitConnectionID    bool // only used for gQUIC
+	IdleTimeout         time.Duration
+	DisableMigration    bool   // only used for IETF QUIC
+	StatelessResetToken []byte // only used for IETF QUIC
 }
 
 // readHelloMap reads the transport parameters from the tags sent in a gQUIC handshake message
@@ -178,6 +178,9 @@ func (p *TransportParameters) getTransportParameters() []transportParameter {
 	}
 	if p.DisableMigration {
 		params = append(params, transportParameter{disableMigrationParameterID, nil})
+	}
+	if len(p.StatelessResetToken) > 0 {
+		params = append(params, transportParameter{statelessResetTokenParameterID, p.StatelessResetToken})
 	}
 	return params
 }

--- a/internal/handshake/transport_parameters.go
+++ b/internal/handshake/transport_parameters.go
@@ -96,98 +96,110 @@ func (p *TransportParameters) getHelloMap() map[Tag][]byte {
 	return tags
 }
 
-// readTransportParameters reads the transport parameters sent in the QUIC TLS extension
-func readTransportParameters(paramsList []transportParameter) (*TransportParameters, error) {
-	params := &TransportParameters{}
-
+func (p *TransportParameters) unmarshal(data []byte) error {
 	var foundIdleTimeout bool
 
-	for _, p := range paramsList {
-		switch p.Parameter {
+	for len(data) >= 4 {
+		paramID := binary.BigEndian.Uint16(data[:2])
+		paramLen := int(binary.BigEndian.Uint16(data[2:4]))
+		data = data[4:]
+		if len(data) < paramLen {
+			return fmt.Errorf("remaining length (%d) smaller than parameter length (%d)", len(data), paramLen)
+		}
+		switch transportParameterID(paramID) {
 		case initialMaxStreamDataParameterID:
-			if len(p.Value) != 4 {
-				return nil, fmt.Errorf("wrong length for initial_max_stream_data: %d (expected 4)", len(p.Value))
+			if paramLen != 4 {
+				return fmt.Errorf("wrong length for initial_max_stream_data: %d (expected 4)", paramLen)
 			}
-			params.StreamFlowControlWindow = protocol.ByteCount(binary.BigEndian.Uint32(p.Value))
+			p.StreamFlowControlWindow = protocol.ByteCount(binary.BigEndian.Uint32(data[:4]))
 		case initialMaxDataParameterID:
-			if len(p.Value) != 4 {
-				return nil, fmt.Errorf("wrong length for initial_max_data: %d (expected 4)", len(p.Value))
+			if paramLen != 4 {
+				return fmt.Errorf("wrong length for initial_max_data: %d (expected 4)", paramLen)
 			}
-			params.ConnectionFlowControlWindow = protocol.ByteCount(binary.BigEndian.Uint32(p.Value))
+			p.ConnectionFlowControlWindow = protocol.ByteCount(binary.BigEndian.Uint32(data[:4]))
 		case initialMaxBidiStreamsParameterID:
-			if len(p.Value) != 2 {
-				return nil, fmt.Errorf("wrong length for initial_max_stream_id_bidi: %d (expected 2)", len(p.Value))
+			if paramLen != 2 {
+				return fmt.Errorf("wrong length for initial_max_stream_id_bidi: %d (expected 2)", paramLen)
 			}
-			params.MaxBidiStreams = binary.BigEndian.Uint16(p.Value)
+			p.MaxBidiStreams = binary.BigEndian.Uint16(data[:2])
 		case initialMaxUniStreamsParameterID:
-			if len(p.Value) != 2 {
-				return nil, fmt.Errorf("wrong length for initial_max_stream_id_uni: %d (expected 2)", len(p.Value))
+			if paramLen != 2 {
+				return fmt.Errorf("wrong length for initial_max_stream_id_uni: %d (expected 2)", paramLen)
 			}
-			params.MaxUniStreams = binary.BigEndian.Uint16(p.Value)
+			p.MaxUniStreams = binary.BigEndian.Uint16(data[:2])
 		case idleTimeoutParameterID:
 			foundIdleTimeout = true
-			if len(p.Value) != 2 {
-				return nil, fmt.Errorf("wrong length for idle_timeout: %d (expected 2)", len(p.Value))
+			if paramLen != 2 {
+				return fmt.Errorf("wrong length for idle_timeout: %d (expected 2)", paramLen)
 			}
-			params.IdleTimeout = utils.MaxDuration(protocol.MinRemoteIdleTimeout, time.Duration(binary.BigEndian.Uint16(p.Value))*time.Second)
+			p.IdleTimeout = utils.MaxDuration(protocol.MinRemoteIdleTimeout, time.Duration(binary.BigEndian.Uint16(data[:2]))*time.Second)
 		case maxPacketSizeParameterID:
-			if len(p.Value) != 2 {
-				return nil, fmt.Errorf("wrong length for max_packet_size: %d (expected 2)", len(p.Value))
+			if paramLen != 2 {
+				return fmt.Errorf("wrong length for max_packet_size: %d (expected 2)", paramLen)
 			}
-			maxPacketSize := protocol.ByteCount(binary.BigEndian.Uint16(p.Value))
+			maxPacketSize := protocol.ByteCount(binary.BigEndian.Uint16(data[:2]))
 			if maxPacketSize < 1200 {
-				return nil, fmt.Errorf("invalid value for max_packet_size: %d (minimum 1200)", maxPacketSize)
+				return fmt.Errorf("invalid value for max_packet_size: %d (minimum 1200)", maxPacketSize)
 			}
-			params.MaxPacketSize = maxPacketSize
+			p.MaxPacketSize = maxPacketSize
 		case disableMigrationParameterID:
-			if len(p.Value) != 0 {
-				return nil, fmt.Errorf("wrong length for disable_migration: %d (expected empty)", len(p.Value))
+			if paramLen != 0 {
+				return fmt.Errorf("wrong length for disable_migration: %d (expected empty)", paramLen)
 			}
-			params.DisableMigration = true
+			p.DisableMigration = true
 		case statelessResetTokenParameterID:
-			if len(p.Value) != 16 {
-				return nil, fmt.Errorf("wrong length for stateless_reset_token: %d (expected 16)", len(p.Value))
+			if paramLen != 16 {
+				return fmt.Errorf("wrong length for stateless_reset_token: %d (expected 16)", paramLen)
 			}
-			params.StatelessResetToken = p.Value
+			p.StatelessResetToken = data[:16]
 		}
+		data = data[paramLen:]
 	}
 
-	if !foundIdleTimeout {
-		return nil, errors.New("missing parameter")
+	if len(data) != 0 {
+		return fmt.Errorf("should have read all data. Still have %d bytes", len(data))
 	}
-	return params, nil
+	if !foundIdleTimeout {
+		return errors.New("missing parameter")
+	}
+	return nil
 }
 
-// GetTransportParameters gets the parameters needed for the TLS handshake.
-// It doesn't send the initial_max_stream_id_uni parameter, so the peer isn't allowed to open any unidirectional streams.
-func (p *TransportParameters) getTransportParameters() []transportParameter {
-	initialMaxStreamData := make([]byte, 4)
-	binary.BigEndian.PutUint32(initialMaxStreamData, uint32(p.StreamFlowControlWindow))
-	initialMaxData := make([]byte, 4)
-	binary.BigEndian.PutUint32(initialMaxData, uint32(p.ConnectionFlowControlWindow))
-	initialMaxBidiStreamID := make([]byte, 2)
-	binary.BigEndian.PutUint16(initialMaxBidiStreamID, p.MaxBidiStreams)
-	initialMaxUniStreamID := make([]byte, 2)
-	binary.BigEndian.PutUint16(initialMaxUniStreamID, p.MaxUniStreams)
-	idleTimeout := make([]byte, 2)
-	binary.BigEndian.PutUint16(idleTimeout, uint16(p.IdleTimeout/time.Second))
-	maxPacketSize := make([]byte, 2)
-	binary.BigEndian.PutUint16(maxPacketSize, uint16(protocol.MaxReceivePacketSize))
-	params := []transportParameter{
-		{initialMaxStreamDataParameterID, initialMaxStreamData},
-		{initialMaxDataParameterID, initialMaxData},
-		{initialMaxBidiStreamsParameterID, initialMaxBidiStreamID},
-		{initialMaxUniStreamsParameterID, initialMaxUniStreamID},
-		{idleTimeoutParameterID, idleTimeout},
-		{maxPacketSizeParameterID, maxPacketSize},
-	}
+func (p *TransportParameters) marshal(b *bytes.Buffer) {
+	// initial_max_stream_data
+	utils.BigEndian.WriteUint16(b, uint16(initialMaxStreamDataParameterID))
+	utils.BigEndian.WriteUint16(b, 4)
+	utils.BigEndian.WriteUint32(b, uint32(p.StreamFlowControlWindow))
+	// initial_max_data
+	utils.BigEndian.WriteUint16(b, uint16(initialMaxDataParameterID))
+	utils.BigEndian.WriteUint16(b, 4)
+	utils.BigEndian.WriteUint32(b, uint32(p.ConnectionFlowControlWindow))
+	// initial_max_bidi_streams
+	utils.BigEndian.WriteUint16(b, uint16(initialMaxBidiStreamsParameterID))
+	utils.BigEndian.WriteUint16(b, 2)
+	utils.BigEndian.WriteUint16(b, p.MaxBidiStreams)
+	// initial_max_uni_streams
+	utils.BigEndian.WriteUint16(b, uint16(initialMaxUniStreamsParameterID))
+	utils.BigEndian.WriteUint16(b, 2)
+	utils.BigEndian.WriteUint16(b, p.MaxUniStreams)
+	// idle_timeout
+	utils.BigEndian.WriteUint16(b, uint16(idleTimeoutParameterID))
+	utils.BigEndian.WriteUint16(b, 2)
+	utils.BigEndian.WriteUint16(b, uint16(p.IdleTimeout/time.Second))
+	// max_packet_size
+	utils.BigEndian.WriteUint16(b, uint16(maxPacketSizeParameterID))
+	utils.BigEndian.WriteUint16(b, 2)
+	utils.BigEndian.WriteUint16(b, uint16(protocol.MaxReceivePacketSize))
+	// disable_migration
 	if p.DisableMigration {
-		params = append(params, transportParameter{disableMigrationParameterID, nil})
+		utils.BigEndian.WriteUint16(b, uint16(disableMigrationParameterID))
+		utils.BigEndian.WriteUint16(b, 0)
 	}
 	if len(p.StatelessResetToken) > 0 {
-		params = append(params, transportParameter{statelessResetTokenParameterID, p.StatelessResetToken})
+		utils.BigEndian.WriteUint16(b, uint16(statelessResetTokenParameterID))
+		utils.BigEndian.WriteUint16(b, uint16(len(p.StatelessResetToken))) // should always be 16 bytes
+		b.Write(p.StatelessResetToken)
 	}
-	return params
 }
 
 // String returns a string representation, intended for logging.

--- a/internal/handshake/transport_parameters.go
+++ b/internal/handshake/transport_parameters.go
@@ -144,6 +144,11 @@ func readTransportParameters(paramsList []transportParameter) (*TransportParamet
 				return nil, fmt.Errorf("wrong length for disable_migration: %d (expected empty)", len(p.Value))
 			}
 			params.DisableMigration = true
+		case statelessResetTokenParameterID:
+			if len(p.Value) != 16 {
+				return nil, fmt.Errorf("wrong length for stateless_reset_token: %d (expected 16)", len(p.Value))
+			}
+			params.StatelessResetToken = p.Value
 		}
 	}
 

--- a/server_tls.go
+++ b/server_tls.go
@@ -51,6 +51,8 @@ func newServerTLS(
 		MaxBidiStreams:              uint16(config.MaxIncomingStreams),
 		MaxUniStreams:               uint16(config.MaxIncomingUniStreams),
 		DisableMigration:            true,
+		// TODO(#855): generate a real token
+		StatelessResetToken: bytes.Repeat([]byte{42}, 16),
 	}
 	mconf, err := tlsToMintConfig(tlsConf, protocol.PerspectiveServer)
 	if err != nil {


### PR DESCRIPTION
Depends on #1490.

So far, this was done by *mint/syntax*. By implementing it directly, we reduce our dependency on mint (and probably speed it up by a factor of 2 or so).