### PR TITLE
add quic.clemente.io to the AppVeyor hosts file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ environment:
     - GOARCH: 386
     - GOARCH: amd64
 
+hosts:
+  quic.clemente.io: 127.0.0.1
+
 clone_folder: c:\gopath\src\github.com\lucas-clemente\quic-go
 
 install:


### PR DESCRIPTION
This should reduce the flakiness of AppVeyor, hopefully.