### PR TITLE
return a net.Error when opening streams

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -120,20 +120,22 @@ type Session interface {
 	// AcceptUniStream returns the next unidirectional stream opened by the peer, blocking until one is available.
 	AcceptUniStream() (ReceiveStream, error)
 	// OpenStream opens a new bidirectional QUIC stream.
-	// It returns a special error when the peer's concurrent stream limit is reached.
 	// There is no signaling to the peer about new streams:
 	// The peer can only accept the stream after data has been sent on the stream.
-	// TODO(#1152): Enable testing for the special error
+	// If the error is non-nil, it satisfies the net.Error interface.
+	// When reaching the peer's stream limit, err.Temporary() will be true.
 	OpenStream() (Stream, error)
 	// OpenStreamSync opens a new bidirectional QUIC stream.
-	// It blocks until the peer's concurrent stream limit allows a new stream to be opened.
+	// It blocks until a new stream can be opened.
+	// If the error is non-nil, it satisfies the net.Error interface.
 	OpenStreamSync() (Stream, error)
 	// OpenUniStream opens a new outgoing unidirectional QUIC stream.
-	// It returns a special error when the peer's concurrent stream limit is reached.
-	// TODO(#1152): Enable testing for the special error
+	// If the error is non-nil, it satisfies the net.Error interface.
+	// When reaching the peer's stream limit, Temporary() will be true.
 	OpenUniStream() (SendStream, error)
 	// OpenUniStreamSync opens a new outgoing unidirectional QUIC stream.
-	// It blocks until the peer's concurrent stream limit allows a new stream to be opened.
+	// It blocks until a new stream can be opened.
+	// If the error is non-nil, it satisfies the net.Error interface.
 	OpenUniStreamSync() (SendStream, error)
 	// LocalAddr returns the local address.
 	LocalAddr() net.Addr

--- a/streams_map.go
+++ b/streams_map.go
@@ -1,13 +1,25 @@
 package quic
 
 import (
+	"errors"
 	"fmt"
+	"net"
 
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
+
+type streamOpenErr struct{ error }
+
+var _ net.Error = &streamOpenErr{}
+
+func (e streamOpenErr) Temporary() bool { return e.error == errTooManyOpenStreams }
+func (streamOpenErr) Timeout() bool     { return false }
+
+// errTooManyOpenStreams is used internally by the outgoing streams maps.
+var errTooManyOpenStreams = errors.New("too many open streams")
 
 type streamsMap struct {
 	perspective protocol.Perspective


### PR DESCRIPTION
Fixes #1152.

`net.Error.Temporary()` will be `true` if no stream can be opened when the peer's stream limit is reached.