### PR TITLE
drop keys 3 PTOs after a key update

### DIFF
--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/lucas-clemente/quic-go/internal/congestion"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/testdata"
@@ -93,6 +94,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			NewMockHandshakeRunner(mockCtrl),
 			tlsConf,
+			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -124,6 +126,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			runner,
 			testdata.GetTLSConfig(),
+			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -161,6 +164,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			runner,
 			testdata.GetTLSConfig(),
+			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -200,6 +204,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			runner,
 			serverConf,
+			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -233,6 +238,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			NewMockHandshakeRunner(mockCtrl),
 			serverConf,
+			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -311,6 +317,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{},
 				cRunner,
 				clientConf,
+				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("client"),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -332,6 +339,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{StatelessResetToken: &token},
 				sRunner,
 				serverConf,
+				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("server"),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -384,6 +392,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{},
 				runner,
 				&tls.Config{InsecureSkipVerify: true},
+				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("client"),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -424,6 +433,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				cTransportParameters,
 				cRunner,
 				clientConf,
+				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("client"),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -446,6 +456,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				sTransportParameters,
 				sRunner,
 				serverConf,
+				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("server"),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -481,6 +492,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{},
 				cRunner,
 				clientConf,
+				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("client"),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -498,6 +510,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{},
 				sRunner,
 				serverConf,
+				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("server"),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -536,6 +549,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{},
 				cRunner,
 				clientConf,
+				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("client"),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -553,6 +567,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{},
 				sRunner,
 				serverConf,
+				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("server"),
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -34,7 +34,7 @@ type LongHeaderOpener interface {
 // ShortHeaderOpener opens a short header packet
 type ShortHeaderOpener interface {
 	headerDecryptor
-	Open(dst, src []byte, pn protocol.PacketNumber, kp protocol.KeyPhase, associatedData []byte) ([]byte, error)
+	Open(dst, src []byte, pn protocol.PacketNumber, kp protocol.KeyPhaseBit, associatedData []byte) ([]byte, error)
 }
 
 // LongHeaderSealer seals a long header packet
@@ -47,7 +47,7 @@ type LongHeaderSealer interface {
 // ShortHeaderSealer seals a short header packet
 type ShortHeaderSealer interface {
 	LongHeaderSealer
-	KeyPhase() protocol.KeyPhase
+	KeyPhase() protocol.KeyPhaseBit
 }
 
 // A tlsExtensionHandler sends and received the QUIC TLS extension.

--- a/internal/handshake/updatable_aead.go
+++ b/internal/handshake/updatable_aead.go
@@ -43,7 +43,7 @@ func setKeyUpdateInterval() {
 type updatableAEAD struct {
 	suite cipherSuite
 
-	keyPhase          protocol.KeyPhase
+	keyPhase          protocol.KeyPhaseBit
 	largestAcked      protocol.PacketNumber
 	keyUpdateInterval uint64
 
@@ -134,7 +134,7 @@ func (a *updatableAEAD) SetWriteKey(suite cipherSuite, trafficSecret []byte) {
 	a.nextSendAEAD = createAEAD(suite, a.nextSendTrafficSecret)
 }
 
-func (a *updatableAEAD) Open(dst, src []byte, pn protocol.PacketNumber, kp protocol.KeyPhase, ad []byte) ([]byte, error) {
+func (a *updatableAEAD) Open(dst, src []byte, pn protocol.PacketNumber, kp protocol.KeyPhaseBit, ad []byte) ([]byte, error) {
 	binary.BigEndian.PutUint64(a.nonceBuf[len(a.nonceBuf)-8:], uint64(pn))
 	if kp != a.keyPhase {
 		if a.firstRcvdWithCurrentKey == protocol.InvalidPacketNumber || pn < a.firstRcvdWithCurrentKey {
@@ -215,7 +215,7 @@ func (a *updatableAEAD) shouldInitiateKeyUpdate() bool {
 	return false
 }
 
-func (a *updatableAEAD) KeyPhase() protocol.KeyPhase {
+func (a *updatableAEAD) KeyPhase() protocol.KeyPhaseBit {
 	if a.shouldInitiateKeyUpdate() {
 		a.rollKeys()
 	}

--- a/internal/mocks/short_header_opener.go
+++ b/internal/mocks/short_header_opener.go
@@ -47,7 +47,7 @@ func (mr *MockShortHeaderOpenerMockRecorder) DecryptHeader(arg0, arg1, arg2 inte
 }
 
 // Open mocks base method
-func (m *MockShortHeaderOpener) Open(arg0, arg1 []byte, arg2 protocol.PacketNumber, arg3 protocol.KeyPhase, arg4 []byte) ([]byte, error) {
+func (m *MockShortHeaderOpener) Open(arg0, arg1 []byte, arg2 protocol.PacketNumber, arg3 protocol.KeyPhaseBit, arg4 []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]byte)

--- a/internal/mocks/short_header_sealer.go
+++ b/internal/mocks/short_header_sealer.go
@@ -47,10 +47,10 @@ func (mr *MockShortHeaderSealerMockRecorder) EncryptHeader(arg0, arg1, arg2 inte
 }
 
 // KeyPhase mocks base method
-func (m *MockShortHeaderSealer) KeyPhase() protocol.KeyPhase {
+func (m *MockShortHeaderSealer) KeyPhase() protocol.KeyPhaseBit {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KeyPhase")
-	ret0, _ := ret[0].(protocol.KeyPhase)
+	ret0, _ := ret[0].(protocol.KeyPhaseBit)
 	return ret0
 }
 

--- a/internal/protocol/key_phase.go
+++ b/internal/protocol/key_phase.go
@@ -1,0 +1,22 @@
+package protocol
+
+// KeyPhaseBit is the key phase bit
+type KeyPhaseBit bool
+
+const (
+	// KeyPhaseZero is key phase 0
+	KeyPhaseZero KeyPhaseBit = false
+	// KeyPhaseOne is key phase 1
+	KeyPhaseOne KeyPhaseBit = true
+)
+
+func (p KeyPhaseBit) String() string {
+	if p == KeyPhaseZero {
+		return "0"
+	}
+	return "1"
+}
+
+func (p KeyPhaseBit) Next() KeyPhaseBit {
+	return !p
+}

--- a/internal/protocol/key_phase.go
+++ b/internal/protocol/key_phase.go
@@ -1,5 +1,12 @@
 package protocol
 
+// KeyPhase is the key phase
+type KeyPhase uint64
+
+func (p KeyPhase) Bit() KeyPhaseBit {
+	return p%2 == 1
+}
+
 // KeyPhaseBit is the key phase bit
 type KeyPhaseBit bool
 
@@ -15,8 +22,4 @@ func (p KeyPhaseBit) String() string {
 		return "0"
 	}
 	return "1"
-}
-
-func (p KeyPhaseBit) Next() KeyPhaseBit {
-	return !p
 }

--- a/internal/protocol/key_phase_test.go
+++ b/internal/protocol/key_phase_test.go
@@ -11,8 +11,12 @@ var _ = Describe("Key Phases", func() {
 		Expect(KeyPhaseOne.String()).To(Equal("1"))
 	})
 
-	It("returns the next key phase", func() {
-		Expect(KeyPhaseZero.Next()).To(Equal(KeyPhaseOne))
-		Expect(KeyPhaseOne.Next()).To(Equal(KeyPhaseZero))
+	It("converts the key phase to the key phase bit", func() {
+		Expect(KeyPhase(0).Bit()).To(Equal(KeyPhaseZero))
+		Expect(KeyPhase(2).Bit()).To(Equal(KeyPhaseZero))
+		Expect(KeyPhase(4).Bit()).To(Equal(KeyPhaseZero))
+		Expect(KeyPhase(1).Bit()).To(Equal(KeyPhaseOne))
+		Expect(KeyPhase(3).Bit()).To(Equal(KeyPhaseOne))
+		Expect(KeyPhase(5).Bit()).To(Equal(KeyPhaseOne))
 	})
 })

--- a/internal/protocol/key_phase_test.go
+++ b/internal/protocol/key_phase_test.go
@@ -1,0 +1,18 @@
+package protocol
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Key Phases", func() {
+	It("has the correct string representation", func() {
+		Expect(KeyPhaseZero.String()).To(Equal("0"))
+		Expect(KeyPhaseOne.String()).To(Equal("1"))
+	})
+
+	It("returns the next key phase", func() {
+		Expect(KeyPhaseZero.Next()).To(Equal(KeyPhaseOne))
+		Expect(KeyPhaseOne.Next()).To(Equal(KeyPhaseZero))
+	})
+})

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -34,27 +34,6 @@ func (t PacketType) String() string {
 	}
 }
 
-// KeyPhase is the key phase
-type KeyPhase bool
-
-const (
-	// KeyPhaseZero is key phase 0
-	KeyPhaseZero KeyPhase = false
-	// KeyPhaseOne is key phase 1
-	KeyPhaseOne KeyPhase = true
-)
-
-func (p KeyPhase) String() string {
-	if p == KeyPhaseZero {
-		return "0"
-	}
-	return "1"
-}
-
-func (p KeyPhase) Next() KeyPhase {
-	return !p
-}
-
 // A ByteCount in QUIC
 type ByteCount uint64
 

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -15,16 +15,4 @@ var _ = Describe("Protocol", func() {
 			Expect(PacketType(10).String()).To(Equal("unknown packet type: 10"))
 		})
 	})
-
-	Context("Key Phases", func() {
-		It("has the correct string representation", func() {
-			Expect(KeyPhaseZero.String()).To(Equal("0"))
-			Expect(KeyPhaseOne.String()).To(Equal("1"))
-		})
-
-		It("returns the next key phase", func() {
-			Expect(KeyPhaseZero.Next()).To(Equal(KeyPhaseOne))
-			Expect(KeyPhaseOne.Next()).To(Equal(KeyPhaseZero))
-		})
-	})
 })

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -25,7 +25,7 @@ type ExtendedHeader struct {
 	PacketNumberLen protocol.PacketNumberLen
 	PacketNumber    protocol.PacketNumber
 
-	KeyPhase protocol.KeyPhase
+	KeyPhase protocol.KeyPhaseBit
 }
 
 func (h *ExtendedHeader) parse(b *bytes.Reader, v protocol.VersionNumber) (*ExtendedHeader, error) {

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -432,7 +432,7 @@ func (p *packetPacker) composeNextPacket(maxFrameSize protocol.ByteCount) (paylo
 	return payload, nil
 }
 
-func (p *packetPacker) getShortHeader(kp protocol.KeyPhase) *wire.ExtendedHeader {
+func (p *packetPacker) getShortHeader(kp protocol.KeyPhaseBit) *wire.ExtendedHeader {
 	pn, pnLen := p.pnManager.PeekPacketNumber(protocol.Encryption1RTT)
 	hdr := &wire.ExtendedHeader{}
 	hdr.PacketNumber = pn

--- a/session.go
+++ b/session.go
@@ -223,6 +223,7 @@ var newSession = func(
 			onHandshakeComplete: func() { close(s.handshakeCompleteChan) },
 		},
 		tlsConf,
+		s.rttStats,
 		logger,
 	)
 	if err != nil {
@@ -296,6 +297,7 @@ var newClientSession = func(
 			onHandshakeComplete: func() { close(s.handshakeCompleteChan) },
 		},
 		tlsConf,
+		s.rttStats,
 		logger,
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes #1966. Depends on #1973.

Keys are dropped on the next call to `Open` 3 PTOs after a key update happened. This ensures that we don't need to create another go routine in the `updatableAEAD` just to drop the keys.
The cost of this is a call to `time.Now()` every time we try to `Open` a packet (as long as we haven't dropped the old keys yet). If this syscall turns out to be a problem, we could pass the receive time of the packet all the way through the `unpacker` to the `updatableAEAD`.