### PR TITLE
make sure that the ACK delay time is always a positive value

### DIFF
--- a/internal/ackhandler/received_packet_tracker.go
+++ b/internal/ackhandler/received_packet_tracker.go
@@ -174,7 +174,9 @@ func (h *receivedPacketTracker) GetAckFrame() *wire.AckFrame {
 
 	ack := &wire.AckFrame{
 		AckRanges: h.packetHistory.GetAckRanges(),
-		DelayTime: now.Sub(h.largestObservedReceivedTime),
+		// Make sure that the DelayTime is always positive.
+		// This is not guaranteed on systems that don't have a monotonic clock.
+		DelayTime: utils.MaxDuration(0, now.Sub(h.largestObservedReceivedTime)),
 	}
 
 	h.lastAck = ack

--- a/internal/ackhandler/received_packet_tracker_test.go
+++ b/internal/ackhandler/received_packet_tracker_test.go
@@ -207,6 +207,13 @@ var _ = Describe("Received Packet Tracker", func() {
 				Expect(ack.DelayTime).To(BeNumerically("~", 1337*time.Millisecond, 50*time.Millisecond))
 			})
 
+			It("uses a 0 delay time if the delay would be negative", func() {
+				tracker.ReceivedPacket(0, time.Now().Add(time.Hour), true)
+				ack := tracker.GetAckFrame()
+				Expect(ack).ToNot(BeNil())
+				Expect(ack.DelayTime).To(BeZero())
+			})
+
 			It("saves the last sent ACK", func() {
 				tracker.ReceivedPacket(1, time.Time{}, true)
 				ack := tracker.GetAckFrame()


### PR DESCRIPTION
Fixes #2059.

On systems without a monotonic clock, this value could become negative, which would cause a uint underflow.