### PR TITLE
account for connection-level flow control on stream resets

### DIFF
--- a/crypto_stream.go
+++ b/crypto_stream.go
@@ -53,11 +53,11 @@ func (s *cryptoStreamImpl) HandleCryptoFrame(f *wire.CryptoFrame) error {
 		return nil
 	}
 	s.highestOffset = utils.MaxByteCount(s.highestOffset, highestOffset)
-	if err := s.queue.Push(f.Data, f.Offset, false); err != nil {
+	if err := s.queue.Push(f.Data, f.Offset); err != nil {
 		return err
 	}
 	for {
-		data, _ := s.queue.Pop()
+		_, data := s.queue.Pop()
 		if data == nil {
 			return nil
 		}

--- a/frame_sorter.go
+++ b/frame_sorter.go
@@ -8,36 +8,31 @@ import (
 )
 
 type frameSorter struct {
-	queue       map[protocol.ByteCount][]byte
-	readPos     protocol.ByteCount
-	finalOffset protocol.ByteCount
-	gaps        *utils.ByteIntervalList
+	queue   map[protocol.ByteCount][]byte
+	readPos protocol.ByteCount
+	gaps    *utils.ByteIntervalList
 }
 
 var errDuplicateStreamData = errors.New("Duplicate Stream Data")
 
 func newFrameSorter() *frameSorter {
 	s := frameSorter{
-		gaps:        utils.NewByteIntervalList(),
-		queue:       make(map[protocol.ByteCount][]byte),
-		finalOffset: protocol.MaxByteCount,
+		gaps:  utils.NewByteIntervalList(),
+		queue: make(map[protocol.ByteCount][]byte),
 	}
 	s.gaps.PushFront(utils.ByteInterval{Start: 0, End: protocol.MaxByteCount})
 	return &s
 }
 
-func (s *frameSorter) Push(data []byte, offset protocol.ByteCount, fin bool) error {
-	err := s.push(data, offset, fin)
+func (s *frameSorter) Push(data []byte, offset protocol.ByteCount) error {
+	err := s.push(data, offset)
 	if err == errDuplicateStreamData {
 		return nil
 	}
 	return err
 }
 
-func (s *frameSorter) push(data []byte, offset protocol.ByteCount, fin bool) error {
-	if fin {
-		s.finalOffset = offset + protocol.ByteCount(len(data))
-	}
+func (s *frameSorter) push(data []byte, offset protocol.ByteCount) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -147,14 +142,15 @@ func (s *frameSorter) push(data []byte, offset protocol.ByteCount, fin bool) err
 	return nil
 }
 
-func (s *frameSorter) Pop() ([]byte /* data */, bool /* fin */) {
+func (s *frameSorter) Pop() (protocol.ByteCount, []byte) {
 	data, ok := s.queue[s.readPos]
 	if !ok {
-		return nil, s.readPos >= s.finalOffset
+		return s.readPos, nil
 	}
 	delete(s.queue, s.readPos)
+	offset := s.readPos
 	s.readPos += protocol.ByteCount(len(data))
-	return data, s.readPos >= s.finalOffset
+	return offset, data
 }
 
 // HasMoreData says if there is any more data queued at *any* offset.

--- a/frame_sorter_test.go
+++ b/frame_sorter_test.go
@@ -25,81 +25,54 @@ var _ = Describe("STREAM frame sorter", func() {
 		s = newFrameSorter()
 	})
 
-	It("head returns nil when empty", func() {
-		Expect(s.Pop()).To(BeNil())
+	It("returns nil when empty", func() {
+		_, data := s.Pop()
+		Expect(data).To(BeNil())
 	})
 
 	Context("Push", func() {
 		It("inserts and pops a single frame", func() {
-			Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
-			data, fin := s.Pop()
+			Expect(s.Push([]byte("foobar"), 0)).To(Succeed())
+			offset, data := s.Pop()
+			Expect(offset).To(BeZero())
 			Expect(data).To(Equal([]byte("foobar")))
-			Expect(fin).To(BeFalse())
-			Expect(s.Pop()).To(BeNil())
+			offset, data = s.Pop()
+			Expect(offset).To(Equal(protocol.ByteCount(6)))
+			Expect(data).To(BeNil())
 		})
 
 		It("inserts and pops two consecutive frame", func() {
-			Expect(s.Push([]byte("foo"), 0, false)).To(Succeed())
-			Expect(s.Push([]byte("bar"), 3, false)).To(Succeed())
-			data, fin := s.Pop()
+			Expect(s.Push([]byte("foo"), 0)).To(Succeed())
+			Expect(s.Push([]byte("bar"), 3)).To(Succeed())
+			offset, data := s.Pop()
+			Expect(offset).To(BeZero())
 			Expect(data).To(Equal([]byte("foo")))
-			Expect(fin).To(BeFalse())
-			data, fin = s.Pop()
+			offset, data = s.Pop()
+			Expect(offset).To(Equal(protocol.ByteCount(3)))
 			Expect(data).To(Equal([]byte("bar")))
-			Expect(fin).To(BeFalse())
-			Expect(s.Pop()).To(BeNil())
+			offset, data = s.Pop()
+			Expect(offset).To(Equal(protocol.ByteCount(6)))
+			Expect(data).To(BeNil())
 		})
 
 		It("ignores empty frames", func() {
-			Expect(s.Push(nil, 0, false)).To(Succeed())
-			Expect(s.Pop()).To(BeNil())
+			Expect(s.Push(nil, 0)).To(Succeed())
+			_, data := s.Pop()
+			Expect(data).To(BeNil())
 		})
 
 		It("says if has more data", func() {
 			Expect(s.HasMoreData()).To(BeFalse())
-			Expect(s.Push([]byte("foo"), 0, false)).To(Succeed())
+			Expect(s.Push([]byte("foo"), 0)).To(Succeed())
 			Expect(s.HasMoreData()).To(BeTrue())
-			data, _ := s.Pop()
+			_, data := s.Pop()
 			Expect(data).To(Equal([]byte("foo")))
 			Expect(s.HasMoreData()).To(BeFalse())
 		})
 
-		Context("FIN handling", func() {
-			It("saves a FIN at offset 0", func() {
-				Expect(s.Push(nil, 0, true)).To(Succeed())
-				data, fin := s.Pop()
-				Expect(data).To(BeEmpty())
-				Expect(fin).To(BeTrue())
-				data, fin = s.Pop()
-				Expect(data).To(BeNil())
-				Expect(fin).To(BeTrue())
-			})
-
-			It("saves a FIN frame at non-zero offset", func() {
-				Expect(s.Push([]byte("foobar"), 0, true)).To(Succeed())
-				data, fin := s.Pop()
-				Expect(data).To(Equal([]byte("foobar")))
-				Expect(fin).To(BeTrue())
-				data, fin = s.Pop()
-				Expect(data).To(BeNil())
-				Expect(fin).To(BeTrue())
-			})
-
-			It("sets the FIN if a stream is closed after receiving some data", func() {
-				Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
-				Expect(s.Push(nil, 6, true)).To(Succeed())
-				data, fin := s.Pop()
-				Expect(data).To(Equal([]byte("foobar")))
-				Expect(fin).To(BeTrue())
-				data, fin = s.Pop()
-				Expect(data).To(BeNil())
-				Expect(fin).To(BeTrue())
-			})
-		})
-
 		Context("Gap handling", func() {
 			It("finds the first gap", func() {
-				Expect(s.Push([]byte("foobar"), 10, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 10)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 10},
 					{Start: 16, End: protocol.MaxByteCount},
@@ -107,15 +80,15 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("correctly sets the first gap for a frame with offset 0", func() {
-				Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 0)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 6, End: protocol.MaxByteCount},
 				})
 			})
 
 			It("finds the two gaps", func() {
-				Expect(s.Push([]byte("foobar"), 10, false)).To(Succeed())
-				Expect(s.Push([]byte("foobar"), 20, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 10)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 20)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 10},
 					{Start: 16, End: 20},
@@ -124,8 +97,8 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("finds the two gaps in reverse order", func() {
-				Expect(s.Push([]byte("foobar"), 20, false)).To(Succeed())
-				Expect(s.Push([]byte("foobar"), 10, false)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 20)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 10)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 10},
 					{Start: 16, End: 20},
@@ -134,8 +107,8 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("shrinks a gap when it is partially filled", func() {
-				Expect(s.Push([]byte("test"), 10, false)).To(Succeed())
-				Expect(s.Push([]byte("foobar"), 4, false)).To(Succeed())
+				Expect(s.Push([]byte("test"), 10)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 4)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 4},
 					{Start: 14, End: protocol.MaxByteCount},
@@ -143,17 +116,17 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("deletes a gap at the beginning, when it is filled", func() {
-				Expect(s.Push([]byte("test"), 6, false)).To(Succeed())
-				Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
+				Expect(s.Push([]byte("test"), 6)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 0)).To(Succeed())
 				checkGaps([]utils.ByteInterval{
 					{Start: 10, End: protocol.MaxByteCount},
 				})
 			})
 
 			It("deletes a gap in the middle, when it is filled", func() {
-				Expect(s.Push([]byte("test"), 0, false)).To(Succeed())
-				Expect(s.Push([]byte("test2"), 10, false)).To(Succeed())
-				Expect(s.Push([]byte("foobar"), 4, false)).To(Succeed())
+				Expect(s.Push([]byte("test"), 0)).To(Succeed())
+				Expect(s.Push([]byte("test2"), 10)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 4)).To(Succeed())
 				Expect(s.queue).To(HaveLen(3))
 				checkGaps([]utils.ByteInterval{
 					{Start: 15, End: protocol.MaxByteCount},
@@ -161,8 +134,8 @@ var _ = Describe("STREAM frame sorter", func() {
 			})
 
 			It("splits a gap into two", func() {
-				Expect(s.Push([]byte("test"), 100, false)).To(Succeed())
-				Expect(s.Push([]byte("foobar"), 50, false)).To(Succeed())
+				Expect(s.Push([]byte("test"), 100)).To(Succeed())
+				Expect(s.Push([]byte("foobar"), 50)).To(Succeed())
 				Expect(s.queue).To(HaveLen(2))
 				checkGaps([]utils.ByteInterval{
 					{Start: 0, End: 50},
@@ -174,9 +147,9 @@ var _ = Describe("STREAM frame sorter", func() {
 			Context("Overlapping Stream Data detection", func() {
 				// create gaps: 0-5, 10-15, 20-25, 30-inf
 				BeforeEach(func() {
-					Expect(s.Push([]byte("12345"), 5, false)).To(Succeed())
-					Expect(s.Push([]byte("12345"), 15, false)).To(Succeed())
-					Expect(s.Push([]byte("12345"), 25, false)).To(Succeed())
+					Expect(s.Push([]byte("12345"), 5)).To(Succeed())
+					Expect(s.Push([]byte("12345"), 15)).To(Succeed())
+					Expect(s.Push([]byte("12345"), 25)).To(Succeed())
 					checkGaps([]utils.ByteInterval{
 						{Start: 0, End: 5},
 						{Start: 10, End: 15},
@@ -186,7 +159,7 @@ var _ = Describe("STREAM frame sorter", func() {
 				})
 
 				It("cuts a frame with offset 0 that overlaps at the end", func() {
-					Expect(s.Push([]byte("foobar"), 0, false)).To(Succeed())
+					Expect(s.Push([]byte("foobar"), 0)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(0)))
 					Expect(s.queue[0]).To(Equal([]byte("fooba")))
 					Expect(s.queue[0]).To(HaveCap(5))
@@ -199,7 +172,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that overlaps at the end", func() {
 					// 4 to 7
-					Expect(s.Push([]byte("foo"), 4, false)).To(Succeed())
+					Expect(s.Push([]byte("foo"), 4)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(4)))
 					Expect(s.queue[4]).To(Equal([]byte("f")))
 					Expect(s.queue[4]).To(HaveCap(1))
@@ -213,7 +186,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that completely fills a gap, but overlaps at the end", func() {
 					// 10 to 16
-					Expect(s.Push([]byte("foobar"), 10, false)).To(Succeed())
+					Expect(s.Push([]byte("foobar"), 10)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(10)))
 					Expect(s.queue[10]).To(Equal([]byte("fooba")))
 					Expect(s.queue[10]).To(HaveCap(5))
@@ -226,7 +199,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that overlaps at the beginning", func() {
 					// 8 to 14
-					Expect(s.Push([]byte("foobar"), 8, false)).To(Succeed())
+					Expect(s.Push([]byte("foobar"), 8)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(8)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(10)))
 					Expect(s.queue[10]).To(Equal([]byte("obar")))
@@ -241,7 +214,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that overlaps at the beginning and at the end, starting in a gap", func() {
 					// 2 to 12
-					Expect(s.Push([]byte("1234567890"), 2, false)).To(Succeed())
+					Expect(s.Push([]byte("1234567890"), 2)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(2)))
 					Expect(s.queue[2]).To(Equal([]byte("1234567890")))
@@ -255,7 +228,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that overlaps at the beginning and at the end, starting in a gap, ending in data", func() {
 					// 2 to 17
-					Expect(s.Push([]byte("123456789012345"), 2, false)).To(Succeed())
+					Expect(s.Push([]byte("123456789012345"), 2)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(2)))
 					Expect(s.queue[2]).To(Equal([]byte("1234567890123")))
@@ -269,7 +242,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that overlaps at the beginning and at the end, starting in a gap, ending in data", func() {
 					// 5 to 22
-					Expect(s.Push([]byte("12345678901234567"), 5, false)).To(Succeed())
+					Expect(s.Push([]byte("12345678901234567"), 5)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(15)))
 					Expect(s.queue[10]).To(Equal([]byte("678901234567")))
@@ -282,7 +255,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that closes multiple gaps", func() {
 					// 2 to 27
-					Expect(s.Push(bytes.Repeat([]byte{'e'}, 25), 2, false)).To(Succeed())
+					Expect(s.Push(bytes.Repeat([]byte{'e'}, 25), 2)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(15)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(25)))
@@ -297,7 +270,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("processes a frame that closes multiple gaps", func() {
 					// 5 to 27
-					Expect(s.Push(bytes.Repeat([]byte{'d'}, 22), 5, false)).To(Succeed())
+					Expect(s.Push(bytes.Repeat([]byte{'d'}, 22), 5)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(5)))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(15)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(25)))
@@ -313,7 +286,7 @@ var _ = Describe("STREAM frame sorter", func() {
 				It("processes a frame that covers multiple gaps and ends at the end of a gap", func() {
 					data := bytes.Repeat([]byte{'e'}, 14)
 					// 1 to 15
-					Expect(s.Push(data, 1, false)).To(Succeed())
+					Expect(s.Push(data, 1)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(1)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(15)))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(5)))
@@ -328,7 +301,7 @@ var _ = Describe("STREAM frame sorter", func() {
 				It("processes a frame that closes all gaps (except for the last one)", func() {
 					data := bytes.Repeat([]byte{'f'}, 32)
 					// 0 to 32
-					Expect(s.Push(data, 0, false)).To(Succeed())
+					Expect(s.Push(data, 0)).To(Succeed())
 					Expect(s.queue).To(HaveLen(1))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(0)))
 					Expect(s.queue[0]).To(Equal(data))
@@ -339,7 +312,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that overlaps at the beginning and at the end, starting in data already received", func() {
 					// 8 to 17
-					Expect(s.Push([]byte("123456789"), 8, false)).To(Succeed())
+					Expect(s.Push([]byte("123456789"), 8)).To(Succeed())
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(8)))
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(10)))
 					Expect(s.queue[10]).To(Equal([]byte("34567")))
@@ -353,7 +326,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("cuts a frame that completely covers two gaps", func() {
 					// 10 to 20
-					Expect(s.Push([]byte("1234567890"), 10, false)).To(Succeed())
+					Expect(s.Push([]byte("1234567890"), 10)).To(Succeed())
 					Expect(s.queue).To(HaveKey(protocol.ByteCount(10)))
 					Expect(s.queue[10]).To(Equal([]byte("12345")))
 					Expect(s.queue[10]).To(HaveCap(5))
@@ -373,8 +346,8 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				BeforeEach(func() {
 					// create gaps: 5-10, 15-inf
-					Expect(s.Push([]byte("12345"), 0, false)).To(Succeed())
-					Expect(s.Push([]byte("12345"), 10, false)).To(Succeed())
+					Expect(s.Push([]byte("12345"), 0)).To(Succeed())
+					Expect(s.Push([]byte("12345"), 10)).To(Succeed())
 					checkGaps(expectedGaps)
 				})
 
@@ -384,21 +357,21 @@ var _ = Describe("STREAM frame sorter", func() {
 				})
 
 				It("does not modify data when receiving a duplicate", func() {
-					err := s.push([]byte("fffff"), 0, false)
+					err := s.push([]byte("fffff"), 0)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[0]).ToNot(Equal([]byte("fffff")))
 				})
 
 				It("detects a duplicate frame that is smaller than the original, starting at the beginning", func() {
 					// 10 to 12
-					err := s.push([]byte("12"), 10, false)
+					err := s.push([]byte("12"), 10)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[10]).To(HaveLen(5))
 				})
 
 				It("detects a duplicate frame that is smaller than the original, somewhere in the middle", func() {
 					// 1 to 4
-					err := s.push([]byte("123"), 1, false)
+					err := s.push([]byte("123"), 1)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[0]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(1)))
@@ -406,7 +379,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("detects a duplicate frame that is smaller than the original, somewhere in the middle in the last block", func() {
 					// 11 to 14
-					err := s.push([]byte("123"), 11, false)
+					err := s.push([]byte("123"), 11)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[10]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(11)))
@@ -414,7 +387,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("detects a duplicate frame that is smaller than the original, with aligned end in the last block", func() {
 					// 11 to 15
-					err := s.push([]byte("1234"), 1, false)
+					err := s.push([]byte("1234"), 1)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[10]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(11)))
@@ -422,7 +395,7 @@ var _ = Describe("STREAM frame sorter", func() {
 
 				It("detects a duplicate frame that is smaller than the original, with aligned end", func() {
 					// 3 to 5
-					err := s.push([]byte("12"), 3, false)
+					err := s.push([]byte("12"), 3)
 					Expect(err).To(MatchError(errDuplicateStreamData))
 					Expect(s.queue[0]).To(HaveLen(5))
 					Expect(s.queue).ToNot(HaveKey(protocol.ByteCount(3)))
@@ -432,10 +405,10 @@ var _ = Describe("STREAM frame sorter", func() {
 			Context("DoS protection", func() {
 				It("errors when too many gaps are created", func() {
 					for i := 0; i < protocol.MaxStreamFrameSorterGaps; i++ {
-						Expect(s.Push([]byte("foobar"), protocol.ByteCount(i*7), false)).To(Succeed())
+						Expect(s.Push([]byte("foobar"), protocol.ByteCount(i*7))).To(Succeed())
 					}
 					Expect(s.gaps.Len()).To(Equal(protocol.MaxStreamFrameSorterGaps))
-					err := s.Push([]byte("foobar"), protocol.ByteCount(protocol.MaxStreamFrameSorterGaps*7)+100, false)
+					err := s.Push([]byte("foobar"), protocol.ByteCount(protocol.MaxStreamFrameSorterGaps*7)+100)
 					Expect(err).To(MatchError("Too many gaps in received data"))
 				})
 			})

--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -54,7 +54,12 @@ func (c *connectionFlowController) IncrementHighestReceived(increment protocol.B
 	return nil
 }
 
-func (c *connectionFlowController) MaybeQueueWindowUpdate() {
+func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) {
+	c.baseFlowController.AddBytesRead(n)
+	c.maybeQueueWindowUpdate()
+}
+
+func (c *connectionFlowController) maybeQueueWindowUpdate() {
 	c.mutex.Lock()
 	hasWindowUpdate := c.hasWindowUpdate()
 	c.mutex.Unlock()

--- a/internal/flowcontrol/connection_flow_controller_test.go
+++ b/internal/flowcontrol/connection_flow_controller_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Connection Flow controller", func() {
 	}
 
 	BeforeEach(func() {
+		queuedWindowUpdate = false
 		controller = &connectionFlowController{}
 		controller.rttStats = &congestion.RTTStats{}
 		controller.logger = utils.DefaultLogger
@@ -58,14 +59,13 @@ var _ = Describe("Connection Flow controller", func() {
 			})
 
 			It("queues window updates", func() {
-				controller.MaybeQueueWindowUpdate()
+				controller.AddBytesRead(1)
 				Expect(queuedWindowUpdate).To(BeFalse())
-				controller.AddBytesRead(30)
-				controller.MaybeQueueWindowUpdate()
+				controller.AddBytesRead(29)
 				Expect(queuedWindowUpdate).To(BeTrue())
 				Expect(controller.GetWindowUpdate()).ToNot(BeZero())
 				queuedWindowUpdate = false
-				controller.MaybeQueueWindowUpdate()
+				controller.AddBytesRead(1)
 				Expect(queuedWindowUpdate).To(BeFalse())
 			})
 

--- a/internal/flowcontrol/interface.go
+++ b/internal/flowcontrol/interface.go
@@ -18,8 +18,12 @@ type StreamFlowController interface {
 	flowController
 	// for receiving
 	// UpdateHighestReceived should be called when a new highest offset is received
-	// final has to be to true if this is the final offset of the stream, as contained in a STREAM frame with FIN bit, and the RESET_STREAM frame
+	// final has to be to true if this is the final offset of the stream,
+	// as contained in a STREAM frame with FIN bit, and the RESET_STREAM frame
 	UpdateHighestReceived(offset protocol.ByteCount, final bool) error
+	// Abandon should be called when reading from the stream is aborted early,
+	// and there won't be any further calls to AddBytesRead.
+	Abandon()
 }
 
 // The ConnectionFlowController is the flow controller for the connection.

--- a/internal/flowcontrol/interface.go
+++ b/internal/flowcontrol/interface.go
@@ -10,7 +10,6 @@ type flowController interface {
 	// for receiving
 	AddBytesRead(protocol.ByteCount)
 	GetWindowUpdate() protocol.ByteCount // returns 0 if no update is necessary
-	MaybeQueueWindowUpdate()             //  queues a window update, if necessary
 	IsNewlyBlocked() (bool, protocol.ByteCount)
 }
 

--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -89,6 +89,7 @@ func (c *streamFlowController) UpdateHighestReceived(byteOffset protocol.ByteCou
 
 func (c *streamFlowController) AddBytesRead(n protocol.ByteCount) {
 	c.baseFlowController.AddBytesRead(n)
+	c.maybeQueueWindowUpdate()
 	c.connection.AddBytesRead(n)
 }
 
@@ -101,14 +102,13 @@ func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
 	return utils.MinByteCount(c.baseFlowController.sendWindowSize(), c.connection.SendWindowSize())
 }
 
-func (c *streamFlowController) MaybeQueueWindowUpdate() {
+func (c *streamFlowController) maybeQueueWindowUpdate() {
 	c.mutex.Lock()
 	hasWindowUpdate := !c.receivedFinalOffset && c.hasWindowUpdate()
 	c.mutex.Unlock()
 	if hasWindowUpdate {
 		c.queueWindowUpdate()
 	}
-	c.connection.MaybeQueueWindowUpdate()
 }
 
 func (c *streamFlowController) GetWindowUpdate() protocol.ByteCount {

--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -93,6 +93,12 @@ func (c *streamFlowController) AddBytesRead(n protocol.ByteCount) {
 	c.connection.AddBytesRead(n)
 }
 
+func (c *streamFlowController) Abandon() {
+	if unread := c.highestReceived - c.bytesRead; unread > 0 {
+		c.connection.AddBytesRead(unread)
+	}
+}
+
 func (c *streamFlowController) AddBytesSent(n protocol.ByteCount) {
 	c.baseFlowController.AddBytesSent(n)
 	c.connection.AddBytesSent(n)

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -13,18 +13,16 @@ import (
 
 var _ = Describe("Stream Flow controller", func() {
 	var (
-		controller             *streamFlowController
-		queuedWindowUpdate     bool
-		queuedConnWindowUpdate bool
+		controller         *streamFlowController
+		queuedWindowUpdate bool
 	)
 
 	BeforeEach(func() {
 		queuedWindowUpdate = false
-		queuedConnWindowUpdate = false
 		rttStats := &congestion.RTTStats{}
 		controller = &streamFlowController{
 			streamID:   10,
-			connection: NewConnectionFlowController(1000, 1000, func() { queuedConnWindowUpdate = true }, rttStats, utils.DefaultLogger).(*connectionFlowController),
+			connection: NewConnectionFlowController(1000, 1000, func() {}, rttStats, utils.DefaultLogger).(*connectionFlowController),
 		}
 		controller.maxReceiveWindowSize = 10000
 		controller.rttStats = rttStats
@@ -57,7 +55,6 @@ var _ = Describe("Stream Flow controller", func() {
 			cc := NewConnectionFlowController(0, 0, nil, nil, utils.DefaultLogger)
 			fc := NewStreamFlowController(5, cc, receiveWindow, maxReceiveWindow, sendWindow, queueWindowUpdate, rttStats, utils.DefaultLogger).(*streamFlowController)
 			fc.AddBytesRead(receiveWindow)
-			fc.MaybeQueueWindowUpdate()
 			Expect(queued).To(BeTrue())
 		})
 	})
@@ -179,23 +176,14 @@ var _ = Describe("Stream Flow controller", func() {
 			})
 
 			It("queues window updates", func() {
-				controller.MaybeQueueWindowUpdate()
+				controller.AddBytesRead(1)
 				Expect(queuedWindowUpdate).To(BeFalse())
-				controller.AddBytesRead(30)
-				controller.MaybeQueueWindowUpdate()
+				controller.AddBytesRead(29)
 				Expect(queuedWindowUpdate).To(BeTrue())
 				Expect(controller.GetWindowUpdate()).ToNot(BeZero())
 				queuedWindowUpdate = false
-				controller.MaybeQueueWindowUpdate()
+				controller.AddBytesRead(1)
 				Expect(queuedWindowUpdate).To(BeFalse())
-			})
-
-			It("queues connection-level window updates", func() {
-				controller.MaybeQueueWindowUpdate()
-				Expect(queuedConnWindowUpdate).To(BeFalse())
-				controller.AddBytesRead(60)
-				controller.MaybeQueueWindowUpdate()
-				Expect(queuedConnWindowUpdate).To(BeTrue())
 			})
 
 			It("tells the connection flow controller when the window was autotuned", func() {
@@ -211,10 +199,8 @@ var _ = Describe("Stream Flow controller", func() {
 			})
 
 			It("doesn't increase the window after a final offset was already received", func() {
+				Expect(controller.UpdateHighestReceived(90, true)).To(Succeed())
 				controller.AddBytesRead(30)
-				err := controller.UpdateHighestReceived(90, true)
-				Expect(err).ToNot(HaveOccurred())
-				controller.MaybeQueueWindowUpdate()
 				Expect(queuedWindowUpdate).To(BeFalse())
 				offset := controller.GetWindowUpdate()
 				Expect(offset).To(BeZero())

--- a/internal/mocks/connection_flow_controller.go
+++ b/internal/mocks/connection_flow_controller.go
@@ -79,16 +79,6 @@ func (mr *MockConnectionFlowControllerMockRecorder) IsNewlyBlocked() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNewlyBlocked", reflect.TypeOf((*MockConnectionFlowController)(nil).IsNewlyBlocked))
 }
 
-// MaybeQueueWindowUpdate mocks base method
-func (m *MockConnectionFlowController) MaybeQueueWindowUpdate() {
-	m.ctrl.Call(m, "MaybeQueueWindowUpdate")
-}
-
-// MaybeQueueWindowUpdate indicates an expected call of MaybeQueueWindowUpdate
-func (mr *MockConnectionFlowControllerMockRecorder) MaybeQueueWindowUpdate() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeQueueWindowUpdate", reflect.TypeOf((*MockConnectionFlowController)(nil).MaybeQueueWindowUpdate))
-}
-
 // SendWindowSize mocks base method
 func (m *MockConnectionFlowController) SendWindowSize() protocol.ByteCount {
 	ret := m.ctrl.Call(m, "SendWindowSize")

--- a/internal/mocks/stream_flow_controller.go
+++ b/internal/mocks/stream_flow_controller.go
@@ -34,6 +34,16 @@ func (m *MockStreamFlowController) EXPECT() *MockStreamFlowControllerMockRecorde
 	return m.recorder
 }
 
+// Abandon mocks base method
+func (m *MockStreamFlowController) Abandon() {
+	m.ctrl.Call(m, "Abandon")
+}
+
+// Abandon indicates an expected call of Abandon
+func (mr *MockStreamFlowControllerMockRecorder) Abandon() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abandon", reflect.TypeOf((*MockStreamFlowController)(nil).Abandon))
+}
+
 // AddBytesRead mocks base method
 func (m *MockStreamFlowController) AddBytesRead(arg0 protocol.ByteCount) {
 	m.ctrl.Call(m, "AddBytesRead", arg0)
@@ -77,16 +87,6 @@ func (m *MockStreamFlowController) IsNewlyBlocked() (bool, protocol.ByteCount) {
 // IsNewlyBlocked indicates an expected call of IsNewlyBlocked
 func (mr *MockStreamFlowControllerMockRecorder) IsNewlyBlocked() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNewlyBlocked", reflect.TypeOf((*MockStreamFlowController)(nil).IsNewlyBlocked))
-}
-
-// MaybeQueueWindowUpdate mocks base method
-func (m *MockStreamFlowController) MaybeQueueWindowUpdate() {
-	m.ctrl.Call(m, "MaybeQueueWindowUpdate")
-}
-
-// MaybeQueueWindowUpdate indicates an expected call of MaybeQueueWindowUpdate
-func (mr *MockStreamFlowControllerMockRecorder) MaybeQueueWindowUpdate() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeQueueWindowUpdate", reflect.TypeOf((*MockStreamFlowController)(nil).MaybeQueueWindowUpdate))
 }
 
 // SendWindowSize mocks base method

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -80,7 +80,7 @@ func (s *receiveStream) StreamID() protocol.StreamID {
 func (s *receiveStream) Read(p []byte) (int, error) {
 	completed, n, err := s.readImpl(p)
 	if completed {
-		s.sender.onStreamCompleted(s.streamID)
+		s.streamCompleted()
 	}
 	return n, err
 }
@@ -197,6 +197,9 @@ func (s *receiveStream) CancelRead(errorCode protocol.ApplicationErrorCode) erro
 	if s.finRead || s.canceledRead || s.resetRemotely {
 		return nil
 	}
+	if s.finalOffset != protocol.MaxByteCount { // final offset was already received
+		s.streamCompleted()
+	}
 	s.canceledRead = true
 	s.cancelReadErr = fmt.Errorf("Read on stream %d canceled with error code %d", s.streamID, errorCode)
 	s.signalRead()
@@ -209,12 +212,22 @@ func (s *receiveStream) CancelRead(errorCode protocol.ApplicationErrorCode) erro
 
 func (s *receiveStream) handleStreamFrame(frame *wire.StreamFrame) error {
 	maxOffset := frame.Offset + frame.DataLen()
-	if err := s.flowController.UpdateHighestReceived(maxOffset, frame.FinBit); err != nil {
-		return err
-	}
 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	if err := s.flowController.UpdateHighestReceived(maxOffset, frame.FinBit); err != nil {
+		return err
+	}
+	if frame.FinBit {
+		s.finalOffset = maxOffset
+	}
+	if s.canceledRead {
+		if frame.FinBit {
+			s.streamCompleted()
+		}
+		return nil
+	}
 	if err := s.frameQueue.Push(frame.Data, frame.Offset); err != nil {
 		return err
 	}
@@ -228,7 +241,7 @@ func (s *receiveStream) handleStreamFrame(frame *wire.StreamFrame) error {
 func (s *receiveStream) handleResetStreamFrame(frame *wire.ResetStreamFrame) error {
 	completed, err := s.handleResetStreamFrameImpl(frame)
 	if completed {
-		s.sender.onStreamCompleted(s.streamID)
+		s.streamCompleted()
 	}
 	return err
 }
@@ -283,6 +296,13 @@ func (s *receiveStream) closeForShutdown(err error) {
 
 func (s *receiveStream) getWindowUpdate() protocol.ByteCount {
 	return s.flowController.GetWindowUpdate()
+}
+
+func (s *receiveStream) streamCompleted() {
+	if !s.finRead {
+		s.flowController.Abandon()
+	}
+	s.sender.onStreamCompleted(s.streamID)
 }
 
 // signalRead performs a non-blocking send on the readChan

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -172,8 +172,6 @@ func (s *receiveStream) readImpl(p []byte) (bool /*stream completed */, int, err
 		if !s.resetRemotely {
 			s.flowController.AddBytesRead(protocol.ByteCount(m))
 		}
-		// increase the flow control window, if necessary
-		s.flowController.MaybeQueueWindowUpdate()
 
 		if s.readPosInFrame >= len(s.currentFrame) && s.currentFrameIsLast {
 			s.finRead = true

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -28,8 +28,9 @@ type receiveStream struct {
 
 	sender streamSender
 
-	frameQueue *frameSorter
-	readOffset protocol.ByteCount
+	frameQueue  *frameSorter
+	readOffset  protocol.ByteCount
+	finalOffset protocol.ByteCount
 
 	currentFrame       []byte
 	currentFrameIsLast bool // is the currentFrame the last frame on this stream
@@ -66,6 +67,7 @@ func newReceiveStream(
 		flowController: flowController,
 		frameQueue:     newFrameSorter(),
 		readChan:       make(chan struct{}, 1),
+		finalOffset:    protocol.MaxByteCount,
 		version:        version,
 	}
 }
@@ -182,7 +184,9 @@ func (s *receiveStream) readImpl(p []byte) (bool /*stream completed */, int, err
 }
 
 func (s *receiveStream) dequeueNextFrame() {
-	s.currentFrame, s.currentFrameIsLast = s.frameQueue.Pop()
+	var offset protocol.ByteCount
+	offset, s.currentFrame = s.frameQueue.Pop()
+	s.currentFrameIsLast = offset+protocol.ByteCount(len(s.currentFrame)) >= s.finalOffset
 	s.readPosInFrame = 0
 }
 
@@ -211,8 +215,11 @@ func (s *receiveStream) handleStreamFrame(frame *wire.StreamFrame) error {
 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	if err := s.frameQueue.Push(frame.Data, frame.Offset, frame.FinBit); err != nil {
+	if err := s.frameQueue.Push(frame.Data, frame.Offset); err != nil {
 		return err
+	}
+	if frame.FinBit {
+		s.finalOffset = maxOffset
 	}
 	s.signalRead()
 	return nil
@@ -236,6 +243,7 @@ func (s *receiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame)
 	if err := s.flowController.UpdateHighestReceived(frame.ByteOffset, true); err != nil {
 		return false, err
 	}
+	s.finalOffset = frame.ByteOffset
 
 	// ignore duplicate RESET_STREAM frames for this stream (after checking their final offset)
 	if s.resetRemotely {

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -190,10 +190,7 @@ func (s *receiveStream) CancelRead(errorCode protocol.ApplicationErrorCode) erro
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if s.finRead {
-		return nil
-	}
-	if s.canceledRead {
+	if s.finRead || s.canceledRead || s.resetRemotely {
 		return nil
 	}
 	s.canceledRead = true

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -43,7 +43,6 @@ var _ = Describe("Receive Stream", func() {
 		It("reads a single STREAM frame", func() {
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(4), false)
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(4))
-			mockFC.EXPECT().MaybeQueueWindowUpdate()
 			frame := wire.StreamFrame{
 				Offset: 0,
 				Data:   []byte{0xDE, 0xAD, 0xBE, 0xEF},
@@ -61,7 +60,6 @@ var _ = Describe("Receive Stream", func() {
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(4), false)
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2))
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2))
-			mockFC.EXPECT().MaybeQueueWindowUpdate().Times(2)
 			frame := wire.StreamFrame{
 				Offset: 0,
 				Data:   []byte{0xDE, 0xAD, 0xBE, 0xEF},
@@ -83,7 +81,6 @@ var _ = Describe("Receive Stream", func() {
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(2), false)
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(4), false)
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2)).Times(2)
-			mockFC.EXPECT().MaybeQueueWindowUpdate().Times(2)
 			frame1 := wire.StreamFrame{
 				Offset: 0,
 				Data:   []byte{0xDE, 0xAD},
@@ -107,7 +104,6 @@ var _ = Describe("Receive Stream", func() {
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(2), false)
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(4), false)
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2)).Times(2)
-			mockFC.EXPECT().MaybeQueueWindowUpdate().Times(2)
 			frame1 := wire.StreamFrame{
 				Offset: 0,
 				Data:   []byte{0xDE, 0xAD},
@@ -130,7 +126,6 @@ var _ = Describe("Receive Stream", func() {
 		It("waits until data is available", func() {
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(2), false)
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2))
-			mockFC.EXPECT().MaybeQueueWindowUpdate()
 			go func() {
 				defer GinkgoRecover()
 				frame := wire.StreamFrame{Data: []byte{0xDE, 0xAD}}
@@ -148,7 +143,6 @@ var _ = Describe("Receive Stream", func() {
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(2), false)
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(4), false)
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2)).Times(2)
-			mockFC.EXPECT().MaybeQueueWindowUpdate().Times(2)
 			frame1 := wire.StreamFrame{
 				Offset: 2,
 				Data:   []byte{0xBE, 0xEF},
@@ -173,7 +167,6 @@ var _ = Describe("Receive Stream", func() {
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(2), false)
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(4), false)
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2)).Times(2)
-			mockFC.EXPECT().MaybeQueueWindowUpdate().Times(2)
 			frame1 := wire.StreamFrame{
 				Offset: 0,
 				Data:   []byte{0xDE, 0xAD},
@@ -204,7 +197,6 @@ var _ = Describe("Receive Stream", func() {
 			mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(6), false)
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2))
 			mockFC.EXPECT().AddBytesRead(protocol.ByteCount(4))
-			mockFC.EXPECT().MaybeQueueWindowUpdate().Times(2)
 			frame1 := wire.StreamFrame{
 				Offset: 0,
 				Data:   []byte("foob"),
@@ -337,7 +329,6 @@ var _ = Describe("Receive Stream", func() {
 				It("returns EOFs", func() {
 					mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(4), true)
 					mockFC.EXPECT().AddBytesRead(protocol.ByteCount(4))
-					mockFC.EXPECT().MaybeQueueWindowUpdate()
 					str.handleStreamFrame(&wire.StreamFrame{
 						Offset: 0,
 						Data:   []byte{0xDE, 0xAD, 0xBE, 0xEF},
@@ -358,7 +349,6 @@ var _ = Describe("Receive Stream", func() {
 					mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(2), false)
 					mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(4), true)
 					mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2)).Times(2)
-					mockFC.EXPECT().MaybeQueueWindowUpdate().Times(2)
 					frame1 := wire.StreamFrame{
 						Offset: 2,
 						Data:   []byte{0xBE, 0xEF},
@@ -386,7 +376,6 @@ var _ = Describe("Receive Stream", func() {
 				It("returns EOFs with partial read", func() {
 					mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(2), true)
 					mockFC.EXPECT().AddBytesRead(protocol.ByteCount(2))
-					mockFC.EXPECT().MaybeQueueWindowUpdate()
 					err := str.handleStreamFrame(&wire.StreamFrame{
 						Offset: 0,
 						Data:   []byte{0xde, 0xad},
@@ -404,7 +393,6 @@ var _ = Describe("Receive Stream", func() {
 				It("handles immediate FINs", func() {
 					mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(0), true)
 					mockFC.EXPECT().AddBytesRead(protocol.ByteCount(0))
-					mockFC.EXPECT().MaybeQueueWindowUpdate()
 					err := str.handleStreamFrame(&wire.StreamFrame{
 						Offset: 0,
 						FinBit: true,
@@ -421,7 +409,6 @@ var _ = Describe("Receive Stream", func() {
 			It("closes when CloseRemote is called", func() {
 				mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(0), true)
 				mockFC.EXPECT().AddBytesRead(protocol.ByteCount(0))
-				mockFC.EXPECT().MaybeQueueWindowUpdate()
 				str.CloseRemote(0)
 				mockSender.EXPECT().onStreamCompleted(streamID)
 				b := make([]byte, 8)
@@ -497,7 +484,6 @@ var _ = Describe("Receive Stream", func() {
 			It("doesn't send a RESET_STREAM frame, if the FIN was already read", func() {
 				mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(6), true)
 				mockFC.EXPECT().AddBytesRead(protocol.ByteCount(6))
-				mockFC.EXPECT().MaybeQueueWindowUpdate()
 				// no calls to mockSender.queueControlFrame
 				err := str.handleStreamFrame(&wire.StreamFrame{
 					StreamID: streamID,


### PR DESCRIPTION
Fixes #1693.

We definitely need a bunch of integration tests that reset streams to make sure this is actually working (see #1210). With these fixes, fixing #1618 will now be straightforward.