### PR TITLE
increase the packet number after version negotiation and retry

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,6 +37,8 @@ type client struct {
 	destConnID     protocol.ConnectionID
 	origDestConnID protocol.ConnectionID // the destination conn ID used on the first Initial (before a Retry)
 
+	initialPacketNumber protocol.PacketNumber
+
 	initialVersion protocol.VersionNumber
 	version        protocol.VersionNumber
 
@@ -340,7 +342,7 @@ func (c *client) handleVersionNegotiationPacket(hdr *wire.Header) {
 	c.version = newVersion
 
 	c.logger.Infof("Switching to QUIC version %s. New connection ID: %s", newVersion, c.destConnID)
-	c.session.closeForRecreating()
+	c.initialPacketNumber = c.session.closeForRecreating()
 }
 
 func (c *client) handleRetryPacket(hdr *wire.Header) {
@@ -366,7 +368,7 @@ func (c *client) handleRetryPacket(hdr *wire.Header) {
 	c.origDestConnID = c.destConnID
 	c.destConnID = hdr.SrcConnectionID
 	c.token = hdr.Token
-	c.session.closeForRecreating()
+	c.initialPacketNumber = c.session.closeForRecreating()
 }
 
 func (c *client) createNewTLSSession(version protocol.VersionNumber) error {
@@ -397,6 +399,7 @@ func (c *client) createNewTLSSession(version protocol.VersionNumber) error {
 		c.srcConnID,
 		c.config,
 		c.tlsConf,
+		c.initialPacketNumber,
 		params,
 		c.initialVersion,
 		c.logger,

--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package quic
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -54,8 +53,6 @@ var (
 	// make it possible to mock connection ID generation in the tests
 	generateConnectionID           = protocol.GenerateConnectionID
 	generateConnectionIDForInitial = protocol.GenerateConnectionIDForInitial
-	errCloseSessionForNewVersion   = errors.New("closing session in order to recreate it with a new version")
-	errCloseSessionForRetry        = errors.New("closing session in response to a stateless retry")
 )
 
 // DialAddr establishes a new QUIC connection to a server.
@@ -255,7 +252,7 @@ func (c *client) dial(ctx context.Context) error {
 		return err
 	}
 	err := c.establishSecureConnection(ctx)
-	if err == errCloseSessionForRetry || err == errCloseSessionForNewVersion {
+	if err == errCloseForRecreating {
 		return c.dial(ctx)
 	}
 	return err
@@ -263,8 +260,7 @@ func (c *client) dial(ctx context.Context) error {
 
 // establishSecureConnection runs the session, and tries to establish a secure connection
 // It returns:
-// - errCloseSessionForNewVersion when the server sends a version negotiation packet
-// - handshake.ErrCloseSessionForRetry when the server performs a stateless retry
+// - errCloseSessionRecreating when the server sends a version negotiation packet, or a stateless retry is performed
 // - any other error that might occur
 // - when the connection is forward-secure
 func (c *client) establishSecureConnection(ctx context.Context) error {
@@ -272,7 +268,7 @@ func (c *client) establishSecureConnection(ctx context.Context) error {
 
 	go func() {
 		err := c.session.run() // returns as soon as the session is closed
-		if err != errCloseSessionForRetry && err != errCloseSessionForNewVersion && c.createdPacketConn {
+		if err != errCloseForRecreating && c.createdPacketConn {
 			c.conn.Close()
 		}
 		errorChan <- err
@@ -344,7 +340,7 @@ func (c *client) handleVersionNegotiationPacket(hdr *wire.Header) {
 	c.version = newVersion
 
 	c.logger.Infof("Switching to QUIC version %s. New connection ID: %s", newVersion, c.destConnID)
-	c.session.destroy(errCloseSessionForNewVersion)
+	c.session.closeForRecreating()
 }
 
 func (c *client) handleRetryPacket(hdr *wire.Header) {
@@ -370,7 +366,7 @@ func (c *client) handleRetryPacket(hdr *wire.Header) {
 	c.origDestConnID = c.destConnID
 	c.destConnID = hdr.SrcConnectionID
 	c.token = hdr.Token
-	c.session.destroy(errCloseSessionForRetry)
+	c.session.closeForRecreating()
 }
 
 func (c *client) createNewTLSSession(version protocol.VersionNumber) error {

--- a/client_test.go
+++ b/client_test.go
@@ -530,8 +530,8 @@ var _ = Describe("Client", func() {
 			sess1.EXPECT().run().DoAndReturn(func() error {
 				return <-run1
 			})
-			sess1.EXPECT().destroy(errCloseSessionForRetry).Do(func(e error) {
-				run1 <- e
+			sess1.EXPECT().closeForRecreating().Do(func() {
+				run1 <- errCloseForRecreating
 			})
 			sess2 := NewMockQuicSession(mockCtrl)
 			sess2.EXPECT().run()
@@ -597,8 +597,8 @@ var _ = Describe("Client", func() {
 				Eventually(run).Should(Receive(&err))
 				return err
 			})
-			sess.EXPECT().destroy(gomock.Any()).Do(func(e error) {
-				run <- e
+			sess.EXPECT().closeForRecreating().Do(func() {
+				run <- errCloseForRecreating
 			})
 			sessions <- sess
 			doneErr := errors.New("nothing to do")
@@ -717,7 +717,7 @@ var _ = Describe("Client", func() {
 
 				sess := NewMockQuicSession(mockCtrl)
 				destroyed := make(chan struct{})
-				sess.EXPECT().destroy(errCloseSessionForNewVersion).Do(func(error) {
+				sess.EXPECT().closeForRecreating().Do(func() {
 					close(destroyed)
 				})
 				cl.session = sess

--- a/client_test.go
+++ b/client_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Client", func() {
 			srcConnID protocol.ConnectionID,
 			conf *Config,
 			tlsConf *tls.Config,
+			initialPacketNumber protocol.PacketNumber,
 			params *handshake.TransportParameters,
 			initialVersion protocol.VersionNumber,
 			logger utils.Logger,
@@ -142,6 +143,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				_ *Config,
 				_ *tls.Config,
+				_ protocol.PacketNumber,
 				_ *handshake.TransportParameters,
 				_ protocol.VersionNumber,
 				_ utils.Logger,
@@ -172,6 +174,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				_ *Config,
 				tlsConf *tls.Config,
+				_ protocol.PacketNumber,
 				_ *handshake.TransportParameters,
 				_ protocol.VersionNumber,
 				_ utils.Logger,
@@ -202,6 +205,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				_ *Config,
 				_ *tls.Config,
+				_ protocol.PacketNumber,
 				_ *handshake.TransportParameters,
 				_ protocol.VersionNumber,
 				_ utils.Logger,
@@ -239,6 +243,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				_ *Config,
 				_ *tls.Config,
+				_ protocol.PacketNumber,
 				_ *handshake.TransportParameters,
 				_ protocol.VersionNumber,
 				_ utils.Logger,
@@ -279,6 +284,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				_ *Config,
 				_ *tls.Config,
+				_ protocol.PacketNumber,
 				_ *handshake.TransportParameters,
 				_ protocol.VersionNumber,
 				_ utils.Logger,
@@ -324,6 +330,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				_ *Config,
 				_ *tls.Config,
+				_ protocol.PacketNumber,
 				_ *handshake.TransportParameters,
 				_ protocol.VersionNumber,
 				_ utils.Logger,
@@ -369,6 +376,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				_ *Config,
 				_ *tls.Config,
+				_ protocol.PacketNumber,
 				_ *handshake.TransportParameters,
 				_ protocol.VersionNumber,
 				_ utils.Logger,
@@ -484,6 +492,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				configP *Config,
 				_ *tls.Config,
+				_ protocol.PacketNumber,
 				params *handshake.TransportParameters,
 				_ protocol.VersionNumber, /* initial version */
 				_ utils.Logger,
@@ -530,8 +539,9 @@ var _ = Describe("Client", func() {
 			sess1.EXPECT().run().DoAndReturn(func() error {
 				return <-run1
 			})
-			sess1.EXPECT().closeForRecreating().Do(func() {
+			sess1.EXPECT().closeForRecreating().DoAndReturn(func() protocol.PacketNumber {
 				run1 <- errCloseForRecreating
+				return 42
 			})
 			sess2 := NewMockQuicSession(mockCtrl)
 			sess2.EXPECT().run()
@@ -547,6 +557,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				_ *Config,
 				_ *tls.Config,
+				initialPacketNumber protocol.PacketNumber,
 				_ *handshake.TransportParameters,
 				_ protocol.VersionNumber,
 				_ utils.Logger,
@@ -554,9 +565,11 @@ var _ = Describe("Client", func() {
 			) (quicSession, error) {
 				switch len(sessions) {
 				case 2: // for the first session
+					Expect(initialPacketNumber).To(BeZero())
 					Expect(origDestConnID).To(BeNil())
 					Expect(destConnID).ToNot(BeNil())
 				case 1: // for the second session
+					Expect(initialPacketNumber).To(Equal(protocol.PacketNumber(42)))
 					Expect(origDestConnID).To(Equal(connID))
 					Expect(destConnID).ToNot(Equal(connID))
 				}
@@ -615,6 +628,7 @@ var _ = Describe("Client", func() {
 				_ protocol.ConnectionID,
 				_ *Config,
 				_ *tls.Config,
+				_ protocol.PacketNumber,
 				_ *handshake.TransportParameters,
 				_ protocol.VersionNumber,
 				_ utils.Logger,
@@ -654,6 +668,7 @@ var _ = Describe("Client", func() {
 					_ protocol.ConnectionID,
 					_ *Config,
 					_ *tls.Config,
+					_ protocol.PacketNumber,
 					_ *handshake.TransportParameters,
 					_ protocol.VersionNumber,
 					_ utils.Logger,

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -78,7 +78,11 @@ type sentPacketHandler struct {
 }
 
 // NewSentPacketHandler creates a new sentPacketHandler
-func NewSentPacketHandler(rttStats *congestion.RTTStats, logger utils.Logger) SentPacketHandler {
+func NewSentPacketHandler(
+	initialPacketNumber protocol.PacketNumber,
+	rttStats *congestion.RTTStats,
+	logger utils.Logger,
+) SentPacketHandler {
 	congestion := congestion.NewCubicSender(
 		congestion.DefaultClock{},
 		rttStats,
@@ -88,7 +92,7 @@ func NewSentPacketHandler(rttStats *congestion.RTTStats, logger utils.Logger) Se
 	)
 
 	return &sentPacketHandler{
-		packetNumberGenerator: newPacketNumberGenerator(0, protocol.SkipPacketAveragePeriodLength),
+		packetNumberGenerator: newPacketNumberGenerator(initialPacketNumber, protocol.SkipPacketAveragePeriodLength),
 		packetHistory:         newSentPacketHistory(),
 		rttStats:              rttStats,
 		congestion:            congestion,
@@ -144,8 +148,10 @@ func (h *sentPacketHandler) SentPacketsAsRetransmission(packets []*Packet, retra
 }
 
 func (h *sentPacketHandler) sentPacketImpl(packet *Packet) bool /* isRetransmittable */ {
-	for p := h.lastSentPacketNumber + 1; p < packet.PacketNumber; p++ {
-		h.logger.Debugf("Skipping packet number %#x", p)
+	if h.logger.Debug() && h.lastSentPacketNumber != 0 {
+		for p := h.lastSentPacketNumber + 1; p < packet.PacketNumber; p++ {
+			h.logger.Debugf("Skipping packet number %#x", p)
+		}
 	}
 
 	h.lastSentPacketNumber = packet.PacketNumber

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -88,7 +88,7 @@ func NewSentPacketHandler(rttStats *congestion.RTTStats, logger utils.Logger) Se
 	)
 
 	return &sentPacketHandler{
-		packetNumberGenerator: newPacketNumberGenerator(1, protocol.SkipPacketAveragePeriodLength),
+		packetNumberGenerator: newPacketNumberGenerator(0, protocol.SkipPacketAveragePeriodLength),
 		packetHistory:         newSentPacketHistory(),
 		rttStats:              rttStats,
 		congestion:            congestion,

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -49,7 +49,7 @@ var _ = Describe("SentPacketHandler", func() {
 
 	BeforeEach(func() {
 		rttStats := &congestion.RTTStats{}
-		handler = NewSentPacketHandler(rttStats, utils.DefaultLogger).(*sentPacketHandler)
+		handler = NewSentPacketHandler(42, rttStats, utils.DefaultLogger).(*sentPacketHandler)
 		handler.SetHandshakeComplete()
 		streamFrame = wire.StreamFrame{
 			StreamID: 5,
@@ -960,6 +960,19 @@ var _ = Describe("SentPacketHandler", func() {
 			Expect(handler.packetHistory.Len()).To(BeZero())
 			packet := handler.DequeuePacketForRetransmission()
 			Expect(packet).To(BeNil())
+		})
+	})
+
+	Context("peeking and popping packet number", func() {
+		It("peeks and pops the initial packet number", func() {
+			pn, _ := handler.PeekPacketNumber()
+			Expect(pn).To(Equal(protocol.PacketNumber(42)))
+			Expect(handler.PopPacketNumber()).To(Equal(protocol.PacketNumber(42)))
+		})
+
+		It("peeks and pops beyond the initial packet number", func() {
+			Expect(handler.PopPacketNumber()).To(Equal(protocol.PacketNumber(42)))
+			Expect(handler.PopPacketNumber()).To(BeNumerically(">", 42))
 		})
 	})
 })

--- a/mock_quic_session_test.go
+++ b/mock_quic_session_test.go
@@ -200,8 +200,10 @@ func (mr *MockQuicSessionMockRecorder) RemoteAddr() *gomock.Call {
 }
 
 // closeForRecreating mocks base method
-func (m *MockQuicSession) closeForRecreating() {
-	m.ctrl.Call(m, "closeForRecreating")
+func (m *MockQuicSession) closeForRecreating() protocol.PacketNumber {
+	ret := m.ctrl.Call(m, "closeForRecreating")
+	ret0, _ := ret[0].(protocol.PacketNumber)
+	return ret0
 }
 
 // closeForRecreating indicates an expected call of closeForRecreating

--- a/mock_quic_session_test.go
+++ b/mock_quic_session_test.go
@@ -199,6 +199,16 @@ func (mr *MockQuicSessionMockRecorder) RemoteAddr() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteAddr", reflect.TypeOf((*MockQuicSession)(nil).RemoteAddr))
 }
 
+// closeForRecreating mocks base method
+func (m *MockQuicSession) closeForRecreating() {
+	m.ctrl.Call(m, "closeForRecreating")
+}
+
+// closeForRecreating indicates an expected call of closeForRecreating
+func (mr *MockQuicSessionMockRecorder) closeForRecreating() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "closeForRecreating", reflect.TypeOf((*MockQuicSession)(nil).closeForRecreating))
+}
+
 // closeRemote mocks base method
 func (m *MockQuicSession) closeRemote(arg0 error) {
 	m.ctrl.Call(m, "closeRemote", arg0)

--- a/server.go
+++ b/server.go
@@ -43,6 +43,7 @@ type quicSession interface {
 	GetVersion() protocol.VersionNumber
 	run() error
 	destroy(error)
+	closeForRecreating()
 	closeRemote(error)
 }
 

--- a/server.go
+++ b/server.go
@@ -43,7 +43,7 @@ type quicSession interface {
 	GetVersion() protocol.VersionNumber
 	run() error
 	destroy(error)
-	closeForRecreating()
+	closeForRecreating() protocol.PacketNumber
 	closeRemote(error)
 }
 

--- a/session.go
+++ b/session.go
@@ -63,6 +63,8 @@ type closeError struct {
 	sendClose bool
 }
 
+var errCloseForRecreating = errors.New("closing session in order to recreate it")
+
 // A Session is a QUIC session
 type session struct {
 	sessionRunner sessionRunner
@@ -716,6 +718,10 @@ func (s *session) destroy(e error) {
 		s.sessionRunner.removeConnectionID(s.srcConnID)
 		s.closeChan <- closeError{err: e, sendClose: false, remote: false}
 	})
+}
+
+func (s *session) closeForRecreating() {
+	s.destroy(errCloseForRecreating)
 }
 
 func (s *session) closeRemote(e error) {

--- a/session_test.go
+++ b/session_test.go
@@ -1325,6 +1325,7 @@ var _ = Describe("Client Session", func() {
 			protocol.ConnectionID{8, 7, 6, 5, 4, 3, 2, 1},
 			populateClientConfig(&Config{}, true),
 			nil, // tls.Config
+			42,  // initial packet number
 			nil, // transport parameters
 			protocol.VersionWhatever,
 			utils.DefaultLogger,


### PR DESCRIPTION
Fixes #1637.

Note that the same mechanism (using return values of `session.closeForRecreating()`) could be used to carry over the RTT stats from one session to the next.