### PR TITLE
delete unused connections from the multiplexer

### DIFF
--- a/multiplexer.go
+++ b/multiplexer.go
@@ -15,6 +15,7 @@ var (
 
 type multiplexer interface {
 	AddConn(net.PacketConn, int) (packetHandlerManager, error)
+	RemoveConn(net.PacketConn) error
 }
 
 type connManager struct {
@@ -60,4 +61,18 @@ func (m *connMultiplexer) AddConn(c net.PacketConn, connIDLen int) (packetHandle
 		return nil, fmt.Errorf("cannot use %d byte connection IDs on a connection that is already using %d byte connction IDs", connIDLen, p.connIDLen)
 	}
 	return p.manager, nil
+}
+
+func (m *connMultiplexer) RemoveConn(c net.PacketConn) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	_, ok := m.conns[c]
+	if !ok {
+		return fmt.Errorf("cannote remove connection, connection is unknown")
+	}
+
+	delete(m.conns, c)
+
+	return nil
 }

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -139,7 +139,7 @@ func (h *packetHandlerMap) close(e error) error {
 	}
 	h.mutex.Unlock()
 	wg.Wait()
-	return nil
+	return getMultiplexer().RemoveConn(h.conn)
 }
 
 func (h *packetHandlerMap) listen() {


### PR DESCRIPTION
This fixes issue #1709 by counting how many packet handlers use a packet conn and once this count reaches zero, the connection is removed from the multiplexer