### PR TITLE
only queue packets for later decryption if the opener is not yet available

### DIFF
--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -47,6 +47,11 @@ func (m messageType) String() string {
 	}
 }
 
+// ErrOpenerNotYetAvailable is returned when an opener is requested for an encryption level,
+// but the corresponding opener has not yet been initialized
+// This can happen when packets arrive out of order.
+var ErrOpenerNotYetAvailable = errors.New("CryptoSetup: opener at this encryption level not yet available")
+
 type cryptoSetup struct {
 	tlsConf *qtls.Config
 
@@ -520,12 +525,12 @@ func (h *cryptoSetup) GetOpener(level protocol.EncryptionLevel) (Opener, error) 
 		return h.initialOpener, nil
 	case protocol.EncryptionHandshake:
 		if h.handshakeOpener == nil {
-			return nil, errors.New("CryptoSetup: no opener with encryption level Handshake")
+			return nil, ErrOpenerNotYetAvailable
 		}
 		return h.handshakeOpener, nil
 	case protocol.Encryption1RTT:
 		if h.opener == nil {
-			return nil, errors.New("CryptoSetup: no opener with encryption level 1-RTT")
+			return nil, ErrOpenerNotYetAvailable
 		}
 		return h.opener, nil
 	default:

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -99,7 +99,7 @@ func (u *packetUnpacker) Unpack(hdr *wire.Header, data []byte) (*unpackedPacket,
 
 	decrypted, err := opener.Open(buf, data, pn, extHdr.Raw)
 	if err != nil {
-		return nil, qerr.Error(qerr.DecryptionFailure, err.Error())
+		return nil, err
 	}
 
 	// Only do this after decrypting, so we are sure the packet is not attacker-controlled

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -61,7 +61,7 @@ func (u *packetUnpacker) Unpack(hdr *wire.Header, data []byte) (*unpackedPacket,
 	}
 	opener, err := u.cs.GetOpener(encLevel)
 	if err != nil {
-		return nil, qerr.Error(qerr.DecryptionFailure, err.Error())
+		return nil, err
 	}
 	hdrLen := int(hdr.ParsedLen())
 	// The packet number can be up to 4 bytes long, but we won't know the length until we decrypt it.

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/golang/mock/gomock"
+	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qerr"
@@ -124,9 +125,9 @@ var _ = Describe("Packet Unpacker", func() {
 			PacketNumberLen: 2,
 		}
 		hdr, hdrRaw := getHeader(extHdr)
-		cs.EXPECT().GetOpener(protocol.Encryption1RTT).Return(nil, errors.New("test err"))
+		cs.EXPECT().GetOpener(protocol.Encryption1RTT).Return(nil, handshake.ErrOpenerNotYetAvailable)
 		_, err := unpacker.Unpack(hdr, hdrRaw)
-		Expect(err).To(MatchError(qerr.Error(qerr.DecryptionFailure, "test err")))
+		Expect(err).To(MatchError(handshake.ErrOpenerNotYetAvailable))
 	})
 
 	It("returns the error when unpacking fails", func() {

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Packet Unpacker", func() {
 		opener.EXPECT().DecryptHeader(gomock.Any(), gomock.Any(), gomock.Any())
 		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("test err"))
 		_, err := unpacker.Unpack(hdr, hdrRaw)
-		Expect(err).To(MatchError(qerr.Error(qerr.DecryptionFailure, "test err")))
+		Expect(err).To(MatchError("test err"))
 	})
 
 	It("decrypts the header", func() {

--- a/session_test.go
+++ b/session_test.go
@@ -468,7 +468,7 @@ var _ = Describe("Session", func() {
 				PacketNumberLen: protocol.PacketNumberLen1,
 			}
 			rcvTime := time.Now().Add(-10 * time.Second)
-			unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).Return(&unpackedPacket{packetNumber: 0x1337}, nil)
+			unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).Return(&unpackedPacket{packetNumber: 0x1337, hdr: hdr}, nil)
 			rph := mockackhandler.NewMockReceivedPacketHandler(mockCtrl)
 			rph.EXPECT().ReceivedPacket(protocol.PacketNumber(0x1337), rcvTime, false)
 			sess.receivedPacketHandler = rph
@@ -476,7 +476,7 @@ var _ = Describe("Session", func() {
 				rcvTime: rcvTime,
 				hdr:     &hdr.Header,
 				data:    getData(hdr),
-			})).To(Succeed())
+			})).To(BeTrue())
 		})
 
 		It("closes when handling a packet fails", func() {
@@ -499,28 +499,29 @@ var _ = Describe("Session", func() {
 		})
 
 		It("handles duplicate packets", func() {
-			unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).Return(&unpackedPacket{}, nil).Times(2)
 			hdr := &wire.ExtendedHeader{
 				PacketNumber:    5,
 				PacketNumberLen: protocol.PacketNumberLen1,
 			}
-			Expect(sess.handlePacketImpl(&receivedPacket{hdr: &hdr.Header, data: getData(hdr)})).To(Succeed())
-			Expect(sess.handlePacketImpl(&receivedPacket{hdr: &hdr.Header, data: getData(hdr)})).To(Succeed())
+			unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).Return(&unpackedPacket{hdr: hdr}, nil).Times(2)
+			Expect(sess.handlePacketImpl(&receivedPacket{hdr: &hdr.Header, data: getData(hdr)})).To(BeTrue())
+			Expect(sess.handlePacketImpl(&receivedPacket{hdr: &hdr.Header, data: getData(hdr)})).To(BeTrue())
 		})
 
 		It("ignores packets with a different source connection ID", func() {
+			hdr := &wire.Header{
+				IsLongHeader:     true,
+				DestConnectionID: sess.destConnID,
+				SrcConnectionID:  sess.srcConnID,
+				Length:           1,
+			}
 			// Send one packet, which might change the connection ID.
 			// only EXPECT one call to the unpacker
-			unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).Return(&unpackedPacket{}, nil)
+			unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).Return(&unpackedPacket{hdr: &wire.ExtendedHeader{Header: *hdr}}, nil)
 			Expect(sess.handlePacketImpl(&receivedPacket{
-				hdr: &wire.Header{
-					IsLongHeader:     true,
-					DestConnectionID: sess.destConnID,
-					SrcConnectionID:  sess.srcConnID,
-					Length:           1,
-				},
+				hdr:  hdr,
 				data: getData(&wire.ExtendedHeader{PacketNumberLen: protocol.PacketNumberLen1}),
-			})).To(Succeed())
+			})).To(BeTrue())
 			// The next packet has to be ignored, since the source connection ID doesn't match.
 			Expect(sess.handlePacketImpl(&receivedPacket{
 				hdr: &wire.Header{
@@ -530,12 +531,12 @@ var _ = Describe("Session", func() {
 					Length:           1,
 				},
 				data: getData(&wire.ExtendedHeader{PacketNumberLen: protocol.PacketNumberLen1}),
-			})).To(Succeed())
+			})).To(BeFalse())
 		})
 
 		Context("updating the remote address", func() {
 			It("doesn't support connection migration", func() {
-				unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).Return(&unpackedPacket{}, nil)
+				unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).Return(&unpackedPacket{hdr: &wire.ExtendedHeader{}}, nil)
 				origAddr := sess.conn.(*mockConnection).remoteAddr
 				remoteIP := &net.IPAddr{IP: net.IPv4(192, 168, 0, 100)}
 				Expect(origAddr).ToNot(Equal(remoteIP))
@@ -544,8 +545,7 @@ var _ = Describe("Session", func() {
 					hdr:        &wire.Header{},
 					data:       getData(&wire.ExtendedHeader{PacketNumberLen: protocol.PacketNumberLen1}),
 				}
-				err := sess.handlePacketImpl(&p)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(sess.handlePacketImpl(&p)).To(BeTrue())
 				Expect(sess.conn.(*mockConnection).remoteAddr).To(Equal(origAddr))
 			})
 		})
@@ -1306,7 +1306,9 @@ var _ = Describe("Client Session", func() {
 
 	It("changes the connection ID when receiving the first packet from the server", func() {
 		unpacker := NewMockUnpacker(mockCtrl)
-		unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).Return(&unpackedPacket{}, nil)
+		unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any()).DoAndReturn(func(hdr *wire.Header, data []byte) (*unpackedPacket, error) {
+			return &unpackedPacket{hdr: &wire.ExtendedHeader{Header: *hdr}}, nil
+		})
 		sess.unpacker = unpacker
 		go func() {
 			defer GinkgoRecover()
@@ -1324,7 +1326,7 @@ var _ = Describe("Client Session", func() {
 				Length:           1,
 			},
 			data: []byte{0},
-		})).To(Succeed())
+		})).To(BeTrue())
 		// make sure the go routine returns
 		packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)
 		sessionRunner.EXPECT().retireConnectionID(gomock.Any())

--- a/session_test.go
+++ b/session_test.go
@@ -508,6 +508,16 @@ var _ = Describe("Session", func() {
 			Expect(sess.handlePacketImpl(&receivedPacket{hdr: &hdr.Header, data: getData(hdr)})).To(BeTrue())
 		})
 
+		It("ignores 0-RTT packets", func() {
+			Expect(sess.handlePacketImpl(&receivedPacket{
+				hdr: &wire.Header{
+					IsLongHeader:     true,
+					Type:             protocol.PacketType0RTT,
+					DestConnectionID: sess.srcConnID,
+				},
+			})).To(BeFalse())
+		})
+
 		It("ignores packets with a different source connection ID", func() {
 			hdr := &wire.Header{
 				IsLongHeader:     true,


### PR DESCRIPTION
Fixes #1583.

In IETF QUIC, we don't have to rely on trial decryption any more, as in gQUIC. We can therefore be a lot smarter about queueing undecryptable packets, and **only** do so when we know that the opener for the encryption level is not yet available.