### PR TITLE
fix deadlock when sending stream data

### DIFF
--- a/send_stream.go
+++ b/send_stream.go
@@ -221,13 +221,14 @@ func (s *sendStream) getDataForWriting(maxBytes protocol.ByteCount) ([]byte, boo
 
 func (s *sendStream) Close() error {
 	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	if s.canceledWrite {
+		s.mutex.Unlock()
 		return fmt.Errorf("Close called for canceled stream %d", s.streamID)
 	}
 	s.finishedWriting = true
-	s.sender.onHasStreamData(s.streamID) // need to send the FIN
+	s.mutex.Unlock()
+
+	s.sender.onHasStreamData(s.streamID) // need to send the FIN, must be called without holding the mutex
 	s.ctxCancel()
 	return nil
 }
@@ -238,7 +239,7 @@ func (s *sendStream) CancelWrite(errorCode protocol.ApplicationErrorCode) error 
 	s.mutex.Unlock()
 
 	if completed {
-		s.sender.onStreamCompleted(s.streamID)
+		s.sender.onStreamCompleted(s.streamID) // must be called without holding the mutex
 	}
 	return err
 }
@@ -271,12 +272,13 @@ func (s *sendStream) handleStopSendingFrame(frame *wire.StopSendingFrame) {
 }
 
 func (s *sendStream) handleMaxStreamDataFrame(frame *wire.MaxStreamDataFrame) {
-	s.flowController.UpdateSendWindow(frame.ByteOffset)
 	s.mutex.Lock()
-	if s.dataForWriting != nil {
+	hasStreamData := s.dataForWriting != nil
+	s.mutex.Unlock()
+	s.flowController.UpdateSendWindow(frame.ByteOffset)
+	if hasStreamData {
 		s.sender.onHasStreamData(s.streamID)
 	}
-	s.mutex.Unlock()
 }
 
 // must be called after locking the mutex


### PR DESCRIPTION
Fixes #1658.

`sender.OnHasStreamData` must be called without holding the stream mutex, because the `framer` could concurrently call `popStreamFrame`, which would also try to lock the mutex.
Because the `framer` locks a mutex when `onHasStreamData` is called, and when popping stream frames, this leads to a deadlock.

@VictoriaRaymond, what do you think?