### PR TITLE
also check for an executable named chromium in chrome integration tests

### DIFF
--- a/integrationtests/chrome/chrome_suite_test.go
+++ b/integrationtests/chrome/chrome_suite_test.go
@@ -99,6 +99,9 @@ func getChromePath() string {
 	if path, err := exec.LookPath("chromium-browser"); err == nil {
 		return path
 	}
+	if path, err := exec.LookPath("chromium"); err == nil {
+		return path
+	}
 	Fail("No Chrome executable found.")
 	return ""
 }


### PR DESCRIPTION
This is how the executable is called in Ubuntu 19.04.