### PR TITLE
fix logging of coalesced packets

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -186,10 +186,6 @@ func (h *packetHandlerMap) parsePacket(
 	var counter int
 	var lastConnID protocol.ConnectionID
 	for len(data) > 0 {
-		if counter > 0 && h.logger.Debug() {
-			h.logger.Debugf("Parsed a coalesced packet. Part %d: %d bytes", counter, len(packets[counter-1].data))
-		}
-
 		hdr, err := wire.ParseHeader(bytes.NewReader(data), h.connIDLen)
 		// drop the packet if we can't parse the header
 		if err != nil {
@@ -221,6 +217,12 @@ func (h *packetHandlerMap) parsePacket(
 			data:       data,
 			buffer:     buffer,
 		})
+
+		// only log if this actually a coalesced packet
+		if h.logger.Debug() && (counter > 1 || len(rest) > 0) {
+			h.logger.Debugf("Parsed a coalesced packet. Part %d: %d bytes. Remaining: %d bytes.", counter, len(packets[counter-1].data), len(rest))
+		}
+
 		data = rest
 	}
 	return packets, nil


### PR DESCRIPTION
The current code wouldn't log the last part of a coalesced packet.