### PR TITLE
properly close session in handshake integration tests

### DIFF
--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -75,6 +75,7 @@ var _ = Describe("Handshake tests", func() {
 			sess, err := quic.DialAddr(server.Addr().String(), &tls.Config{InsecureSkipVerify: true}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sess.(versioner).GetVersion()).To(Equal(protocol.SupportedVersions[0]))
+			Expect(sess.Close()).To(Succeed())
 		})
 
 		It("when the client supports more versions than the server supports", func() {
@@ -89,6 +90,7 @@ var _ = Describe("Handshake tests", func() {
 			sess, err := quic.DialAddr(server.Addr().String(), &tls.Config{InsecureSkipVerify: true}, conf)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sess.(versioner).GetVersion()).To(Equal(protocol.SupportedVersions[0]))
+			Expect(sess.Close()).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
Fixes #1708.

Otherwise there's a race condition when setting the supported versions.