### PR TITLE
remove unneeded check if stream data can be sent in packet packer

### DIFF
--- a/packet_packer.go
+++ b/packet_packer.go
@@ -288,7 +288,7 @@ func (p *packetPacker) PackPacket() (*packedPacket, error) {
 	}
 
 	maxSize := p.maxPacketSize - protocol.ByteCount(sealer.Overhead()) - headerLen
-	frames, err := p.composeNextPacket(maxSize, p.canSendData(encLevel))
+	frames, err := p.composeNextPacket(maxSize)
 	if err != nil {
 		return nil, err
 	}
@@ -360,10 +360,7 @@ func (p *packetPacker) maybePackCryptoPacket() (*packedPacket, error) {
 	}, nil
 }
 
-func (p *packetPacker) composeNextPacket(
-	maxFrameSize protocol.ByteCount,
-	canSendStreamFrames bool,
-) ([]wire.Frame, error) {
+func (p *packetPacker) composeNextPacket(maxFrameSize protocol.ByteCount) ([]wire.Frame, error) {
 	var length protocol.ByteCount
 	var frames []wire.Frame
 
@@ -376,10 +373,6 @@ func (p *packetPacker) composeNextPacket(
 	var lengthAdded protocol.ByteCount
 	frames, lengthAdded = p.framer.AppendControlFrames(frames, maxFrameSize-length)
 	length += lengthAdded
-
-	if !canSendStreamFrames {
-		return frames, nil
-	}
 
 	// temporarily increase the maxFrameSize by the (minimum) length of the DataLen field
 	// this leads to a properly sized packet in all cases, since we do all the packet length calculations with STREAM frames that have the DataLen set
@@ -486,10 +479,6 @@ func (p *packetPacker) writeAndSealPacket(
 	}
 	p.hasSentPacket = true
 	return raw, nil
-}
-
-func (p *packetPacker) canSendData(encLevel protocol.EncryptionLevel) bool {
-	return encLevel == protocol.Encryption1RTT
 }
 
 func (p *packetPacker) ChangeDestConnectionID(connID protocol.ConnectionID) {

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -429,17 +429,6 @@ var _ = Describe("Packet packer", func() {
 				Expect(p.frames[2].(*wire.StreamFrame).Data).To(Equal([]byte("frame 3")))
 				Expect(p.frames[2].(*wire.StreamFrame).DataLenPresent).To(BeFalse())
 			})
-
-			It("doesn't send unencrypted stream data on a data stream", func() {
-				pnManager.EXPECT().PeekPacketNumber().Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)
-				sealingManager.EXPECT().GetSealer().Return(protocol.EncryptionInitial, sealer)
-				ackFramer.EXPECT().GetAckFrame()
-				expectAppendControlFrames()
-				// don't expect a call to framer.PopStreamFrames
-				p, err := packer.PackPacket()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(p).To(BeNil())
-			})
 		})
 
 		Context("retransmissions", func() {


### PR DESCRIPTION
We don't return the session before the handshake completes, so there shouldn't be any stream data to send.