### PR TITLE
remove wire dependency in the frame sorter

### DIFF
--- a/crypto_stream.go
+++ b/crypto_stream.go
@@ -37,5 +37,5 @@ func newCryptoStream(sender streamSender, flowController flowcontrol.StreamFlowC
 // It must not be called concurrently with any other stream methods, especially Read and Write.
 func (s *cryptoStreamImpl) setReadOffset(offset protocol.ByteCount) {
 	s.receiveStream.readOffset = offset
-	s.receiveStream.frameQueue.readPosition = offset
+	s.receiveStream.frameQueue.readPos = offset
 }

--- a/crypto_stream_test.go
+++ b/crypto_stream_test.go
@@ -21,6 +21,6 @@ var _ = Describe("Crypto Stream", func() {
 	It("sets the read offset", func() {
 		str.setReadOffset(0x42)
 		Expect(str.receiveStream.readOffset).To(Equal(protocol.ByteCount(0x42)))
-		Expect(str.receiveStream.frameQueue.readPosition).To(Equal(protocol.ByteCount(0x42)))
+		Expect(str.receiveStream.frameQueue.readPos).To(Equal(protocol.ByteCount(0x42)))
 	})
 })

--- a/frame_sorter.go
+++ b/frame_sorter.go
@@ -7,7 +7,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
-type streamFrameSorter struct {
+type frameSorter struct {
 	queue       map[protocol.ByteCount][]byte
 	readPos     protocol.ByteCount
 	finalOffset protocol.ByteCount
@@ -16,8 +16,8 @@ type streamFrameSorter struct {
 
 var errDuplicateStreamData = errors.New("Duplicate Stream Data")
 
-func newStreamFrameSorter() *streamFrameSorter {
-	s := streamFrameSorter{
+func newFrameSorter() *frameSorter {
+	s := frameSorter{
 		gaps:        utils.NewByteIntervalList(),
 		queue:       make(map[protocol.ByteCount][]byte),
 		finalOffset: protocol.MaxByteCount,
@@ -26,7 +26,7 @@ func newStreamFrameSorter() *streamFrameSorter {
 	return &s
 }
 
-func (s *streamFrameSorter) Push(data []byte, offset protocol.ByteCount, fin bool) error {
+func (s *frameSorter) Push(data []byte, offset protocol.ByteCount, fin bool) error {
 	err := s.push(data, offset, fin)
 	if err == errDuplicateStreamData {
 		return nil
@@ -34,7 +34,7 @@ func (s *streamFrameSorter) Push(data []byte, offset protocol.ByteCount, fin boo
 	return err
 }
 
-func (s *streamFrameSorter) push(data []byte, offset protocol.ByteCount, fin bool) error {
+func (s *frameSorter) push(data []byte, offset protocol.ByteCount, fin bool) error {
 	if fin {
 		s.finalOffset = offset + protocol.ByteCount(len(data))
 	}
@@ -147,7 +147,7 @@ func (s *streamFrameSorter) push(data []byte, offset protocol.ByteCount, fin boo
 	return nil
 }
 
-func (s *streamFrameSorter) Pop() ([]byte /* data */, bool /* fin */) {
+func (s *frameSorter) Pop() ([]byte /* data */, bool /* fin */) {
 	data, ok := s.queue[s.readPos]
 	if !ok {
 		return nil, s.readPos >= s.finalOffset

--- a/frame_sorter_test.go
+++ b/frame_sorter_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = Describe("STREAM frame sorter", func() {
-	var s *streamFrameSorter
+	var s *frameSorter
 
 	checkGaps := func(expectedGaps []utils.ByteInterval) {
 		Expect(s.gaps.Len()).To(Equal(len(expectedGaps)))
@@ -22,7 +22,7 @@ var _ = Describe("STREAM frame sorter", func() {
 	}
 
 	BeforeEach(func() {
-		s = newStreamFrameSorter()
+		s = newFrameSorter()
 	})
 
 	It("head returns nil when empty", func() {

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -209,7 +209,7 @@ func (s *receiveStream) handleStreamFrame(frame *wire.StreamFrame) error {
 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	if err := s.frameQueue.Push(frame); err != nil && err != errDuplicateStreamData {
+	if err := s.frameQueue.Push(frame.Data, frame.Offset, frame.FinBit); err != nil && err != errDuplicateStreamData {
 		return err
 	}
 	s.signalRead()

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -209,7 +209,7 @@ func (s *receiveStream) handleStreamFrame(frame *wire.StreamFrame) error {
 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	if err := s.frameQueue.Push(frame.Data, frame.Offset, frame.FinBit); err != nil && err != errDuplicateStreamData {
+	if err := s.frameQueue.Push(frame.Data, frame.Offset, frame.FinBit); err != nil {
 		return err
 	}
 	s.signalRead()

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -27,7 +27,7 @@ type receiveStream struct {
 
 	sender streamSender
 
-	frameQueue *streamFrameSorter
+	frameQueue *frameSorter
 	readOffset protocol.ByteCount
 
 	currentFrame       []byte
@@ -63,7 +63,7 @@ func newReceiveStream(
 		streamID:       streamID,
 		sender:         sender,
 		flowController: flowController,
-		frameQueue:     newStreamFrameSorter(),
+		frameQueue:     newFrameSorter(),
 		readChan:       make(chan struct{}, 1),
 		version:        version,
 	}

--- a/stream_frame_sorter.go
+++ b/stream_frame_sorter.go
@@ -141,17 +141,12 @@ func (s *streamFrameSorter) Push(frame *wire.StreamFrame) error {
 	return nil
 }
 
-func (s *streamFrameSorter) Pop() {
-	if frame := s.Head(); frame != nil {
-		s.readPosition += frame.DataLen()
-		delete(s.queuedFrames, frame.Offset)
-	}
-}
-
-func (s *streamFrameSorter) Head() *wire.StreamFrame {
+func (s *streamFrameSorter) Pop() *wire.StreamFrame {
 	frame, ok := s.queuedFrames[s.readPosition]
-	if ok {
-		return frame
+	if !ok {
+		return nil
 	}
-	return nil
+	s.readPosition += frame.DataLen()
+	delete(s.queuedFrames, frame.Offset)
+	return frame
 }

--- a/stream_frame_sorter.go
+++ b/stream_frame_sorter.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
-	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
 type streamFrameSorter struct {
@@ -30,11 +29,7 @@ func newStreamFrameSorter() *streamFrameSorter {
 	return &s
 }
 
-func (s *streamFrameSorter) Push(frame *wire.StreamFrame) error {
-	return s.push(frame.Data, frame.Offset, frame.FinBit)
-}
-
-func (s *streamFrameSorter) push(data []byte, offset protocol.ByteCount, fin bool) error {
+func (s *streamFrameSorter) Push(data []byte, offset protocol.ByteCount, fin bool) error {
 	if fin {
 		s.finalOffset = offset + protocol.ByteCount(len(data))
 	}

--- a/stream_frame_sorter.go
+++ b/stream_frame_sorter.go
@@ -141,13 +141,11 @@ func (s *streamFrameSorter) Push(frame *wire.StreamFrame) error {
 	return nil
 }
 
-func (s *streamFrameSorter) Pop() *wire.StreamFrame {
-	frame := s.Head()
-	if frame != nil {
+func (s *streamFrameSorter) Pop() {
+	if frame := s.Head(); frame != nil {
 		s.readPosition += frame.DataLen()
 		delete(s.queuedFrames, frame.Offset)
 	}
-	return frame
 }
 
 func (s *streamFrameSorter) Head() *wire.StreamFrame {

--- a/stream_frame_sorter.go
+++ b/stream_frame_sorter.go
@@ -9,9 +9,10 @@ import (
 )
 
 type streamFrameSorter struct {
-	queuedFrames map[protocol.ByteCount]*wire.StreamFrame
-	readPosition protocol.ByteCount
-	gaps         *utils.ByteIntervalList
+	queue       map[protocol.ByteCount][]byte
+	readPos     protocol.ByteCount
+	finalOffset protocol.ByteCount
+	gaps        *utils.ByteIntervalList
 }
 
 var (
@@ -21,33 +22,38 @@ var (
 
 func newStreamFrameSorter() *streamFrameSorter {
 	s := streamFrameSorter{
-		gaps:         utils.NewByteIntervalList(),
-		queuedFrames: make(map[protocol.ByteCount]*wire.StreamFrame),
+		gaps:        utils.NewByteIntervalList(),
+		queue:       make(map[protocol.ByteCount][]byte),
+		finalOffset: protocol.MaxByteCount,
 	}
 	s.gaps.PushFront(utils.ByteInterval{Start: 0, End: protocol.MaxByteCount})
 	return &s
 }
 
 func (s *streamFrameSorter) Push(frame *wire.StreamFrame) error {
-	if frame.DataLen() == 0 {
-		if frame.FinBit {
-			s.queuedFrames[frame.Offset] = frame
-		}
+	return s.push(frame.Data, frame.Offset, frame.FinBit)
+}
+
+func (s *streamFrameSorter) push(data []byte, offset protocol.ByteCount, fin bool) error {
+	if fin {
+		s.finalOffset = offset + protocol.ByteCount(len(data))
+	}
+	if len(data) == 0 {
 		return nil
 	}
 
 	var wasCut bool
-	if oldFrame, ok := s.queuedFrames[frame.Offset]; ok {
-		if frame.DataLen() <= oldFrame.DataLen() {
+	if oldData, ok := s.queue[offset]; ok {
+		if len(data) <= len(oldData) {
 			return errDuplicateStreamData
 		}
-		frame.Data = frame.Data[oldFrame.DataLen():]
-		frame.Offset += oldFrame.DataLen()
+		data = data[len(oldData):]
+		offset += protocol.ByteCount(len(oldData))
 		wasCut = true
 	}
 
-	start := frame.Offset
-	end := frame.Offset + frame.DataLen()
+	start := offset
+	end := offset + protocol.ByteCount(len(data))
 
 	// skip all gaps that are before this stream frame
 	var gap *utils.ByteIntervalElement
@@ -67,9 +73,9 @@ func (s *streamFrameSorter) Push(frame *wire.StreamFrame) error {
 
 	if start < gap.Value.Start {
 		add := gap.Value.Start - start
-		frame.Offset += add
+		offset += add
 		start += add
-		frame.Data = frame.Data[add:]
+		data = data[add:]
 		wasCut = true
 	}
 
@@ -87,15 +93,15 @@ func (s *streamFrameSorter) Push(frame *wire.StreamFrame) error {
 			break
 		}
 		// delete queued frames completely covered by the current frame
-		delete(s.queuedFrames, endGap.Value.End)
+		delete(s.queue, endGap.Value.End)
 		endGap = nextEndGap
 	}
 
 	if end > endGap.Value.End {
 		cutLen := end - endGap.Value.End
-		len := frame.DataLen() - cutLen
+		len := protocol.ByteCount(len(data)) - cutLen
 		end -= cutLen
-		frame.Data = frame.Data[:len]
+		data = data[:len]
 		wasCut = true
 	}
 
@@ -132,21 +138,21 @@ func (s *streamFrameSorter) Push(frame *wire.StreamFrame) error {
 	}
 
 	if wasCut {
-		data := make([]byte, frame.DataLen())
-		copy(data, frame.Data)
-		frame.Data = data
+		newData := make([]byte, len(data))
+		copy(newData, data)
+		data = newData
 	}
 
-	s.queuedFrames[frame.Offset] = frame
+	s.queue[offset] = data
 	return nil
 }
 
-func (s *streamFrameSorter) Pop() *wire.StreamFrame {
-	frame, ok := s.queuedFrames[s.readPosition]
+func (s *streamFrameSorter) Pop() ([]byte /* data */, bool /* fin */) {
+	data, ok := s.queue[s.readPos]
 	if !ok {
-		return nil
+		return nil, s.readPos >= s.finalOffset
 	}
-	s.readPosition += frame.DataLen()
-	delete(s.queuedFrames, frame.Offset)
-	return frame
+	delete(s.queue, s.readPos)
+	s.readPos += protocol.ByteCount(len(data))
+	return data, s.readPos >= s.finalOffset
 }

--- a/stream_frame_sorter_test.go
+++ b/stream_frame_sorter_test.go
@@ -39,7 +39,7 @@ var _ = Describe("STREAM frame sorter", func() {
 			err := s.Push(f)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(s.Head()).To(Equal(f))
-			Expect(s.Pop()).To(Equal(f))
+			s.Pop()
 			Expect(s.Head()).To(BeNil())
 		})
 
@@ -56,8 +56,10 @@ var _ = Describe("STREAM frame sorter", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = s.Push(f2)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(s.Pop()).To(Equal(f1))
-			Expect(s.Pop()).To(Equal(f2))
+			Expect(s.Head()).To(Equal(f1))
+			s.Pop()
+			Expect(s.Head()).To(Equal(f2))
+			s.Pop()
 			Expect(s.Head()).To(BeNil())
 		})
 
@@ -65,7 +67,7 @@ var _ = Describe("STREAM frame sorter", func() {
 			f := &wire.StreamFrame{}
 			err := s.Push(f)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(s.Pop()).To(BeNil())
+			Expect(s.Head()).To(BeNil())
 		})
 
 		Context("FinBit handling", func() {
@@ -92,8 +94,9 @@ var _ = Describe("STREAM frame sorter", func() {
 				}
 				err = s.Push(f2)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(s.Pop()).To(Equal(f1))
-				Expect(s.Pop()).To(Equal(f2))
+				Expect(s.Head()).To(Equal(f1))
+				s.Pop()
+				Expect(s.Head()).To(Equal(f2))
 			})
 		})
 

--- a/stream_frame_sorter_test.go
+++ b/stream_frame_sorter_test.go
@@ -27,7 +27,7 @@ var _ = Describe("STREAM frame sorter", func() {
 	})
 
 	It("head returns nil when empty", func() {
-		Expect(s.Head()).To(BeNil())
+		Expect(s.Pop()).To(BeNil())
 	})
 
 	Context("Push", func() {
@@ -36,11 +36,9 @@ var _ = Describe("STREAM frame sorter", func() {
 				Offset: 0,
 				Data:   []byte("foobar"),
 			}
-			err := s.Push(f)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s.Head()).To(Equal(f))
-			s.Pop()
-			Expect(s.Head()).To(BeNil())
+			Expect(s.Push(f)).To(Succeed())
+			Expect(s.Pop()).To(Equal(f))
+			Expect(s.Pop()).To(BeNil())
 		})
 
 		It("inserts and pops two consecutive frame", func() {
@@ -52,22 +50,17 @@ var _ = Describe("STREAM frame sorter", func() {
 				Offset: 6,
 				Data:   []byte("foobar2"),
 			}
-			err := s.Push(f1)
-			Expect(err).ToNot(HaveOccurred())
-			err = s.Push(f2)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s.Head()).To(Equal(f1))
-			s.Pop()
-			Expect(s.Head()).To(Equal(f2))
-			s.Pop()
-			Expect(s.Head()).To(BeNil())
+			Expect(s.Push(f1)).To(Succeed())
+			Expect(s.Push(f2)).To(Succeed())
+			Expect(s.Pop()).To(Equal(f1))
+			Expect(s.Pop()).To(Equal(f2))
+			Expect(s.Pop()).To(BeNil())
 		})
 
 		It("ignores empty frames", func() {
 			f := &wire.StreamFrame{}
-			err := s.Push(f)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(s.Head()).To(BeNil())
+			Expect(s.Push(f)).To(Succeed())
+			Expect(s.Pop()).To(BeNil())
 		})
 
 		Context("FinBit handling", func() {
@@ -76,9 +69,8 @@ var _ = Describe("STREAM frame sorter", func() {
 					Offset: 0,
 					FinBit: true,
 				}
-				err := s.Push(f)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(s.Head()).To(Equal(f))
+				Expect(s.Push(f)).To(Succeed())
+				Expect(s.Pop()).To(Equal(f))
 			})
 
 			It("sets the FinBit if a stream is closed after receiving some data", func() {
@@ -86,17 +78,14 @@ var _ = Describe("STREAM frame sorter", func() {
 					Offset: 0,
 					Data:   []byte("foobar"),
 				}
-				err := s.Push(f1)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(s.Push(f1)).To(Succeed())
 				f2 := &wire.StreamFrame{
 					Offset: 6,
 					FinBit: true,
 				}
-				err = s.Push(f2)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(s.Head()).To(Equal(f1))
-				s.Pop()
-				Expect(s.Head()).To(Equal(f2))
+				Expect(s.Push(f2)).To(Succeed())
+				Expect(s.Pop()).To(Equal(f1))
+				Expect(s.Pop()).To(Equal(f2))
 			})
 		})
 

--- a/stream_frame_sorter_test.go
+++ b/stream_frame_sorter_test.go
@@ -375,21 +375,21 @@ var _ = Describe("STREAM frame sorter", func() {
 				})
 
 				It("does not modify data when receiving a duplicate", func() {
-					err := s.Push([]byte("fffff"), 0, false)
+					err := s.push([]byte("fffff"), 0, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[0]).ToNot(Equal([]byte("fffff")))
 				})
 
 				It("detects a duplicate frame that is smaller than the original, starting at the beginning", func() {
 					// 10 to 12
-					err := s.Push([]byte("12"), 10, false)
+					err := s.push([]byte("12"), 10, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[10]).To(HaveLen(5))
 				})
 
 				It("detects a duplicate frame that is smaller than the original, somewhere in the middle", func() {
 					// 1 to 4
-					err := s.Push([]byte("123"), 1, false)
+					err := s.push([]byte("123"), 1, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[0]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(1)))
@@ -397,7 +397,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("detects a duplicate frame that is smaller than the original, somewhere in the middle in the last block", func() {
 					// 11 to 14
-					err := s.Push([]byte("123"), 11, false)
+					err := s.push([]byte("123"), 11, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[10]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(11)))
@@ -405,7 +405,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("detects a duplicate frame that is smaller than the original, with aligned end in the last block", func() {
 					// 11 to 15
-					err := s.Push([]byte("1234"), 1, false)
+					err := s.push([]byte("1234"), 1, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[10]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(11)))
@@ -413,7 +413,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("detects a duplicate frame that is smaller than the original, with aligned end", func() {
 					// 3 to 5
-					err := s.Push([]byte("12"), 3, false)
+					err := s.push([]byte("12"), 3, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[0]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(3)))
@@ -427,7 +427,7 @@ var _ = Describe("STREAM frame sorter", func() {
 					}
 					Expect(s.gaps.Len()).To(Equal(protocol.MaxStreamFrameSorterGaps))
 					err := s.Push([]byte("foobar"), protocol.ByteCount(protocol.MaxStreamFrameSorterGaps*7)+100, false)
-					Expect(err).To(MatchError(errTooManyGapsInReceivedStreamData))
+					Expect(err).To(MatchError("Too many gaps in received data"))
 				})
 			})
 		})

--- a/stream_frame_sorter_test.go
+++ b/stream_frame_sorter_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
-	"github.com/lucas-clemente/quic-go/internal/wire"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -32,52 +31,35 @@ var _ = Describe("STREAM frame sorter", func() {
 
 	Context("Push", func() {
 		It("inserts and pops a single frame", func() {
-			f := &wire.StreamFrame{
-				Offset: 0,
-				Data:   []byte("foobar"),
-			}
-			Expect(s.Push(f)).To(Succeed())
+			Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
 			data, fin := s.Pop()
-			Expect(data).To(Equal(f.Data))
+			Expect(data).To(Equal([]byte("foobar")))
 			Expect(fin).To(BeFalse())
 			Expect(s.Pop()).To(BeNil())
 		})
 
 		It("inserts and pops two consecutive frame", func() {
-			f1 := &wire.StreamFrame{
-				Offset: 0,
-				Data:   []byte("foobar"),
-			}
-			f2 := &wire.StreamFrame{
-				Offset: 6,
-				Data:   []byte("foobar2"),
-			}
-			Expect(s.Push(f1)).To(Succeed())
-			Expect(s.Push(f2)).To(Succeed())
+			Expect(s.Push([]byte("foo"), 0, false)).To(Succeed())
+			Expect(s.Push([]byte("bar"), 3, false)).To(Succeed())
 			data, fin := s.Pop()
-			Expect(data).To(Equal(f1.Data))
+			Expect(data).To(Equal([]byte("foo")))
 			Expect(fin).To(BeFalse())
 			data, fin = s.Pop()
-			Expect(data).To(Equal(f2.Data))
+			Expect(data).To(Equal([]byte("bar")))
 			Expect(fin).To(BeFalse())
 			Expect(s.Pop()).To(BeNil())
 		})
 
 		It("ignores empty frames", func() {
-			f := &wire.StreamFrame{}
-			Expect(s.Push(f)).To(Succeed())
+			Expect(s.Push(nil, 0, false)).To(Succeed())
 			Expect(s.Pop()).To(BeNil())
 		})
 
 		Context("FIN handling", func() {
-			It("saves a FIN frame at offset 0", func() {
-				f := &wire.StreamFrame{
-					Offset: 0,
-					FinBit: true,
-				}
-				Expect(s.Push(f)).To(Succeed())
+			It("saves a FIN at offset 0", func() {
+				Expect(s.Push(nil, 0, true)).To(Succeed())
 				data, fin := s.Pop()
-				Expect(data).To(Equal(f.Data))
+				Expect(data).To(BeEmpty())
 				Expect(fin).To(BeTrue())
 				data, fin = s.Pop()
 				Expect(data).To(BeNil())
@@ -85,14 +67,9 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("saves a FIN frame at non-zero offset", func() {
-				f := &wire.StreamFrame{
-					Offset: 0,
-					Data:   []byte("foobar"),
-					FinBit: true,
-				}
-				Expect(s.Push(f)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 0, true)).To(Succeed())
 				data, fin := s.Pop()
-				Expect(data).To(Equal(f.Data))
+				Expect(data).To(Equal([]byte("foobar")))
 				Expect(fin).To(BeTrue())
 				data, fin = s.Pop()
 				Expect(data).To(BeNil())
@@ -100,18 +77,10 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("sets the FIN if a stream is closed after receiving some data", func() {
-				f1 := &wire.StreamFrame{
-					Offset: 0,
-					Data:   []byte("foobar"),
-				}
-				Expect(s.Push(f1)).To(Succeed())
-				f2 := &wire.StreamFrame{
-					Offset: 6,
-					FinBit: true,
-				}
-				Expect(s.Push(f2)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
+				Expect(s.Push(nil, 6, true)).To(Succeed())
 				data, fin := s.Pop()
-				Expect(data).To(Equal(f1.Data))
+				Expect(data).To(Equal([]byte("foobar")))
 				Expect(fin).To(BeTrue())
 				data, fin = s.Pop()
 				Expect(data).To(BeNil())
@@ -121,12 +90,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 		Context("Gap handling", func() {
 			It("finds the first gap", func() {
-				f := &wire.StreamFrame{
-					Offset: 10,
-					Data:   []byte("foobar"),
-				}
-				err := s.Push(f)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(s.Push([]byte("foobar"), 10, false)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 10},
 					{Start: 16, End: protocol.MaxByteCount},
@@ -134,30 +98,15 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("correctly sets the first gap for a frame with offset 0", func() {
-				f := &wire.StreamFrame{
-					Offset: 0,
-					Data:   []byte("foobar"),
-				}
-				err := s.Push(f)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 6, End: protocol.MaxByteCount},
 				})
 			})
 
 			It("finds the two gaps", func() {
-				f1 := &wire.StreamFrame{
-					Offset: 10,
-					Data:   []byte("foobar"),
-				}
-				err := s.Push(f1)
-				Expect(err).ToNot(HaveOccurred())
-				f2 := &wire.StreamFrame{
-					Offset: 20,
-					Data:   []byte("foobar"),
-				}
-				err = s.Push(f2)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(s.Push([]byte("foobar"), 10, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 20, false)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 10},
 					{Start: 16, End: 20},
@@ -166,18 +115,8 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("finds the two gaps in reverse order", func() {
-				f1 := &wire.StreamFrame{
-					Offset: 20,
-					Data:   []byte("foobar"),
-				}
-				err := s.Push(f1)
-				Expect(err).ToNot(HaveOccurred())
-				f2 := &wire.StreamFrame{
-					Offset: 10,
-					Data:   []byte("foobar"),
-				}
-				err = s.Push(f2)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(s.Push([]byte("foobar"), 20, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 10, false)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 10},
 					{Start: 16, End: 20},
@@ -186,18 +125,8 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("shrinks a gap when it is partially filled", func() {
-				f1 := &wire.StreamFrame{
-					Offset: 10,
-					Data:   []byte("test"),
-				}
-				err := s.Push(f1)
-				Expect(err).ToNot(HaveOccurred())
-				f2 := &wire.StreamFrame{
-					Offset: 4,
-					Data:   []byte("foobar"),
-				}
-				err = s.Push(f2)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(s.Push([]byte("test"), 10, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 4, false)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 4},
 					{Start: 14, End: protocol.MaxByteCount},
@@ -205,42 +134,17 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("deletes a gap at the beginning, when it is filled", func() {
-				f1 := &wire.StreamFrame{
-					Offset: 6,
-					Data:   []byte("test"),
-				}
-				err := s.Push(f1)
-				Expect(err).ToNot(HaveOccurred())
-				f2 := &wire.StreamFrame{
-					Offset: 0,
-					Data:   []byte("foobar"),
-				}
-				err = s.Push(f2)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(s.Push([]byte("test"), 6, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 10, End: protocol.MaxByteCount},
 				})
 			})
 
 			It("deletes a gap in the middle, when it is filled", func() {
-				f1 := &wire.StreamFrame{
-					Offset: 0,
-					Data:   []byte("test"),
-				}
-				err := s.Push(f1)
-				Expect(err).ToNot(HaveOccurred())
-				f2 := &wire.StreamFrame{
-					Offset: 10,
-					Data:   []byte("test2"),
-				}
-				err = s.Push(f2)
-				Expect(err).ToNot(HaveOccurred())
-				f3 := &wire.StreamFrame{
-					Offset: 4,
-					Data:   []byte("foobar"),
-				}
-				err = s.Push(f3)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(s.Push([]byte("test"), 0, false)).To(Succeed())
+				Expect(s.Push([]byte("test2"), 10, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 4, false)).To(Succeed())
 				Expect(s.queue).To(HaveLen(3))
 				checkGaps([]utils.ByteInterval{
 					{Start: 15, End: protocol.MaxByteCount},
@@ -248,18 +152,8 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("splits a gap into two", func() {
-				f1 := &wire.StreamFrame{
-					Offset: 100,
-					Data:   []byte("test"),
-				}
-				err := s.Push(f1)
-				Expect(err).ToNot(HaveOccurred())
-				f2 := &wire.StreamFrame{
-					Offset: 50,
-					Data:   []byte("foobar"),
-				}
-				err = s.Push(f2)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(s.Push([]byte("test"), 100, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 50, false)).To(Succeed())
 				Expect(s.queue).To(HaveLen(2))
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 50},
@@ -271,12 +165,9 @@ var _ = Describe("STREAM frame sorter", func() {
 			Context("Overlapping Stream Data detection", func() {
 				// create gaps: 0-5, 10-15, 20-25, 30-inf
 				BeforeEach(func() {
-					err := s.Push(&wire.StreamFrame{Offset: 5, Data: []byte("12345")})
-					Expect(err).ToNot(HaveOccurred())
-					err = s.Push(&wire.StreamFrame{Offset: 15, Data: []byte("12345")})
-					Expect(err).ToNot(HaveOccurred())
-					err = s.Push(&wire.StreamFrame{Offset: 25, Data: []byte("12345")})
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("12345"), 5, false)).To(Succeed())
+					Expect(s.Push([]byte("12345"), 15, false)).To(Succeed())
+					Expect(s.Push([]byte("12345"), 25, false)).To(Succeed())
 					checkGaps([]utils.ByteInterval{
 						{Start: 0, End: 5},
 						{Start: 10, End: 15},
@@ -286,12 +177,7 @@ var _ = Describe("STREAM frame sorter", func() {
 				})
 
 				It("cuts a frame with offset 0 that overlaps at the end", func() {
-					f := &wire.StreamFrame{
-						Offset: 0,
-						Data:   []byte("foobar"),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(0)))
 					Expect(s.queue[0]).To(Equal([]byte("fooba")))
 					Expect(s.queue[0]).To(HaveCap(5))
@@ -304,12 +190,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that overlaps at the end", func() {
 					// 4 to 7
-					f := &wire.StreamFrame{
-						Offset: 4,
-						Data:   []byte("foo"),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("foo"), 4, false)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(4)))
 					Expect(s.queue[4]).To(Equal([]byte("f")))
 					Expect(s.queue[4]).To(HaveCap(1))
@@ -323,12 +204,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that completely fills a gap, but overlaps at the end", func() {
 					// 10 to 16
-					f := &wire.StreamFrame{
-						Offset: 10,
-						Data:   []byte("foobar"),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("foobar"), 10, false)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(10)))
 					Expect(s.queue[10]).To(Equal([]byte("fooba")))
 					Expect(s.queue[10]).To(HaveCap(5))
@@ -341,12 +217,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that overlaps at the beginning", func() {
 					// 8 to 14
-					f := &wire.StreamFrame{
-						Offset: 8,
-						Data:   []byte("foobar"),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("foobar"), 8, false)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(8)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(10)))
 					Expect(s.queue[10]).To(Equal([]byte("obar")))
@@ -361,12 +232,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that overlaps at the beginning and at the end, starting in a gap", func() {
 					// 2 to 12
-					f := &wire.StreamFrame{
-						Offset: 2,
-						Data:   []byte("1234567890"),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("1234567890"), 2, false)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(2)))
 					Expect(s.queue[2]).To(Equal([]byte("1234567890")))
@@ -380,12 +246,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that overlaps at the beginning and at the end, starting in a gap, ending in data", func() {
 					// 2 to 17
-					f := &wire.StreamFrame{
-						Offset: 2,
-						Data:   []byte("123456789012345"),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("123456789012345"), 2, false)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(2)))
 					Expect(s.queue[2]).To(Equal([]byte("1234567890123")))
@@ -399,12 +260,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that overlaps at the beginning and at the end, starting in a gap, ending in data", func() {
 					// 5 to 22
-					f := &wire.StreamFrame{
-						Offset: 5,
-						Data:   []byte("12345678901234567"),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("12345678901234567"), 5, false)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(15)))
 					Expect(s.queue[10]).To(Equal([]byte("678901234567")))
@@ -417,12 +273,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that closes multiple gaps", func() {
 					// 2 to 27
-					f := &wire.StreamFrame{
-						Offset: 2,
-						Data:   bytes.Repeat([]byte{'e'}, 25),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push(bytes.Repeat([]byte{'e'}, 25), 2, false)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(15)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(25)))
@@ -437,12 +288,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that closes multiple gaps", func() {
 					// 5 to 27
-					f := &wire.StreamFrame{
-						Offset: 5,
-						Data:   bytes.Repeat([]byte{'d'}, 22),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push(bytes.Repeat([]byte{'d'}, 22), 5, false)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(15)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(25)))
@@ -456,17 +302,13 @@ var _ = Describe("STREAM frame sorter", func() {
 				})
 
 				It("processes a frame that covers multiple gaps and ends at the end of a gap", func() {
+					data := bytes.Repeat([]byte{'e'}, 14)
 					// 1 to 15
-					f := &wire.StreamFrame{
-						Offset: 1,
-						Data:   bytes.Repeat([]byte{'f'}, 14),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push(data, 1, false)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(1)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(15)))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(5)))
-					Expect(s.queue[1]).To(Equal(f.Data))
+					Expect(s.queue[1]).To(Equal(data))
 					checkGaps([]utils.ByteInterval{
 						{Start: 0, End: 1},
 						{Start: 20, End: 25},
@@ -475,16 +317,12 @@ var _ = Describe("STREAM frame sorter", func() {
 				})
 
 				It("processes a frame that closes all gaps (except for the last one)", func() {
+					data := bytes.Repeat([]byte{'f'}, 32)
 					// 0 to 32
-					f := &wire.StreamFrame{
-						Offset: 0,
-						Data:   bytes.Repeat([]byte{'f'}, 32),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push(data, 0, false)).To(Succeed())
 					Expect(s.queue).To(HaveLen(1))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(0)))
-					Expect(s.queue[0]).To(Equal(f.Data))
+					Expect(s.queue[0]).To(Equal(data))
 					checkGaps([]utils.ByteInterval{
 						{Start: 32, End: protocol.MaxByteCount},
 					})
@@ -492,12 +330,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that overlaps at the beginning and at the end, starting in data already received", func() {
 					// 8 to 17
-					f := &wire.StreamFrame{
-						Offset: 8,
-						Data:   []byte("123456789"),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("123456789"), 8, false)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(8)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(10)))
 					Expect(s.queue[10]).To(Equal([]byte("34567")))
@@ -511,12 +344,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that completely covers two gaps", func() {
 					// 10 to 20
-					f := &wire.StreamFrame{
-						Offset: 10,
-						Data:   []byte("1234567890"),
-					}
-					err := s.Push(f)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("1234567890"), 10, false)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(10)))
 					Expect(s.queue[10]).To(Equal([]byte("12345")))
 					Expect(s.queue[10]).To(HaveCap(5))
@@ -536,10 +364,8 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				BeforeEach(func() {
 					// create gaps: 5-10, 15-inf
-					err := s.Push(&wire.StreamFrame{Offset: 0, Data: []byte("12345")})
-					Expect(err).ToNot(HaveOccurred())
-					err = s.Push(&wire.StreamFrame{Offset: 10, Data: []byte("12345")})
-					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Push([]byte("12345"), 0, false)).To(Succeed())
+					Expect(s.Push([]byte("12345"), 10, false)).To(Succeed())
 					checkGaps(expectedGaps)
 				})
 
@@ -549,21 +375,21 @@ var _ = Describe("STREAM frame sorter", func() {
 				})
 
 				It("does not modify data when receiving a duplicate", func() {
-					err := s.Push(&wire.StreamFrame{Offset: 0, Data: []byte("fffff")})
+					err := s.Push([]byte("fffff"), 0, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[0]).ToNot(Equal([]byte("fffff")))
 				})
 
 				It("detects a duplicate frame that is smaller than the original, starting at the beginning", func() {
 					// 10 to 12
-					err := s.Push(&wire.StreamFrame{Offset: 10, Data: []byte("12")})
+					err := s.Push([]byte("12"), 10, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[10]).To(HaveLen(5))
 				})
 
 				It("detects a duplicate frame that is smaller than the original, somewhere in the middle", func() {
 					// 1 to 4
-					err := s.Push(&wire.StreamFrame{Offset: 1, Data: []byte("123")})
+					err := s.Push([]byte("123"), 1, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[0]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(1)))
@@ -571,15 +397,15 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("detects a duplicate frame that is smaller than the original, somewhere in the middle in the last block", func() {
 					// 11 to 14
-					err := s.Push(&wire.StreamFrame{Offset: 11, Data: []byte("123")})
+					err := s.Push([]byte("123"), 11, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[10]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(11)))
 				})
 
 				It("detects a duplicate frame that is smaller than the original, with aligned end in the last block", func() {
-					// 11 to 14
-					err := s.Push(&wire.StreamFrame{Offset: 11, Data: []byte("1234")})
+					// 11 to 15
+					err := s.Push([]byte("1234"), 1, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[10]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(11)))
@@ -587,7 +413,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("detects a duplicate frame that is smaller than the original, with aligned end", func() {
 					// 3 to 5
-					err := s.Push(&wire.StreamFrame{Offset: 3, Data: []byte("12")})
+					err := s.Push([]byte("12"), 3, false)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[0]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(3)))
@@ -597,19 +423,10 @@ var _ = Describe("STREAM frame sorter", func() {
 			Context("DoS protection", func() {
 				It("errors when too many gaps are created", func() {
 					for i := 0; i < protocol.MaxStreamFrameSorterGaps; i++ {
-						f := &wire.StreamFrame{
-							Data:   []byte("foobar"),
-							Offset: protocol.ByteCount(i * 7),
-						}
-						err := s.Push(f)
-						Expect(err).ToNot(HaveOccurred())
+						Expect(s.Push([]byte("foobar"), protocol.ByteCount(i*7), false)).To(Succeed())
 					}
 					Expect(s.gaps.Len()).To(Equal(protocol.MaxStreamFrameSorterGaps))
-					f := &wire.StreamFrame{
-						Data:   []byte("foobar"),
-						Offset: protocol.ByteCount(protocol.MaxStreamFrameSorterGaps*7) + 100,
-					}
-					err := s.Push(f)
+					err := s.Push([]byte("foobar"), protocol.ByteCount(protocol.MaxStreamFrameSorterGaps*7)+100, false)
 					Expect(err).To(MatchError(errTooManyGapsInReceivedStreamData))
 				})
 			})


### PR DESCRIPTION
Superseds #1494.

In the `streamFrameSorter`, we used to store the `wire.StreamFrame` directly.
Since we'll need to sort CRYPTO frames as well, this PR changes the sorter such that we're storing the data as `[]byte` directly, allowing us to use it for STREAM and CRYPTO frames without any hacks.