### PR TITLE
Fix memory leak in packetHandlerMap closure

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -78,6 +78,7 @@ func (h *packetHandlerMap) Remove(id protocol.ConnectionID) {
 func (h *packetHandlerMap) removeByConnectionIDAsString(id string) {
 	h.mutex.Lock()
 	delete(h.handlers, id)
+	delete(h.deletionTimers, id)
 	h.mutex.Unlock()
 }
 
@@ -86,10 +87,10 @@ func (h *packetHandlerMap) Retire(id protocol.ConnectionID) {
 }
 
 func (h *packetHandlerMap) retireByConnectionIDAsString(id string) {
+	h.mutex.Lock()
 	timer := time.AfterFunc(h.deleteRetiredSessionsAfter, func() {
 		h.removeByConnectionIDAsString(id)
 	})
-	h.mutex.Lock()
 	h.deletionTimers[id] = timer
 	h.mutex.Unlock()
 }

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -87,6 +87,10 @@ func (h *packetHandlerMap) Retire(id protocol.ConnectionID) {
 }
 
 func (h *packetHandlerMap) retireByConnectionIDAsString(id string) {
+	// Acquire lock before creating timer to ensure that it can be inserted into
+	// deletionTimers map before the corresponding delete in
+	// removeByConnectionIDAsString is executed. Otherwise, this could leak if
+	// deleteRetiredSessionsAfter is 0.
 	h.mutex.Lock()
 	timer := time.AfterFunc(h.deleteRetiredSessionsAfter, func() {
 		h.removeByConnectionIDAsString(id)

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -41,10 +41,6 @@ type packetHandlerMap struct {
 	logger utils.Logger
 }
 
-type packetHandlerMapWeakPtr struct {
-	m *packetHandlerMap
-}
-
 var _ packetHandlerManager = &packetHandlerMap{}
 
 func newPacketHandlerMap(


### PR DESCRIPTION
The closure used to cleanup sessions after the ClosedSessionDeleteTimeout would keep a reference to the
packetHandlerMap, preventing it from being garbage collected until the timer actually runs. However, once the packetHandlerMap is closed, this becomes pointless.
When rapidly opening and closing many sessions, this delay in garbage collecting the packetHandlerMap led to large memory leaks.

---

It seems fairly hard to add a testcase that covers this.

In order to demonstrate that this patch is effective, I ran the following program that quickly connects to the local "example" server. Without the proposed changes, the memory usage of the program quickly shoots up. When I run it here, it seems to stabilize at around 150M (resident set size). With this PR applied, the observed memory usage stays constant (at around 10M).

Note: In our use case, we call `quic.Dial` with a somewhat fatter type for `net.PacketConn` which made the leak much more apparent.

```go
package main

import (
        "crypto/tls"
        "time"

        "github.com/lucas-clemente/quic-go"
        "github.com/lucas-clemente/quic-go/internal/testdata"
)

func main() {
        cfg := quic.Config{
                HandshakeTimeout: 5 * time.Millisecond,
        }
        tlsCfg := tls.Config{RootCAs: testdata.GetRootCA()}
        for {
                session, _ := quic.DialAddr("localhost:6121", &tlsCfg, &cfg)
                if session != nil {
                        _ = session.Close()
                }
        }
}
```