### PR TITLE
error when Listen is called without a tls.Config or certificates

### DIFF
--- a/server.go
+++ b/server.go
@@ -128,6 +128,10 @@ func Listen(conn net.PacketConn, tlsConf *tls.Config, config *Config) (Listener,
 }
 
 func listen(conn net.PacketConn, tlsConf *tls.Config, config *Config) (*server, error) {
+	// TODO(#1655): only require that tls.Config.Certificates or tls.Config.GetCertificate is set
+	if tlsConf == nil || len(tlsConf.Certificates) == 0 {
+		return nil, errors.New("quic: Certificates not set in tls.Config")
+	}
 	config = populateServerConfig(config)
 	for _, v := range config.Versions {
 		if !protocol.IsValidVersion(v) {


### PR DESCRIPTION
Closes #1653.

Once we fixx #1655, it should also be valid to call `Listen` without `tls.Config.Certificates`, as long as `tls.Config.GetCertificate` is set.