### PR TITLE
remove 6 byte packet numbers

### DIFF
--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -24,7 +24,7 @@ var _ = Describe("QUIC Proxy", func() {
 		b := &bytes.Buffer{}
 		hdr := wire.Header{
 			PacketNumber:     p,
-			PacketNumberLen:  protocol.PacketNumberLen6,
+			PacketNumberLen:  protocol.PacketNumberLen4,
 			DestConnectionID: protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0, 0, 0x13, 0x37},
 			SrcConnectionID:  protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0, 0, 0x13, 0x37},
 		}

--- a/internal/protocol/packet_number.go
+++ b/internal/protocol/packet_number.go
@@ -58,8 +58,5 @@ func GetPacketNumberLength(packetNumber PacketNumber) PacketNumberLen {
 	if packetNumber < (1 << (uint8(PacketNumberLen2) * 8)) {
 		return PacketNumberLen2
 	}
-	if packetNumber < (1 << (uint8(PacketNumberLen4) * 8)) {
-		return PacketNumberLen4
-	}
-	return PacketNumberLen6
+	return PacketNumberLen4
 }

--- a/internal/protocol/packet_number_test.go
+++ b/internal/protocol/packet_number_test.go
@@ -228,9 +228,5 @@ var _ = Describe("packet number calculation", func() {
 		It("4 byte", func() {
 			Expect(GetPacketNumberLength(0xFFFFFFFF)).To(Equal(PacketNumberLen4))
 		})
-
-		It("6 byte", func() {
-			Expect(GetPacketNumberLength(0xFFFFFFFFFFFF)).To(Equal(PacketNumberLen6))
-		})
 	})
 })

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -19,8 +19,6 @@ const (
 	PacketNumberLen2 PacketNumberLen = 2
 	// PacketNumberLen4 is a packet number length of 4 bytes
 	PacketNumberLen4 PacketNumberLen = 4
-	// PacketNumberLen6 is a packet number length of 6 bytes
-	PacketNumberLen6 PacketNumberLen = 6
 )
 
 // The PacketType is the Long Header Type

--- a/session_test.go
+++ b/session_test.go
@@ -453,7 +453,7 @@ var _ = Describe("Session", func() {
 		BeforeEach(func() {
 			unpacker = NewMockUnpacker(mockCtrl)
 			sess.unpacker = unpacker
-			hdr = &wire.Header{PacketNumberLen: protocol.PacketNumberLen6}
+			hdr = &wire.Header{PacketNumberLen: protocol.PacketNumberLen4}
 		})
 
 		It("sets the {last,largest}RcvdPacketNumber", func() {


### PR DESCRIPTION
6 byte packet numbers were only used in gQUIC.