### PR TITLE
use the full pacing rate, also when not in slow start

### DIFF
--- a/internal/congestion/cubic_sender.go
+++ b/internal/congestion/cubic_sender.go
@@ -89,11 +89,7 @@ func (c *cubicSender) TimeUntilSend(bytesInFlight protocol.ByteCount) time.Durat
 			return 0
 		}
 	}
-	delay := c.rttStats.SmoothedRTT() * time.Duration(protocol.DefaultTCPMSS) / time.Duration(2*c.GetCongestionWindow())
-	if !c.InSlowStart() { // adjust delay, such that it's 1.25*cwd/rtt
-		delay = delay * 8 / 5
-	}
-	return delay
+	return c.rttStats.SmoothedRTT() * time.Duration(protocol.DefaultTCPMSS) / time.Duration(2*c.GetCongestionWindow())
 }
 
 func (c *cubicSender) OnPacketSent(


### PR DESCRIPTION
I don't remember why we would only send with 5/8 of the pacing rate when not in slow start, this guarantees that we'd only use ~60% of the congestion window. I guess it's because we copied this code from Chrome at some point, but Chrome does [something completely different](https://cs.chromium.org/chromium/src/net/third_party/quiche/src/quic/core/congestion_control/pacing_sender.cc?sq=package:chromium&g=0&l=124) now, so it seems justified to remove this for now.

## Benchmarks

before:
```
+-----------------+-------------+-------------+
|                 |     TCP     |    QUIC     |
+-----------------+-------------+-------------+
| direct transfer | 0.02 ± 0.01 | 0.22 ± 0.01 |
| 5ms RTT         | 0.10 ± 0.00 | 0.36 ± 0.04 |
| 10ms RTT        | 0.20 ± 0.00 | 0.43 ± 0.01 |
| 25ms RTT        | 0.49 ± 0.00 | 0.90 ± 0.00 |
| 50ms RTT        | 0.82 ± 0.00 | 1.86 ± 0.01 |
| 100ms RTT       | 1.60 ± 0.02 | 3.48 ± 0.02 |
+-----------------+-------------+-------------+
Based on 3 samples (25 MB).
```

after:
```
+-----------------+-------------+-------------+
|                 |     TCP     |    QUIC     |
+-----------------+-------------+-------------+
| direct transfer | 0.02 ± 0.00 | 0.23 ± 0.01 |
| 5ms RTT         | 0.10 ± 0.01 | 0.34 ± 0.02 |
| 10ms RTT        | 0.20 ± 0.00 | 0.43 ± 0.03 |
| 25ms RTT        | 0.49 ± 0.00 | 0.63 ± 0.00 |
| 50ms RTT        | 0.82 ± 0.00 | 1.33 ± 0.02 |
| 100ms RTT       | 1.62 ± 0.00 | 2.81 ± 0.02 |
+-----------------+-------------+-------------+
Based on 3 samples (25 MB).
```