### PR TITLE
don't require servers to send stateless reset tokens in transport params

### DIFF
--- a/session.go
+++ b/session.go
@@ -945,10 +945,6 @@ func (s *session) processTransportParametersForClient(data []byte) (*handshake.T
 		return nil, err
 	}
 
-	// check that the server sent a stateless reset token
-	if params.StatelessResetToken == nil {
-		return nil, errors.New("server didn't send stateless_reset_token")
-	}
 	// check the Retry token
 	if !params.OriginalConnectionID.Equal(s.origDestConnID) {
 		return nil, fmt.Errorf("expected original_connection_id to equal %s, is %s", s.origDestConnID, params.OriginalConnectionID)

--- a/session_test.go
+++ b/session_test.go
@@ -1661,12 +1661,6 @@ var _ = Describe("Client Session", func() {
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 
-		It("errors if the TransportParameters don't contain the stateless reset token", func() {
-			params := &handshake.TransportParameters{}
-			_, err := sess.processTransportParametersForClient(params.Marshal())
-			Expect(err).To(MatchError("server didn't send stateless_reset_token"))
-		})
-
 		It("errors if the TransportParameters contain an original_connection_id, although no Retry was performed", func() {
 			params := &handshake.TransportParameters{
 				OriginalConnectionID: protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad},


### PR DESCRIPTION
Fixes #1833.