### PR TITLE
fix reading of the EOF in the HTTP/3 server

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -191,7 +191,7 @@ func (s *Server) handleRequest(str quic.Stream, decoder *qpack.Decoder) error {
 		}()
 		handler.ServeHTTP(responseWriter, req)
 		// read the eof
-		if _, err = str.Read([]byte{}); err == io.EOF {
+		if _, err = str.Read([]byte{0}); err == io.EOF {
 			readEOF = true
 		}
 	}()


### PR DESCRIPTION
Fixes #1874.

`Read([]byte{})` returns immediately, whereas `Read([]byte{0})` blocks until the stream is actually closed. This make as difference if the STREAM frame with the FIN is received after the HTTP handler returned.