### PR TITLE
fix support for gQUIC 44

### DIFF
--- a/integrationtests/chrome/chrome_suite_test.go
+++ b/integrationtests/chrome/chrome_suite_test.go
@@ -115,7 +115,6 @@ func chromeTest(version protocol.VersionNumber, url string, blockUntilDone func(
 		"--user-data-dir=" + userDataDir,
 		"--enable-quic=true",
 		"--no-proxy-server=true",
-		"--no-sandbox",
 		"--origin-to-force-quic-on=quic.clemente.io:443",
 		fmt.Sprintf(`--host-resolver-rules=MAP quic.clemente.io:443 127.0.0.1:%s`, testserver.Port()),
 		fmt.Sprintf("--quic-version=QUIC_VERSION_%s", version.ToAltSvc()),

--- a/server_session.go
+++ b/server_session.go
@@ -48,6 +48,11 @@ func (s *serverSession) handlePacketImpl(p *receivedPacket) error {
 		switch hdr.Type {
 		case protocol.PacketTypeHandshake, protocol.PacketType0RTT: // 0-RTT accepted for gQUIC 44
 			// nothing to do here. Packet will be passed to the session.
+		case protocol.PacketTypeInitial:
+			if hdr.Version == protocol.Version44 {
+				break
+			}
+			fallthrough
 		default:
 			// Note that this also drops 0-RTT packets.
 			return fmt.Errorf("Received unsupported packet type: %s", hdr.Type)


### PR DESCRIPTION
No idea why the integration test so far wasn't failing.
Maybe Google changed something in the wire format after rolling out the experiment.