### PR TITLE
remove the error return value from wire.Header.GetLength()

### DIFF
--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -86,21 +86,18 @@ func (h *Header) writeShortHeader(b *bytes.Buffer, v protocol.VersionNumber) err
 }
 
 // GetLength determines the length of the Header.
-func (h *Header) GetLength(v protocol.VersionNumber) (protocol.ByteCount, error) {
+func (h *Header) GetLength(v protocol.VersionNumber) protocol.ByteCount {
 	if h.IsLongHeader {
 		length := 1 /* type byte */ + 4 /* version */ + 1 /* conn id len byte */ + protocol.ByteCount(h.DestConnectionID.Len()+h.SrcConnectionID.Len()) + protocol.ByteCount(h.PacketNumberLen) + utils.VarIntLen(uint64(h.PayloadLen))
 		if h.Type == protocol.PacketTypeInitial {
 			length += utils.VarIntLen(uint64(len(h.Token))) + protocol.ByteCount(len(h.Token))
 		}
-		return length, nil
+		return length
 	}
 
 	length := protocol.ByteCount(1 /* type byte */ + h.DestConnectionID.Len())
-	if h.PacketNumberLen != protocol.PacketNumberLen1 && h.PacketNumberLen != protocol.PacketNumberLen2 && h.PacketNumberLen != protocol.PacketNumberLen4 {
-		return 0, fmt.Errorf("invalid packet number length: %d", h.PacketNumberLen)
-	}
 	length += protocol.ByteCount(h.PacketNumberLen)
-	return length, nil
+	return length
 }
 
 // Log logs the Header

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -317,13 +317,6 @@ var _ = Describe("Header", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(buf.Len()).To(Equal(5))
 		})
-
-		It("errors when given an invalid packet number length", func() {
-			h := &Header{PacketNumberLen: 5}
-			_, err := h.GetLength(versionIETFHeader)
-			Expect(err).To(MatchError("invalid packet number length: 5"))
-		})
-
 	})
 
 	Context("Logging", func() {

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -193,11 +193,8 @@ func (p *packetPacker) PackRetransmission(packet *ackhandler.Packet) ([]*packedP
 		var length protocol.ByteCount
 
 		header := p.getHeader(encLevel)
-		headerLength, err := header.GetLength(p.version)
-		if err != nil {
-			return nil, err
-		}
-		maxSize := p.maxPacketSize - protocol.ByteCount(sealer.Overhead()) - headerLength
+		headerLen := header.GetLength(p.version)
+		maxSize := p.maxPacketSize - protocol.ByteCount(sealer.Overhead()) - headerLen
 
 		for len(controlFrames) > 0 {
 			frame := controlFrames[0]
@@ -283,12 +280,12 @@ func (p *packetPacker) PackPacket() (*packedPacket, error) {
 
 	encLevel, sealer := p.cryptoSetup.GetSealer()
 	header := p.getHeader(encLevel)
-	headerLength, err := header.GetLength(p.version)
+	headerLen := header.GetLength(p.version)
 	if err != nil {
 		return nil, err
 	}
 
-	maxSize := p.maxPacketSize - protocol.ByteCount(sealer.Overhead()) - headerLength
+	maxSize := p.maxPacketSize - protocol.ByteCount(sealer.Overhead()) - headerLen
 	frames, err := p.composeNextPacket(maxSize, p.canSendData(encLevel))
 	if err != nil {
 		return nil, err
@@ -336,7 +333,7 @@ func (p *packetPacker) maybePackCryptoPacket() (*packedPacket, error) {
 		return nil, nil
 	}
 	hdr := p.getHeader(encLevel)
-	hdrLen, _ := hdr.GetLength(p.version)
+	hdrLen := hdr.GetLength(p.version)
 	sealer, err := p.cryptoSetup.GetSealerWithEncryptionLevel(encLevel)
 	if err != nil {
 		return nil, err
@@ -442,7 +439,7 @@ func (p *packetPacker) writeAndSealPacket(
 			header.Token = p.token
 		}
 		if addPadding {
-			headerLen, _ := header.GetLength(p.version)
+			headerLen := header.GetLength(p.version)
 			header.PayloadLen = protocol.ByteCount(protocol.MinInitialPacketSize) - headerLen
 		} else {
 			payloadLen := protocol.ByteCount(sealer.Overhead())


### PR DESCRIPTION
Using an invalid packet number length would error on `Header.Write()`, so it's not necessary to check this on `GetLength()`.