### PR TITLE
only copy stream data to write when popping a STREAM frame

### DIFF
--- a/send_stream.go
+++ b/send_stream.go
@@ -95,8 +95,7 @@ func (s *sendStream) Write(p []byte) (int, error) {
 		return 0, nil
 	}
 
-	s.dataForWriting = make([]byte, len(p))
-	copy(s.dataForWriting, p)
+	s.dataForWriting = p
 	s.sender.onHasStreamData(s.streamID)
 
 	var bytesWritten int
@@ -202,10 +201,12 @@ func (s *sendStream) getDataForWriting(maxBytes protocol.ByteCount) ([]byte, boo
 
 	var ret []byte
 	if protocol.ByteCount(len(s.dataForWriting)) > maxBytes {
-		ret = s.dataForWriting[:maxBytes]
+		ret = make([]byte, int(maxBytes))
+		copy(ret, s.dataForWriting[:maxBytes])
 		s.dataForWriting = s.dataForWriting[maxBytes:]
 	} else {
-		ret = s.dataForWriting
+		ret = make([]byte, len(s.dataForWriting))
+		copy(ret, s.dataForWriting)
 		s.dataForWriting = nil
 		s.signalWrite()
 	}

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -149,9 +149,10 @@ var _ = Describe("Send Stream", func() {
 			waitForWrite()
 			frame, _ := str.popStreamFrame(frameHeaderSize + 1)
 			Expect(frame.Data).To(Equal([]byte("f")))
-			s[1] = 'e'
 			f, _ := str.popStreamFrame(100)
 			Expect(f).ToNot(BeNil())
+			Expect(f.Data).To(Equal([]byte("oo")))
+			s[1] = 'e'
 			Expect(f.Data).To(Equal([]byte("oo")))
 			Eventually(done).Should(BeClosed())
 		})


### PR DESCRIPTION
Fixes #1675.

`stream.Write` can be called with arbitrarily large slices of data. We should avoid copying all that data up front since this can take a long time. Instead, we can copy the data that is dequeued when a STREAM frame is popped.