### PR TITLE
drop support for gQUIC 42

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.0 (unreleased)
+
+- Drop support for QUIC 42.
+
 ## v0.9.0 (2018-08-15)
 
 - Add a `quic.Config` option for the length of the connection ID (for IETF QUIC).

--- a/interface.go
+++ b/interface.go
@@ -19,8 +19,6 @@ type VersionNumber = protocol.VersionNumber
 const (
 	// VersionGQUIC39 is gQUIC version 39.
 	VersionGQUIC39 = protocol.Version39
-	// VersionGQUIC42 is gQUIC version 42.
-	VersionGQUIC42 = protocol.Version42
 	// VersionGQUIC43 is gQUIC version 43.
 	VersionGQUIC43 = protocol.Version43
 )

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -19,7 +19,6 @@ const (
 // The version numbers, making grepping easier
 const (
 	Version39       VersionNumber = gquicVersion0 + 3*0x100 + 0x9
-	Version42       VersionNumber = gquicVersion0 + 4*0x100 + 0x2
 	Version43       VersionNumber = gquicVersion0 + 4*0x100 + 0x3
 	VersionTLS      VersionNumber = 101
 	VersionWhatever VersionNumber = 0 // for when the version doesn't matter
@@ -30,7 +29,6 @@ const (
 // must be in sorted descending order
 var SupportedVersions = []VersionNumber{
 	Version43,
-	Version42,
 	Version39,
 }
 

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -13,13 +13,11 @@ var _ = Describe("Version", func() {
 	// version numbers taken from the wiki: https://github.com/quicwg/base-drafts/wiki/QUIC-Versions
 	It("has the right gQUIC version number", func() {
 		Expect(Version39).To(BeEquivalentTo(0x51303339))
-		Expect(Version42).To(BeEquivalentTo(0x51303432))
 		Expect(Version43).To(BeEquivalentTo(0x51303433))
 	})
 
 	It("says if a version is valid", func() {
 		Expect(IsValidVersion(Version39)).To(BeTrue())
-		Expect(IsValidVersion(Version42)).To(BeTrue())
 		Expect(IsValidVersion(Version43)).To(BeTrue())
 		Expect(IsValidVersion(VersionTLS)).To(BeTrue())
 		Expect(IsValidVersion(VersionWhatever)).To(BeFalse())
@@ -29,14 +27,12 @@ var _ = Describe("Version", func() {
 
 	It("says if a version supports TLS", func() {
 		Expect(Version39.UsesTLS()).To(BeFalse())
-		Expect(Version42.UsesTLS()).To(BeFalse())
 		Expect(Version43.UsesTLS()).To(BeFalse())
 		Expect(VersionTLS.UsesTLS()).To(BeTrue())
 	})
 
 	It("versions don't have reserved version numbers", func() {
 		Expect(isReservedVersion(Version39)).To(BeFalse())
-		Expect(isReservedVersion(Version42)).To(BeFalse())
 		Expect(isReservedVersion(Version43)).To(BeFalse())
 		Expect(isReservedVersion(VersionTLS)).To(BeFalse())
 	})
@@ -56,7 +52,6 @@ var _ = Describe("Version", func() {
 
 	It("has the right representation for the H2 Alt-Svc tag", func() {
 		Expect(Version39.ToAltSvc()).To(Equal("39"))
-		Expect(Version42.ToAltSvc()).To(Equal("42"))
 		Expect(Version43.ToAltSvc()).To(Equal("43"))
 		Expect(VersionTLS.ToAltSvc()).To(Equal("101"))
 		// check with unsupported version numbers from the wiki
@@ -67,41 +62,36 @@ var _ = Describe("Version", func() {
 
 	It("tells the Stream ID of the crypto stream", func() {
 		Expect(Version39.CryptoStreamID()).To(Equal(StreamID(1)))
-		Expect(Version42.CryptoStreamID()).To(Equal(StreamID(1)))
 		Expect(Version43.CryptoStreamID()).To(Equal(StreamID(1)))
 		Expect(VersionTLS.CryptoStreamID()).To(Equal(StreamID(0)))
 	})
 
 	It("tells if a version uses the IETF frame types", func() {
 		Expect(Version39.UsesIETFFrameFormat()).To(BeFalse())
-		Expect(Version42.UsesIETFFrameFormat()).To(BeFalse())
 		Expect(Version43.UsesIETFFrameFormat()).To(BeFalse())
 		Expect(VersionTLS.UsesIETFFrameFormat()).To(BeTrue())
 	})
 
 	It("tells if a version uses varint packet numbers", func() {
 		Expect(Version39.UsesVarintPacketNumbers()).To(BeFalse())
-		Expect(Version42.UsesVarintPacketNumbers()).To(BeFalse())
 		Expect(Version43.UsesVarintPacketNumbers()).To(BeFalse())
 		Expect(VersionTLS.UsesVarintPacketNumbers()).To(BeTrue())
 	})
 
 	It("tells if a version uses the IETF frame types", func() {
 		Expect(Version39.UsesIETFFrameFormat()).To(BeFalse())
-		Expect(Version42.UsesIETFFrameFormat()).To(BeFalse())
 		Expect(Version43.UsesIETFFrameFormat()).To(BeFalse())
 		Expect(VersionTLS.UsesIETFFrameFormat()).To(BeTrue())
 	})
 
 	It("tells if a version uses STOP_WAITING frames", func() {
 		Expect(Version39.UsesStopWaitingFrames()).To(BeTrue())
-		Expect(Version42.UsesStopWaitingFrames()).To(BeTrue())
 		Expect(Version43.UsesStopWaitingFrames()).To(BeTrue())
 		Expect(VersionTLS.UsesStopWaitingFrames()).To(BeFalse())
 	})
 
 	It("says if a stream contributes to connection-level flowcontrol, for gQUIC", func() {
-		for _, v := range []VersionNumber{Version39, Version42, Version43} {
+		for _, v := range []VersionNumber{Version39, Version43} {
 			version := v
 			Expect(version.StreamContributesToConnectionFlowControl(1)).To(BeFalse())
 			Expect(version.StreamContributesToConnectionFlowControl(2)).To(BeTrue())


### PR DESCRIPTION
gQUIC 42 was never rolled out, and the current Chromium code [doesn't support it anymore](https://cs.chromium.org/chromium/src/net/third_party/quic/core/quic_versions.h?q=quic_version_43&sq=package:chromium&dr=CSs&l=23-40).