### PR TITLE
implement changes to the CONNECTION_CLOSE frame

### DIFF
--- a/internal/wire/connection_close_frame.go
+++ b/internal/wire/connection_close_frame.go
@@ -2,39 +2,44 @@ package wire
 
 import (
 	"bytes"
-	"errors"
 	"io"
-	"math"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/qerr"
 )
 
-// A ConnectionCloseFrame in QUIC
+// A ConnectionCloseFrame is a CONNECTION_CLOSE frame
 type ConnectionCloseFrame struct {
-	ErrorCode    qerr.ErrorCode
-	ReasonPhrase string
+	IsApplicationError bool
+	ErrorCode          qerr.ErrorCode
+	ReasonPhrase       string
 }
 
 // parseConnectionCloseFrame reads a CONNECTION_CLOSE frame
 func parseConnectionCloseFrame(r *bytes.Reader, version protocol.VersionNumber) (*ConnectionCloseFrame, error) {
-	if _, err := r.ReadByte(); err != nil { // read the TypeByte
+	typeByte, err := r.ReadByte()
+	if err != nil {
 		return nil, err
 	}
 
-	var errorCode qerr.ErrorCode
-	var reasonPhraseLen uint64
+	f := &ConnectionCloseFrame{IsApplicationError: typeByte == 0x03}
 	ec, err := utils.BigEndian.ReadUint16(r)
 	if err != nil {
 		return nil, err
 	}
-	errorCode = qerr.ErrorCode(ec)
+	f.ErrorCode = qerr.ErrorCode(ec)
+	// read the Frame Type, if this is not an application error
+	if !f.IsApplicationError {
+		if _, err := utils.ReadVarInt(r); err != nil {
+			return nil, err
+		}
+	}
+	var reasonPhraseLen uint64
 	reasonPhraseLen, err = utils.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
-
 	// shortcut to prevent the unnecessary allocation of dataLen bytes
 	// if the dataLen is larger than the remaining length of the packet
 	// reading the whole reason phrase would result in EOF when attempting to READ
@@ -47,29 +52,32 @@ func parseConnectionCloseFrame(r *bytes.Reader, version protocol.VersionNumber) 
 		// this should never happen, since we already checked the reasonPhraseLen earlier
 		return nil, err
 	}
-
-	return &ConnectionCloseFrame{
-		ErrorCode:    errorCode,
-		ReasonPhrase: string(reasonPhrase),
-	}, nil
+	f.ReasonPhrase = string(reasonPhrase)
+	return f, nil
 }
 
 // Length of a written frame
 func (f *ConnectionCloseFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + 2 + utils.VarIntLen(uint64(len(f.ReasonPhrase))) + protocol.ByteCount(len(f.ReasonPhrase))
+	length := 1 + 2 + utils.VarIntLen(uint64(len(f.ReasonPhrase))) + protocol.ByteCount(len(f.ReasonPhrase))
+	if !f.IsApplicationError {
+		length++ // for the frame type
+	}
+	return length
 }
 
 // Write writes an CONNECTION_CLOSE frame.
 func (f *ConnectionCloseFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
-	b.WriteByte(0x02)
-
-	if len(f.ReasonPhrase) > math.MaxUint16 {
-		return errors.New("ConnectionFrame: ReasonPhrase too long")
+	if f.IsApplicationError {
+		b.WriteByte(0x03)
+	} else {
+		b.WriteByte(0x02)
 	}
 
 	utils.BigEndian.WriteUint16(b, uint16(f.ErrorCode))
+	if !f.IsApplicationError {
+		utils.WriteVarInt(b, 0)
+	}
 	utils.WriteVarInt(b, uint64(len(f.ReasonPhrase)))
 	b.WriteString(f.ReasonPhrase)
-
 	return nil
 }

--- a/internal/wire/frame_parser.go
+++ b/internal/wire/frame_parser.go
@@ -40,7 +40,7 @@ func parseFrame(r *bytes.Reader, typeByte byte, v protocol.VersionNumber) (Frame
 		if err != nil {
 			err = qerr.Error(qerr.InvalidRstStreamData, err.Error())
 		}
-	case 0x2:
+	case 0x2, 0x3:
 		frame, err = parseConnectionCloseFrame(r, v)
 		if err != nil {
 			err = qerr.Error(qerr.InvalidConnectionCloseData, err.Error())

--- a/internal/wire/frame_parser_test.go
+++ b/internal/wire/frame_parser_test.go
@@ -51,8 +51,20 @@ var _ = Describe("Frame parsing", func() {
 		Expect(frame).To(Equal(f))
 	})
 
-	It("unpacks CONNECTION_CLOSE frames", func() {
+	It("unpacks CONNECTION_CLOSE frames containing QUIC error codes", func() {
 		f := &ConnectionCloseFrame{ReasonPhrase: "foo"}
+		err := f.Write(buf, versionIETFFrames)
+		Expect(err).ToNot(HaveOccurred())
+		frame, err := ParseNextFrame(bytes.NewReader(buf.Bytes()), nil, versionIETFFrames)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(frame).To(Equal(f))
+	})
+
+	It("unpacks CONNECTION_CLOSE frames containing application error codes", func() {
+		f := &ConnectionCloseFrame{
+			IsApplicationError: true,
+			ReasonPhrase:       "foo",
+		}
 		err := f.Write(buf, versionIETFFrames)
 		Expect(err).ToNot(HaveOccurred())
 		frame, err := ParseNextFrame(bytes.NewReader(buf.Bytes()), nil, versionIETFFrames)

--- a/qerr/quic_error.go
+++ b/qerr/quic_error.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ErrorCode can be used as a normal error without reason.
-type ErrorCode uint32
+type ErrorCode uint16
 
 func (e ErrorCode) Error() string {
 	return e.String()


### PR DESCRIPTION
Fixes #1564.
We're not yet sending application error codes. This will require some refactoring of our error codes (which is a mess anyway), see #1567.