### PR TITLE
remove some unneccessary type conversions

### DIFF
--- a/framer_test.go
+++ b/framer_test.go
@@ -62,10 +62,10 @@ var _ = Describe("Stream Framer", func() {
 			for i := 0; i < numFrames+1; i++ {
 				framer.QueueControlFrame(bf)
 			}
-			frames, length := framer.AppendControlFrames(nil, protocol.ByteCount(maxSize))
+			frames, length := framer.AppendControlFrames(nil, maxSize)
 			Expect(frames).To(HaveLen(numFrames))
 			Expect(length).To(BeNumerically(">", maxSize-bfLen))
-			frames, length = framer.AppendControlFrames(nil, protocol.ByteCount(maxSize))
+			frames, length = framer.AppendControlFrames(nil, maxSize)
 			Expect(frames).To(HaveLen(1))
 			Expect(length).To(Equal(bfLen))
 		})

--- a/internal/congestion/prr_sender_test.go
+++ b/internal/congestion/prr_sender_test.go
@@ -70,7 +70,7 @@ var _ = Describe("PRR sender", func() {
 	})
 
 	It("burst loss results in slow start", func() {
-		bytesInFlight := protocol.ByteCount(20 * protocol.DefaultTCPMSS)
+		bytesInFlight := 20 * protocol.DefaultTCPMSS
 		const numPacketsLost = 13
 		const ssthreshAfterLoss = 10
 		const congestionWindow = ssthreshAfterLoss * protocol.DefaultTCPMSS

--- a/internal/flowcontrol/base_flow_controller_test.go
+++ b/internal/flowcontrol/base_flow_controller_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Base Flow controller", func() {
 				newWindowSize := controller.receiveWindowSize
 				Expect(newWindowSize).To(Equal(2 * oldWindowSize))
 				// check that the new window size was used to increase the offset
-				Expect(offset).To(Equal(protocol.ByteCount(bytesRead + dataRead + newWindowSize)))
+				Expect(offset).To(Equal(bytesRead + dataRead + newWindowSize))
 			})
 
 			It("doesn't increase the window size if data is read so fast that the window would be consumed in less than 4 RTTs, but less than half the window has been read", func() {
@@ -188,7 +188,7 @@ var _ = Describe("Base Flow controller", func() {
 				newWindowSize := controller.receiveWindowSize
 				Expect(newWindowSize).To(Equal(oldWindowSize))
 				// check that the new window size was used to increase the offset
-				Expect(offset).To(Equal(protocol.ByteCount(bytesRead + dataRead + newWindowSize)))
+				Expect(offset).To(Equal(bytesRead + dataRead + newWindowSize))
 			})
 
 			It("doesn't increase the window size if read too slowly", func() {
@@ -206,7 +206,7 @@ var _ = Describe("Base Flow controller", func() {
 				// check that the window size was not increased
 				Expect(controller.receiveWindowSize).To(Equal(oldWindowSize))
 				// check that the new window size was used to increase the offset
-				Expect(offset).To(Equal(protocol.ByteCount(bytesRead + dataRead + oldWindowSize)))
+				Expect(offset).To(Equal(bytesRead + dataRead + oldWindowSize))
 			})
 
 			It("doesn't increase the window size to a value higher than the maxReceiveWindowSize", func() {

--- a/internal/flowcontrol/connection_flow_controller_test.go
+++ b/internal/flowcontrol/connection_flow_controller_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Connection Flow controller", func() {
 				dataRead := windowSize/2 - 1 // make sure not to trigger auto-tuning
 				controller.AddBytesRead(dataRead)
 				offset := controller.GetWindowUpdate()
-				Expect(offset).To(Equal(protocol.ByteCount(oldOffset + dataRead + 60)))
+				Expect(offset).To(Equal(oldOffset + dataRead + 60))
 			})
 
 			It("autotunes the window", func() {
@@ -90,7 +90,7 @@ var _ = Describe("Connection Flow controller", func() {
 				offset := controller.GetWindowUpdate()
 				newWindowSize := controller.receiveWindowSize
 				Expect(newWindowSize).To(Equal(2 * oldWindowSize))
-				Expect(offset).To(Equal(protocol.ByteCount(oldOffset + dataRead + newWindowSize)))
+				Expect(offset).To(Equal(oldOffset + dataRead + newWindowSize))
 			})
 		})
 	})

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Stream Flow controller", func() {
 				controller.epochStartTime = time.Now().Add(-time.Millisecond)
 				controller.AddBytesRead(55)
 				offset := controller.GetWindowUpdate()
-				Expect(offset).To(Equal(protocol.ByteCount(oldOffset + 55 + 2*oldWindowSize)))
+				Expect(offset).To(Equal(oldOffset + 55 + 2*oldWindowSize))
 				Expect(controller.receiveWindowSize).To(Equal(2 * oldWindowSize))
 				Expect(controller.connection.(*connectionFlowController).receiveWindowSize).To(Equal(protocol.ByteCount(float64(controller.receiveWindowSize) * protocol.ConnectionFlowControlMultiplier)))
 			})

--- a/internal/utils/log_test.go
+++ b/internal/utils/log_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Log", func() {
 		DefaultLogger.SetLogTimeFormat(format)
 		DefaultLogger.SetLogLevel(LogLevelInfo)
 		DefaultLogger.Infof("info")
-		t, err := time.Parse(format, string(b.String()[:b.Len()-6]))
+		t, err := time.Parse(format, b.String()[:b.Len()-6])
 		Expect(err).ToNot(HaveOccurred())
 		Expect(t).To(BeTemporally("~", time.Now(), 25*time.Hour))
 	})


### PR DESCRIPTION
I'm not sure why the gometalinter on Travis didn't find these, it did locally.