### PR TITLE
 fix length check for too short packets

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -202,7 +202,7 @@ func (h *packetHandlerMap) parsePacket(
 
 		var rest []byte
 		if hdr.IsLongHeader {
-			if protocol.ByteCount(len(data)) < hdr.Length {
+			if protocol.ByteCount(len(data)) < hdr.ParsedLen()+hdr.Length {
 				return packets, fmt.Errorf("packet length (%d bytes) is smaller than the expected length (%d bytes)", len(data)-int(hdr.ParsedLen()), hdr.Length)
 			}
 			packetLen := int(hdr.ParsedLen() + hdr.Length)

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -138,7 +138,14 @@ var _ = Describe("Packet Handler Map", func() {
 		})
 
 		Context("coalesced packets", func() {
-			It("errors on packets that are smaller than the length in the packet header", func() {
+			It("errors on packets that are smaller than the length in the packet header, for too small packet number", func() {
+				connID := protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}
+				data := getPacketWithLength(connID, 3) // gets a packet with a 2 byte packet number
+				_, err := handler.parsePacket(nil, nil, data)
+				Expect(err).To(MatchError("packet length (2 bytes) is smaller than the expected length (3 bytes)"))
+			})
+
+			It("errors on packets that are smaller than the length in the packet header, for too small payload", func() {
 				connID := protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}
 				data := append(getPacketWithLength(connID, 1000), make([]byte, 500-2 /* for packet number length */)...)
 				_, err := handler.parsePacket(nil, nil, data)


### PR DESCRIPTION
Depends on #1698.

A too short packet would lead to an out-of-bounds slice access (which panics).