### PR TITLE
use the self-signed certificate for the example server and client

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"flag"
 	"io"
 	"net/http"
 	"sync"
 
 	"github.com/lucas-clemente/quic-go/h2quic"
+	"github.com/lucas-clemente/quic-go/internal/testdata"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
@@ -26,7 +28,11 @@ func main() {
 	}
 	logger.SetLogTimeFormat("")
 
-	roundTripper := &h2quic.RoundTripper{}
+	roundTripper := &h2quic.RoundTripper{
+		TLSClientConfig: &tls.Config{
+			RootCAs: testdata.GetRootCA(),
+		},
+	}
 	defer roundTripper.Close()
 	hclient := &http.Client{
 		Transport: roundTripper,


### PR DESCRIPTION
This is broken since we merged #1666.

This PR also removes the `certPath` command line flag.