### PR TITLE
activate gQUIC 44 in the Chrome integration tests

### DIFF
--- a/integrationtests/chrome/chrome_test.go
+++ b/integrationtests/chrome/chrome_test.go
@@ -13,11 +13,6 @@ var _ = Describe("Chrome tests", func() {
 	for i := range protocol.SupportedVersions {
 		version := protocol.SupportedVersions[i]
 
-		// TODO: activate Chrome integration tests with gQUIC 44
-		if version == protocol.Version44 {
-			continue
-		}
-
 		Context(fmt.Sprintf("with version %s", version), func() {
 			JustBeforeEach(func() {
 				testserver.StartQuicServer([]protocol.VersionNumber{version})


### PR DESCRIPTION
Fixes #1505.

Chrome Stable was just updated to version 69, which now supports gQUIC 44.