### PR TITLE
use the original tls.Config if tls.Config.GetConfigForClient returns nil

### DIFF
--- a/internal/crypto/cert_chain_test.go
+++ b/internal/crypto/cert_chain_test.go
@@ -124,6 +124,19 @@ var _ = Describe("Proof", func() {
 			Expect(cert2).To(Equal(cert.Certificate[0]))
 		})
 
+		It("uses the originail config if GetConfigForClient returns nil", func() {
+			config.Certificates = []tls.Certificate{cert}
+			var called bool
+			config.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+				called = true
+				return nil, nil
+			}
+			cert2, err := cc.GetLeafCert("")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cert2).To(Equal(cert.Certificate[0]))
+			Expect(called).To(BeTrue())
+		})
+
 		It("errors when it can't retrieve a leaf certificate", func() {
 			_, err := cc.GetLeafCert("invalid domain")
 			Expect(err).To(MatchError(errNoMatchingCertificate))


### PR DESCRIPTION
Hopefully fixes https://github.com/mholt/caddy/issues/2346.