### PR TITLE
remove unused Session.GetOrOpenStream

### DIFF
--- a/session.go
+++ b/session.go
@@ -1159,21 +1159,6 @@ func (s *session) logPacket(packet *packedPacket) {
 	}
 }
 
-// GetOrOpenStream either returns an existing stream, a newly opened stream, or nil if a stream with the provided ID is already closed.
-// It is *only* needed for gQUIC's H2.
-// It will be removed as soon as gQUIC moves towards the IETF H2/QUIC stream mapping.
-func (s *session) GetOrOpenStream(id protocol.StreamID) (Stream, error) {
-	str, err := s.streamsMap.GetOrOpenSendStream(id)
-	if str != nil {
-		if bstr, ok := str.(Stream); ok {
-			return bstr, err
-		}
-		return nil, fmt.Errorf("Stream %d is not a bidirectional stream", id)
-	}
-	// make sure to return an actual nil value here, not an Stream with value nil
-	return nil, err
-}
-
 // AcceptStream returns the next stream openend by the peer
 func (s *session) AcceptStream() (Stream, error) {
 	return s.streamsMap.AcceptStream()

--- a/session_test.go
+++ b/session_test.go
@@ -1429,30 +1429,6 @@ var _ = Describe("Session", func() {
 	}, 0.5)
 
 	Context("getting streams", func() {
-		It("returns a new stream", func() {
-			mstr := NewMockStreamI(mockCtrl)
-			streamManager.EXPECT().GetOrOpenSendStream(protocol.StreamID(11)).Return(mstr, nil)
-			str, err := sess.GetOrOpenStream(11)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(str).To(Equal(mstr))
-		})
-
-		It("returns a nil-value (not an interface with value nil) for closed streams", func() {
-			strI := Stream(nil)
-			streamManager.EXPECT().GetOrOpenSendStream(protocol.StreamID(1337)).Return(strI, nil)
-			str, err := sess.GetOrOpenStream(1337)
-			Expect(err).ToNot(HaveOccurred())
-			// make sure that the returned value is a plain nil, not an Stream with value nil
-			_, ok := str.(Stream)
-			Expect(ok).To(BeFalse())
-		})
-
-		It("errors when trying to get a unidirectional stream", func() {
-			streamManager.EXPECT().GetOrOpenSendStream(protocol.StreamID(100)).Return(&sendStream{}, nil)
-			_, err := sess.GetOrOpenStream(100)
-			Expect(err).To(MatchError("Stream 100 is not a bidirectional stream"))
-		})
-
 		It("opens streams", func() {
 			mstr := NewMockStreamI(mockCtrl)
 			streamManager.EXPECT().OpenStream().Return(mstr, nil)


### PR DESCRIPTION
This method was only needed for the gQUIC H2 mapping.