### PR TITLE
fix nonce usage in the AEAD, use the AEAD provided by qtls for Initials

### DIFF
--- a/internal/handshake/aead_test.go
+++ b/internal/handshake/aead_test.go
@@ -12,19 +12,19 @@ import (
 var _ = Describe("AEAD", func() {
 	getSealerAndOpener := func(is1RTT bool) (Sealer, Opener) {
 		key := make([]byte, 16)
-		pnKey := make([]byte, 16)
+		hpKey := make([]byte, 16)
 		rand.Read(key)
-		rand.Read(pnKey)
+		rand.Read(hpKey)
 		block, err := aes.NewCipher(key)
 		Expect(err).ToNot(HaveOccurred())
 		aead, err := cipher.NewGCM(block)
 		Expect(err).ToNot(HaveOccurred())
-		pnBlock, err := aes.NewCipher(pnKey)
+		hpBlock, err := aes.NewCipher(hpKey)
 		Expect(err).ToNot(HaveOccurred())
 
 		iv := make([]byte, 12)
 		rand.Read(iv)
-		return newSealer(aead, iv, pnBlock, is1RTT), newOpener(aead, iv, pnBlock, is1RTT)
+		return newSealer(aead, hpBlock, is1RTT), newOpener(aead, hpBlock, is1RTT)
 	}
 
 	Context("message encryption", func() {

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -419,7 +419,6 @@ func (h *cryptoSetup) SetReadKey(suite *qtls.CipherSuite, trafficSecret []byte) 
 	}
 	opener := newOpener(
 		suite.AEAD(key, iv),
-		iv,
 		hpDecrypter,
 		h.readEncLevel == protocol.Encryption1RTT,
 	)
@@ -449,7 +448,6 @@ func (h *cryptoSetup) SetWriteKey(suite *qtls.CipherSuite, trafficSecret []byte)
 	}
 	sealer := newSealer(
 		suite.AEAD(key, iv),
-		iv,
 		hpEncrypter,
 		h.writeEncLevel == protocol.Encryption1RTT,
 	)

--- a/vendor/github.com/marten-seemann/qtls/cipher_suites.go
+++ b/vendor/github.com/marten-seemann/qtls/cipher_suites.go
@@ -250,6 +250,11 @@ func aeadAESGCM12(key, fixedNonce []byte) cipher.AEAD {
 	return ret
 }
 
+// AEADAESGCM13 creates a new AES-GCM AEAD for TLS 1.3
+func AEADAESGCM13(key, fixedNonce []byte) cipher.AEAD {
+	return aeadAESGCM13(key, fixedNonce)
+}
+
 func aeadAESGCM13(key, fixedNonce []byte) cipher.AEAD {
 	aes, err := aes.NewCipher(key)
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,10 +45,10 @@
 			"revisionTime": "2018-11-11T22:04:28Z"
 		},
 		{
-			"checksumSHA1": "FDYRKDgqEto8ahW65hY3RruQLmg=",
+			"checksumSHA1": "dpjM/eonkDPExO4QWg4+R0wZPCs=",
 			"path": "github.com/marten-seemann/qtls",
-			"revision": "061d608f3d22ea089c4c9039e1216eea999b9341",
-			"revisionTime": "2018-12-25T08:07:48Z"
+			"revision": "26b223ad36d4436ed3eeb843041b66ac21dcee34",
+			"revisionTime": "2019-01-06T03:45:47Z"
 		},
 		{
 			"checksumSHA1": "9TPZ7plxFmlYtMEv2LLXRCEQg7c=",


### PR DESCRIPTION
It turns out that #1696 was wrong, and actually introduced the problem it was trying to fix.
The reason is that the cipher suite we use is provided by qtls, and is the `qtls.aeadAESGCM13`. This cipher suite uses the IV passes into the constructor and XORs it with the nonce provided on every call of `Open` and `Seal`. Thus, by XORing the packet number with the IV in quic-go, we'll actually end up not using the IV at all, but just using the packet number as an IV.
This only leaves the Initial AEAD, which we used correctly, since we built it from the crypto primitives ourselves. It makes sense to also use the `qtls.aeadAESGCM13` for this encryption level, which is why I'm exposing it in qtls now.