### PR TITLE
make packet handling as non-blocking as possible

### DIFF
--- a/client.go
+++ b/client.go
@@ -295,9 +295,7 @@ func (c *client) handlePacket(p *receivedPacket) {
 	}
 
 	if p.hdr.Type == protocol.PacketTypeRetry {
-		c.mutex.Lock()
-		c.handleRetryPacket(p.hdr)
-		c.mutex.Unlock()
+		go c.handleRetryPacket(p.hdr)
 		return
 	}
 
@@ -347,6 +345,9 @@ func (c *client) handleVersionNegotiationPacket(hdr *wire.Header) {
 }
 
 func (c *client) handleRetryPacket(hdr *wire.Header) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	c.logger.Debugf("<- Received Retry")
 	(&wire.ExtendedHeader{Header: *hdr}).Log(c.logger)
 	if !hdr.OrigDestConnectionID.Equal(c.destConnID) {

--- a/client.go
+++ b/client.go
@@ -308,11 +308,6 @@ func (c *client) handlePacketImpl(p *receivedPacket) error {
 		return err
 	}
 
-	// reject packets with the wrong connection ID
-	if !p.hdr.DestConnectionID.Equal(c.srcConnID) {
-		return fmt.Errorf("received a packet with an unexpected connection ID (%s, expected %s)", p.hdr.DestConnectionID, c.srcConnID)
-	}
-
 	if p.hdr.Type == protocol.PacketTypeRetry {
 		c.handleRetryPacket(p.hdr)
 		return nil

--- a/client_test.go
+++ b/client_test.go
@@ -687,7 +687,7 @@ var _ = Describe("Client", func() {
 					},
 				})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cl.versionNegotiated).To(BeTrue())
+				Expect(cl.versionNegotiated.Get()).To(BeTrue())
 			})
 
 			It("errors if no matching version is found", func() {

--- a/client_test.go
+++ b/client_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"net"
 	"os"
 	"time"
@@ -734,19 +733,5 @@ var _ = Describe("Client", func() {
 	It("tells its version", func() {
 		Expect(cl.version).ToNot(BeZero())
 		Expect(cl.GetVersion()).To(Equal(cl.version))
-	})
-
-	It("ignores packets with the wrong destination connection ID", func() {
-		cl.session = NewMockQuicSession(mockCtrl) // don't EXPECT any handlePacket calls
-		connID2 := protocol.ConnectionID{8, 7, 6, 5, 4, 3, 2, 1}
-		Expect(connID).ToNot(Equal(connID2))
-		Expect(cl.handlePacketImpl(&receivedPacket{
-			remoteAddr: addr,
-			hdr: &wire.Header{
-				DestConnectionID: connID2,
-				SrcConnectionID:  connID,
-				Version:          cl.version,
-			},
-		})).To(MatchError(fmt.Sprintf("received a packet with an unexpected connection ID (0x0807060504030201, expected %s)", connID)))
 	})
 })

--- a/server.go
+++ b/server.go
@@ -299,23 +299,17 @@ func (s *server) Addr() net.Addr {
 }
 
 func (s *server) handlePacket(p *receivedPacket) {
-	if err := s.handlePacketImpl(p); err != nil {
-		s.logger.Debugf("error handling packet from %s: %s", p.remoteAddr, err)
-	}
-}
-
-func (s *server) handlePacketImpl(p *receivedPacket) error {
 	hdr := p.hdr
 
 	// send a Version Negotiation Packet if the client is speaking a different protocol version
 	if !protocol.IsSupportedVersion(s.config.Versions, hdr.Version) {
-		return s.sendVersionNegotiationPacket(p)
+		go s.sendVersionNegotiationPacket(p)
+		return
 	}
 	if hdr.Type == protocol.PacketTypeInitial {
 		go s.handleInitial(p)
 	}
 	// TODO(#943): send Stateless Reset
-	return nil
 }
 
 func (s *server) handleInitial(p *receivedPacket) {
@@ -450,14 +444,15 @@ func (s *server) sendRetry(remoteAddr net.Addr, hdr *wire.Header) error {
 	return nil
 }
 
-func (s *server) sendVersionNegotiationPacket(p *receivedPacket) error {
+func (s *server) sendVersionNegotiationPacket(p *receivedPacket) {
 	hdr := p.hdr
-	s.logger.Debugf("Client offered version %s, sending VersionNegotiationPacket", hdr.Version)
-
+	s.logger.Debugf("Client offered version %s, sending Version Negotiation", hdr.Version)
 	data, err := wire.ComposeVersionNegotiation(hdr.SrcConnectionID, hdr.DestConnectionID, s.config.Versions)
 	if err != nil {
-		return err
+		s.logger.Debugf("Error composing Version Negotiation: %s", err)
+		return
 	}
-	_, err = s.conn.WriteTo(data, p.remoteAddr)
-	return err
+	if _, err := s.conn.WriteTo(data, p.remoteAddr); err != nil {
+		s.logger.Debugf("Error sending Version Negotiation: %s", err)
+	}
 }


### PR DESCRIPTION
Merge after #1636.

When accepting new packets in the `packetHandlerMap`, we should make sure that handling of those packets occurs asynchronously, so that the read loop can read the next packet from the packet conn as quickly as possible.
There are 3 places where we handle packets:

1. sessions (directly, for the server): packets are put into the `receivedPackets` (buffered) channel
2. clients: regular are passed to the session directly, Version Negotiation and Retry packets are handled in separate Go routines
3. Initial packets for servers: Version Negotiation packets are sent from separate Go routines, new sessions as well