### PR TITLE
h2quic/request: Fix URL parsing of leading double slashes after authotiy

### DIFF
--- a/h2quic/request.go
+++ b/h2quic/request.go
@@ -41,7 +41,7 @@ func requestFromHeaders(headers []hpack.HeaderField) (*http.Request, error) {
 		return nil, errors.New(":path, :authority and :method must not be empty")
 	}
 
-	u, err := url.Parse(path)
+	u, err := url.ParseRequestURI(path)
 	if err != nil {
 		return nil, err
 	}

--- a/h2quic/request_test.go
+++ b/h2quic/request_test.go
@@ -28,9 +28,25 @@ var _ = Describe("Request", func() {
 		Expect(req.ContentLength).To(Equal(int64(42)))
 		Expect(req.Header).To(BeEmpty())
 		Expect(req.Body).To(BeNil())
+		Expect(req.URL.Host).To(BeEmpty())
 		Expect(req.Host).To(Equal("quic.clemente.io"))
 		Expect(req.RequestURI).To(Equal("/foo"))
 		Expect(req.TLS).ToNot(BeNil())
+	})
+
+	It("parses path with leading double slashes", func() {
+		headers := []hpack.HeaderField{
+			{Name: ":path", Value: "//foo"},
+			{Name: ":authority", Value: "quic.clemente.io"},
+			{Name: ":method", Value: "GET"},
+		}
+		req, err := requestFromHeaders(headers)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Header).To(BeEmpty())
+		Expect(req.Body).To(BeNil())
+		Expect(req.URL.Host).To(BeEmpty())
+		Expect(req.Host).To(Equal("quic.clemente.io"))
+		Expect(req.RequestURI).To(Equal("//foo"))
 	})
 
 	It("concatenates the cookie headers", func() {


### PR DESCRIPTION
`url.Parse` with a raw url "https://example.com//some_path"  will result in
`url.Host = "//some_path"`
and empty `url.Path`

This fix can also be applied in the master branch but it seems that the request_test.go file has been deleted, so there will be no unit test for that in the master branch.

We can maybe add a test to the `http3/server_test.go` but I think it's not the right place to add a test for this.
  
