### PR TITLE
http3/request: Fix URL parsing of leading double slashes after authority

### DIFF
--- a/http3/request.go
+++ b/http3/request.go
@@ -41,7 +41,7 @@ func requestFromHeaders(headers []qpack.HeaderField) (*http.Request, error) {
 		return nil, errors.New(":path, :authority and :method must not be empty")
 	}
 
-	u, err := url.Parse(path)
+	u, err := url.ParseRequestURI(path)
 	if err != nil {
 		return nil, err
 	}

--- a/http3/request_test.go
+++ b/http3/request_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Request", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(req.Method).To(Equal("GET"))
 		Expect(req.URL.Path).To(Equal("/foo"))
+		Expect(req.URL.Host).To(BeEmpty())
 		Expect(req.Proto).To(Equal("HTTP/3"))
 		Expect(req.ProtoMajor).To(Equal(3))
 		Expect(req.ProtoMinor).To(BeZero())
@@ -30,6 +31,22 @@ var _ = Describe("Request", func() {
 		Expect(req.Host).To(Equal("quic.clemente.io"))
 		Expect(req.RequestURI).To(Equal("/foo"))
 		Expect(req.TLS).ToNot(BeNil())
+	})
+
+	It("parses path with leading double slashes", func() {
+		headers := []qpack.HeaderField{
+			{Name: ":path", Value: "//foo"},
+			{Name: ":authority", Value: "quic.clemente.io"},
+			{Name: ":method", Value: "GET"},
+		}
+		req, err := requestFromHeaders(headers)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Header).To(BeEmpty())
+		Expect(req.Body).To(BeNil())
+		Expect(req.URL.Path).To(Equal("//foo"))
+		Expect(req.URL.Host).To(BeEmpty())
+		Expect(req.Host).To(Equal("quic.clemente.io"))
+		Expect(req.RequestURI).To(Equal("//foo"))
 	})
 
 	It("concatenates the cookie headers", func() {


### PR DESCRIPTION
This is the same fix merged  into the gquic branch, see https://github.com/lucas-clemente/quic-go/pull/1898