### PR TITLE
initiate key updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@
 - Use a varint for error codes.
 - Add support for [quic-trace](https://github.com/google/quic-trace).
 - Add a context to `Listener.Accept`, `Session.Accept{Uni}Stream` and `Session.Open{Uni}StreamSync`.
-- Implement receiving of TLS key updates.
+- Implement TLS key updates.
 
 ## v0.11.0 (2019-04-05)
 

--- a/integrationtests/self/key_update_test.go
+++ b/integrationtests/self/key_update_test.go
@@ -1,0 +1,57 @@
+package self_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+
+	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go/integrationtests/tools/testserver"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Key Update tests", func() {
+	var server quic.Listener
+
+	runServer := func() {
+		var err error
+		// start the server
+		server, err = quic.ListenAddr("localhost:0", getTLSConfig(), nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		go func() {
+			defer GinkgoRecover()
+			sess, err := server.Accept(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			str, err := sess.OpenUniStream()
+			Expect(err).ToNot(HaveOccurred())
+			defer str.Close()
+			_, err = str.Write(testserver.PRDataLong)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+	}
+
+	BeforeEach(func() {
+		// update keys as frequently as possible
+		os.Setenv("QUIC_GO_KEY_UPDATE_INTERVAL", "1")
+		runServer()
+	})
+
+	It("downloads a large file", func() {
+		sess, err := quic.DialAddr(
+			fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
+			getTLSClientConfig(),
+			nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		defer sess.Close()
+		str, err := sess.AcceptUniStream(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		data, err := ioutil.ReadAll(str)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal(testserver.PRDataLong))
+	})
+})

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -223,7 +223,7 @@ func (h *cryptoSetup) ChangeConnectionID(id protocol.ConnectionID) error {
 	return nil
 }
 
-func (h *cryptoSetup) Received1RTTAck() {
+func (h *cryptoSetup) SetLargest1RTTAcked(_ protocol.PacketNumber) {
 	// drop initial keys
 	// TODO: do this earlier
 	if h.initialOpener != nil {

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -223,7 +223,8 @@ func (h *cryptoSetup) ChangeConnectionID(id protocol.ConnectionID) error {
 	return nil
 }
 
-func (h *cryptoSetup) SetLargest1RTTAcked(_ protocol.PacketNumber) {
+func (h *cryptoSetup) SetLargest1RTTAcked(pn protocol.PacketNumber) {
+	h.aead.SetLargestAcked(pn)
 	// drop initial keys
 	// TODO: do this earlier
 	if h.initialOpener != nil {

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -71,7 +71,7 @@ type CryptoSetup interface {
 	ChangeConnectionID(protocol.ConnectionID) error
 
 	HandleMessage([]byte, protocol.EncryptionLevel) bool
-	Received1RTTAck()
+	SetLargest1RTTAcked(protocol.PacketNumber)
 	ConnectionState() tls.ConnectionState
 
 	GetInitialOpener() (LongHeaderOpener, error)

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"os"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
@@ -205,6 +206,29 @@ var _ = Describe("Updatable AEAD", func() {
 					server.Seal(nil, msg, 1, ad)
 					server.SetLargestAcked(1)
 					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
+				})
+			})
+
+			Context("reading the key update env", func() {
+				AfterEach(func() {
+					os.Setenv(keyUpdateEnv, "")
+					setKeyUpdateInterval()
+				})
+
+				It("uses the default value if the env is not set", func() {
+					setKeyUpdateInterval()
+					Expect(keyUpdateInterval).To(BeEquivalentTo(protocol.KeyUpdateInterval))
+				})
+
+				It("uses the env", func() {
+					os.Setenv(keyUpdateEnv, "1337")
+					setKeyUpdateInterval()
+					Expect(keyUpdateInterval).To(BeEquivalentTo(1337))
+				})
+
+				It("panics when it can't parse the env", func() {
+					os.Setenv(keyUpdateEnv, "foobar")
+					Expect(setKeyUpdateInterval).To(Panic())
 				})
 			})
 		})

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -95,79 +95,117 @@ var _ = Describe("Updatable AEAD", func() {
 		})
 
 		Context("key updates", func() {
-			It("updates keys", func() {
-				Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
-				encrypted0 := server.Seal(nil, msg, 0x1337, ad)
-				server.rollKeys()
-				Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
-				encrypted1 := server.Seal(nil, msg, 0x1337, ad)
-				Expect(encrypted0).ToNot(Equal(encrypted1))
-				// expect opening to fail. The client didn't roll keys yet
-				_, err := client.Open(nil, encrypted1, 0x1337, protocol.KeyPhaseZero, ad)
-				Expect(err).To(MatchError(ErrDecryptionFailed))
-				client.rollKeys()
-				decrypted, err := client.Open(nil, encrypted1, 0x1337, protocol.KeyPhaseOne, ad)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(decrypted).To(Equal(msg))
+			Context("receiving key updates", func() {
+				It("updates keys", func() {
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
+					encrypted0 := server.Seal(nil, msg, 0x1337, ad)
+					server.rollKeys()
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
+					encrypted1 := server.Seal(nil, msg, 0x1337, ad)
+					Expect(encrypted0).ToNot(Equal(encrypted1))
+					// expect opening to fail. The client didn't roll keys yet
+					_, err := client.Open(nil, encrypted1, 0x1337, protocol.KeyPhaseZero, ad)
+					Expect(err).To(MatchError(ErrDecryptionFailed))
+					client.rollKeys()
+					decrypted, err := client.Open(nil, encrypted1, 0x1337, protocol.KeyPhaseOne, ad)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(decrypted).To(Equal(msg))
+				})
+
+				It("updates the keys when receiving a packet with the next key phase", func() {
+					// receive the first packet at key phase zero
+					encrypted0 := client.Seal(nil, msg, 0x42, ad)
+					decrypted, err := server.Open(nil, encrypted0, 0x42, protocol.KeyPhaseZero, ad)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(decrypted).To(Equal(msg))
+					// send one packet at key phase zero
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
+					_ = server.Seal(nil, msg, 0x1, ad)
+					// now received a message at key phase one
+					client.rollKeys()
+					encrypted1 := client.Seal(nil, msg, 0x43, ad)
+					decrypted, err = server.Open(nil, encrypted1, 0x43, protocol.KeyPhaseOne, ad)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(decrypted).To(Equal(msg))
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
+				})
+
+				It("opens a reordered packet with the old keys after an update", func() {
+					encrypted01 := client.Seal(nil, msg, 0x42, ad)
+					encrypted02 := client.Seal(nil, msg, 0x43, ad)
+					// receive the first packet with key phase 0
+					_, err := server.Open(nil, encrypted01, 0x42, protocol.KeyPhaseZero, ad)
+					Expect(err).ToNot(HaveOccurred())
+					// send one packet at key phase zero
+					_ = server.Seal(nil, msg, 0x1, ad)
+					// now receive a packet with key phase 1
+					client.rollKeys()
+					encrypted1 := client.Seal(nil, msg, 0x44, ad)
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
+					_, err = server.Open(nil, encrypted1, 0x44, protocol.KeyPhaseOne, ad)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
+					// now receive a reordered packet with key phase 0
+					decrypted, err := server.Open(nil, encrypted02, 0x43, protocol.KeyPhaseZero, ad)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(decrypted).To(Equal(msg))
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
+				})
+
+				It("errors when the peer starts with key phase 1", func() {
+					client.rollKeys()
+					encrypted := client.Seal(nil, msg, 0x1337, ad)
+					_, err := server.Open(nil, encrypted, 0x1337, protocol.KeyPhaseOne, ad)
+					Expect(err).To(MatchError("PROTOCOL_VIOLATION: wrong initial keyphase"))
+				})
+
+				It("errors when the peer updates keys too frequently", func() {
+					// receive the first packet at key phase zero
+					encrypted0 := client.Seal(nil, msg, 0x42, ad)
+					_, err := server.Open(nil, encrypted0, 0x42, protocol.KeyPhaseZero, ad)
+					Expect(err).ToNot(HaveOccurred())
+					// now receive a packet at key phase one, before having sent any packets
+					client.rollKeys()
+					encrypted1 := client.Seal(nil, msg, 0x42, ad)
+					_, err = server.Open(nil, encrypted1, 0x42, protocol.KeyPhaseOne, ad)
+					Expect(err).To(MatchError("PROTOCOL_VIOLATION: keys updated too quickly"))
+				})
 			})
 
-			It("updates the keys when receiving a packet with the next key phase", func() {
-				// receive the first packet at key phase zero
-				encrypted0 := client.Seal(nil, msg, 0x42, ad)
-				decrypted, err := server.Open(nil, encrypted0, 0x42, protocol.KeyPhaseZero, ad)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(decrypted).To(Equal(msg))
-				// send one packet at key phase zero
-				Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
-				_ = server.Seal(nil, msg, 0x1, ad)
-				// now received a message at key phase one
-				client.rollKeys()
-				encrypted1 := client.Seal(nil, msg, 0x43, ad)
-				decrypted, err = server.Open(nil, encrypted1, 0x43, protocol.KeyPhaseOne, ad)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(decrypted).To(Equal(msg))
-				Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
-			})
+			Context("initiating key updates", func() {
+				const keyUpdateInterval = 20
 
-			It("opens a reordered packet with the old keys after an update", func() {
-				encrypted01 := client.Seal(nil, msg, 0x42, ad)
-				encrypted02 := client.Seal(nil, msg, 0x43, ad)
-				// receive the first packet with key phase 0
-				_, err := server.Open(nil, encrypted01, 0x42, protocol.KeyPhaseZero, ad)
-				Expect(err).ToNot(HaveOccurred())
-				// send one packet at key phase zero
-				_ = server.Seal(nil, msg, 0x1, ad)
-				// now receive a packet with key phase 1
-				client.rollKeys()
-				encrypted1 := client.Seal(nil, msg, 0x44, ad)
-				Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
-				_, err = server.Open(nil, encrypted1, 0x44, protocol.KeyPhaseOne, ad)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
-				// now receive a reordered packet with key phase 0
-				decrypted, err := server.Open(nil, encrypted02, 0x43, protocol.KeyPhaseZero, ad)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(decrypted).To(Equal(msg))
-				Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
-			})
+				BeforeEach(func() {
+					Expect(server.keyUpdateInterval).To(BeEquivalentTo(protocol.KeyUpdateInterval))
+					server.keyUpdateInterval = keyUpdateInterval
+				})
 
-			It("errors when the peer starts with key phase 1", func() {
-				client.rollKeys()
-				encrypted := client.Seal(nil, msg, 0x1337, ad)
-				_, err := server.Open(nil, encrypted, 0x1337, protocol.KeyPhaseOne, ad)
-				Expect(err).To(MatchError("PROTOCOL_VIOLATION: wrong initial keyphase"))
-			})
+				It("initiates a key update after sealing the maximum number of packets", func() {
+					for i := 0; i < keyUpdateInterval; i++ {
+						pn := protocol.PacketNumber(i)
+						Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
+						server.Seal(nil, msg, pn, ad)
+					}
+					// no update allowed before receiving an acknowledgement for the current key phase
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
+					server.SetLargestAcked(0)
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
+				})
 
-			It("errors when the peer updates keys too frequently", func() {
-				// receive the first packet at key phase zero
-				encrypted0 := client.Seal(nil, msg, 0x42, ad)
-				_, err := server.Open(nil, encrypted0, 0x42, protocol.KeyPhaseZero, ad)
-				Expect(err).ToNot(HaveOccurred())
-				// now receive a packet at key phase one, before having sent any packets
-				client.rollKeys()
-				encrypted1 := client.Seal(nil, msg, 0x42, ad)
-				_, err = server.Open(nil, encrypted1, 0x42, protocol.KeyPhaseOne, ad)
-				Expect(err).To(MatchError("PROTOCOL_VIOLATION: keys updated too quickly"))
+				It("initiates a key update after opening the maximum number of packets", func() {
+					for i := 0; i < keyUpdateInterval; i++ {
+						pn := protocol.PacketNumber(i)
+						Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
+						encrypted := client.Seal(nil, msg, pn, ad)
+						_, err := server.Open(nil, encrypted, pn, protocol.KeyPhaseZero, ad)
+						Expect(err).ToNot(HaveOccurred())
+					}
+					// no update allowed before receiving an acknowledgement for the current key phase
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
+					server.Seal(nil, msg, 1, ad)
+					server.SetLargestAcked(1)
+					Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
+				})
 			})
 		})
 	})

--- a/internal/mocks/crypto_setup.go
+++ b/internal/mocks/crypto_setup.go
@@ -182,18 +182,6 @@ func (mr *MockCryptoSetupMockRecorder) HandleMessage(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleMessage", reflect.TypeOf((*MockCryptoSetup)(nil).HandleMessage), arg0, arg1)
 }
 
-// Received1RTTAck mocks base method
-func (m *MockCryptoSetup) Received1RTTAck() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Received1RTTAck")
-}
-
-// Received1RTTAck indicates an expected call of Received1RTTAck
-func (mr *MockCryptoSetupMockRecorder) Received1RTTAck() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Received1RTTAck", reflect.TypeOf((*MockCryptoSetup)(nil).Received1RTTAck))
-}
-
 // RunHandshake mocks base method
 func (m *MockCryptoSetup) RunHandshake() {
 	m.ctrl.T.Helper()
@@ -204,4 +192,16 @@ func (m *MockCryptoSetup) RunHandshake() {
 func (mr *MockCryptoSetupMockRecorder) RunHandshake() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunHandshake", reflect.TypeOf((*MockCryptoSetup)(nil).RunHandshake))
+}
+
+// SetLargest1RTTAcked mocks base method
+func (m *MockCryptoSetup) SetLargest1RTTAcked(arg0 protocol.PacketNumber) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLargest1RTTAcked", arg0)
+}
+
+// SetLargest1RTTAcked indicates an expected call of SetLargest1RTTAcked
+func (mr *MockCryptoSetupMockRecorder) SetLargest1RTTAcked(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLargest1RTTAcked", reflect.TypeOf((*MockCryptoSetup)(nil).SetLargest1RTTAcked), arg0)
 }

--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -139,3 +139,6 @@ const MaxAckDelay = 25 * time.Millisecond
 // MaxAckDelayInclGranularity is the max_ack_delay including the timer granularity.
 // This is the value that should be advertised to the peer.
 const MaxAckDelayInclGranularity = MaxAckDelay + TimerGranularity
+
+// KeyUpdateInterval is the maximum number of packets we send or receive before initiating a key udpate.
+const KeyUpdateInterval = 100 * 1000

--- a/session.go
+++ b/session.go
@@ -50,7 +50,7 @@ type streamManager interface {
 type cryptoStreamHandler interface {
 	RunHandshake()
 	ChangeConnectionID(protocol.ConnectionID) error
-	Received1RTTAck()
+	SetLargest1RTTAcked(protocol.PacketNumber)
 	io.Closer
 	ConnectionState() tls.ConnectionState
 }
@@ -890,7 +890,7 @@ func (s *session) handleAckFrame(frame *wire.AckFrame, pn protocol.PacketNumber,
 	}
 	if encLevel == protocol.Encryption1RTT {
 		s.receivedPacketHandler.IgnoreBelow(s.sentPacketHandler.GetLowestPacketNotConfirmedAcked())
-		s.cryptoStreamHandler.Received1RTTAck()
+		s.cryptoStreamHandler.SetLargest1RTTAcked(frame.LargestAcked())
 	}
 	return nil
 }

--- a/session_test.go
+++ b/session_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Session", func() {
 			})
 
 			It("tells the ReceivedPacketHandler to ignore low ranges", func() {
-				cryptoSetup.EXPECT().Received1RTTAck()
+				cryptoSetup.EXPECT().SetLargest1RTTAcked(protocol.PacketNumber(3))
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 2, Largest: 3}}}
 				sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 				sph.EXPECT().ReceivedAck(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())


### PR DESCRIPTION
I set the interval to 100,000 packets. For full size packets, this means every ~120 MB. This should be way more often than needed to be within the security bounds of the AEADs we use. Computationally, it's infrequent enough to be completely negligible.