### PR TITLE
don't set the server's transport parameters as the client's parameters

### DIFF
--- a/server_tls.go
+++ b/server_tls.go
@@ -25,7 +25,7 @@ type serverTLS struct {
 	params          *handshake.TransportParameters
 	cookieGenerator *handshake.CookieGenerator
 
-	newSession func(connection, sessionRunner, protocol.ConnectionID, protocol.ConnectionID, protocol.ConnectionID, protocol.PacketNumber, *Config, *mint.Config, *handshake.TransportParameters, utils.Logger, protocol.VersionNumber) (quicSession, error)
+	newSession func(connection, sessionRunner, protocol.ConnectionID, protocol.ConnectionID, protocol.ConnectionID, protocol.PacketNumber, *Config, *mint.Config, <-chan handshake.TransportParameters, utils.Logger, protocol.VersionNumber) (quicSession, error)
 
 	sessionRunner sessionRunner
 	sessionChan   chan<- tlsSession
@@ -132,7 +132,7 @@ func (s *serverTLS) handleInitialImpl(p *receivedPacket) (quicSession, protocol.
 		1,
 		s.config,
 		mconf,
-		s.params,
+		extHandler.GetPeerParams(),
 		s.logger,
 		hdr.Version,
 	)

--- a/server_tls_test.go
+++ b/server_tls_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Stateless TLS handling", func() {
 			data:   bytes.Repeat([]byte{0}, protocol.MinInitialPacketSize),
 		}
 		run := make(chan struct{})
-		server.newSession = func(connection, sessionRunner, protocol.ConnectionID, protocol.ConnectionID, protocol.ConnectionID, protocol.PacketNumber, *Config, *mint.Config, *handshake.TransportParameters, utils.Logger, protocol.VersionNumber) (quicSession, error) {
+		server.newSession = func(connection, sessionRunner, protocol.ConnectionID, protocol.ConnectionID, protocol.ConnectionID, protocol.PacketNumber, *Config, *mint.Config, <-chan handshake.TransportParameters, utils.Logger, protocol.VersionNumber) (quicSession, error) {
 			sess := NewMockQuicSession(mockCtrl)
 			sess.EXPECT().handlePacket(p)
 			sess.EXPECT().run().Do(func() { close(run) })

--- a/session.go
+++ b/session.go
@@ -302,7 +302,7 @@ func newTLSServerSession(
 	initialPacketNumber protocol.PacketNumber,
 	config *Config,
 	mintConf *mint.Config,
-	peerParams *handshake.TransportParameters,
+	paramsChan <-chan handshake.TransportParameters,
 	logger utils.Logger,
 	v protocol.VersionNumber,
 ) (quicSession, error) {
@@ -316,6 +316,7 @@ func newTLSServerSession(
 		perspective:    protocol.PerspectiveServer,
 		version:        v,
 		handshakeEvent: handshakeEvent,
+		paramsChan:     paramsChan,
 		logger:         logger,
 	}
 	s.preSetup()
@@ -349,8 +350,6 @@ func newTLSServerSession(
 	if err := s.postSetup(); err != nil {
 		return nil, err
 	}
-	s.peerParams = peerParams
-	s.processTransportParameters(peerParams)
 	s.unpacker = newPacketUnpacker(cs, s.version)
 	return s, nil
 }


### PR DESCRIPTION
We will need this when we rebase the stream-related changes onto the gQUIC branch.