### PR TITLE
don't add ACK ranges for delayed packets, if history was already deleted 

### DIFF
--- a/internal/ackhandler/received_packet_history.go
+++ b/internal/ackhandler/received_packet_history.go
@@ -86,10 +86,11 @@ func (h *receivedPacketHistory) DeleteBelow(p protocol.PacketNumber) {
 	for el := h.ranges.Front(); nextEl != nil; el = nextEl {
 		nextEl = el.Next()
 
-		if p > el.Value.Start && p <= el.Value.End {
-			el.Value.Start = p
-		} else if el.Value.End < p { // delete a whole range
+		if el.Value.End < p { // delete a whole range
 			h.ranges.Remove(el)
+		} else if p > el.Value.Start && p <= el.Value.End {
+			el.Value.Start = p
+			return
 		} else { // no ranges affected. Nothing to do
 			return
 		}

--- a/internal/ackhandler/received_packet_history.go
+++ b/internal/ackhandler/received_packet_history.go
@@ -12,8 +12,6 @@ import (
 // It does not store packet contents.
 type receivedPacketHistory struct {
 	ranges *utils.PacketIntervalList
-
-	lowestInReceivedPacketNumbers protocol.PacketNumber
 }
 
 var errTooManyOutstandingReceivedAckRanges = qerr.Error(qerr.InternalError, "Too many outstanding received ACK ranges")
@@ -77,11 +75,6 @@ func (h *receivedPacketHistory) ReceivedPacket(p protocol.PacketNumber) error {
 
 // DeleteBelow deletes all entries below (but not including) p
 func (h *receivedPacketHistory) DeleteBelow(p protocol.PacketNumber) {
-	if p <= h.lowestInReceivedPacketNumbers {
-		return
-	}
-	h.lowestInReceivedPacketNumbers = p
-
 	nextEl := h.ranges.Front()
 	for el := h.ranges.Front(); nextEl != nil; el = nextEl {
 		nextEl = el.Next()

--- a/internal/ackhandler/received_packet_history_test.go
+++ b/internal/ackhandler/received_packet_history_test.go
@@ -174,6 +174,18 @@ var _ = Describe("receivedPacketHistory", func() {
 			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 4, End: 4}))
 		})
 
+		It("doesn't add delayed packets below deleted ranges", func() {
+			hist.ReceivedPacket(4)
+			hist.ReceivedPacket(5)
+			hist.ReceivedPacket(6)
+			hist.DeleteBelow(5)
+			Expect(hist.ranges.Len()).To(Equal(1))
+			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 5, End: 6}))
+			hist.ReceivedPacket(2)
+			Expect(hist.ranges.Len()).To(Equal(1))
+			Expect(hist.ranges.Front().Value).To(Equal(utils.PacketInterval{Start: 5, End: 6}))
+		})
+
 		Context("DoS protection", func() {
 			It("doesn't create more than MaxTrackedReceivedAckRanges ranges", func() {
 				for i := protocol.PacketNumber(1); i <= protocol.MaxTrackedReceivedAckRanges; i++ {


### PR DESCRIPTION
This might or might not be a fix for #2010. It definitely fixes a bug (`lowestInReceivedPacketNumbers` would not be adjusted when receiving delayed packets).

I'll submit another PR, based on this one, that removes the `errTooManyOutstandingReceivedAckRanges`, and replaces it by automatic pruning of ACK ranges.