### PR TITLE
don't run the version negotiation tests with race detector

### DIFF
--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go/integrationtests/tools/israce"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/testdata"
@@ -62,6 +63,10 @@ var _ = Describe("Handshake tests", func() {
 		BeforeEach(func() {
 			supportedVersions = protocol.SupportedVersions
 			protocol.SupportedVersions = append(protocol.SupportedVersions, []protocol.VersionNumber{7, 8, 9, 10}...)
+
+			if israce.Enabled {
+				Skip("This test modifies protocol.SupportedVersions, and can't be run with race detector.")
+			}
 		})
 
 		AfterEach(func() {

--- a/integrationtests/tools/israce/norace.go
+++ b/integrationtests/tools/israce/norace.go
@@ -1,0 +1,6 @@
+// +build !race
+
+package israce
+
+// Enabled reports if the race detector is enabled.
+const Enabled = false

--- a/integrationtests/tools/israce/race.go
+++ b/integrationtests/tools/israce/race.go
@@ -1,0 +1,6 @@
+// +build race
+
+package israce
+
+// Enabled reports if the race detector is enabled.
+const Enabled = true


### PR DESCRIPTION
Closes #1772.

Solution inspired by https://stackoverflow.com/questions/44944959/how-can-i-check-if-the-race-detector-is-enabled-at-runtime.