### PR TITLE
immediately remove sessions that were closed remotely

### DIFF
--- a/client.go
+++ b/client.go
@@ -407,6 +407,7 @@ func (c *client) createNewTLSSession(version protocol.VersionNumber) error {
 	runner := &runner{
 		onHandshakeCompleteImpl: func(_ Session) { close(c.handshakeChan) },
 		retireConnectionIDImpl:  c.packetHandlers.Retire,
+		removeConnectionIDImpl:  c.packetHandlers.Remove,
 	}
 	sess, err := newClientSession(
 		c.conn,

--- a/client.go
+++ b/client.go
@@ -406,7 +406,7 @@ func (c *client) createNewTLSSession(version protocol.VersionNumber) error {
 	defer c.mutex.Unlock()
 	runner := &runner{
 		onHandshakeCompleteImpl: func(_ Session) { close(c.handshakeChan) },
-		removeConnectionIDImpl:  c.packetHandlers.Remove,
+		retireConnectionIDImpl:  c.packetHandlers.Retire,
 	}
 	sess, err := newClientSession(
 		c.conn,

--- a/client_test.go
+++ b/client_test.go
@@ -311,7 +311,7 @@ var _ = Describe("Client", func() {
 		It("removes closed sessions from the multiplexer", func() {
 			manager := NewMockPacketHandlerManager(mockCtrl)
 			manager.EXPECT().Add(connID, gomock.Any())
-			manager.EXPECT().Remove(connID)
+			manager.EXPECT().Retire(connID)
 			mockMultiplexer.EXPECT().AddConn(packetConn, gomock.Any()).Return(manager, nil)
 
 			var runner sessionRunner
@@ -334,7 +334,7 @@ var _ = Describe("Client", func() {
 				return sess, nil
 			}
 			sess.EXPECT().run().Do(func() {
-				runner.removeConnectionID(connID)
+				runner.retireConnectionID(connID)
 			})
 
 			_, err := DialContext(

--- a/internal/protocol/server_parameters.go
+++ b/internal/protocol/server_parameters.go
@@ -96,7 +96,7 @@ const DefaultHandshakeTimeout = 10 * time.Second
 
 // RetiredConnectionIDDeleteTimeout is the time we keep closed sessions around in order to retransmit the CONNECTION_CLOSE.
 // after this time all information about the old connection will be deleted
-const RetiredConnectionIDDeleteTimeout = time.Minute
+const RetiredConnectionIDDeleteTimeout = 5 * time.Second
 
 // MinStreamFrameSize is the minimum size that has to be left in a packet, so that we add another STREAM frame.
 // This avoids splitting up STREAM frames into small pieces, which has 2 advantages:

--- a/internal/protocol/server_parameters.go
+++ b/internal/protocol/server_parameters.go
@@ -94,9 +94,9 @@ const DefaultIdleTimeout = 30 * time.Second
 // DefaultHandshakeTimeout is the default timeout for a connection until the crypto handshake succeeds.
 const DefaultHandshakeTimeout = 10 * time.Second
 
-// ClosedSessionDeleteTimeout the server ignores packets arriving on a connection that is already closed
+// RetiredConnectionIDDeleteTimeout is the time we keep closed sessions around in order to retransmit the CONNECTION_CLOSE.
 // after this time all information about the old connection will be deleted
-const ClosedSessionDeleteTimeout = time.Minute
+const RetiredConnectionIDDeleteTimeout = time.Minute
 
 // MinStreamFrameSize is the minimum size that has to be left in a packet, so that we add another STREAM frame.
 // This avoids splitting up STREAM frames into small pieces, which has 2 advantages:

--- a/mock_packet_handler_manager_test.go
+++ b/mock_packet_handler_manager_test.go
@@ -54,14 +54,14 @@ func (mr *MockPacketHandlerManagerMockRecorder) CloseServer() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseServer", reflect.TypeOf((*MockPacketHandlerManager)(nil).CloseServer))
 }
 
-// Remove mocks base method
-func (m *MockPacketHandlerManager) Remove(arg0 protocol.ConnectionID) {
-	m.ctrl.Call(m, "Remove", arg0)
+// Retire mocks base method
+func (m *MockPacketHandlerManager) Retire(arg0 protocol.ConnectionID) {
+	m.ctrl.Call(m, "Retire", arg0)
 }
 
-// Remove indicates an expected call of Remove
-func (mr *MockPacketHandlerManagerMockRecorder) Remove(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockPacketHandlerManager)(nil).Remove), arg0)
+// Retire indicates an expected call of Retire
+func (mr *MockPacketHandlerManagerMockRecorder) Retire(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Retire", reflect.TypeOf((*MockPacketHandlerManager)(nil).Retire), arg0)
 }
 
 // SetServer mocks base method

--- a/mock_packet_handler_manager_test.go
+++ b/mock_packet_handler_manager_test.go
@@ -54,6 +54,16 @@ func (mr *MockPacketHandlerManagerMockRecorder) CloseServer() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseServer", reflect.TypeOf((*MockPacketHandlerManager)(nil).CloseServer))
 }
 
+// Remove mocks base method
+func (m *MockPacketHandlerManager) Remove(arg0 protocol.ConnectionID) {
+	m.ctrl.Call(m, "Remove", arg0)
+}
+
+// Remove indicates an expected call of Remove
+func (mr *MockPacketHandlerManagerMockRecorder) Remove(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockPacketHandlerManager)(nil).Remove), arg0)
+}
+
 // Retire mocks base method
 func (m *MockPacketHandlerManager) Retire(arg0 protocol.ConnectionID) {
 	m.ctrl.Call(m, "Retire", arg0)

--- a/mock_session_runner_test.go
+++ b/mock_session_runner_test.go
@@ -44,12 +44,12 @@ func (mr *MockSessionRunnerMockRecorder) onHandshakeComplete(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "onHandshakeComplete", reflect.TypeOf((*MockSessionRunner)(nil).onHandshakeComplete), arg0)
 }
 
-// removeConnectionID mocks base method
-func (m *MockSessionRunner) removeConnectionID(arg0 protocol.ConnectionID) {
-	m.ctrl.Call(m, "removeConnectionID", arg0)
+// retireConnectionID mocks base method
+func (m *MockSessionRunner) retireConnectionID(arg0 protocol.ConnectionID) {
+	m.ctrl.Call(m, "retireConnectionID", arg0)
 }
 
-// removeConnectionID indicates an expected call of removeConnectionID
-func (mr *MockSessionRunnerMockRecorder) removeConnectionID(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "removeConnectionID", reflect.TypeOf((*MockSessionRunner)(nil).removeConnectionID), arg0)
+// retireConnectionID indicates an expected call of retireConnectionID
+func (mr *MockSessionRunnerMockRecorder) retireConnectionID(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "retireConnectionID", reflect.TypeOf((*MockSessionRunner)(nil).retireConnectionID), arg0)
 }

--- a/mock_session_runner_test.go
+++ b/mock_session_runner_test.go
@@ -44,6 +44,16 @@ func (mr *MockSessionRunnerMockRecorder) onHandshakeComplete(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "onHandshakeComplete", reflect.TypeOf((*MockSessionRunner)(nil).onHandshakeComplete), arg0)
 }
 
+// removeConnectionID mocks base method
+func (m *MockSessionRunner) removeConnectionID(arg0 protocol.ConnectionID) {
+	m.ctrl.Call(m, "removeConnectionID", arg0)
+}
+
+// removeConnectionID indicates an expected call of removeConnectionID
+func (mr *MockSessionRunnerMockRecorder) removeConnectionID(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "removeConnectionID", reflect.TypeOf((*MockSessionRunner)(nil).removeConnectionID), arg0)
+}
+
 // retireConnectionID mocks base method
 func (m *MockSessionRunner) retireConnectionID(arg0 protocol.ConnectionID) {
 	m.ctrl.Call(m, "retireConnectionID", arg0)

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -26,7 +26,7 @@ type packetHandlerMap struct {
 	server   unknownPacketHandler
 	closed   bool
 
-	deleteClosedSessionsAfter time.Duration
+	deleteRetiredSessionsAfter time.Duration
 
 	logger utils.Logger
 }
@@ -35,11 +35,11 @@ var _ packetHandlerManager = &packetHandlerMap{}
 
 func newPacketHandlerMap(conn net.PacketConn, connIDLen int, logger utils.Logger) packetHandlerManager {
 	m := &packetHandlerMap{
-		conn:                      conn,
-		connIDLen:                 connIDLen,
-		handlers:                  make(map[string]packetHandler),
-		deleteClosedSessionsAfter: protocol.ClosedSessionDeleteTimeout,
-		logger:                    logger,
+		conn:                       conn,
+		connIDLen:                  connIDLen,
+		handlers:                   make(map[string]packetHandler),
+		deleteRetiredSessionsAfter: protocol.RetiredConnectionIDDeleteTimeout,
+		logger:                     logger,
 	}
 	go m.listen()
 	return m
@@ -56,7 +56,7 @@ func (h *packetHandlerMap) Retire(id protocol.ConnectionID) {
 }
 
 func (h *packetHandlerMap) retireByConnectionIDAsString(id string) {
-	time.AfterFunc(h.deleteClosedSessionsAfter, func() {
+	time.AfterFunc(h.deleteRetiredSessionsAfter, func() {
 		h.mutex.Lock()
 		delete(h.handlers, id)
 		h.mutex.Unlock()

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -51,11 +51,11 @@ func (h *packetHandlerMap) Add(id protocol.ConnectionID, handler packetHandler) 
 	h.mutex.Unlock()
 }
 
-func (h *packetHandlerMap) Remove(id protocol.ConnectionID) {
-	h.removeByConnectionIDAsString(string(id))
+func (h *packetHandlerMap) Retire(id protocol.ConnectionID) {
+	h.retireByConnectionIDAsString(string(id))
 }
 
-func (h *packetHandlerMap) removeByConnectionIDAsString(id string) {
+func (h *packetHandlerMap) retireByConnectionIDAsString(id string) {
 	time.AfterFunc(h.deleteClosedSessionsAfter, func() {
 		h.mutex.Lock()
 		delete(h.handlers, id)
@@ -79,7 +79,7 @@ func (h *packetHandlerMap) CloseServer() {
 			go func(id string, handler packetHandler) {
 				// session.Close() blocks until the CONNECTION_CLOSE has been sent and the run-loop has stopped
 				_ = handler.Close()
-				h.removeByConnectionIDAsString(id)
+				h.retireByConnectionIDAsString(id)
 				wg.Done()
 			}(id, handler)
 		}

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -51,6 +51,12 @@ func (h *packetHandlerMap) Add(id protocol.ConnectionID, handler packetHandler) 
 	h.mutex.Unlock()
 }
 
+func (h *packetHandlerMap) Remove(id protocol.ConnectionID) {
+	h.mutex.Lock()
+	delete(h.handlers, string(id))
+	h.mutex.Unlock()
+}
+
 func (h *packetHandlerMap) Retire(id protocol.ConnectionID) {
 	h.retireByConnectionIDAsString(string(id))
 }

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Packet Handler Map", func() {
 			handler.deleteClosedSessionsAfter = 10 * time.Millisecond
 			connID := protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}
 			handler.Add(connID, NewMockPacketHandler(mockCtrl))
-			handler.Remove(connID)
+			handler.Retire(connID)
 			time.Sleep(30 * time.Millisecond)
 			Expect(handler.handlePacket(nil, getPacket(connID))).To(MatchError("received a packet with an unexpected connection ID 0x0102030405060708"))
 		})
@@ -105,7 +105,7 @@ var _ = Describe("Packet Handler Map", func() {
 			packetHandler.EXPECT().GetPerspective().Return(protocol.PerspectiveClient)
 			packetHandler.EXPECT().handlePacket(gomock.Any())
 			handler.Add(connID, packetHandler)
-			handler.Remove(connID)
+			handler.Retire(connID)
 			err := handler.handlePacket(nil, getPacket(connID))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -88,7 +88,15 @@ var _ = Describe("Packet Handler Map", func() {
 			Expect(err.Error()).To(ContainSubstring("error parsing invariant header:"))
 		})
 
-		It("deletes closed session entries after a wait time", func() {
+		It("deletes removed session immediately", func() {
+			handler.deleteRetiredSessionsAfter = time.Hour
+			connID := protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}
+			handler.Add(connID, NewMockPacketHandler(mockCtrl))
+			handler.Remove(connID)
+			Expect(handler.handlePacket(nil, getPacket(connID))).To(MatchError("received a packet with an unexpected connection ID 0x0102030405060708"))
+		})
+
+		It("deletes retired session entries after a wait time", func() {
 			handler.deleteRetiredSessionsAfter = 10 * time.Millisecond
 			connID := protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}
 			handler.Add(connID, NewMockPacketHandler(mockCtrl))

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Packet Handler Map", func() {
 		})
 
 		It("deletes closed session entries after a wait time", func() {
-			handler.deleteClosedSessionsAfter = 10 * time.Millisecond
+			handler.deleteRetiredSessionsAfter = 10 * time.Millisecond
 			connID := protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}
 			handler.Add(connID, NewMockPacketHandler(mockCtrl))
 			handler.Retire(connID)
@@ -98,7 +98,7 @@ var _ = Describe("Packet Handler Map", func() {
 		})
 
 		It("passes packets arriving late for closed sessions to that session", func() {
-			handler.deleteClosedSessionsAfter = time.Hour
+			handler.deleteRetiredSessionsAfter = time.Hour
 			connID := protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}
 			packetHandler := NewMockPacketHandler(mockCtrl)
 			packetHandler.EXPECT().GetVersion().Return(protocol.VersionWhatever)

--- a/session.go
+++ b/session.go
@@ -424,7 +424,7 @@ runLoop:
 	}
 	s.closed.Set(true)
 	s.logger.Infof("Connection %s closed.", s.srcConnID)
-	s.sessionRunner.removeConnectionID(s.srcConnID)
+	s.sessionRunner.retireConnectionID(s.srcConnID)
 	s.cryptoStreamHandler.Close()
 	return closeErr.err
 }

--- a/session_test.go
+++ b/session_test.go
@@ -326,7 +326,7 @@ var _ = Describe("Session", func() {
 		It("handles CONNECTION_CLOSE frames", func() {
 			testErr := qerr.Error(qerr.ProofInvalid, "foobar")
 			streamManager.EXPECT().CloseWithError(testErr)
-			sessionRunner.EXPECT().retireConnectionID(gomock.Any())
+			sessionRunner.EXPECT().removeConnectionID(gomock.Any())
 			cryptoSetup.EXPECT().Close()
 
 			go func() {
@@ -402,7 +402,7 @@ var _ = Describe("Session", func() {
 
 		It("closes the session in order to replace it with another QUIC version", func() {
 			streamManager.EXPECT().CloseWithError(gomock.Any())
-			sessionRunner.EXPECT().retireConnectionID(gomock.Any())
+			sessionRunner.EXPECT().removeConnectionID(gomock.Any())
 			cryptoSetup.EXPECT().Close()
 			sess.destroy(errCloseSessionForNewVersion)
 			Eventually(areSessionsRunning).Should(BeFalse())


### PR DESCRIPTION
Fixes #1597.
Merge after #1601.

We only need to keep sessions that were closed locally, in order to retransmit the CONNECTION_CLOSE packet. For sessions that were closed by the peer, we don't need to wait for any more packets, and there's also no CONNECTION_CLOSE to retransmit. The same applies for sessions that were destroyed when receiving a Version Negotiation or a Retry packet.