### PR TITLE
drop short header packets for unknown sessions

### DIFF
--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Packet Handler Map", func() {
 			Expect(handler.handlePacket(nil, getPacket(connID))).To(MatchError("received a packet with an unexpected connection ID 0xdeadbeef42"))
 			packet := append([]byte{0x40, 0xde, 0xca, 0xfb, 0xad, 0x99} /* short header packet */, make([]byte, 50)...)
 			packet = append(packet, token[:]...)
-			Expect(handler.handlePacket(nil, packet)).To(MatchError("received a packet with an unexpected connection ID 0xdecafbad99"))
+			Expect(handler.handlePacket(nil, packet)).To(MatchError("received a short header packet with an unexpected connection ID 0xdecafbad99"))
 			Expect(handler.resetTokens).To(BeEmpty())
 		})
 	})

--- a/server.go
+++ b/server.go
@@ -308,11 +308,9 @@ func (s *server) handlePacket(p *receivedPacket) {
 func (s *server) handlePacketImpl(p *receivedPacket) error {
 	hdr := p.header
 
-	if hdr.IsLongHeader {
-		// send a Version Negotiation Packet if the client is speaking a different protocol version
-		if !protocol.IsSupportedVersion(s.config.Versions, hdr.Version) {
-			return s.sendVersionNegotiationPacket(p)
-		}
+	// send a Version Negotiation Packet if the client is speaking a different protocol version
+	if !protocol.IsSupportedVersion(s.config.Versions, hdr.Version) {
+		return s.sendVersionNegotiationPacket(p)
 	}
 	if hdr.Type == protocol.PacketTypeInitial {
 		go s.handleInitial(p)


### PR DESCRIPTION
Currently, we'd pass them to the server, where they would get dropped.