### PR TITLE
change the version number for the development version

### DIFF
--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -18,7 +18,7 @@ const (
 
 // The version numbers, making grepping easier
 const (
-	VersionTLS      VersionNumber = 101
+	VersionTLS      VersionNumber = 0x51474fff
 	VersionWhatever VersionNumber = 1 // for when the version doesn't matter
 	VersionUnknown  VersionNumber = math.MaxUint32
 )

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -33,10 +33,6 @@ var _ = Describe("Version", func() {
 		Expect(VersionNumber(0x01234567).String()).To(Equal("0x1234567"))
 	})
 
-	It("has the right representation for the H2 Alt-Svc tag", func() {
-		Expect(VersionTLS.ToAltSvc()).To(Equal("101"))
-	})
-
 	It("recognizes supported versions", func() {
 		Expect(IsSupportedVersion(SupportedVersions, 0)).To(BeFalse())
 		Expect(IsSupportedVersion(SupportedVersions, SupportedVersions[0])).To(BeTrue())


### PR DESCRIPTION
It turns out that the version number we were using for development purposes is one of the version number reserved for IETF QUIC versions. And apparently people decided to deploy that version out in the wild, why ever you would want to deploy a version that becomes incompatible every other day...

This PR changes the version number to the highest version number reserved for quic-go in https://github.com/quicwg/base-drafts/wiki/QUIC-Versions.