### PR TITLE
encode the connection ID that will be used in the token

### DIFF
--- a/session.go
+++ b/session.go
@@ -510,7 +510,11 @@ func (s *session) handleHandshakeComplete() {
 	// in order to stop retransmitting handshake packets.
 	// They will stop retransmitting handshake packets when receiving the first 1-RTT packet.
 	if s.perspective == protocol.PerspectiveServer {
-		token, err := s.tokenGenerator.NewToken(s.conn.RemoteAddr())
+		nextConnID, err := protocol.GenerateConnectionID(s.config.ConnectionIDLength)
+		if err != nil {
+			s.closeLocal(err)
+		}
+		token, err := s.tokenGenerator.NewToken(s.conn.RemoteAddr(), nextConnID)
 		if err != nil {
 			s.closeLocal(err)
 		}


### PR DESCRIPTION
Fixes #1652.

This ensures that a token can only be used once at a time. If it is used multiple times, all packets will end up in the same session. 

This provides 2 advantages:
1. In the case of an attack, an attacker can only use a token to establish a single connection (until this connection has timed out).
2. If a client retransmits an Initial containing a token, we will only end up with a single session, instead of multiple session (which would all time out but one).