### PR TITLE
reduce the Retry token expiry time to 10 seconds

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -189,7 +189,7 @@ type Config struct {
 	IdleTimeout time.Duration
 	// AcceptToken determines if a Token is accepted.
 	// It is called with token = nil if the client didn't send a token.
-	// If not set, it verifies that the address matches, and that the token was issued within the last 24 hours.
+	// If not set, it verifies that the address matches, and that the token was issued within the last 5 seconds.
 	// This option is only valid for the server.
 	AcceptToken func(clientAddr net.Addr, token *Token) bool
 	// MaxReceiveStreamFlowControlWindow is the maximum stream-level flow control window for receiving data.

--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -57,8 +57,8 @@ const MaxTrackedSkippedPackets = 10
 // If the queue is full, new connection attempts will be rejected.
 const MaxAcceptQueueSize = 32
 
-// TokenExpiryTime is the valid time of a token
-const TokenExpiryTime = 24 * time.Hour
+// RetryTokenValidity is the duration that a retry token is considered valid
+const RetryTokenValidity = 10 * time.Second
 
 // MaxOutstandingSentPackets is maximum number of packets saved for retransmission.
 // When reached, it imposes a soft limit on sending new packets:

--- a/server.go
+++ b/server.go
@@ -198,7 +198,7 @@ var defaultAcceptToken = func(clientAddr net.Addr, token *Token) bool {
 	if token == nil {
 		return false
 	}
-	if time.Now().After(token.SentTime.Add(protocol.TokenExpiryTime)) {
+	if time.Now().After(token.SentTime.Add(protocol.RetryTokenValidity)) {
 		return false
 	}
 	var sourceAddr string

--- a/server_test.go
+++ b/server_test.go
@@ -545,7 +545,7 @@ var _ = Describe("default source address verification", func() {
 		remoteAddr := &net.UDPAddr{IP: net.IPv4(192, 168, 0, 1)}
 		token := &Token{
 			RemoteAddr: "192.168.0.1",
-			SentTime:   time.Now().Add(-protocol.TokenExpiryTime).Add(time.Second), // will expire in 1 second
+			SentTime:   time.Now().Add(-protocol.RetryTokenValidity).Add(time.Second), // will expire in 1 second
 		}
 		Expect(defaultAcceptToken(remoteAddr, token)).To(BeTrue())
 	})
@@ -586,7 +586,7 @@ var _ = Describe("default source address verification", func() {
 		remoteAddr := &net.UDPAddr{IP: net.IPv4(192, 168, 0, 1)}
 		token := &Token{
 			RemoteAddr: "192.168.0.1",
-			SentTime:   time.Now().Add(-protocol.TokenExpiryTime).Add(-time.Second), // expired 1 second ago
+			SentTime:   time.Now().Add(-protocol.RetryTokenValidity).Add(-time.Second), // expired 1 second ago
 		}
 		Expect(defaultAcceptToken(remoteAddr, token)).To(BeFalse())
 	})


### PR DESCRIPTION
The expiry time used to be 24 hours before. The reason for this long duration was that this included tokens that were issued to be used between separate connections in gQUIC. At the moment (since we don't have a fix for #1913 yet), we are only generating tokens for Retry packets, i.e. within a single connection. They are therefore expected to be used within a single round trip.