### PR TITLE
close the TLS crypto setup when the session closes

### DIFF
--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -2,6 +2,7 @@ package handshake
 
 import (
 	"crypto/x509"
+	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/marten-seemann/qtls"
@@ -44,6 +45,7 @@ type CryptoSetup interface {
 type CryptoSetupTLS interface {
 	baseCryptoSetup
 
+	io.Closer
 	HandleMessage([]byte, protocol.EncryptionLevel) bool
 	OpenInitial(dst, src []byte, pn protocol.PacketNumber, ad []byte) ([]byte, error)
 	OpenHandshake(dst, src []byte, pn protocol.PacketNumber, ad []byte) ([]byte, error)

--- a/session.go
+++ b/session.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"sync"
 	"time"
@@ -603,6 +604,9 @@ runLoop:
 	}
 	s.logger.Infof("Connection %s closed.", s.srcConnID)
 	s.sessionRunner.removeConnectionID(s.srcConnID)
+	if s.version.UsesTLS() {
+		s.cryptoStreamHandler.(io.Closer).Close()
+	}
 	return closeErr.err
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -1638,6 +1638,7 @@ var _ = Describe("Client Session", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 		// make sure the go routine returns
+		sess.version = protocol.Version39
 		packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)
 		sessionRunner.EXPECT().removeConnectionID(gomock.Any())
 		Expect(sess.Close()).To(Succeed())


### PR DESCRIPTION
Should be merged after #1556.

We need to make sure that the go routine running `qtls.Handshake()` returns if the session is closed during the handshake.