### PR TITLE
consistently return timeout errors after timeouts

### DIFF
--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -1,0 +1,89 @@
+package self_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"time"
+
+	quic "github.com/lucas-clemente/quic-go"
+	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
+	"github.com/lucas-clemente/quic-go/internal/testdata"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Timeout tests", func() {
+	checkTimeoutError := func(err error) {
+		ExpectWithOffset(1, err).To(HaveOccurred())
+		nerr, ok := err.(net.Error)
+		ExpectWithOffset(1, ok).To(BeTrue())
+		ExpectWithOffset(1, nerr.Timeout()).To(BeTrue())
+	}
+
+	It("returns net.Error timeout errors when an idle timeout occurs", func() {
+		const idleTimeout = 100 * time.Millisecond
+
+		server, err := quic.ListenAddr(
+			"localhost:0",
+			testdata.GetTLSConfig(),
+			nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		defer server.Close()
+
+		go func() {
+			defer GinkgoRecover()
+			sess, err := server.Accept()
+			Expect(err).ToNot(HaveOccurred())
+			str, err := sess.OpenStream()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = str.Write([]byte("foobar"))
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		drop := utils.AtomicBool{}
+
+		proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+			RemoteAddr: fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
+			DropPacket: func(d quicproxy.Direction, p uint64) bool {
+				return drop.Get()
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		defer proxy.Close()
+
+		sess, err := quic.DialAddr(
+			fmt.Sprintf("localhost:%d", proxy.LocalPort()),
+			&tls.Config{RootCAs: testdata.GetRootCA()},
+			&quic.Config{IdleTimeout: idleTimeout},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		strIn, err := sess.AcceptStream()
+		Expect(err).ToNot(HaveOccurred())
+		strOut, err := sess.OpenStream()
+		Expect(err).ToNot(HaveOccurred())
+		_, err = strIn.Read(make([]byte, 6))
+		Expect(err).ToNot(HaveOccurred())
+
+		drop.Set(true)
+		time.Sleep(2 * idleTimeout)
+		_, err = strIn.Write([]byte("test"))
+		checkTimeoutError(err)
+		_, err = strIn.Read([]byte{0})
+		checkTimeoutError(err)
+		_, err = strOut.Write([]byte("test"))
+		checkTimeoutError(err)
+		_, err = strOut.Read([]byte{0})
+		checkTimeoutError(err)
+		_, err = sess.OpenStream()
+		checkTimeoutError(err)
+		_, err = sess.OpenUniStream()
+		checkTimeoutError(err)
+		_, err = sess.AcceptStream()
+		checkTimeoutError(err)
+		_, err = sess.AcceptUniStream()
+		checkTimeoutError(err)
+	})
+})

--- a/interface.go
+++ b/interface.go
@@ -37,12 +37,16 @@ type Stream interface {
 	// after a fixed time limit; see SetDeadline and SetReadDeadline.
 	// If the stream was canceled by the peer, the error implements the StreamError
 	// interface, and Canceled() == true.
+	// If the session was closed due to a timeout, the error satisfies
+	// the net.Error interface, and Timeout() will be true.
 	io.Reader
 	// Write writes data to the stream.
 	// Write can be made to time out and return a net.Error with Timeout() == true
 	// after a fixed time limit; see SetDeadline and SetWriteDeadline.
 	// If the stream was canceled by the peer, the error implements the StreamError
 	// interface, and Canceled() == true.
+	// If the session was closed due to a timeout, the error satisfies
+	// the net.Error interface, and Timeout() will be true.
 	io.Writer
 	// Close closes the write-direction of the stream.
 	// Future calls to Write are not permitted after calling Close.
@@ -117,26 +121,34 @@ type StreamError interface {
 // A Session is a QUIC connection between two peers.
 type Session interface {
 	// AcceptStream returns the next stream opened by the peer, blocking until one is available.
+	// If the session was closed due to a timeout, the error satisfies
+	// the net.Error interface, and Timeout() will be true.
 	AcceptStream() (Stream, error)
 	// AcceptUniStream returns the next unidirectional stream opened by the peer, blocking until one is available.
+	// If the session was closed due to a timeout, the error satisfies
+	// the net.Error interface, and Timeout() will be true.
 	AcceptUniStream() (ReceiveStream, error)
 	// OpenStream opens a new bidirectional QUIC stream.
 	// There is no signaling to the peer about new streams:
 	// The peer can only accept the stream after data has been sent on the stream.
 	// If the error is non-nil, it satisfies the net.Error interface.
 	// When reaching the peer's stream limit, err.Temporary() will be true.
+	// If the session was closed due to a timeout, Timeout() will be true.
 	OpenStream() (Stream, error)
 	// OpenStreamSync opens a new bidirectional QUIC stream.
 	// It blocks until a new stream can be opened.
 	// If the error is non-nil, it satisfies the net.Error interface.
+	// If the session was closed due to a timeout, Timeout() will be true.
 	OpenStreamSync() (Stream, error)
 	// OpenUniStream opens a new outgoing unidirectional QUIC stream.
 	// If the error is non-nil, it satisfies the net.Error interface.
 	// When reaching the peer's stream limit, Temporary() will be true.
+	// If the session was closed due to a timeout, Timeout() will be true.
 	OpenUniStream() (SendStream, error)
 	// OpenUniStreamSync opens a new outgoing unidirectional QUIC stream.
 	// It blocks until a new stream can be opened.
 	// If the error is non-nil, it satisfies the net.Error interface.
+	// If the session was closed due to a timeout, Timeout() will be true.
 	OpenUniStreamSync() (SendStream, error)
 	// LocalAddr returns the local address.
 	LocalAddr() net.Addr

--- a/internal/qerr/quic_error.go
+++ b/internal/qerr/quic_error.go
@@ -2,6 +2,7 @@ package qerr
 
 import (
 	"fmt"
+	"net"
 )
 
 // ErrorCode can be used as a normal error without reason.
@@ -17,6 +18,8 @@ type QuicError struct {
 	ErrorMessage string
 }
 
+var _ net.Error = &QuicError{}
+
 // Error creates a new QuicError instance
 func Error(errorCode ErrorCode, errorMessage string) *QuicError {
 	return &QuicError{
@@ -27,6 +30,11 @@ func Error(errorCode ErrorCode, errorMessage string) *QuicError {
 
 func (e *QuicError) Error() string {
 	return fmt.Sprintf("%s: %s", e.ErrorCode.String(), e.ErrorMessage)
+}
+
+// Temporary says if the error is temporary.
+func (e *QuicError) Temporary() bool {
+	return false
 }
 
 // Timeout says if this error is a timeout.

--- a/streams_map_outgoing_bidi.go
+++ b/streams_map_outgoing_bidi.go
@@ -49,6 +49,10 @@ func (m *outgoingBidiStreamsMap) OpenStream() (streamI, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	if m.closeErr != nil {
+		return nil, m.closeErr
+	}
+
 	str, err := m.openStreamImpl()
 	if err != nil {
 		return nil, streamOpenErr{err}
@@ -61,6 +65,9 @@ func (m *outgoingBidiStreamsMap) OpenStreamSync() (streamI, error) {
 	defer m.mutex.Unlock()
 
 	for {
+		if m.closeErr != nil {
+			return nil, m.closeErr
+		}
 		str, err := m.openStreamImpl()
 		if err == nil {
 			return str, nil
@@ -73,9 +80,6 @@ func (m *outgoingBidiStreamsMap) OpenStreamSync() (streamI, error) {
 }
 
 func (m *outgoingBidiStreamsMap) openStreamImpl() (streamI, error) {
-	if m.closeErr != nil {
-		return nil, m.closeErr
-	}
 	if !m.maxStreamSet || m.nextStream > m.maxStream {
 		if !m.blockedSent {
 			if m.maxStreamSet {

--- a/streams_map_outgoing_generic.go
+++ b/streams_map_outgoing_generic.go
@@ -47,6 +47,10 @@ func (m *outgoingItemsMap) OpenStream() (item, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	if m.closeErr != nil {
+		return nil, m.closeErr
+	}
+
 	str, err := m.openStreamImpl()
 	if err != nil {
 		return nil, streamOpenErr{err}
@@ -59,6 +63,9 @@ func (m *outgoingItemsMap) OpenStreamSync() (item, error) {
 	defer m.mutex.Unlock()
 
 	for {
+		if m.closeErr != nil {
+			return nil, m.closeErr
+		}
 		str, err := m.openStreamImpl()
 		if err == nil {
 			return str, nil
@@ -71,9 +78,6 @@ func (m *outgoingItemsMap) OpenStreamSync() (item, error) {
 }
 
 func (m *outgoingItemsMap) openStreamImpl() (item, error) {
-	if m.closeErr != nil {
-		return nil, m.closeErr
-	}
 	if !m.maxStreamSet || m.nextStream > m.maxStream {
 		if !m.blockedSent {
 			if m.maxStreamSet {

--- a/streams_map_outgoing_generic_test.go
+++ b/streams_map_outgoing_generic_test.go
@@ -2,7 +2,6 @@ package quic
 
 import (
 	"errors"
-	"net"
 
 	"github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
@@ -47,12 +46,7 @@ var _ = Describe("Streams Map (outgoing)", func() {
 			testErr := errors.New("close")
 			m.CloseWithError(testErr)
 			_, err := m.OpenStream()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal(testErr.Error()))
-			nerr, ok := err.(net.Error)
-			Expect(ok).To(BeTrue())
-			Expect(nerr.Timeout()).To(BeFalse())
-			Expect(nerr.Temporary()).To(BeFalse())
+			Expect(err).To(MatchError(testErr))
 		})
 
 		It("gets streams", func() {
@@ -155,8 +149,7 @@ var _ = Describe("Streams Map (outgoing)", func() {
 			go func() {
 				defer GinkgoRecover()
 				_, err := m.OpenStreamSync()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(testErr.Error()))
+				Expect(err).To(MatchError(testErr))
 				close(done)
 			}()
 

--- a/streams_map_outgoing_uni.go
+++ b/streams_map_outgoing_uni.go
@@ -49,6 +49,10 @@ func (m *outgoingUniStreamsMap) OpenStream() (sendStreamI, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	if m.closeErr != nil {
+		return nil, m.closeErr
+	}
+
 	str, err := m.openStreamImpl()
 	if err != nil {
 		return nil, streamOpenErr{err}
@@ -61,6 +65,9 @@ func (m *outgoingUniStreamsMap) OpenStreamSync() (sendStreamI, error) {
 	defer m.mutex.Unlock()
 
 	for {
+		if m.closeErr != nil {
+			return nil, m.closeErr
+		}
 		str, err := m.openStreamImpl()
 		if err == nil {
 			return str, nil
@@ -73,9 +80,6 @@ func (m *outgoingUniStreamsMap) OpenStreamSync() (sendStreamI, error) {
 }
 
 func (m *outgoingUniStreamsMap) openStreamImpl() (sendStreamI, error) {
-	if m.closeErr != nil {
-		return nil, m.closeErr
-	}
 	if !m.maxStreamSet || m.nextStream > m.maxStream {
 		if !m.blockedSent {
 			if m.maxStreamSet {


### PR DESCRIPTION
Fixes #1720.

Unrelated to this issue and PR, but I noticed that if you're using stream deadlines, you have no way to distinguish between deadline errors and session timeouts.