### PR TITLE
improve logging of stream limit frames

### DIFF
--- a/internal/wire/log.go
+++ b/internal/wire/log.go
@@ -33,6 +33,13 @@ func LogFrame(logger utils.Logger, frame Frame, sent bool) {
 		} else {
 			logger.Debugf("\t%s &wire.AckFrame{LargestAcked: %#x, LowestAcked: %#x, DelayTime: %s}", dir, f.LargestAcked(), f.LowestAcked(), f.DelayTime.String())
 		}
+	case *MaxStreamsFrame:
+		switch f.Type {
+		case protocol.StreamTypeUni:
+			logger.Debugf("\t%s &wire.MaxStreamsFrame{Type: uni, MaxStreams: %d}", dir, f.MaxStreams)
+		case protocol.StreamTypeBidi:
+			logger.Debugf("\t%s &wire.MaxStreamsFrame{Type: bidi, MaxStreams: %d}", dir, f.MaxStreams)
+		}
 	case *NewConnectionIDFrame:
 		logger.Debugf("\t%s &wire.NewConnectionIDFrame{SequenceNumber: %d, ConnectionID: %s, StatelessResetToken: %#x}", dir, f.SequenceNumber, f.ConnectionID, f.StatelessResetToken)
 	case *NewTokenFrame:

--- a/internal/wire/log.go
+++ b/internal/wire/log.go
@@ -40,6 +40,13 @@ func LogFrame(logger utils.Logger, frame Frame, sent bool) {
 		case protocol.StreamTypeBidi:
 			logger.Debugf("\t%s &wire.MaxStreamsFrame{Type: bidi, MaxStreams: %d}", dir, f.MaxStreams)
 		}
+	case *StreamsBlockedFrame:
+		switch f.Type {
+		case protocol.StreamTypeUni:
+			logger.Debugf("\t%s &wire.StreamsBlockedFrame{Type: uni, MaxStreams: %d}", dir, f.StreamLimit)
+		case protocol.StreamTypeBidi:
+			logger.Debugf("\t%s &wire.StreamsBlockedFrame{Type: bidi, MaxStreams: %d}", dir, f.StreamLimit)
+		}
 	case *NewConnectionIDFrame:
 		logger.Debugf("\t%s &wire.NewConnectionIDFrame{SequenceNumber: %d, ConnectionID: %s, StatelessResetToken: %#x}", dir, f.SequenceNumber, f.ConnectionID, f.StatelessResetToken)
 	case *NewTokenFrame:

--- a/internal/wire/log_test.go
+++ b/internal/wire/log_test.go
@@ -87,6 +87,15 @@ var _ = Describe("Frame logging", func() {
 		Expect(buf.String()).To(ContainSubstring("\t<- &wire.AckFrame{LargestAcked: 0x8, LowestAcked: 0x2, AckRanges: {{Largest: 0x8, Smallest: 0x5}, {Largest: 0x3, Smallest: 0x2}}, DelayTime: 12ms}\n"))
 	})
 
+	It("logs MAX_STREAMS frames", func() {
+		frame := &MaxStreamsFrame{
+			Type:       protocol.StreamTypeBidi,
+			MaxStreams: 42,
+		}
+		LogFrame(logger, frame, false)
+		Expect(buf.String()).To(ContainSubstring("\t<- &wire.MaxStreamsFrame{Type: bidi, MaxStreams: 42}\n"))
+	})
+
 	It("logs NEW_CONNECTION_ID frames", func() {
 		LogFrame(logger, &NewConnectionIDFrame{
 			SequenceNumber:      42,

--- a/internal/wire/log_test.go
+++ b/internal/wire/log_test.go
@@ -96,6 +96,15 @@ var _ = Describe("Frame logging", func() {
 		Expect(buf.String()).To(ContainSubstring("\t<- &wire.MaxStreamsFrame{Type: bidi, MaxStreams: 42}\n"))
 	})
 
+	It("logs STREAMS_BLOCKED frames", func() {
+		frame := &StreamsBlockedFrame{
+			Type:        protocol.StreamTypeBidi,
+			StreamLimit: 42,
+		}
+		LogFrame(logger, frame, false)
+		Expect(buf.String()).To(ContainSubstring("\t<- &wire.StreamsBlockedFrame{Type: bidi, MaxStreams: 42}\n"))
+	})
+
 	It("logs NEW_CONNECTION_ID frames", func() {
 		LogFrame(logger, &NewConnectionIDFrame{
 			SequenceNumber:      42,


### PR DESCRIPTION
We might at some point think about adding an (optional) `Log()` method to the `wire.Frame` interface.