### PR TITLE
internal/protocol: fix doc comment formatting

### DIFF
--- a/internal/protocol/stream_id.go
+++ b/internal/protocol/stream_id.go
@@ -21,7 +21,7 @@ func (s StreamID) InitiatedBy() Perspective {
 	return PerspectiveServer
 }
 
-//Type says if this is a unidirectional or bidirectional stream
+// Type says if this is a unidirectional or bidirectional stream
 func (s StreamID) Type() StreamType {
 	if s%4 >= 2 {
 		return StreamTypeUni


### PR DESCRIPTION
Put a space between "//" and doc comment text.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>