### PR TITLE
send ACK frames in the correct packet number space

### DIFF
--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -41,9 +41,9 @@ type SentPacketHandler interface {
 
 // ReceivedPacketHandler handles ACKs needed to send for incoming packets
 type ReceivedPacketHandler interface {
-	ReceivedPacket(packetNumber protocol.PacketNumber, rcvTime time.Time, shouldInstigateAck bool) error
+	ReceivedPacket(pn protocol.PacketNumber, encLevel protocol.EncryptionLevel, rcvTime time.Time, shouldInstigateAck bool) error
 	IgnoreBelow(protocol.PacketNumber)
 
 	GetAlarmTimeout() time.Time
-	GetAckFrame() *wire.AckFrame
+	GetAckFrame(protocol.EncryptionLevel) *wire.AckFrame
 }

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -27,6 +27,7 @@ type SentPacketHandler interface {
 	// Before sending any packet, SendingAllowed() must be called to learn if we can actually send it.
 	ShouldSendNumPackets() int
 
+	// only to be called once the handshake is complete
 	GetLowestPacketNotConfirmedAcked() protocol.PacketNumber
 	DequeuePacketForRetransmission() *Packet
 	DequeueProbePacket() (*Packet, error)

--- a/internal/ackhandler/received_packet_handler.go
+++ b/internal/ackhandler/received_packet_handler.go
@@ -1,0 +1,98 @@
+package ackhandler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lucas-clemente/quic-go/internal/congestion"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/internal/wire"
+)
+
+const (
+	// maximum delay that can be applied to an ACK for a retransmittable packet
+	ackSendDelay = 25 * time.Millisecond
+	// initial maximum number of retransmittable packets received before sending an ack.
+	initialRetransmittablePacketsBeforeAck = 2
+	// number of retransmittable that an ACK is sent for
+	retransmittablePacketsBeforeAck = 10
+	// 1/5 RTT delay when doing ack decimation
+	ackDecimationDelay = 1.0 / 4
+	// 1/8 RTT delay when doing ack decimation
+	shortAckDecimationDelay = 1.0 / 8
+	// Minimum number of packets received before ack decimation is enabled.
+	// This intends to avoid the beginning of slow start, when CWNDs may be
+	// rapidly increasing.
+	minReceivedBeforeAckDecimation = 100
+	// Maximum number of packets to ack immediately after a missing packet for
+	// fast retransmission to kick in at the sender.  This limit is created to
+	// reduce the number of acks sent that have no benefit for fast retransmission.
+	// Set to the number of nacks needed for fast retransmit plus one for protection
+	// against an ack loss
+	maxPacketsAfterNewMissing = 4
+)
+
+type receivedPacketHandler struct {
+	initialPackets   *receivedPacketTracker
+	handshakePackets *receivedPacketTracker
+	oneRTTPackets    *receivedPacketTracker
+}
+
+var _ ReceivedPacketHandler = &receivedPacketHandler{}
+
+// NewReceivedPacketHandler creates a new receivedPacketHandler
+func NewReceivedPacketHandler(
+	rttStats *congestion.RTTStats,
+	logger utils.Logger,
+	version protocol.VersionNumber,
+) ReceivedPacketHandler {
+	return &receivedPacketHandler{
+		initialPackets:   newReceivedPacketTracker(rttStats, logger, version),
+		handshakePackets: newReceivedPacketTracker(rttStats, logger, version),
+		oneRTTPackets:    newReceivedPacketTracker(rttStats, logger, version),
+	}
+}
+
+func (h *receivedPacketHandler) ReceivedPacket(
+	pn protocol.PacketNumber,
+	encLevel protocol.EncryptionLevel,
+	rcvTime time.Time,
+	shouldInstigateAck bool,
+) error {
+	switch encLevel {
+	case protocol.EncryptionInitial:
+		return h.initialPackets.ReceivedPacket(pn, rcvTime, shouldInstigateAck)
+	case protocol.EncryptionHandshake:
+		return h.handshakePackets.ReceivedPacket(pn, rcvTime, shouldInstigateAck)
+	case protocol.Encryption1RTT:
+		return h.oneRTTPackets.ReceivedPacket(pn, rcvTime, shouldInstigateAck)
+	default:
+		return fmt.Errorf("received packet with unknown encryption level: %s", encLevel)
+	}
+}
+
+// only to be used with 1-RTT packets
+func (h *receivedPacketHandler) IgnoreBelow(pn protocol.PacketNumber) {
+	h.oneRTTPackets.IgnoreBelow(pn)
+}
+
+func (h *receivedPacketHandler) GetAlarmTimeout() time.Time {
+	initialAlarm := h.initialPackets.GetAlarmTimeout()
+	handshakeAlarm := h.handshakePackets.GetAlarmTimeout()
+	oneRTTAlarm := h.oneRTTPackets.GetAlarmTimeout()
+	return utils.MinNonZeroTime(utils.MinNonZeroTime(initialAlarm, handshakeAlarm), oneRTTAlarm)
+}
+
+func (h *receivedPacketHandler) GetAckFrame(encLevel protocol.EncryptionLevel) *wire.AckFrame {
+	switch encLevel {
+	case protocol.EncryptionInitial:
+		return h.initialPackets.GetAckFrame()
+	case protocol.EncryptionHandshake:
+		return h.handshakePackets.GetAckFrame()
+	case protocol.Encryption1RTT:
+		return h.oneRTTPackets.GetAckFrame()
+	default:
+		return nil
+	}
+}

--- a/internal/ackhandler/received_packet_handler_test.go
+++ b/internal/ackhandler/received_packet_handler_test.go
@@ -1,0 +1,47 @@
+package ackhandler
+
+import (
+	"time"
+
+	"github.com/lucas-clemente/quic-go/internal/congestion"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/internal/wire"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Received Packet Handler", func() {
+	var handler ReceivedPacketHandler
+
+	BeforeEach(func() {
+		handler = NewReceivedPacketHandler(
+			&congestion.RTTStats{},
+			utils.DefaultLogger,
+			protocol.VersionWhatever,
+		)
+	})
+
+	It("generates ACKs for different packet number spaces", func() {
+		now := time.Now()
+		Expect(handler.ReceivedPacket(2, protocol.EncryptionInitial, now, true)).To(Succeed())
+		Expect(handler.ReceivedPacket(1, protocol.EncryptionHandshake, now, true)).To(Succeed())
+		Expect(handler.ReceivedPacket(5, protocol.Encryption1RTT, now, true)).To(Succeed())
+		Expect(handler.ReceivedPacket(3, protocol.EncryptionInitial, now, true)).To(Succeed())
+		Expect(handler.ReceivedPacket(2, protocol.EncryptionHandshake, now, true)).To(Succeed())
+		Expect(handler.ReceivedPacket(4, protocol.Encryption1RTT, now, true)).To(Succeed())
+		initialAck := handler.GetAckFrame(protocol.EncryptionInitial)
+		Expect(initialAck).ToNot(BeNil())
+		Expect(initialAck.AckRanges).To(HaveLen(1))
+		Expect(initialAck.AckRanges[0]).To(Equal(wire.AckRange{Smallest: 2, Largest: 3}))
+		handshakeAck := handler.GetAckFrame(protocol.EncryptionHandshake)
+		Expect(handshakeAck).ToNot(BeNil())
+		Expect(handshakeAck.AckRanges).To(HaveLen(1))
+		Expect(handshakeAck.AckRanges[0]).To(Equal(wire.AckRange{Smallest: 1, Largest: 2}))
+		oneRTTAck := handler.GetAckFrame(protocol.Encryption1RTT)
+		Expect(oneRTTAck).ToNot(BeNil())
+		Expect(oneRTTAck.AckRanges).To(HaveLen(1))
+		Expect(oneRTTAck.AckRanges[0]).To(Equal(wire.AckRange{Smallest: 4, Largest: 5}))
+	})
+})

--- a/internal/ackhandler/received_packet_history.go
+++ b/internal/ackhandler/received_packet_history.go
@@ -8,6 +8,7 @@ import (
 )
 
 // The receivedPacketHistory stores if a packet number has already been received.
+// It generates ACK ranges which can be used to assemble an ACK frame.
 // It does not store packet contents.
 type receivedPacketHistory struct {
 	ranges *utils.PacketIntervalList

--- a/internal/ackhandler/received_packet_tracker.go
+++ b/internal/ackhandler/received_packet_tracker.go
@@ -30,35 +30,11 @@ type receivedPacketTracker struct {
 	version protocol.VersionNumber
 }
 
-const (
-	// maximum delay that can be applied to an ACK for a retransmittable packet
-	ackSendDelay = 25 * time.Millisecond
-	// initial maximum number of retransmittable packets received before sending an ack.
-	initialRetransmittablePacketsBeforeAck = 2
-	// number of retransmittable that an ACK is sent for
-	retransmittablePacketsBeforeAck = 10
-	// 1/5 RTT delay when doing ack decimation
-	ackDecimationDelay = 1.0 / 4
-	// 1/8 RTT delay when doing ack decimation
-	shortAckDecimationDelay = 1.0 / 8
-	// Minimum number of packets received before ack decimation is enabled.
-	// This intends to avoid the beginning of slow start, when CWNDs may be
-	// rapidly increasing.
-	minReceivedBeforeAckDecimation = 100
-	// Maximum number of packets to ack immediately after a missing packet for
-	// fast retransmission to kick in at the sender.  This limit is created to
-	// reduce the number of acks sent that have no benefit for fast retransmission.
-	// Set to the number of nacks needed for fast retransmit plus one for protection
-	// against an ack loss
-	maxPacketsAfterNewMissing = 4
-)
-
-// NewReceivedPacketHandler creates a new receivedPacketHandler
-func NewReceivedPacketHandler(
+func newReceivedPacketTracker(
 	rttStats *congestion.RTTStats,
 	logger utils.Logger,
 	version protocol.VersionNumber,
-) ReceivedPacketHandler {
+) *receivedPacketTracker {
 	return &receivedPacketTracker{
 		packetHistory: newReceivedPacketHistory(),
 		ackSendDelay:  ackSendDelay,

--- a/internal/ackhandler/received_packet_tracker_test.go
+++ b/internal/ackhandler/received_packet_tracker_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Received Packet Tracker", func() {
 
 	BeforeEach(func() {
 		rttStats = &congestion.RTTStats{}
-		tracker = NewReceivedPacketHandler(rttStats, utils.DefaultLogger, protocol.VersionWhatever).(*receivedPacketTracker)
+		tracker = newReceivedPacketTracker(rttStats, utils.DefaultLogger, protocol.VersionWhatever)
 	})
 
 	Context("accepting packets", func() {

--- a/internal/ackhandler/received_packet_tracker_test.go
+++ b/internal/ackhandler/received_packet_tracker_test.go
@@ -12,58 +12,58 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("receivedPacketHandler", func() {
+var _ = Describe("Received Packet Tracker", func() {
 	var (
-		handler  *receivedPacketHandler
+		tracker  *receivedPacketTracker
 		rttStats *congestion.RTTStats
 	)
 
 	BeforeEach(func() {
 		rttStats = &congestion.RTTStats{}
-		handler = NewReceivedPacketHandler(rttStats, utils.DefaultLogger, protocol.VersionWhatever).(*receivedPacketHandler)
+		tracker = NewReceivedPacketHandler(rttStats, utils.DefaultLogger, protocol.VersionWhatever).(*receivedPacketTracker)
 	})
 
 	Context("accepting packets", func() {
 		It("handles a packet that arrives late", func() {
-			err := handler.ReceivedPacket(protocol.PacketNumber(1), time.Time{}, true)
+			err := tracker.ReceivedPacket(protocol.PacketNumber(1), time.Time{}, true)
 			Expect(err).ToNot(HaveOccurred())
-			err = handler.ReceivedPacket(protocol.PacketNumber(3), time.Time{}, true)
+			err = tracker.ReceivedPacket(protocol.PacketNumber(3), time.Time{}, true)
 			Expect(err).ToNot(HaveOccurred())
-			err = handler.ReceivedPacket(protocol.PacketNumber(2), time.Time{}, true)
+			err = tracker.ReceivedPacket(protocol.PacketNumber(2), time.Time{}, true)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("saves the time when each packet arrived", func() {
-			err := handler.ReceivedPacket(protocol.PacketNumber(3), time.Now(), true)
+			err := tracker.ReceivedPacket(protocol.PacketNumber(3), time.Now(), true)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(handler.largestObservedReceivedTime).To(BeTemporally("~", time.Now(), 10*time.Millisecond))
+			Expect(tracker.largestObservedReceivedTime).To(BeTemporally("~", time.Now(), 10*time.Millisecond))
 		})
 
 		It("updates the largestObserved and the largestObservedReceivedTime", func() {
 			now := time.Now()
-			handler.largestObserved = 3
-			handler.largestObservedReceivedTime = now.Add(-1 * time.Second)
-			err := handler.ReceivedPacket(5, now, true)
+			tracker.largestObserved = 3
+			tracker.largestObservedReceivedTime = now.Add(-1 * time.Second)
+			err := tracker.ReceivedPacket(5, now, true)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(handler.largestObserved).To(Equal(protocol.PacketNumber(5)))
-			Expect(handler.largestObservedReceivedTime).To(Equal(now))
+			Expect(tracker.largestObserved).To(Equal(protocol.PacketNumber(5)))
+			Expect(tracker.largestObservedReceivedTime).To(Equal(now))
 		})
 
 		It("doesn't update the largestObserved and the largestObservedReceivedTime for a belated packet", func() {
 			now := time.Now()
 			timestamp := now.Add(-1 * time.Second)
-			handler.largestObserved = 5
-			handler.largestObservedReceivedTime = timestamp
-			err := handler.ReceivedPacket(4, now, true)
+			tracker.largestObserved = 5
+			tracker.largestObservedReceivedTime = timestamp
+			err := tracker.ReceivedPacket(4, now, true)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(handler.largestObserved).To(Equal(protocol.PacketNumber(5)))
-			Expect(handler.largestObservedReceivedTime).To(Equal(timestamp))
+			Expect(tracker.largestObserved).To(Equal(protocol.PacketNumber(5)))
+			Expect(tracker.largestObservedReceivedTime).To(Equal(timestamp))
 		})
 
 		It("passes on errors from receivedPacketHistory", func() {
 			var err error
 			for i := protocol.PacketNumber(0); i < 5*protocol.MaxTrackedReceivedAckRanges; i++ {
-				err = handler.ReceivedPacket(2*i+1, time.Time{}, true)
+				err = tracker.ReceivedPacket(2*i+1, time.Time{}, true)
 				// this will eventually return an error
 				// details about when exactly the receivedPacketHistory errors are tested there
 				if err != nil {
@@ -78,50 +78,50 @@ var _ = Describe("receivedPacketHandler", func() {
 		Context("queueing ACKs", func() {
 			receiveAndAck10Packets := func() {
 				for i := 1; i <= 10; i++ {
-					err := handler.ReceivedPacket(protocol.PacketNumber(i), time.Time{}, true)
+					err := tracker.ReceivedPacket(protocol.PacketNumber(i), time.Time{}, true)
 					Expect(err).ToNot(HaveOccurred())
 				}
-				Expect(handler.GetAckFrame()).ToNot(BeNil())
-				Expect(handler.ackQueued).To(BeFalse())
+				Expect(tracker.GetAckFrame()).ToNot(BeNil())
+				Expect(tracker.ackQueued).To(BeFalse())
 			}
 
 			receiveAndAckPacketsUntilAckDecimation := func() {
 				for i := 1; i <= minReceivedBeforeAckDecimation; i++ {
-					err := handler.ReceivedPacket(protocol.PacketNumber(i), time.Time{}, true)
+					err := tracker.ReceivedPacket(protocol.PacketNumber(i), time.Time{}, true)
 					Expect(err).ToNot(HaveOccurred())
 				}
-				Expect(handler.GetAckFrame()).ToNot(BeNil())
-				Expect(handler.ackQueued).To(BeFalse())
+				Expect(tracker.GetAckFrame()).ToNot(BeNil())
+				Expect(tracker.ackQueued).To(BeFalse())
 			}
 
 			It("always queues an ACK for the first packet", func() {
-				Expect(handler.ReceivedPacket(1, time.Now(), false)).To(Succeed())
-				Expect(handler.ackQueued).To(BeTrue())
-				Expect(handler.GetAlarmTimeout()).To(BeZero())
-				Expect(handler.GetAckFrame().DelayTime).To(BeNumerically("~", 0, time.Second))
+				Expect(tracker.ReceivedPacket(1, time.Now(), false)).To(Succeed())
+				Expect(tracker.ackQueued).To(BeTrue())
+				Expect(tracker.GetAlarmTimeout()).To(BeZero())
+				Expect(tracker.GetAckFrame().DelayTime).To(BeNumerically("~", 0, time.Second))
 			})
 
 			It("works with packet number 0", func() {
-				Expect(handler.ReceivedPacket(0, time.Now(), false)).To(Succeed())
-				Expect(handler.ackQueued).To(BeTrue())
-				Expect(handler.GetAlarmTimeout()).To(BeZero())
-				Expect(handler.GetAckFrame().DelayTime).To(BeNumerically("~", 0, time.Second))
+				Expect(tracker.ReceivedPacket(0, time.Now(), false)).To(Succeed())
+				Expect(tracker.ackQueued).To(BeTrue())
+				Expect(tracker.GetAlarmTimeout()).To(BeZero())
+				Expect(tracker.GetAckFrame().DelayTime).To(BeNumerically("~", 0, time.Second))
 			})
 
 			It("queues an ACK for every second retransmittable packet at the beginning", func() {
 				receiveAndAck10Packets()
 				p := protocol.PacketNumber(11)
 				for i := 0; i <= 20; i++ {
-					err := handler.ReceivedPacket(p, time.Time{}, true)
+					err := tracker.ReceivedPacket(p, time.Time{}, true)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(handler.ackQueued).To(BeFalse())
+					Expect(tracker.ackQueued).To(BeFalse())
 					p++
-					err = handler.ReceivedPacket(p, time.Time{}, true)
+					err = tracker.ReceivedPacket(p, time.Time{}, true)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(handler.ackQueued).To(BeTrue())
+					Expect(tracker.ackQueued).To(BeTrue())
 					p++
 					// dequeue the ACK frame
-					Expect(handler.GetAckFrame()).ToNot(BeNil())
+					Expect(tracker.GetAckFrame()).ToNot(BeNil())
 				}
 			})
 
@@ -129,73 +129,73 @@ var _ = Describe("receivedPacketHandler", func() {
 				receiveAndAck10Packets()
 				p := protocol.PacketNumber(10000)
 				for i := 0; i < 9; i++ {
-					err := handler.ReceivedPacket(p, time.Now(), true)
+					err := tracker.ReceivedPacket(p, time.Now(), true)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(handler.ackQueued).To(BeFalse())
+					Expect(tracker.ackQueued).To(BeFalse())
 					p++
 				}
-				Expect(handler.GetAlarmTimeout()).NotTo(BeZero())
-				err := handler.ReceivedPacket(p, time.Now(), true)
+				Expect(tracker.GetAlarmTimeout()).NotTo(BeZero())
+				err := tracker.ReceivedPacket(p, time.Now(), true)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.ackQueued).To(BeTrue())
-				Expect(handler.GetAlarmTimeout()).To(BeZero())
+				Expect(tracker.ackQueued).To(BeTrue())
+				Expect(tracker.GetAlarmTimeout()).To(BeZero())
 			})
 
 			It("only sets the timer when receiving a retransmittable packets", func() {
 				receiveAndAck10Packets()
-				err := handler.ReceivedPacket(11, time.Now(), false)
+				err := tracker.ReceivedPacket(11, time.Now(), false)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.ackQueued).To(BeFalse())
-				Expect(handler.GetAlarmTimeout()).To(BeZero())
+				Expect(tracker.ackQueued).To(BeFalse())
+				Expect(tracker.GetAlarmTimeout()).To(BeZero())
 				rcvTime := time.Now().Add(10 * time.Millisecond)
-				err = handler.ReceivedPacket(12, rcvTime, true)
+				err = tracker.ReceivedPacket(12, rcvTime, true)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.ackQueued).To(BeFalse())
-				Expect(handler.GetAlarmTimeout()).To(Equal(rcvTime.Add(ackSendDelay)))
+				Expect(tracker.ackQueued).To(BeFalse())
+				Expect(tracker.GetAlarmTimeout()).To(Equal(rcvTime.Add(ackSendDelay)))
 			})
 
 			It("queues an ACK if it was reported missing before", func() {
 				receiveAndAck10Packets()
-				err := handler.ReceivedPacket(11, time.Time{}, true)
+				err := tracker.ReceivedPacket(11, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = handler.ReceivedPacket(13, time.Time{}, true)
+				err = tracker.ReceivedPacket(13, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame() // ACK: 1-11 and 13, missing: 12
+				ack := tracker.GetAckFrame() // ACK: 1-11 and 13, missing: 12
 				Expect(ack).ToNot(BeNil())
 				Expect(ack.HasMissingRanges()).To(BeTrue())
-				Expect(handler.ackQueued).To(BeFalse())
-				err = handler.ReceivedPacket(12, time.Time{}, false)
+				Expect(tracker.ackQueued).To(BeFalse())
+				err = tracker.ReceivedPacket(12, time.Time{}, false)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.ackQueued).To(BeTrue())
+				Expect(tracker.ackQueued).To(BeTrue())
 			})
 
 			It("doesn't queue an ACK if it was reported missing before, but is below the threshold", func() {
 				receiveAndAck10Packets()
 				// 11 is missing
-				err := handler.ReceivedPacket(12, time.Time{}, true)
+				err := tracker.ReceivedPacket(12, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = handler.ReceivedPacket(13, time.Time{}, true)
+				err = tracker.ReceivedPacket(13, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame() // ACK: 1-10, 12-13
+				ack := tracker.GetAckFrame() // ACK: 1-10, 12-13
 				Expect(ack).ToNot(BeNil())
 				// now receive 11
-				handler.IgnoreBelow(12)
-				err = handler.ReceivedPacket(11, time.Time{}, false)
+				tracker.IgnoreBelow(12)
+				err = tracker.ReceivedPacket(11, time.Time{}, false)
 				Expect(err).ToNot(HaveOccurred())
-				ack = handler.GetAckFrame()
+				ack = tracker.GetAckFrame()
 				Expect(ack).To(BeNil())
 			})
 
 			It("doesn't queue an ACK if the packet closes a gap that was not yet reported", func() {
 				receiveAndAckPacketsUntilAckDecimation()
 				p := protocol.PacketNumber(minReceivedBeforeAckDecimation + 1)
-				err := handler.ReceivedPacket(p+1, time.Now(), true) // p is missing now
+				err := tracker.ReceivedPacket(p+1, time.Now(), true) // p is missing now
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.ackQueued).To(BeFalse())
-				Expect(handler.GetAlarmTimeout()).ToNot(BeZero())
-				err = handler.ReceivedPacket(p, time.Now(), true) // p is not missing any more
+				Expect(tracker.ackQueued).To(BeFalse())
+				Expect(tracker.GetAlarmTimeout()).ToNot(BeZero())
+				err = tracker.ReceivedPacket(p, time.Now(), true) // p is not missing any more
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.ackQueued).To(BeFalse())
+				Expect(tracker.ackQueued).To(BeFalse())
 			})
 
 			It("sets an ACK alarm after 1/4 RTT if it creates a new missing range", func() {
@@ -205,14 +205,14 @@ var _ = Describe("receivedPacketHandler", func() {
 				receiveAndAckPacketsUntilAckDecimation()
 				p := protocol.PacketNumber(minReceivedBeforeAckDecimation + 1)
 				for i := p; i < p+6; i++ {
-					err := handler.ReceivedPacket(i, now, true)
+					err := tracker.ReceivedPacket(i, now, true)
 					Expect(err).ToNot(HaveOccurred())
 				}
-				err := handler.ReceivedPacket(p+10, now, true) // we now know that packets p+7, p+8 and p+9
+				err := tracker.ReceivedPacket(p+10, now, true) // we now know that packets p+7, p+8 and p+9
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rttStats.MinRTT()).To(Equal(rtt))
-				Expect(handler.ackAlarm.Sub(now)).To(Equal(rtt / 8))
-				ack := handler.GetAckFrame()
+				Expect(tracker.ackAlarm.Sub(now)).To(Equal(rtt / 8))
+				ack := tracker.GetAckFrame()
 				Expect(ack.HasMissingRanges()).To(BeTrue())
 				Expect(ack).ToNot(BeNil())
 			})
@@ -220,15 +220,15 @@ var _ = Describe("receivedPacketHandler", func() {
 
 		Context("ACK generation", func() {
 			BeforeEach(func() {
-				handler.ackQueued = true
+				tracker.ackQueued = true
 			})
 
 			It("generates a simple ACK frame", func() {
-				err := handler.ReceivedPacket(1, time.Time{}, true)
+				err := tracker.ReceivedPacket(1, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = handler.ReceivedPacket(2, time.Time{}, true)
+				err = tracker.ReceivedPacket(2, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame()
+				ack := tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
 				Expect(ack.LargestAcked()).To(Equal(protocol.PacketNumber(2)))
 				Expect(ack.LowestAcked()).To(Equal(protocol.PacketNumber(1)))
@@ -236,9 +236,9 @@ var _ = Describe("receivedPacketHandler", func() {
 			})
 
 			It("generates an ACK for packet number 0", func() {
-				err := handler.ReceivedPacket(0, time.Time{}, true)
+				err := tracker.ReceivedPacket(0, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame()
+				ack := tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
 				Expect(ack.LargestAcked()).To(Equal(protocol.PacketNumber(0)))
 				Expect(ack.LowestAcked()).To(Equal(protocol.PacketNumber(0)))
@@ -246,35 +246,35 @@ var _ = Describe("receivedPacketHandler", func() {
 			})
 
 			It("sets the delay time", func() {
-				err := handler.ReceivedPacket(1, time.Time{}, true)
+				err := tracker.ReceivedPacket(1, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = handler.ReceivedPacket(2, time.Now().Add(-1337*time.Millisecond), true)
+				err = tracker.ReceivedPacket(2, time.Now().Add(-1337*time.Millisecond), true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame()
+				ack := tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
 				Expect(ack.DelayTime).To(BeNumerically("~", 1337*time.Millisecond, 50*time.Millisecond))
 			})
 
 			It("saves the last sent ACK", func() {
-				err := handler.ReceivedPacket(1, time.Time{}, true)
+				err := tracker.ReceivedPacket(1, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame()
+				ack := tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
-				Expect(handler.lastAck).To(Equal(ack))
-				err = handler.ReceivedPacket(2, time.Time{}, true)
+				Expect(tracker.lastAck).To(Equal(ack))
+				err = tracker.ReceivedPacket(2, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				handler.ackQueued = true
-				ack = handler.GetAckFrame()
+				tracker.ackQueued = true
+				ack = tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
-				Expect(handler.lastAck).To(Equal(ack))
+				Expect(tracker.lastAck).To(Equal(ack))
 			})
 
 			It("generates an ACK frame with missing packets", func() {
-				err := handler.ReceivedPacket(1, time.Time{}, true)
+				err := tracker.ReceivedPacket(1, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = handler.ReceivedPacket(4, time.Time{}, true)
+				err = tracker.ReceivedPacket(4, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame()
+				ack := tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
 				Expect(ack.LargestAcked()).To(Equal(protocol.PacketNumber(4)))
 				Expect(ack.LowestAcked()).To(Equal(protocol.PacketNumber(1)))
@@ -285,13 +285,13 @@ var _ = Describe("receivedPacketHandler", func() {
 			})
 
 			It("generates an ACK for packet number 0 and other packets", func() {
-				err := handler.ReceivedPacket(0, time.Time{}, true)
+				err := tracker.ReceivedPacket(0, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = handler.ReceivedPacket(1, time.Time{}, true)
+				err = tracker.ReceivedPacket(1, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = handler.ReceivedPacket(3, time.Time{}, true)
+				err = tracker.ReceivedPacket(3, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame()
+				ack := tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
 				Expect(ack.LargestAcked()).To(Equal(protocol.PacketNumber(3)))
 				Expect(ack.LowestAcked()).To(Equal(protocol.PacketNumber(0)))
@@ -302,18 +302,18 @@ var _ = Describe("receivedPacketHandler", func() {
 			})
 
 			It("accepts packets below the lower limit", func() {
-				handler.IgnoreBelow(6)
-				err := handler.ReceivedPacket(2, time.Time{}, true)
+				tracker.IgnoreBelow(6)
+				err := tracker.ReceivedPacket(2, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("doesn't add delayed packets to the packetHistory", func() {
-				handler.IgnoreBelow(7)
-				err := handler.ReceivedPacket(4, time.Time{}, true)
+				tracker.IgnoreBelow(7)
+				err := tracker.ReceivedPacket(4, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = handler.ReceivedPacket(10, time.Time{}, true)
+				err = tracker.ReceivedPacket(10, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame()
+				ack := tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
 				Expect(ack.LargestAcked()).To(Equal(protocol.PacketNumber(10)))
 				Expect(ack.LowestAcked()).To(Equal(protocol.PacketNumber(10)))
@@ -321,12 +321,12 @@ var _ = Describe("receivedPacketHandler", func() {
 
 			It("deletes packets from the packetHistory when a lower limit is set", func() {
 				for i := 1; i <= 12; i++ {
-					err := handler.ReceivedPacket(protocol.PacketNumber(i), time.Time{}, true)
+					err := tracker.ReceivedPacket(protocol.PacketNumber(i), time.Time{}, true)
 					Expect(err).ToNot(HaveOccurred())
 				}
-				handler.IgnoreBelow(7)
+				tracker.IgnoreBelow(7)
 				// check that the packets were deleted from the receivedPacketHistory by checking the values in an ACK frame
-				ack := handler.GetAckFrame()
+				ack := tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
 				Expect(ack.LargestAcked()).To(Equal(protocol.PacketNumber(12)))
 				Expect(ack.LowestAcked()).To(Equal(protocol.PacketNumber(7)))
@@ -335,47 +335,47 @@ var _ = Describe("receivedPacketHandler", func() {
 
 			// TODO: remove this test when dropping support for STOP_WAITINGs
 			It("handles a lower limit of 0", func() {
-				handler.IgnoreBelow(0)
-				err := handler.ReceivedPacket(1337, time.Time{}, true)
+				tracker.IgnoreBelow(0)
+				err := tracker.ReceivedPacket(1337, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				ack := handler.GetAckFrame()
+				ack := tracker.GetAckFrame()
 				Expect(ack).ToNot(BeNil())
 				Expect(ack.LargestAcked()).To(Equal(protocol.PacketNumber(1337)))
 			})
 
 			It("resets all counters needed for the ACK queueing decision when sending an ACK", func() {
-				err := handler.ReceivedPacket(1, time.Time{}, true)
+				err := tracker.ReceivedPacket(1, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				handler.ackAlarm = time.Now().Add(-time.Minute)
-				Expect(handler.GetAckFrame()).ToNot(BeNil())
-				Expect(handler.packetsReceivedSinceLastAck).To(BeZero())
-				Expect(handler.GetAlarmTimeout()).To(BeZero())
-				Expect(handler.retransmittablePacketsReceivedSinceLastAck).To(BeZero())
-				Expect(handler.ackQueued).To(BeFalse())
+				tracker.ackAlarm = time.Now().Add(-time.Minute)
+				Expect(tracker.GetAckFrame()).ToNot(BeNil())
+				Expect(tracker.packetsReceivedSinceLastAck).To(BeZero())
+				Expect(tracker.GetAlarmTimeout()).To(BeZero())
+				Expect(tracker.retransmittablePacketsReceivedSinceLastAck).To(BeZero())
+				Expect(tracker.ackQueued).To(BeFalse())
 			})
 
 			It("doesn't generate an ACK when none is queued and the timer is not set", func() {
-				err := handler.ReceivedPacket(1, time.Time{}, true)
+				err := tracker.ReceivedPacket(1, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				handler.ackQueued = false
-				handler.ackAlarm = time.Time{}
-				Expect(handler.GetAckFrame()).To(BeNil())
+				tracker.ackQueued = false
+				tracker.ackAlarm = time.Time{}
+				Expect(tracker.GetAckFrame()).To(BeNil())
 			})
 
 			It("doesn't generate an ACK when none is queued and the timer has not yet expired", func() {
-				err := handler.ReceivedPacket(1, time.Time{}, true)
+				err := tracker.ReceivedPacket(1, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				handler.ackQueued = false
-				handler.ackAlarm = time.Now().Add(time.Minute)
-				Expect(handler.GetAckFrame()).To(BeNil())
+				tracker.ackQueued = false
+				tracker.ackAlarm = time.Now().Add(time.Minute)
+				Expect(tracker.GetAckFrame()).To(BeNil())
 			})
 
 			It("generates an ACK when the timer has expired", func() {
-				err := handler.ReceivedPacket(1, time.Time{}, true)
+				err := tracker.ReceivedPacket(1, time.Time{}, true)
 				Expect(err).ToNot(HaveOccurred())
-				handler.ackQueued = false
-				handler.ackAlarm = time.Now().Add(-time.Minute)
-				Expect(handler.GetAckFrame()).ToNot(BeNil())
+				tracker.ackQueued = false
+				tracker.ackAlarm = time.Now().Add(-time.Minute)
+				Expect(tracker.GetAckFrame()).ToNot(BeNil())
 			})
 		})
 	})

--- a/internal/mocks/ackhandler/received_packet_handler.go
+++ b/internal/mocks/ackhandler/received_packet_handler.go
@@ -37,15 +37,15 @@ func (m *MockReceivedPacketHandler) EXPECT() *MockReceivedPacketHandlerMockRecor
 }
 
 // GetAckFrame mocks base method
-func (m *MockReceivedPacketHandler) GetAckFrame() *wire.AckFrame {
-	ret := m.ctrl.Call(m, "GetAckFrame")
+func (m *MockReceivedPacketHandler) GetAckFrame(arg0 protocol.EncryptionLevel) *wire.AckFrame {
+	ret := m.ctrl.Call(m, "GetAckFrame", arg0)
 	ret0, _ := ret[0].(*wire.AckFrame)
 	return ret0
 }
 
 // GetAckFrame indicates an expected call of GetAckFrame
-func (mr *MockReceivedPacketHandlerMockRecorder) GetAckFrame() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAckFrame", reflect.TypeOf((*MockReceivedPacketHandler)(nil).GetAckFrame))
+func (mr *MockReceivedPacketHandlerMockRecorder) GetAckFrame(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAckFrame", reflect.TypeOf((*MockReceivedPacketHandler)(nil).GetAckFrame), arg0)
 }
 
 // GetAlarmTimeout mocks base method
@@ -71,13 +71,13 @@ func (mr *MockReceivedPacketHandlerMockRecorder) IgnoreBelow(arg0 interface{}) *
 }
 
 // ReceivedPacket mocks base method
-func (m *MockReceivedPacketHandler) ReceivedPacket(arg0 protocol.PacketNumber, arg1 time.Time, arg2 bool) error {
-	ret := m.ctrl.Call(m, "ReceivedPacket", arg0, arg1, arg2)
+func (m *MockReceivedPacketHandler) ReceivedPacket(arg0 protocol.PacketNumber, arg1 protocol.EncryptionLevel, arg2 time.Time, arg3 bool) error {
+	ret := m.ctrl.Call(m, "ReceivedPacket", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReceivedPacket indicates an expected call of ReceivedPacket
-func (mr *MockReceivedPacketHandlerMockRecorder) ReceivedPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedPacket", reflect.TypeOf((*MockReceivedPacketHandler)(nil).ReceivedPacket), arg0, arg1, arg2)
+func (mr *MockReceivedPacketHandlerMockRecorder) ReceivedPacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedPacket", reflect.TypeOf((*MockReceivedPacketHandler)(nil).ReceivedPacket), arg0, arg1, arg2, arg3)
 }

--- a/internal/utils/minmax.go
+++ b/internal/utils/minmax.go
@@ -122,6 +122,18 @@ func MinTime(a, b time.Time) time.Time {
 	return a
 }
 
+// MinNonZeroTime returns the earlist time that is not time.Time{}
+// If both a and b are time.Time{}, it returns time.Time{}
+func MinNonZeroTime(a, b time.Time) time.Time {
+	if a.IsZero() {
+		return b
+	}
+	if b.IsZero() {
+		return a
+	}
+	return MinTime(a, b)
+}
+
 // MaxTime returns the later time
 func MaxTime(a, b time.Time) time.Time {
 	if a.After(b) {

--- a/internal/utils/minmax_test.go
+++ b/internal/utils/minmax_test.go
@@ -95,6 +95,16 @@ var _ = Describe("Min / Max", func() {
 			Expect(MinTime(a, b)).To(Equal(a))
 			Expect(MinTime(b, a)).To(Equal(a))
 		})
+
+		It("returns the minium non-zero time", func() {
+			a := time.Time{}
+			b := time.Now()
+			Expect(MinNonZeroTime(time.Time{}, time.Time{})).To(Equal(time.Time{}))
+			Expect(MinNonZeroTime(a, b)).To(Equal(b))
+			Expect(MinNonZeroTime(b, a)).To(Equal(b))
+			Expect(MinNonZeroTime(b, b.Add(time.Second))).To(Equal(b))
+			Expect(MinNonZeroTime(b.Add(time.Second), b)).To(Equal(b))
+		})
 	})
 
 	It("returns the abs time", func() {

--- a/mock_ack_frame_source_test.go
+++ b/mock_ack_frame_source_test.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
 	wire "github.com/lucas-clemente/quic-go/internal/wire"
 )
 
@@ -35,13 +36,13 @@ func (m *MockAckFrameSource) EXPECT() *MockAckFrameSourceMockRecorder {
 }
 
 // GetAckFrame mocks base method
-func (m *MockAckFrameSource) GetAckFrame() *wire.AckFrame {
-	ret := m.ctrl.Call(m, "GetAckFrame")
+func (m *MockAckFrameSource) GetAckFrame(arg0 protocol.EncryptionLevel) *wire.AckFrame {
+	ret := m.ctrl.Call(m, "GetAckFrame", arg0)
 	ret0, _ := ret[0].(*wire.AckFrame)
 	return ret0
 }
 
 // GetAckFrame indicates an expected call of GetAckFrame
-func (mr *MockAckFrameSourceMockRecorder) GetAckFrame() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAckFrame", reflect.TypeOf((*MockAckFrameSource)(nil).GetAckFrame))
+func (mr *MockAckFrameSourceMockRecorder) GetAckFrame(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAckFrame", reflect.TypeOf((*MockAckFrameSource)(nil).GetAckFrame), arg0)
 }

--- a/session.go
+++ b/session.go
@@ -726,7 +726,9 @@ func (s *session) handleAckFrame(frame *wire.AckFrame, pn protocol.PacketNumber,
 	if err := s.sentPacketHandler.ReceivedAck(frame, pn, encLevel, s.lastNetworkActivityTime); err != nil {
 		return err
 	}
-	s.receivedPacketHandler.IgnoreBelow(s.sentPacketHandler.GetLowestPacketNotConfirmedAcked())
+	if encLevel == protocol.Encryption1RTT {
+		s.receivedPacketHandler.IgnoreBelow(s.sentPacketHandler.GetLowestPacketNotConfirmedAcked())
+	}
 	return nil
 }
 

--- a/session.go
+++ b/session.go
@@ -566,7 +566,7 @@ func (s *session) handleUnpackedPacket(packet *unpackedPacket, rcvTime time.Time
 		}
 	}
 
-	if err := s.receivedPacketHandler.ReceivedPacket(packet.packetNumber, rcvTime, isRetransmittable); err != nil {
+	if err := s.receivedPacketHandler.ReceivedPacket(packet.packetNumber, packet.encryptionLevel, rcvTime, isRetransmittable); err != nil {
 		return err
 	}
 	return nil

--- a/session_test.go
+++ b/session_test.go
@@ -159,7 +159,6 @@ var _ = Describe("Session", func() {
 				f := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 2, Largest: 3}}}
 				sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 				sph.EXPECT().ReceivedAck(f, protocol.PacketNumber(42), protocol.EncryptionHandshake, gomock.Any())
-				sph.EXPECT().GetLowestPacketNotConfirmedAcked()
 				sess.sentPacketHandler = sph
 				err := sess.handleAckFrame(f, 42, protocol.EncryptionHandshake)
 				Expect(err).ToNot(HaveOccurred())
@@ -174,7 +173,7 @@ var _ = Describe("Session", func() {
 				rph := mockackhandler.NewMockReceivedPacketHandler(mockCtrl)
 				rph.EXPECT().IgnoreBelow(protocol.PacketNumber(0x42))
 				sess.receivedPacketHandler = rph
-				Expect(sess.handleAckFrame(ack, 0, protocol.EncryptionInitial)).To(Succeed())
+				Expect(sess.handleAckFrame(ack, 0, protocol.Encryption1RTT)).To(Succeed())
 			})
 		})
 


### PR DESCRIPTION
Fixes #1639.
Part of the fix for #1534.