### PR TITLE
fix large file integration test on Chrome

### DIFF
--- a/integrationtests/chrome/chrome_suite_test.go
+++ b/integrationtests/chrome/chrome_suite_test.go
@@ -147,7 +147,7 @@ var prng = new Uint8Array(buf);
 var seed = 1;
 for (var i = 0; i < LENGTH; i++) {
 	// https://en.wikipedia.org/wiki/Lehmer_random_number_generator
-	seed = seed * 48271 % 2147483647;
+	seed = seed * 75 % 65537;
 	prng[i] = seed;
 }
 `

--- a/integrationtests/tools/testserver/server.go
+++ b/integrationtests/tools/testserver/server.go
@@ -74,7 +74,7 @@ func GeneratePRData(l int) []byte {
 	res := make([]byte, l)
 	seed := uint64(1)
 	for i := 0; i < l; i++ {
-		seed = seed * 48271 % 2147483647
+		seed = seed * 75 % 65537
 		res[i] = byte(seed)
 	}
 	return res


### PR DESCRIPTION
The Chrome integration tests downloading and uploading 50 MB of data fails on CircleCI and on Ubuntu 19.04. Chrome doesn't output any error message, and also seems to completely calculate the array buffer containing the random data, but it doesn't execute the AJAX requesting to load the file from the QUIC server.
Using different parameters for the Lehmer random number generator apparently fixes the test. I have no idea why.