### PR TITLE
include the packet number length in the length calculation for long headers

### DIFF
--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -28,7 +28,7 @@ type Header struct {
 	Type         protocol.PacketType
 	IsLongHeader bool
 	KeyPhase     int
-	PayloadLen   protocol.ByteCount
+	Length       protocol.ByteCount
 	Token        []byte
 }
 
@@ -72,7 +72,7 @@ func (h *Header) writeLongHeader(b *bytes.Buffer, v protocol.VersionNumber) erro
 		return nil
 	}
 
-	utils.WriteVarInt(b, uint64(h.PayloadLen))
+	utils.WriteVarInt(b, uint64(h.Length))
 	return utils.WriteVarIntPacketNumber(b, h.PacketNumber, h.PacketNumberLen)
 }
 
@@ -88,7 +88,7 @@ func (h *Header) writeShortHeader(b *bytes.Buffer, v protocol.VersionNumber) err
 // GetLength determines the length of the Header.
 func (h *Header) GetLength(v protocol.VersionNumber) protocol.ByteCount {
 	if h.IsLongHeader {
-		length := 1 /* type byte */ + 4 /* version */ + 1 /* conn id len byte */ + protocol.ByteCount(h.DestConnectionID.Len()+h.SrcConnectionID.Len()) + protocol.ByteCount(h.PacketNumberLen) + utils.VarIntLen(uint64(h.PayloadLen))
+		length := 1 /* type byte */ + 4 /* version */ + 1 /* conn id len byte */ + protocol.ByteCount(h.DestConnectionID.Len()+h.SrcConnectionID.Len()) + protocol.ByteCount(h.PacketNumberLen) + utils.VarIntLen(uint64(h.Length))
 		if h.Type == protocol.PacketTypeInitial {
 			length += utils.VarIntLen(uint64(len(h.Token))) + protocol.ByteCount(len(h.Token))
 		}
@@ -118,7 +118,7 @@ func (h *Header) Log(logger utils.Logger) {
 				logger.Debugf("\tLong Header{Type: %s, DestConnectionID: %s, SrcConnectionID: %s, %sOrigDestConnectionID: %s, Version: %s}", h.Type, h.DestConnectionID, h.SrcConnectionID, token, h.OrigDestConnectionID, h.Version)
 				return
 			}
-			logger.Debugf("\tLong Header{Type: %s, DestConnectionID: %s, SrcConnectionID: %s, %sPacketNumber: %#x, PacketNumberLen: %d, PayloadLen: %d, Version: %s}", h.Type, h.DestConnectionID, h.SrcConnectionID, token, h.PacketNumber, h.PacketNumberLen, h.PayloadLen, h.Version)
+			logger.Debugf("\tLong Header{Type: %s, DestConnectionID: %s, SrcConnectionID: %s, %sPacketNumber: %#x, PacketNumberLen: %d, Length: %d, Version: %s}", h.Type, h.DestConnectionID, h.SrcConnectionID, token, h.PacketNumber, h.PacketNumberLen, h.Length, h.Version)
 		}
 	} else {
 		logger.Debugf("\tShort Header{DestConnectionID: %s, PacketNumber: %#x, PacketNumberLen: %d, KeyPhase: %d}", h.DestConnectionID, h.PacketNumber, h.PacketNumberLen, h.KeyPhase)

--- a/internal/wire/header_parser.go
+++ b/internal/wire/header_parser.go
@@ -141,7 +141,7 @@ func (iv *InvariantHeader) parseLongHeader(b *bytes.Reader, sentBy protocol.Pers
 	if err != nil {
 		return nil, err
 	}
-	h.PayloadLen = protocol.ByteCount(pl)
+	h.Length = protocol.ByteCount(pl)
 	pn, pnLen, err := utils.ReadVarIntPacketNumber(b)
 	if err != nil {
 		return nil, err

--- a/internal/wire/header_parser_test.go
+++ b/internal/wire/header_parser_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, srcConnID...)
 			data = append(data, encodeVarInt(6)...)      // token length
 			data = append(data, []byte("foobar")...)     // token
-			data = append(data, encodeVarInt(0x1337)...) // payload length
+			data = append(data, encodeVarInt(0x1337)...) // length
 			// packet number
 			data = appendPacketNumber(data, 0xbeef, protocol.PacketNumberLen4)
 
@@ -98,7 +98,7 @@ var _ = Describe("Header Parsing", func() {
 			Expect(hdr.DestConnectionID).To(Equal(destConnID))
 			Expect(hdr.SrcConnectionID).To(Equal(srcConnID))
 			Expect(hdr.Token).To(Equal([]byte("foobar")))
-			Expect(hdr.PayloadLen).To(Equal(protocol.ByteCount(0x1337)))
+			Expect(hdr.Length).To(Equal(protocol.ByteCount(0x1337)))
 			Expect(hdr.PacketNumber).To(Equal(protocol.PacketNumber(0xbeef)))
 			Expect(hdr.PacketNumberLen).To(Equal(protocol.PacketNumberLen4))
 			Expect(hdr.Version).To(Equal(protocol.VersionNumber(0x1020304)))
@@ -113,7 +113,7 @@ var _ = Describe("Header Parsing", func() {
 				0x01,                   // connection ID lengths
 				0xde, 0xad, 0xbe, 0xef, // source connection ID
 			}
-			data = append(data, encodeVarInt(0x42)...) // payload length
+			data = append(data, encodeVarInt(0x42)...) // length
 			data = append(data, []byte{0xde, 0xca, 0xfb, 0xad}...)
 			b := bytes.NewReader(data)
 			iHdr, err := ParseInvariantHeader(b, 0)
@@ -129,7 +129,7 @@ var _ = Describe("Header Parsing", func() {
 				0x70,                          // connection ID lengths
 				1, 2, 3, 4, 5, 6, 7, 8, 9, 10, // source connection ID
 			}
-			data = append(data, encodeVarInt(0x42)...) // payload length
+			data = append(data, encodeVarInt(0x42)...) // length
 			data = append(data, []byte{0xde, 0xca, 0xfb, 0xad}...)
 			b := bytes.NewReader(data)
 			iHdr, err := ParseInvariantHeader(b, 0)
@@ -145,7 +145,7 @@ var _ = Describe("Header Parsing", func() {
 				0x0, // connection ID lengths
 			}
 			data = append(data, encodeVarInt(0)...)    // token length
-			data = append(data, encodeVarInt(0x42)...) // payload length
+			data = append(data, encodeVarInt(0x42)...) // length
 			data = appendPacketNumber(data, 0x123, protocol.PacketNumberLen2)
 
 			b := bytes.NewReader(data)
@@ -202,7 +202,7 @@ var _ = Describe("Header Parsing", func() {
 				0x0, // connection ID lengths
 			}
 			data = append(data, encodeVarInt(4)...)                           // token length: 4 bytes (1 byte too long)
-			data = append(data, encodeVarInt(0x42)...)                        // payload length, 1 byte
+			data = append(data, encodeVarInt(0x42)...)                        // length, 1 byte
 			data = appendPacketNumber(data, 0x123, protocol.PacketNumberLen2) // 2 bytes
 
 			b := bytes.NewReader(data)

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Header", func() {
 					Type:             0x5,
 					DestConnectionID: protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe},
 					SrcConnectionID:  protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad, 0x0, 0x0, 0x13, 0x37},
-					PayloadLen:       0xcafe,
+					Length:           0xcafe,
 					PacketNumber:     0xdecaf,
 					PacketNumberLen:  protocol.PacketNumberLen4,
 					Version:          0x1020304,
@@ -49,7 +49,7 @@ var _ = Describe("Header", func() {
 					0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, // dest connection ID
 					0xde, 0xca, 0xfb, 0xad, 0x0, 0x0, 0x13, 0x37, // source connection ID
 				}
-				expected = append(expected, encodeVarInt(0xcafe)...) // payload length
+				expected = append(expected, encodeVarInt(0xcafe)...) // length
 				expected = appendPacketNumber(expected, 0xdecaf, protocol.PacketNumberLen4)
 				Expect(buf.Bytes()).To(Equal(expected))
 			})
@@ -220,30 +220,30 @@ var _ = Describe("Header", func() {
 			buf = &bytes.Buffer{}
 		})
 
-		It("has the right length for the Long Header, for a short payload length", func() {
+		It("has the right length for the Long Header, for a short length", func() {
 			h := &Header{
 				IsLongHeader:     true,
-				PayloadLen:       1,
+				Length:           1,
 				DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				SrcConnectionID:  protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				PacketNumberLen:  protocol.PacketNumberLen1,
 			}
-			expectedLen := 1 /* type byte */ + 4 /* version */ + 1 /* conn ID len */ + 8 /* dest conn id */ + 8 /* src conn id */ + 1 /* short payload len */ + 1 /* packet number */
+			expectedLen := 1 /* type byte */ + 4 /* version */ + 1 /* conn ID len */ + 8 /* dest conn id */ + 8 /* src conn id */ + 1 /* short len */ + 1 /* packet number */
 			Expect(h.GetLength(versionIETFHeader)).To(BeEquivalentTo(expectedLen))
 			err := h.Write(buf, protocol.PerspectiveClient, versionIETFHeader)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(buf.Len()).To(Equal(expectedLen))
 		})
 
-		It("has the right length for the Long Header, for a long payload length", func() {
+		It("has the right length for the Long Header, for a long length", func() {
 			h := &Header{
 				IsLongHeader:     true,
-				PayloadLen:       1500,
+				Length:           1500,
 				DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				SrcConnectionID:  protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				PacketNumberLen:  protocol.PacketNumberLen2,
 			}
-			expectedLen := 1 /* type byte */ + 4 /* version */ + 1 /* conn ID len */ + 8 /* dest conn id */ + 8 /* src conn id */ + 2 /* long payload len */ + 2 /* packet number */
+			expectedLen := 1 /* type byte */ + 4 /* version */ + 1 /* conn ID len */ + 8 /* dest conn id */ + 8 /* src conn id */ + 2 /* long len */ + 2 /* packet number */
 			Expect(h.GetLength(versionIETFHeader)).To(BeEquivalentTo(expectedLen))
 			err := h.Write(buf, protocol.PerspectiveServer, versionIETFHeader)
 			Expect(err).ToNot(HaveOccurred())
@@ -254,12 +254,12 @@ var _ = Describe("Header", func() {
 			h := &Header{
 				Type:             protocol.PacketTypeInitial,
 				IsLongHeader:     true,
-				PayloadLen:       1500,
+				Length:           1500,
 				DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				SrcConnectionID:  protocol.ConnectionID{1, 2, 3, 4},
 				PacketNumberLen:  protocol.PacketNumberLen2,
 			}
-			expectedLen := 1 /* type byte */ + 4 /* version */ + 1 /* conn ID len */ + 8 /* dest conn id */ + 4 /* src conn id */ + 1 /* token length */ + 2 /* long payload len */ + 2 /* packet number */
+			expectedLen := 1 /* type byte */ + 4 /* version */ + 1 /* conn ID len */ + 8 /* dest conn id */ + 4 /* src conn id */ + 1 /* token length */ + 2 /* long len */ + 2 /* packet number */
 			Expect(h.GetLength(versionIETFHeader)).To(BeEquivalentTo(expectedLen))
 			err := h.Write(buf, protocol.PerspectiveServer, versionIETFHeader)
 			Expect(err).ToNot(HaveOccurred())
@@ -270,13 +270,13 @@ var _ = Describe("Header", func() {
 			h := &Header{
 				Type:             protocol.PacketTypeInitial,
 				IsLongHeader:     true,
-				PayloadLen:       1500,
+				Length:           1500,
 				DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				SrcConnectionID:  protocol.ConnectionID{1, 2, 3, 4},
 				PacketNumberLen:  protocol.PacketNumberLen2,
 				Token:            []byte("foo"),
 			}
-			expectedLen := 1 /* type byte */ + 4 /* version */ + 1 /* conn ID len */ + 8 /* dest conn id */ + 4 /* src conn id */ + 1 /* token length */ + 3 /* token */ + 2 /* long payload len */ + 2 /* packet number */
+			expectedLen := 1 /* type byte */ + 4 /* version */ + 1 /* conn ID len */ + 8 /* dest conn id */ + 4 /* src conn id */ + 1 /* token length */ + 3 /* token */ + 2 /* long len */ + 2 /* packet number */
 			Expect(h.GetLength(versionIETFHeader)).To(BeEquivalentTo(expectedLen))
 			err := h.Write(buf, protocol.PerspectiveServer, versionIETFHeader)
 			Expect(err).ToNot(HaveOccurred())
@@ -358,12 +358,12 @@ var _ = Describe("Header", func() {
 				Type:             protocol.PacketTypeHandshake,
 				PacketNumber:     0x1337,
 				PacketNumberLen:  protocol.PacketNumberLen2,
-				PayloadLen:       54321,
+				Length:           54321,
 				DestConnectionID: protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37},
 				SrcConnectionID:  protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad, 0x013, 0x37, 0x13, 0x37},
 				Version:          0xfeed,
 			}).Log(logger)
-			Expect(buf.String()).To(ContainSubstring("Long Header{Type: Handshake, DestConnectionID: 0xdeadbeefcafe1337, SrcConnectionID: 0xdecafbad13371337, PacketNumber: 0x1337, PacketNumberLen: 2, PayloadLen: 54321, Version: 0xfeed}"))
+			Expect(buf.String()).To(ContainSubstring("Long Header{Type: Handshake, DestConnectionID: 0xdeadbeefcafe1337, SrcConnectionID: 0xdecafbad13371337, PacketNumber: 0x1337, PacketNumberLen: 2, Length: 54321, Version: 0xfeed}"))
 		})
 
 		It("logs Initial Packets with a Token", func() {
@@ -373,12 +373,12 @@ var _ = Describe("Header", func() {
 				Token:            []byte{0xde, 0xad, 0xbe, 0xef},
 				PacketNumber:     0x42,
 				PacketNumberLen:  protocol.PacketNumberLen2,
-				PayloadLen:       100,
+				Length:           100,
 				DestConnectionID: protocol.ConnectionID{0xca, 0xfe, 0x13, 0x37},
 				SrcConnectionID:  protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad},
 				Version:          0xfeed,
 			}).Log(logger)
-			Expect(buf.String()).To(ContainSubstring("Long Header{Type: Initial, DestConnectionID: 0xcafe1337, SrcConnectionID: 0xdecafbad, Token: 0xdeadbeef, PacketNumber: 0x42, PacketNumberLen: 2, PayloadLen: 100, Version: 0xfeed}"))
+			Expect(buf.String()).To(ContainSubstring("Long Header{Type: Initial, DestConnectionID: 0xcafe1337, SrcConnectionID: 0xdecafbad, Token: 0xdeadbeef, PacketNumber: 0x42, PacketNumberLen: 2, Length: 100, Version: 0xfeed}"))
 		})
 
 		It("logs Initial Packets without a Token", func() {
@@ -387,12 +387,12 @@ var _ = Describe("Header", func() {
 				Type:             protocol.PacketTypeInitial,
 				PacketNumber:     0x42,
 				PacketNumberLen:  protocol.PacketNumberLen2,
-				PayloadLen:       100,
+				Length:           100,
 				DestConnectionID: protocol.ConnectionID{0xca, 0xfe, 0x13, 0x37},
 				SrcConnectionID:  protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad},
 				Version:          0xfeed,
 			}).Log(logger)
-			Expect(buf.String()).To(ContainSubstring("Long Header{Type: Initial, DestConnectionID: 0xcafe1337, SrcConnectionID: 0xdecafbad, Token: (empty), PacketNumber: 0x42, PacketNumberLen: 2, PayloadLen: 100, Version: 0xfeed}"))
+			Expect(buf.String()).To(ContainSubstring("Long Header{Type: Initial, DestConnectionID: 0xcafe1337, SrcConnectionID: 0xdecafbad, Token: (empty), PacketNumber: 0x42, PacketNumberLen: 2, Length: 100, Version: 0xfeed}"))
 		})
 
 		It("logs Initial Packets with a Token", func() {

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -409,9 +409,9 @@ func (p *packetPacker) getHeader(encLevel protocol.EncryptionLevel) *wire.Header
 	if encLevel != protocol.Encryption1RTT {
 		header.IsLongHeader = true
 		header.SrcConnectionID = p.srcConnID
-		// Set the payload len to maximum size.
+		// Set the length to the maximum packet size.
 		// Since it is encoded as a varint, this guarantees us that the header will end up at most as big as GetLength() returns.
-		header.PayloadLen = p.maxPacketSize
+		header.Length = p.maxPacketSize
 		switch encLevel {
 		case protocol.EncryptionInitial:
 			header.Type = protocol.PacketTypeInitial
@@ -433,20 +433,20 @@ func (p *packetPacker) writeAndSealPacket(
 
 	addPadding := p.perspective == protocol.PerspectiveClient && header.Type == protocol.PacketTypeInitial && !p.hasSentPacket
 
-	// the payload length is only needed for Long Headers
+	// the length is only needed for Long Headers
 	if header.IsLongHeader {
 		if p.perspective == protocol.PerspectiveClient && header.Type == protocol.PacketTypeInitial {
 			header.Token = p.token
 		}
 		if addPadding {
 			headerLen := header.GetLength(p.version)
-			header.PayloadLen = protocol.ByteCount(protocol.MinInitialPacketSize) - headerLen
+			header.Length = protocol.ByteCount(header.PacketNumberLen) + protocol.MinInitialPacketSize - headerLen
 		} else {
-			payloadLen := protocol.ByteCount(sealer.Overhead())
+			length := protocol.ByteCount(sealer.Overhead()) + protocol.ByteCount(header.PacketNumberLen)
 			for _, frame := range frames {
-				payloadLen += frame.Length(p.version)
+				length += frame.Length(p.version)
 			}
-			header.PayloadLen = payloadLen
+			header.Length = length
 		}
 	}
 


### PR DESCRIPTION
Fixes #1377.