### PR TITLE
pack crypto packets in a separate code path

### DIFF
--- a/mock_packer_test.go
+++ b/mock_packer_test.go
@@ -91,6 +91,21 @@ func (mr *MockPackerMockRecorder) PackConnectionClose(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackConnectionClose", reflect.TypeOf((*MockPacker)(nil).PackConnectionClose), arg0)
 }
 
+// PackCryptoPacket mocks base method
+func (m *MockPacker) PackCryptoPacket() (*packedPacket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PackCryptoPacket")
+	ret0, _ := ret[0].(*packedPacket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PackCryptoPacket indicates an expected call of PackCryptoPacket
+func (mr *MockPackerMockRecorder) PackCryptoPacket() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackCryptoPacket", reflect.TypeOf((*MockPacker)(nil).PackCryptoPacket))
+}
+
 // PackPacket mocks base method
 func (m *MockPacker) PackPacket() (*packedPacket, error) {
 	m.ctrl.T.Helper()

--- a/session.go
+++ b/session.go
@@ -360,8 +360,6 @@ runLoop:
 		select {
 		case closeErr = <-s.closeChan:
 			break runLoop
-		case <-s.handshakeCompleteChan:
-			s.handleHandshakeComplete()
 		default:
 		}
 


### PR DESCRIPTION
After the handshake completes (i.e. after TLS tells us that our side has successfully completed the handshake), there's no need to send any more crypto packets. We might have to send retransmissions of crypto packets, but they are handled in a separate code path.

**EDIT**: This PR in its current form is wrong, since the handshake complete callback might be called before the last flight of the handshake has been sent.