### PR TITLE
Add function to use *tls.Config with HTTP3 ListenAndServe

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -293,6 +293,13 @@ func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error 
 		Certificates: certs,
 	}
 
+	return ListenAndServeTLSConfig(addr, config, handler)
+}
+
+// ListenAndServeTLSConfig does the same as ListenAndServe (listens on the
+// given network address for both, TLS and QUIC connetions in parallel)
+// but it takes a *tls.Config instead of the path to certificate and key files.
+func ListenAndServeTLSConfig(addr string, config *tls.Config, handler http.Handler) error {
 	// Open the listeners
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {


### PR DESCRIPTION
Adds **http3.ListenAndServeTLSConfig** function which is a clone of **http3.ListenAndServe** where ***tls.Config** struct is used instead of **certFile, keyFile _string_** to start a http3.Server.

My goal is to have full access to the *tls.Config capabilities.