### PR TITLE
simplify `x = x <op> ...` to `x <op>= ...`

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -633,7 +633,7 @@ func (h *sentPacketHandler) computeRTOTimeout() time.Duration {
 	}
 	rto = utils.MaxDuration(rto, minRTOTimeout)
 	// Exponential backoff
-	rto = rto << h.rtoCount
+	rto <<= h.rtoCount
 	return utils.MinDuration(rto, maxRTOTimeout)
 }
 

--- a/internal/congestion/cubic_sender.go
+++ b/internal/congestion/cubic_sender.go
@@ -193,7 +193,7 @@ func (c *cubicSender) OnPacketLost(
 		if c.congestionWindow >= 2*c.initialCongestionWindow {
 			c.minSlowStartExitWindow = c.congestionWindow / 2
 		}
-		c.congestionWindow = c.congestionWindow - protocol.DefaultTCPMSS
+		c.congestionWindow -= protocol.DefaultTCPMSS
 	} else if c.reno {
 		c.congestionWindow = protocol.ByteCount(float32(c.congestionWindow) * c.RenoBeta())
 	} else {


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#assignOp-ref