### PR TITLE
implement a workaround in the h2quic server that accepts data streams

### DIFF
--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -77,12 +77,11 @@ var _ = Describe("HTTP tests", func() {
 				Expect(body).To(Equal(testserver.PRDataLong))
 			})
 
-			// TODO(#1756): this test times out
-			PIt("downloads many files, if the response is not read", func() {
+			It("downloads many files, if the response is not read", func() {
 				const num = 150
 
 				for i := 0; i < num; i++ {
-					resp, err := client.Get("https://localhost:" + testserver.Port() + "/prdata")
+					resp, err := client.Get("https://localhost:" + testserver.Port() + "/hello")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(resp.StatusCode).To(Equal(200))
 					Expect(resp.Body.Close()).To(Succeed())


### PR DESCRIPTION
The problem with #1756 was introduced in #1754. There, we changed the streams map such that a stream is not deleted from the map until it has been accepted. This fix is correct, and the problem lies (again...) in the layer violation between gQUIC's H2 mapping and the QUIC transport.
The workaround here is to accept (and immediately forget) the response stream (and all lower streams in case of reordering) just to make sure that the streams map can delete a stream. Note that in the case of reordering, lower streams will stay in the streams map until the client closes it (again, because of the layer violation this implicit via `CloseRemote`), i.e. until they're used for a request. Thus, this shouldn't open us up to a DoS vulnerability.