### PR TITLE
use separate packet number spaces for sending packets

### DIFF
--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -33,8 +33,8 @@ type SentPacketHandler interface {
 	DequeuePacketForRetransmission() *Packet
 	DequeueProbePacket() (*Packet, error)
 
-	PeekPacketNumber() (protocol.PacketNumber, protocol.PacketNumberLen)
-	PopPacketNumber() protocol.PacketNumber
+	PeekPacketNumber(protocol.EncryptionLevel) (protocol.PacketNumber, protocol.PacketNumberLen)
+	PopPacketNumber(protocol.EncryptionLevel) protocol.PacketNumber
 
 	GetAlarmTimeout() time.Time
 	OnAlarm() error

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -30,8 +30,7 @@ type sentPacketHandler struct {
 
 	nextSendTime time.Time
 
-	largestAcked           protocol.PacketNumber
-	largestReceivedWithAck protocol.PacketNumber
+	largestAcked protocol.PacketNumber
 	// lowestNotConfirmedAcked is the lowest packet number that we sent an ACK for, but haven't received confirmation, that this ACK actually arrived
 	// example: we send an ACK for packets 90-100 with packet number 20
 	// once we receive an ACK from the peer for packet 20, the lowestNotConfirmedAcked is 101
@@ -176,12 +175,6 @@ func (h *sentPacketHandler) ReceivedAck(ackFrame *wire.AckFrame, withPacketNumbe
 		return qerr.Error(qerr.InvalidAckData, "Received ACK for an unsent package")
 	}
 
-	// duplicate or out of order ACK
-	if withPacketNumber != 0 && withPacketNumber < h.largestReceivedWithAck {
-		h.logger.Debugf("Ignoring ACK frame (duplicate or out of order).")
-		return nil
-	}
-	h.largestReceivedWithAck = withPacketNumber
 	h.largestAcked = utils.MaxPacketNumber(h.largestAcked, largestAcked)
 
 	if !h.packetNumberGenerator.Validate(ackFrame) {

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -159,19 +159,6 @@ var _ = Describe("SentPacketHandler", func() {
 				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(4)))
 			})
 
-			It("rejects out of order ACKs", func() {
-				// acks packets 0, 1, 2, 3
-				ack1 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 3}}}
-				ack2 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 4}}}
-				err := handler.ReceivedAck(ack1, 1337, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				// this wouldn't happen in practive
-				// a receiver wouldn't send an ACK for a lower largest acked in a packet sent later
-				err = handler.ReceivedAck(ack2, 1337-1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(3)))
-			})
-
 			It("rejects ACKs with a too high LargestAcked packet number", func() {
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 9999}}}
 				err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -93,16 +93,16 @@ var _ = Describe("SentPacketHandler", func() {
 		It("accepts two consecutive packets", func() {
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 1}))
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 2}))
-			Expect(handler.lastSentPacketNumber).To(Equal(protocol.PacketNumber(2)))
+			Expect(handler.largestSent).To(Equal(protocol.PacketNumber(2)))
 			expectInPacketHistory([]protocol.PacketNumber{1, 2})
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
 		})
 
 		It("accepts packet number 0", func() {
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 0}))
-			Expect(handler.lastSentPacketNumber).To(BeZero())
+			Expect(handler.largestSent).To(BeZero())
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 1}))
-			Expect(handler.lastSentPacketNumber).To(Equal(protocol.PacketNumber(1)))
+			Expect(handler.largestSent).To(Equal(protocol.PacketNumber(1)))
 			expectInPacketHistory([]protocol.PacketNumber{0, 1})
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
 		})

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -57,17 +57,17 @@ var _ = Describe("SentPacketHandler", func() {
 		}
 	})
 
-	getPacket := func(pn protocol.PacketNumber) *Packet {
-		if el, ok := handler.packetHistory.packetMap[pn]; ok {
+	getPacket := func(pn protocol.PacketNumber, encLevel protocol.EncryptionLevel) *Packet {
+		if el, ok := handler.getPacketNumberSpace(encLevel).history.packetMap[pn]; ok {
 			return &el.Value
 		}
 		return nil
 	}
 
-	losePacket := func(pn protocol.PacketNumber) {
-		p := getPacket(pn)
+	losePacket := func(pn protocol.PacketNumber, encLevel protocol.EncryptionLevel) {
+		p := getPacket(pn, encLevel)
 		ExpectWithOffset(1, p).ToNot(BeNil())
-		handler.queuePacketForRetransmission(p)
+		handler.queuePacketForRetransmission(p, handler.getPacketNumberSpace(encLevel))
 		if p.includedInBytesInFlight {
 			p.includedInBytesInFlight = false
 			handler.bytesInFlight -= p.Length
@@ -77,10 +77,11 @@ var _ = Describe("SentPacketHandler", func() {
 		ExpectWithOffset(1, r.PacketNumber).To(Equal(pn))
 	}
 
-	expectInPacketHistory := func(expected []protocol.PacketNumber) {
-		ExpectWithOffset(1, handler.packetHistory.Len()).To(Equal(len(expected)))
+	expectInPacketHistory := func(expected []protocol.PacketNumber, encLevel protocol.EncryptionLevel) {
+		pnSpace := handler.getPacketNumberSpace(encLevel)
+		ExpectWithOffset(1, pnSpace.history.Len()).To(Equal(len(expected)))
 		for _, p := range expected {
-			ExpectWithOffset(1, handler.packetHistory.packetMap).To(HaveKey(p))
+			ExpectWithOffset(1, pnSpace.history.packetMap).To(HaveKey(p))
 		}
 	}
 
@@ -91,19 +92,19 @@ var _ = Describe("SentPacketHandler", func() {
 
 	Context("registering sent packets", func() {
 		It("accepts two consecutive packets", func() {
-			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 1}))
-			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 2}))
-			Expect(handler.largestSent).To(Equal(protocol.PacketNumber(2)))
-			expectInPacketHistory([]protocol.PacketNumber{1, 2})
+			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 1, EncryptionLevel: protocol.EncryptionHandshake}))
+			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 2, EncryptionLevel: protocol.EncryptionHandshake}))
+			Expect(handler.handshakePackets.largestSent).To(Equal(protocol.PacketNumber(2)))
+			expectInPacketHistory([]protocol.PacketNumber{1, 2}, protocol.EncryptionHandshake)
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
 		})
 
 		It("accepts packet number 0", func() {
-			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 0}))
-			Expect(handler.largestSent).To(BeZero())
-			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 1}))
-			Expect(handler.largestSent).To(Equal(protocol.PacketNumber(1)))
-			expectInPacketHistory([]protocol.PacketNumber{0, 1})
+			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 0, EncryptionLevel: protocol.Encryption1RTT}))
+			Expect(handler.oneRTTPackets.largestSent).To(BeZero())
+			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 1, EncryptionLevel: protocol.Encryption1RTT}))
+			Expect(handler.oneRTTPackets.largestSent).To(Equal(protocol.PacketNumber(1)))
+			expectInPacketHistory([]protocol.PacketNumber{0, 1}, protocol.Encryption1RTT)
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
 		})
 
@@ -121,8 +122,8 @@ var _ = Describe("SentPacketHandler", func() {
 		})
 
 		It("does not store non-retransmittable packets", func() {
-			handler.SentPacket(nonRetransmittablePacket(&Packet{PacketNumber: 1}))
-			Expect(handler.packetHistory.Len()).To(BeZero())
+			handler.SentPacket(nonRetransmittablePacket(&Packet{PacketNumber: 1, EncryptionLevel: protocol.Encryption1RTT}))
+			Expect(handler.oneRTTPackets.history.Len()).To(BeZero())
 			Expect(handler.lastSentRetransmittablePacketTime).To(BeZero())
 			Expect(handler.bytesInFlight).To(BeZero())
 		})
@@ -143,37 +144,33 @@ var _ = Describe("SentPacketHandler", func() {
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 5}}}
 				err := handler.ReceivedAck(ack, 0, protocol.Encryption1RTT, time.Now())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(5)))
+				Expect(handler.oneRTTPackets.largestAcked).To(Equal(protocol.PacketNumber(5)))
 			})
 
 			It("accepts multiple ACKs sent in the same packet", func() {
 				ack1 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 3}}}
 				ack2 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 4}}}
-				err := handler.ReceivedAck(ack1, 1337, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(3)))
+				Expect(handler.ReceivedAck(ack1, 1337, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				Expect(handler.oneRTTPackets.largestAcked).To(Equal(protocol.PacketNumber(3)))
 				// this wouldn't happen in practice
 				// for testing purposes, we pretend send a different ACK frame in a duplicated packet, to be able to verify that it actually doesn't get processed
-				err = handler.ReceivedAck(ack2, 1337, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(4)))
+				Expect(handler.ReceivedAck(ack2, 1337, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				Expect(handler.oneRTTPackets.largestAcked).To(Equal(protocol.PacketNumber(4)))
 			})
 
 			It("rejects ACKs with a too high LargestAcked packet number", func() {
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 9999}}}
 				err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).To(MatchError("InvalidAckData: Received ACK for an unsent package"))
+				Expect(err).To(MatchError("InvalidAckData: Received ACK for an unsent packet"))
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(10)))
 			})
 
 			It("ignores repeated ACKs", func() {
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 3}}}
-				err := handler.ReceivedAck(ack, 1337, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
+				Expect(handler.ReceivedAck(ack, 1337, protocol.Encryption1RTT, time.Now())).To(Succeed())
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(7)))
-				err = handler.ReceivedAck(ack, 1337+1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(3)))
+				Expect(handler.ReceivedAck(ack, 1337+1, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				Expect(handler.oneRTTPackets.largestAcked).To(Equal(protocol.PacketNumber(3)))
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(7)))
 			})
 		})
@@ -181,19 +178,17 @@ var _ = Describe("SentPacketHandler", func() {
 		Context("acks and nacks the right packets", func() {
 			It("adjusts the LargestAcked, and adjusts the bytes in flight", func() {
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 5}}}
-				err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(handler.largestAcked).To(Equal(protocol.PacketNumber(5)))
-				expectInPacketHistory([]protocol.PacketNumber{6, 7, 8, 9})
+				Expect(handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				Expect(handler.oneRTTPackets.largestAcked).To(Equal(protocol.PacketNumber(5)))
+				expectInPacketHistory([]protocol.PacketNumber{6, 7, 8, 9}, protocol.Encryption1RTT)
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(4)))
 			})
 
 			It("acks packet 0", func() {
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 0}}}
-				err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(getPacket(0)).To(BeNil())
-				expectInPacketHistory([]protocol.PacketNumber{1, 2, 3, 4, 5, 6, 7, 8, 9})
+				Expect(handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				Expect(getPacket(0, protocol.Encryption1RTT)).To(BeNil())
+				expectInPacketHistory([]protocol.PacketNumber{1, 2, 3, 4, 5, 6, 7, 8, 9}, protocol.Encryption1RTT)
 			})
 
 			It("handles an ACK frame with one missing packet range", func() {
@@ -203,16 +198,14 @@ var _ = Describe("SentPacketHandler", func() {
 						{Smallest: 1, Largest: 3},
 					},
 				}
-				err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 4, 5})
+				Expect(handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				expectInPacketHistory([]protocol.PacketNumber{0, 4, 5}, protocol.Encryption1RTT)
 			})
 
 			It("does not ack packets below the LowestAcked", func() {
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 3, Largest: 8}}}
-				err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 1, 2, 9})
+				Expect(handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				expectInPacketHistory([]protocol.PacketNumber{0, 1, 2, 9}, protocol.Encryption1RTT)
 			})
 
 			It("handles an ACK with multiple missing packet ranges", func() {
@@ -224,9 +217,8 @@ var _ = Describe("SentPacketHandler", func() {
 						{Smallest: 1, Largest: 1},
 					},
 				}
-				err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 2, 4, 5, 8})
+				Expect(handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				expectInPacketHistory([]protocol.PacketNumber{0, 2, 4, 5, 8}, protocol.Encryption1RTT)
 			})
 
 			It("processes an ACK frame that would be sent after a late arrival of a packet", func() {
@@ -236,14 +228,12 @@ var _ = Describe("SentPacketHandler", func() {
 						{Smallest: 1, Largest: 2},
 					},
 				}
-				err := handler.ReceivedAck(ack1, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 3, 7, 8, 9})
+				Expect(handler.ReceivedAck(ack1, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				expectInPacketHistory([]protocol.PacketNumber{0, 3, 7, 8, 9}, protocol.Encryption1RTT)
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(5)))
 				ack2 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 6}}} // now ack 3
-				err = handler.ReceivedAck(ack2, 2, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 7, 8, 9})
+				Expect(handler.ReceivedAck(ack2, 2, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				expectInPacketHistory([]protocol.PacketNumber{0, 7, 8, 9}, protocol.Encryption1RTT)
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(4)))
 			})
 
@@ -254,22 +244,19 @@ var _ = Describe("SentPacketHandler", func() {
 						{Smallest: 0, Largest: 2},
 					},
 				}
-				err := handler.ReceivedAck(ack1, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{3, 7, 8, 9})
+				Expect(handler.ReceivedAck(ack1, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				expectInPacketHistory([]protocol.PacketNumber{3, 7, 8, 9}, protocol.Encryption1RTT)
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(4)))
 				ack2 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 7}}}
-				err = handler.ReceivedAck(ack2, 2, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
+				Expect(handler.ReceivedAck(ack2, 2, protocol.Encryption1RTT, time.Now())).To(Succeed())
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
-				expectInPacketHistory([]protocol.PacketNumber{8, 9})
+				expectInPacketHistory([]protocol.PacketNumber{8, 9}, protocol.Encryption1RTT)
 			})
 
 			It("processes an ACK that contains old ACK ranges", func() {
 				ack1 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 6}}}
-				err := handler.ReceivedAck(ack1, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 7, 8, 9})
+				Expect(handler.ReceivedAck(ack1, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				expectInPacketHistory([]protocol.PacketNumber{0, 7, 8, 9}, protocol.Encryption1RTT)
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(4)))
 				ack2 := &wire.AckFrame{
 					AckRanges: []wire.AckRange{
@@ -278,9 +265,8 @@ var _ = Describe("SentPacketHandler", func() {
 						{Smallest: 1, Largest: 1},
 					},
 				}
-				err = handler.ReceivedAck(ack2, 2, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
-				expectInPacketHistory([]protocol.PacketNumber{0, 7, 9})
+				Expect(handler.ReceivedAck(ack2, 2, protocol.Encryption1RTT, time.Now())).To(Succeed())
+				expectInPacketHistory([]protocol.PacketNumber{0, 7, 9}, protocol.Encryption1RTT)
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(3)))
 			})
 		})
@@ -289,9 +275,9 @@ var _ = Describe("SentPacketHandler", func() {
 			It("computes the RTT", func() {
 				now := time.Now()
 				// First, fake the sent times of the first, second and last packet
-				getPacket(1).SendTime = now.Add(-10 * time.Minute)
-				getPacket(2).SendTime = now.Add(-5 * time.Minute)
-				getPacket(6).SendTime = now.Add(-1 * time.Minute)
+				getPacket(1, protocol.Encryption1RTT).SendTime = now.Add(-10 * time.Minute)
+				getPacket(2, protocol.Encryption1RTT).SendTime = now.Add(-5 * time.Minute)
+				getPacket(6, protocol.Encryption1RTT).SendTime = now.Add(-1 * time.Minute)
 				// Now, check that the proper times are used when calculating the deltas
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 1}}}
 				err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
@@ -311,7 +297,7 @@ var _ = Describe("SentPacketHandler", func() {
 				now := time.Now()
 				// make sure the rttStats have a min RTT, so that the delay is used
 				handler.rttStats.UpdateRTT(5*time.Minute, 0, time.Now())
-				getPacket(1).SendTime = now.Add(-10 * time.Minute)
+				getPacket(1, protocol.Encryption1RTT).SendTime = now.Add(-10 * time.Minute)
 				ack := &wire.AckFrame{
 					AckRanges: []wire.AckRange{{Smallest: 1, Largest: 1}},
 					DelayTime: 5 * time.Minute,
@@ -327,9 +313,9 @@ var _ = Describe("SentPacketHandler", func() {
 				ack1 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 80, Largest: 100}}}
 				ack2 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 50, Largest: 200}}}
 				morePackets := []*Packet{
-					{PacketNumber: 13, Frames: []wire.Frame{ack1, &streamFrame}, Length: 1},
-					{PacketNumber: 14, Frames: []wire.Frame{ack2, &streamFrame}, Length: 1},
-					{PacketNumber: 15, Frames: []wire.Frame{&streamFrame}, Length: 1},
+					{PacketNumber: 13, Frames: []wire.Frame{ack1, &streamFrame}, Length: 1, EncryptionLevel: protocol.Encryption1RTT},
+					{PacketNumber: 14, Frames: []wire.Frame{ack2, &streamFrame}, Length: 1, EncryptionLevel: protocol.Encryption1RTT},
+					{PacketNumber: 15, Frames: []wire.Frame{&streamFrame}, Length: 1, EncryptionLevel: protocol.Encryption1RTT},
 				}
 				for _, packet := range morePackets {
 					handler.SentPacket(packet)
@@ -337,28 +323,26 @@ var _ = Describe("SentPacketHandler", func() {
 			})
 
 			It("determines which ACK we have received an ACK for", func() {
-				err := handler.ReceivedAck(&wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 13, Largest: 15}}}, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
+				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 13, Largest: 15}}}
+				Expect(handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(201)))
 			})
 
 			It("doesn't do anything when the acked packet didn't contain an ACK", func() {
-				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 13, Largest: 13}}}
-				err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
+				ack1 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 13, Largest: 13}}}
+				ack2 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 15, Largest: 15}}}
+				Expect(handler.ReceivedAck(ack1, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(101)))
-				ack = &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 15, Largest: 15}}}
-				err = handler.ReceivedAck(ack, 2, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
+				Expect(handler.ReceivedAck(ack2, 2, protocol.Encryption1RTT, time.Now())).To(Succeed())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(101)))
 			})
 
 			It("doesn't decrease the value", func() {
-				err := handler.ReceivedAck(&wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 14, Largest: 14}}}, 1, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
+				ack1 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 14, Largest: 14}}}
+				ack2 := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 13, Largest: 13}}}
+				Expect(handler.ReceivedAck(ack1, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(201)))
-				err = handler.ReceivedAck(&wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 13, Largest: 13}}}, 2, protocol.Encryption1RTT, time.Now())
-				Expect(err).ToNot(HaveOccurred())
+				Expect(handler.ReceivedAck(ack2, 2, protocol.Encryption1RTT, time.Now())).To(Succeed())
 				Expect(handler.GetLowestPacketNotConfirmedAcked()).To(Equal(protocol.PacketNumber(201)))
 			})
 		})
@@ -367,9 +351,9 @@ var _ = Describe("SentPacketHandler", func() {
 	Context("ACK processing, for retransmitted packets", func() {
 		It("sends a packet as retransmission", func() {
 			// packet 5 was retransmitted as packet 6
-			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 5, Length: 10}))
+			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 5, Length: 10, EncryptionLevel: protocol.Encryption1RTT}))
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(10)))
-			losePacket(5)
+			losePacket(5, protocol.Encryption1RTT)
 			Expect(handler.bytesInFlight).To(BeZero())
 			handler.SentPacketsAsRetransmission([]*Packet{retransmittablePacket(&Packet{PacketNumber: 6, Length: 11})}, 5)
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(11)))
@@ -378,21 +362,21 @@ var _ = Describe("SentPacketHandler", func() {
 		It("removes a packet when it is acked", func() {
 			// packet 5 was retransmitted as packet 6
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 5, Length: 10}))
-			losePacket(5)
+			losePacket(5, protocol.Encryption1RTT)
 			handler.SentPacketsAsRetransmission([]*Packet{retransmittablePacket(&Packet{PacketNumber: 6, Length: 11})}, 5)
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(11)))
 			// ack 5
 			ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 5, Largest: 5}}}
 			err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
 			Expect(err).ToNot(HaveOccurred())
-			expectInPacketHistory([]protocol.PacketNumber{6})
+			expectInPacketHistory([]protocol.PacketNumber{6}, protocol.Encryption1RTT)
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(11)))
 		})
 
 		It("handles ACKs that ack the original packet as well as the retransmission", func() {
 			// packet 5 was retransmitted as packet 7
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 5, Length: 10}))
-			losePacket(5)
+			losePacket(5, protocol.Encryption1RTT)
 			handler.SentPacketsAsRetransmission([]*Packet{retransmittablePacket(&Packet{PacketNumber: 7, Length: 11})}, 5)
 			// ack 5 and 7
 			ack := &wire.AckFrame{
@@ -403,13 +387,13 @@ var _ = Describe("SentPacketHandler", func() {
 			}
 			err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(handler.packetHistory.Len()).To(BeZero())
+			Expect(handler.oneRTTPackets.history.Len()).To(BeZero())
 			Expect(handler.bytesInFlight).To(BeZero())
 		})
 	})
 
-	It("does not dequeue a packet if no ack has been received", func() {
-		handler.SentPacket(&Packet{PacketNumber: 1})
+	It("does not dequeue a packet if no ACK has been received", func() {
+		handler.SentPacket(&Packet{PacketNumber: 1, EncryptionLevel: protocol.Encryption1RTT, SendTime: time.Now().Add(-time.Hour)})
 		Expect(handler.DequeuePacketForRetransmission()).To(BeNil())
 	})
 
@@ -430,12 +414,12 @@ var _ = Describe("SentPacketHandler", func() {
 				true,
 			)
 			cong.EXPECT().TimeUntilSend(gomock.Any())
-			p := &Packet{
-				PacketNumber: 1,
-				Length:       42,
-				Frames:       []wire.Frame{&wire.PingFrame{}},
-			}
-			handler.SentPacket(p)
+			handler.SentPacket(&Packet{
+				PacketNumber:    1,
+				Length:          42,
+				Frames:          []wire.Frame{&wire.PingFrame{}},
+				EncryptionLevel: protocol.Encryption1RTT,
+			})
 		})
 
 		It("should call MaybeExitSlowStart and OnPacketAcked", func() {
@@ -557,7 +541,7 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.bytesInFlight = 100
 			cong.EXPECT().OnPacketSent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			cong.EXPECT().TimeUntilSend(protocol.ByteCount(100)).Return(time.Hour)
-			handler.SentPacket(&Packet{PacketNumber: 1, SendTime: sendTime})
+			handler.SentPacket(&Packet{PacketNumber: 1, SendTime: sendTime, EncryptionLevel: protocol.Encryption1RTT})
 			Expect(handler.TimeUntilSend()).To(Equal(sendTime.Add(time.Hour)))
 		})
 
@@ -672,7 +656,7 @@ var _ = Describe("SentPacketHandler", func() {
 			Expect(handler.ptoCount).To(BeEquivalentTo(3))
 		})
 
-		It("doesn't delete packets transmitted as RTO from the history", func() {
+		It("doesn't delete packets transmitted as PTO from the history", func() {
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 1, SendTime: time.Now().Add(-time.Hour)}))
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 2, SendTime: time.Now().Add(-time.Hour)}))
 			handler.rttStats.UpdateRTT(time.Second, 0, time.Now())
@@ -683,15 +667,15 @@ var _ = Describe("SentPacketHandler", func() {
 			Expect(err).ToNot(HaveOccurred())
 			_, err = handler.DequeueProbePacket()
 			Expect(err).ToNot(HaveOccurred())
-			expectInPacketHistory([]protocol.PacketNumber{1, 2})
+			expectInPacketHistory([]protocol.PacketNumber{1, 2}, protocol.Encryption1RTT)
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(2)))
 			// Send a probe packet and receive an ACK for it.
 			// This verifies the RTO.
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 3}))
 			ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 3, Largest: 3}}}
-			err = handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
+			Expect(handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())).To(Succeed())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(handler.packetHistory.Len()).To(BeZero())
+			Expect(handler.oneRTTPackets.history.Len()).To(BeZero())
 			Expect(handler.bytesInFlight).To(BeZero())
 			Expect(handler.retransmissionQueue).To(BeEmpty()) // 1 and 2 were already sent as probe packets
 		})
@@ -709,14 +693,14 @@ var _ = Describe("SentPacketHandler", func() {
 			Expect(err).ToNot(HaveOccurred())
 			_, err = handler.DequeueProbePacket()
 			Expect(err).ToNot(HaveOccurred())
-			expectInPacketHistory([]protocol.PacketNumber{1, 2, 3, 4, 5})
+			expectInPacketHistory([]protocol.PacketNumber{1, 2, 3, 4, 5}, protocol.Encryption1RTT)
 			// Send a probe packet and receive an ACK for it.
 			// This verifies the RTO.
 			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 6}))
 			ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 6, Largest: 6}}}
 			err = handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, time.Now())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(handler.packetHistory.Len()).To(BeZero())
+			Expect(handler.oneRTTPackets.history.Len()).To(BeZero())
 			Expect(handler.bytesInFlight).To(BeZero())
 			Expect(handler.retransmissionQueue).To(HaveLen(3)) // packets 3, 4, 5
 		})
@@ -764,22 +748,20 @@ var _ = Describe("SentPacketHandler", func() {
 
 		It("sets the early retransmit alarm", func() {
 			now := time.Now()
-			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 1, SendTime: now.Add(-2 * time.Second)}))
-			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 2, SendTime: now.Add(-2 * time.Second)}))
-			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 3, SendTime: now.Add(-time.Second)}))
+			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 1, SendTime: now.Add(-2 * time.Second), EncryptionLevel: protocol.Encryption1RTT}))
+			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 2, SendTime: now.Add(-2 * time.Second), EncryptionLevel: protocol.Encryption1RTT}))
+			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 3, SendTime: now.Add(-time.Second), EncryptionLevel: protocol.Encryption1RTT}))
 			Expect(handler.lossTime.IsZero()).To(BeTrue())
 
 			ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 2, Largest: 2}}}
-			err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, now.Add(-time.Second))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, now.Add(-time.Second))).To(Succeed())
 			Expect(handler.rttStats.SmoothedRTT()).To(Equal(time.Second))
 
 			// Packet 1 should be considered lost (1+1/8) RTTs after it was sent.
 			Expect(handler.lossTime.IsZero()).To(BeFalse())
-			Expect(handler.lossTime.Sub(getPacket(1).SendTime)).To(Equal(time.Second * 9 / 8))
+			Expect(handler.lossTime.Sub(getPacket(1, protocol.Encryption1RTT).SendTime)).To(Equal(time.Second * 9 / 8))
 
-			err = handler.OnAlarm()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.OnAlarm()).To(Succeed())
 			Expect(handler.DequeuePacketForRetransmission()).NotTo(BeNil())
 			// make sure this is not an RTO: only packet 1 is retransmissted
 			Expect(handler.DequeuePacketForRetransmission()).To(BeNil())
@@ -795,22 +777,20 @@ var _ = Describe("SentPacketHandler", func() {
 			now := time.Now()
 			sendTime := now.Add(-time.Minute)
 			lastCryptoPacketSendTime := now.Add(-30 * time.Second)
-			// send crypto packets: 1, 3
-			// send a forward-secure packet: 2
-			handler.SentPacket(cryptoPacket(&Packet{PacketNumber: 1, SendTime: sendTime}))
-			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 2, SendTime: sendTime}))
-			handler.SentPacket(cryptoPacket(&Packet{PacketNumber: 3, SendTime: sendTime}))
+			// send Initial packets: 1, 3
+			// send 1-RTT packet: 100
+			handler.SentPacket(cryptoPacket(&Packet{PacketNumber: 1, SendTime: sendTime, EncryptionLevel: protocol.EncryptionInitial}))
+			handler.SentPacket(cryptoPacket(&Packet{PacketNumber: 3, SendTime: sendTime, EncryptionLevel: protocol.EncryptionInitial}))
+			handler.SentPacket(retransmittablePacket(&Packet{PacketNumber: 100, SendTime: sendTime, EncryptionLevel: protocol.Encryption1RTT}))
 
 			ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 1}}}
-			err := handler.ReceivedAck(ack, 1, protocol.Encryption1RTT, now)
+			Expect(handler.ReceivedAck(ack, 1, protocol.EncryptionInitial, now)).To(Succeed())
 			// RTT is now 1 minute
 			Expect(handler.rttStats.SmoothedRTT()).To(Equal(time.Minute))
-			Expect(err).NotTo(HaveOccurred())
 			Expect(handler.lossTime.IsZero()).To(BeTrue())
 			Expect(handler.GetAlarmTimeout().Sub(sendTime)).To(Equal(2 * time.Minute))
 
-			err = handler.OnAlarm()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(handler.OnAlarm()).To(Succeed())
 			p := handler.DequeuePacketForRetransmission()
 			Expect(p).ToNot(BeNil())
 			Expect(p.PacketNumber).To(Equal(protocol.PacketNumber(3)))
@@ -820,8 +800,7 @@ var _ = Describe("SentPacketHandler", func() {
 			Expect(handler.GetAlarmTimeout().Sub(lastCryptoPacketSendTime)).To(Equal(4 * time.Minute))
 		})
 
-		// TODO(#1534): also check the encryption level for IETF QUIC
-		PIt("rejects an ACK that acks packets with a higher encryption level", func() {
+		It("rejects an ACK that acks packets with a higher encryption level", func() {
 			handler.SentPacket(&Packet{
 				PacketNumber:    13,
 				EncryptionLevel: protocol.Encryption1RTT,
@@ -830,19 +809,23 @@ var _ = Describe("SentPacketHandler", func() {
 			})
 			ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 13, Largest: 13}}}
 			err := handler.ReceivedAck(ack, 1, protocol.EncryptionHandshake, time.Now())
-			Expect(err).To(MatchError("Received ACK with encryption level encrypted (not forward-secure) that acks a packet 13 (encryption level forward-secure)"))
+			Expect(err).To(MatchError("InvalidAckData: Received ACK for an unsent packet"))
 		})
 
 		It("deletes crypto packets when the handshake completes", func() {
-			for i := protocol.PacketNumber(1); i <= 6; i++ {
-				p := retransmittablePacket(&Packet{PacketNumber: i})
-				p.EncryptionLevel = protocol.EncryptionHandshake
+			for i := protocol.PacketNumber(0); i < 6; i++ {
+				p := retransmittablePacket(&Packet{PacketNumber: i, EncryptionLevel: protocol.EncryptionInitial})
 				handler.SentPacket(p)
 			}
-			handler.queuePacketForRetransmission(getPacket(1))
-			handler.queuePacketForRetransmission(getPacket(3))
+			for i := protocol.PacketNumber(0); i <= 6; i++ {
+				p := retransmittablePacket(&Packet{PacketNumber: i, EncryptionLevel: protocol.EncryptionHandshake})
+				handler.SentPacket(p)
+			}
+			handler.queuePacketForRetransmission(getPacket(1, protocol.EncryptionInitial), handler.getPacketNumberSpace(protocol.EncryptionInitial))
+			handler.queuePacketForRetransmission(getPacket(3, protocol.EncryptionHandshake), handler.getPacketNumberSpace(protocol.EncryptionHandshake))
 			handler.SetHandshakeComplete()
-			Expect(handler.packetHistory.Len()).To(BeZero())
+			Expect(handler.initialPackets.history.Len()).To(BeZero())
+			Expect(handler.handshakePackets.history.Len()).To(BeZero())
 			packet := handler.DequeuePacketForRetransmission()
 			Expect(packet).To(BeNil())
 		})
@@ -850,14 +833,23 @@ var _ = Describe("SentPacketHandler", func() {
 
 	Context("peeking and popping packet number", func() {
 		It("peeks and pops the initial packet number", func() {
-			pn, _ := handler.PeekPacketNumber()
+			pn, _ := handler.PeekPacketNumber(protocol.EncryptionInitial)
 			Expect(pn).To(Equal(protocol.PacketNumber(42)))
-			Expect(handler.PopPacketNumber()).To(Equal(protocol.PacketNumber(42)))
+			Expect(handler.PopPacketNumber(protocol.EncryptionInitial)).To(Equal(protocol.PacketNumber(42)))
 		})
 
 		It("peeks and pops beyond the initial packet number", func() {
-			Expect(handler.PopPacketNumber()).To(Equal(protocol.PacketNumber(42)))
-			Expect(handler.PopPacketNumber()).To(BeNumerically(">", 42))
+			Expect(handler.PopPacketNumber(protocol.EncryptionInitial)).To(Equal(protocol.PacketNumber(42)))
+			Expect(handler.PopPacketNumber(protocol.EncryptionInitial)).To(BeNumerically(">", 42))
+		})
+
+		It("starts at 0 for handshake and application-data packet number space", func() {
+			pn, _ := handler.PeekPacketNumber(protocol.EncryptionHandshake)
+			Expect(pn).To(BeZero())
+			Expect(handler.PopPacketNumber(protocol.EncryptionHandshake)).To(BeZero())
+			pn, _ = handler.PeekPacketNumber(protocol.Encryption1RTT)
+			Expect(pn).To(BeZero())
+			Expect(handler.PopPacketNumber(protocol.Encryption1RTT)).To(BeZero())
 		})
 	})
 

--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -10,8 +10,7 @@ type sentPacketHistory struct {
 	packetList *PacketList
 	packetMap  map[protocol.PacketNumber]*PacketElement
 
-	numOutstandingPackets       int
-	numOutstandingCryptoPackets int
+	numOutstandingPackets int
 
 	firstOutstanding *PacketElement
 }
@@ -35,9 +34,6 @@ func (h *sentPacketHistory) sentPacketImpl(p *Packet) *PacketElement {
 	}
 	if p.canBeRetransmitted {
 		h.numOutstandingPackets++
-		if p.EncryptionLevel != protocol.Encryption1RTT {
-			h.numOutstandingCryptoPackets++
-		}
 	}
 	return el
 }
@@ -106,12 +102,6 @@ func (h *sentPacketHistory) MarkCannotBeRetransmitted(pn protocol.PacketNumber) 
 		if h.numOutstandingPackets < 0 {
 			panic("numOutstandingHandshakePackets negative")
 		}
-		if el.Value.EncryptionLevel != protocol.Encryption1RTT {
-			h.numOutstandingCryptoPackets--
-			if h.numOutstandingCryptoPackets < 0 {
-				panic("numOutstandingHandshakePackets negative")
-			}
-		}
 	}
 	el.Value.canBeRetransmitted = false
 	if el == h.firstOutstanding {
@@ -147,12 +137,6 @@ func (h *sentPacketHistory) Remove(p protocol.PacketNumber) error {
 		if h.numOutstandingPackets < 0 {
 			panic("numOutstandingHandshakePackets negative")
 		}
-		if el.Value.EncryptionLevel != protocol.Encryption1RTT {
-			h.numOutstandingCryptoPackets--
-			if h.numOutstandingCryptoPackets < 0 {
-				panic("numOutstandingHandshakePackets negative")
-			}
-		}
 	}
 	h.packetList.Remove(el)
 	delete(h.packetMap, p)
@@ -161,8 +145,4 @@ func (h *sentPacketHistory) Remove(p protocol.PacketNumber) error {
 
 func (h *sentPacketHistory) HasOutstandingPackets() bool {
 	return h.numOutstandingPackets > 0
-}
-
-func (h *sentPacketHistory) HasOutstandingCryptoPackets() bool {
-	return h.numOutstandingCryptoPackets > 0
 }

--- a/internal/ackhandler/sent_packet_history_test.go
+++ b/internal/ackhandler/sent_packet_history_test.go
@@ -199,23 +199,12 @@ var _ = Describe("SentPacketHistory", func() {
 	})
 
 	Context("outstanding packets", func() {
-		It("says if it has outstanding crypto packets", func() {
-			Expect(hist.HasOutstandingCryptoPackets()).To(BeFalse())
-			hist.SentPacket(&Packet{
-				EncryptionLevel:    protocol.EncryptionInitial,
-				canBeRetransmitted: true,
-			})
-			Expect(hist.HasOutstandingCryptoPackets()).To(BeTrue())
-		})
-
 		It("says if it has outstanding packets", func() {
-			Expect(hist.HasOutstandingCryptoPackets()).To(BeFalse())
 			Expect(hist.HasOutstandingPackets()).To(BeFalse())
 			hist.SentPacket(&Packet{
 				EncryptionLevel:    protocol.Encryption1RTT,
 				canBeRetransmitted: true,
 			})
-			Expect(hist.HasOutstandingCryptoPackets()).To(BeFalse())
 			Expect(hist.HasOutstandingPackets()).To(BeTrue())
 		})
 
@@ -223,20 +212,7 @@ var _ = Describe("SentPacketHistory", func() {
 			hist.SentPacket(&Packet{
 				EncryptionLevel: protocol.EncryptionInitial,
 			})
-			Expect(hist.HasOutstandingCryptoPackets()).To(BeFalse())
 			Expect(hist.HasOutstandingPackets()).To(BeFalse())
-		})
-
-		It("accounts for deleted crypto packets", func() {
-			hist.SentPacket(&Packet{
-				PacketNumber:       5,
-				EncryptionLevel:    protocol.EncryptionHandshake,
-				canBeRetransmitted: true,
-			})
-			Expect(hist.HasOutstandingCryptoPackets()).To(BeTrue())
-			err := hist.Remove(5)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hist.HasOutstandingCryptoPackets()).To(BeFalse())
 		})
 
 		It("accounts for deleted packets", func() {
@@ -249,18 +225,6 @@ var _ = Describe("SentPacketHistory", func() {
 			err := hist.Remove(10)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hist.HasOutstandingPackets()).To(BeFalse())
-		})
-
-		It("doesn't count crypto packets marked as non-retransmittable", func() {
-			hist.SentPacket(&Packet{
-				PacketNumber:       5,
-				EncryptionLevel:    protocol.EncryptionInitial,
-				canBeRetransmitted: true,
-			})
-			Expect(hist.HasOutstandingCryptoPackets()).To(BeTrue())
-			err := hist.MarkCannotBeRetransmitted(5)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hist.HasOutstandingCryptoPackets()).To(BeFalse())
 		})
 
 		It("doesn't count packets marked as non-retransmittable", func() {

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -99,28 +99,28 @@ func (mr *MockSentPacketHandlerMockRecorder) OnAlarm() *gomock.Call {
 }
 
 // PeekPacketNumber mocks base method
-func (m *MockSentPacketHandler) PeekPacketNumber() (protocol.PacketNumber, protocol.PacketNumberLen) {
-	ret := m.ctrl.Call(m, "PeekPacketNumber")
+func (m *MockSentPacketHandler) PeekPacketNumber(arg0 protocol.EncryptionLevel) (protocol.PacketNumber, protocol.PacketNumberLen) {
+	ret := m.ctrl.Call(m, "PeekPacketNumber", arg0)
 	ret0, _ := ret[0].(protocol.PacketNumber)
 	ret1, _ := ret[1].(protocol.PacketNumberLen)
 	return ret0, ret1
 }
 
 // PeekPacketNumber indicates an expected call of PeekPacketNumber
-func (mr *MockSentPacketHandlerMockRecorder) PeekPacketNumber() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeekPacketNumber", reflect.TypeOf((*MockSentPacketHandler)(nil).PeekPacketNumber))
+func (mr *MockSentPacketHandlerMockRecorder) PeekPacketNumber(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeekPacketNumber", reflect.TypeOf((*MockSentPacketHandler)(nil).PeekPacketNumber), arg0)
 }
 
 // PopPacketNumber mocks base method
-func (m *MockSentPacketHandler) PopPacketNumber() protocol.PacketNumber {
-	ret := m.ctrl.Call(m, "PopPacketNumber")
+func (m *MockSentPacketHandler) PopPacketNumber(arg0 protocol.EncryptionLevel) protocol.PacketNumber {
+	ret := m.ctrl.Call(m, "PopPacketNumber", arg0)
 	ret0, _ := ret[0].(protocol.PacketNumber)
 	return ret0
 }
 
 // PopPacketNumber indicates an expected call of PopPacketNumber
-func (mr *MockSentPacketHandlerMockRecorder) PopPacketNumber() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopPacketNumber", reflect.TypeOf((*MockSentPacketHandler)(nil).PopPacketNumber))
+func (mr *MockSentPacketHandlerMockRecorder) PopPacketNumber(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopPacketNumber", reflect.TypeOf((*MockSentPacketHandler)(nil).PopPacketNumber), arg0)
 }
 
 // ReceivedAck mocks base method

--- a/session.go
+++ b/session.go
@@ -805,7 +805,7 @@ func (s *session) destroy(e error) {
 // It returns the first packet number that should be used in the new session.
 func (s *session) closeForRecreating() protocol.PacketNumber {
 	s.destroy(errCloseForRecreating)
-	nextPN, _ := s.sentPacketHandler.PeekPacketNumber()
+	nextPN, _ := s.sentPacketHandler.PeekPacketNumber(protocol.EncryptionInitial)
 	return nextPN
 }
 
@@ -1028,7 +1028,7 @@ func (s *session) maybeSendRetransmission() (bool, error) {
 		break
 	}
 
-	s.logger.Debugf("Dequeueing retransmission for packet 0x%x", retransmitPacket.PacketNumber)
+	s.logger.Debugf("Dequeueing retransmission for packet 0x%x (%s)", retransmitPacket.PacketNumber, retransmitPacket.EncryptionLevel)
 	packets, err := s.packer.PackRetransmission(retransmitPacket)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Fixes #1534.

Packet numbers now start at 0 for every packet number spaces.
Furthermore, an ACK frame now only acknowledges packets in the packet number space it was sent in.