### PR TITLE
add basic support for 0-RTT

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 run:
   skip-files:
+    - internal/handshake/client_session_state.go
     - internal/handshake/unsafe_test.go
 
 linters-settings:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.15.0 (unreleased)
+
+- Add support for 0-RTT.
+
 ## v0.14.0 (2019-12-04)
 
 - Supports QUIC WG draft-24.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/protobuf v1.3.0
 	github.com/marten-seemann/chacha20 v0.2.0
 	github.com/marten-seemann/qpack v0.1.0
-	github.com/marten-seemann/qtls v0.4.1
+	github.com/marten-seemann/qtls v0.5.0
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/marten-seemann/chacha20 v0.2.0 h1:f40vqzzx+3GdOmzQoItkLX5WLvHgPgyYqFF
 github.com/marten-seemann/chacha20 v0.2.0/go.mod h1:HSdjFau7GzYRj+ahFNwsO3ouVJr1HFkWoEwNDb4TMtE=
 github.com/marten-seemann/qpack v0.1.0 h1:/0M7lkda/6mus9B8u34Asqm8ZhHAAt9Ho0vniNuVSVg=
 github.com/marten-seemann/qpack v0.1.0/go.mod h1:LFt1NU/Ptjip0C2CPkhimBz5CGE3WGDAUWqna+CNTrI=
-github.com/marten-seemann/qtls v0.4.1 h1:YlT8QP3WCCvvok7MGEZkMldXbyqgr8oFg5/n8Gtbkks=
-github.com/marten-seemann/qtls v0.4.1/go.mod h1:pxVXcHHw1pNIt8Qo0pwSYQEoZ8yYOOPXTCZLQQunvRc=
+github.com/marten-seemann/qtls v0.5.0 h1:psje4bHl6372lku0pTIt2PZ9HcVJyBIuW9pZn+u2vhY=
+github.com/marten-seemann/qtls v0.5.0/go.mod h1:pxVXcHHw1pNIt8Qo0pwSYQEoZ8yYOOPXTCZLQQunvRc=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -34,6 +34,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6Zh
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd h1:DBH9mDw0zluJT/R+nGuV3jWFWLFaHyYZWD4tOT+cjn0=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -1,0 +1,221 @@
+package self_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	mrand "math/rand"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	quic "github.com/lucas-clemente/quic-go"
+	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/wire"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("0-RTT", func() {
+	const rtt = 50 * time.Millisecond
+	for _, v := range protocol.SupportedVersions {
+		version := v
+
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
+			runTest := func(ln quic.Listener, proxyPort int, testdata []byte) {
+				// dial the first session in order to receive a session ticket
+				go func() {
+					defer GinkgoRecover()
+					_, err := ln.Accept(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				clientConf := getTLSClientConfig()
+				gets := make(chan string, 100)
+				puts := make(chan string, 100)
+				clientConf.ClientSessionCache = newClientSessionCache(gets, puts)
+				sess, err := quic.DialAddr(
+					fmt.Sprintf("localhost:%d", proxyPort),
+					clientConf,
+					&quic.Config{Versions: []protocol.VersionNumber{version}},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(puts).Should(Receive())
+				// received the session ticket. We're done here.
+				Expect(sess.Close()).To(Succeed())
+
+				// now dial the second session, and use 0-RTT to send some data
+				done := make(chan struct{})
+				go func() {
+					defer GinkgoRecover()
+					sess, err := ln.Accept(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+					str, err := sess.AcceptUniStream(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+					data, err := ioutil.ReadAll(str)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(data).To(Equal(testdata))
+					close(done)
+				}()
+
+				sess, err = quic.DialAddrEarly(
+					fmt.Sprintf("localhost:%d", proxyPort),
+					clientConf,
+					&quic.Config{Versions: []protocol.VersionNumber{version}},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				str, err := sess.OpenUniStream()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = str.Write(testdata)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(str.Close()).To(Succeed())
+				Eventually(done).Should(BeClosed())
+			}
+
+			It("transfers 0-RTT data", func() {
+				var num0RTTPackets uint32 // to be used as an atomic
+
+				ln, err := quic.ListenAddr(
+					"localhost:0",
+					getTLSConfig(),
+					&quic.Config{
+						Versions:    []protocol.VersionNumber{version},
+						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer ln.Close()
+				serverPort := ln.Addr().(*net.UDPAddr).Port
+
+				proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+					RemoteAddr: fmt.Sprintf("localhost:%d", serverPort),
+					DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
+						hdr, _, _, err := wire.ParsePacket(data, 0)
+						Expect(err).ToNot(HaveOccurred())
+						if hdr.Type == protocol.PacketType0RTT {
+							atomic.AddUint32(&num0RTTPackets, 1)
+						}
+						return rtt / 2
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				defer proxy.Close()
+
+				runTest(ln, proxy.LocalPort(), PRData)
+
+				num0RTT := atomic.LoadUint32(&num0RTTPackets)
+				fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
+				Expect(num0RTT).ToNot(BeZero())
+			})
+
+			It("transfers 0-RTT data, when 0-RTT packets are lost", func() {
+				var (
+					num0RTTPackets uint32 // to be used as an atomic
+					num0RTTDropped uint32
+				)
+
+				ln, err := quic.ListenAddr(
+					"localhost:0",
+					getTLSConfig(),
+					&quic.Config{
+						Versions:    []protocol.VersionNumber{version},
+						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer ln.Close()
+				serverPort := ln.Addr().(*net.UDPAddr).Port
+
+				proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+					RemoteAddr: fmt.Sprintf("localhost:%d", serverPort),
+					DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
+						hdr, _, _, err := wire.ParsePacket(data, 0)
+						Expect(err).ToNot(HaveOccurred())
+						if hdr.Type == protocol.PacketType0RTT {
+							atomic.AddUint32(&num0RTTPackets, 1)
+						}
+						return rtt / 2
+					},
+					DropPacket: func(_ quicproxy.Direction, data []byte) bool {
+						hdr, _, _, err := wire.ParsePacket(data, 0)
+						Expect(err).ToNot(HaveOccurred())
+						if hdr.Type == protocol.PacketType0RTT {
+							// drop 25% of the 0-RTT packets
+							drop := mrand.Intn(4) == 0
+							if drop {
+								atomic.AddUint32(&num0RTTDropped, 1)
+							}
+							return drop
+						}
+						return false
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				defer proxy.Close()
+
+				runTest(ln, proxy.LocalPort(), PRData)
+
+				num0RTT := atomic.LoadUint32(&num0RTTPackets)
+				numDropped := atomic.LoadUint32(&num0RTTDropped)
+				fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets. Dropped %d of those.", num0RTT, numDropped)
+				Expect(numDropped).ToNot(BeZero())
+				Expect(num0RTT).ToNot(BeZero())
+			})
+
+			It("retransmits all 0-RTT data when the server performs a Retry", func() {
+				var mutex sync.Mutex
+				var firstConnID, secondConnID protocol.ConnectionID
+				var firstCounter, secondCounter int
+
+				ln, err := quic.ListenAddr(
+					"localhost:0",
+					getTLSConfig(),
+					&quic.Config{Versions: []protocol.VersionNumber{version}},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer ln.Close()
+				serverPort := ln.Addr().(*net.UDPAddr).Port
+
+				proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+					RemoteAddr: fmt.Sprintf("localhost:%d", serverPort),
+					DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
+						hdr, _, _, err := wire.ParsePacket(data, 0)
+						Expect(err).ToNot(HaveOccurred())
+						if hdr.Type == protocol.PacketType0RTT {
+							connID := hdr.DestConnectionID
+							mutex.Lock()
+							defer mutex.Unlock()
+							if firstConnID == nil {
+								firstConnID = connID
+								firstCounter++
+							} else if firstConnID != nil && firstConnID.Equal(connID) {
+								Expect(secondConnID).To(BeNil())
+								firstCounter++
+							} else if secondConnID == nil {
+								secondConnID = connID
+								secondCounter++
+							} else if secondConnID != nil && secondConnID.Equal(connID) {
+								secondCounter++
+							} else {
+								Fail("received 3 connection IDs on 0-RTT packets")
+							}
+						}
+						return rtt / 2
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				defer proxy.Close()
+
+				runTest(ln, proxy.LocalPort(), GeneratePRData(5*1100)) // ~5 packets
+
+				mutex.Lock()
+				defer mutex.Unlock()
+				Expect(firstCounter).To(BeNumerically("~", 5, 1)) // the FIN bit might be sent extra
+				Expect(secondCounter).To(Equal(firstCounter))
+			})
+		})
+	}
+})

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -57,7 +57,7 @@ type SentPacketHandler interface {
 
 // ReceivedPacketHandler handles ACKs needed to send for incoming packets
 type ReceivedPacketHandler interface {
-	ReceivedPacket(pn protocol.PacketNumber, encLevel protocol.EncryptionLevel, rcvTime time.Time, shouldInstigateAck bool)
+	ReceivedPacket(pn protocol.PacketNumber, encLevel protocol.EncryptionLevel, rcvTime time.Time, shouldInstigateAck bool) error
 	IgnoreBelow(protocol.PacketNumber)
 	DropPackets(protocol.EncryptionLevel)
 

--- a/internal/ackhandler/received_packet_handler_test.go
+++ b/internal/ackhandler/received_packet_handler_test.go
@@ -48,6 +48,16 @@ var _ = Describe("Received Packet Handler", func() {
 		Expect(oneRTTAck.DelayTime).To(BeNumerically("~", time.Second, 50*time.Millisecond))
 	})
 
+	It("uses the same packet number space for 0-RTT and 1-RTT packets", func() {
+		sendTime := time.Now().Add(-time.Second)
+		handler.ReceivedPacket(2, protocol.Encryption0RTT, sendTime, true)
+		handler.ReceivedPacket(3, protocol.Encryption1RTT, sendTime, true)
+		ack := handler.GetAckFrame(protocol.Encryption1RTT)
+		Expect(ack).ToNot(BeNil())
+		Expect(ack.AckRanges).To(HaveLen(1))
+		Expect(ack.AckRanges[0]).To(Equal(wire.AckRange{Smallest: 2, Largest: 3}))
+	})
+
 	It("drops Initial packets", func() {
 		sendTime := time.Now().Add(-time.Second)
 		handler.ReceivedPacket(2, protocol.EncryptionInitial, sendTime, true)

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -598,7 +598,15 @@ func (h *sentPacketHandler) ResetForRetry() error {
 		h.queueFramesForRetransmission(p)
 		return true, nil
 	})
+	// All application data packets sent at this point are 0-RTT packets.
+	// In the case of a Retry, we can assume that the server dropped all of them.
+	h.appDataPackets.history.Iterate(func(p *Packet) (bool, error) {
+		h.queueFramesForRetransmission(p)
+		return true, nil
+	})
+
 	h.initialPackets = newPacketNumberSpace(h.initialPackets.pns.Pop())
+	h.appDataPackets = newPacketNumberSpace(h.appDataPackets.pns.Pop())
 	h.setLossDetectionTimer()
 	return nil
 }

--- a/internal/handshake/client_session_cache.go
+++ b/internal/handshake/client_session_cache.go
@@ -1,0 +1,83 @@
+package handshake
+
+import (
+	"crypto/tls"
+	"encoding/asn1"
+	"unsafe"
+
+	"github.com/marten-seemann/qtls"
+)
+
+type nonceField struct {
+	Nonce   []byte
+	AppData []byte
+}
+
+type clientSessionCache struct {
+	tls.ClientSessionCache
+
+	getAppData func() []byte
+	setAppData func([]byte)
+}
+
+func newClientSessionCache(cache tls.ClientSessionCache, get func() []byte, set func([]byte)) *clientSessionCache {
+	return &clientSessionCache{
+		ClientSessionCache: cache,
+		getAppData:         get,
+		setAppData:         set,
+	}
+}
+
+var _ qtls.ClientSessionCache = &clientSessionCache{}
+
+func (c *clientSessionCache) Get(sessionKey string) (*qtls.ClientSessionState, bool) {
+	sess, ok := c.ClientSessionCache.Get(sessionKey)
+	if sess == nil {
+		return nil, ok
+	}
+	// qtls.ClientSessionState is identical to the tls.ClientSessionState.
+	// In order to allow users of quic-go to use a tls.Config,
+	// we need this workaround to use the ClientSessionCache.
+	// In unsafe.go we check that the two structs are actually identical.
+	tlsSessBytes := (*[unsafe.Sizeof(*sess)]byte)(unsafe.Pointer(sess))[:]
+	var session clientSessionState
+	sessBytes := (*[unsafe.Sizeof(session)]byte)(unsafe.Pointer(&session))[:]
+	copy(sessBytes, tlsSessBytes)
+	var nf nonceField
+	if _, err := asn1.Unmarshal(session.nonce, &nf); err != nil {
+		return nil, false
+	}
+	c.setAppData(nf.AppData)
+	session.nonce = nf.Nonce
+	var qtlsSession qtls.ClientSessionState
+	qtlsSessBytes := (*[unsafe.Sizeof(qtlsSession)]byte)(unsafe.Pointer(&qtlsSession))[:]
+	copy(qtlsSessBytes, sessBytes)
+	return &qtlsSession, ok
+}
+
+func (c *clientSessionCache) Put(sessionKey string, cs *qtls.ClientSessionState) {
+	if cs == nil {
+		c.ClientSessionCache.Put(sessionKey, nil)
+		return
+	}
+	// qtls.ClientSessionState is identical to the tls.ClientSessionState.
+	// In order to allow users of quic-go to use a tls.Config,
+	// we need this workaround to use the ClientSessionCache.
+	// In unsafe.go we check that the two structs are actually identical.
+	qtlsSessBytes := (*[unsafe.Sizeof(*cs)]byte)(unsafe.Pointer(cs))[:]
+	var session clientSessionState
+	sessBytes := (*[unsafe.Sizeof(session)]byte)(unsafe.Pointer(&session))[:]
+	copy(sessBytes, qtlsSessBytes)
+	nonce, err := asn1.Marshal(nonceField{
+		Nonce:   session.nonce,
+		AppData: c.getAppData(),
+	})
+	if err != nil { // marshaling
+		panic(err)
+	}
+	session.nonce = nonce
+	var tlsSession tls.ClientSessionState
+	tlsSessBytes := (*[unsafe.Sizeof(tlsSession)]byte)(unsafe.Pointer(&tlsSession))[:]
+	copy(tlsSessBytes, sessBytes)
+	c.ClientSessionCache.Put(sessionKey, &tlsSession)
+}

--- a/internal/handshake/client_session_cache_test.go
+++ b/internal/handshake/client_session_cache_test.go
@@ -1,0 +1,38 @@
+package handshake
+
+import (
+	"crypto/tls"
+
+	"github.com/marten-seemann/qtls"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ClientSessionCache", func() {
+	var (
+		csc      *clientSessionCache
+		get, set chan []byte
+	)
+
+	BeforeEach(func() {
+		get = make(chan []byte, 100)
+		set = make(chan []byte, 100)
+		csc = newClientSessionCache(
+			tls.NewLRUClientSessionCache(100),
+			func() []byte { return <-get },
+			func(b []byte) { set <- b },
+		)
+	})
+
+	It("puts and gets", func() {
+		get <- []byte("foobar")
+		csc.Put("localhost", &qtls.ClientSessionState{})
+		Expect(set).To(BeEmpty())
+
+		state, ok := csc.Get("localhost")
+		Expect(ok).To(BeTrue())
+		Expect(state).ToNot(BeNil())
+		Expect(set).To(Receive(Equal([]byte("foobar"))))
+	})
+})

--- a/internal/handshake/client_session_state.go
+++ b/internal/handshake/client_session_state.go
@@ -1,0 +1,23 @@
+package handshake
+
+import (
+	"crypto/x509"
+	"time"
+)
+
+// copied from crypto/tls
+// Needs to be in a separate file so golangci-lint can skip it.
+type clientSessionState struct {
+	sessionTicket      []uint8               // Encrypted ticket used for session resumption with server
+	vers               uint16                // SSL/TLS version negotiated for the session
+	cipherSuite        uint16                // Ciphersuite negotiated for the session
+	masterSecret       []byte                // Full handshake MasterSecret, or TLS 1.3 resumption_master_secret
+	serverCertificates []*x509.Certificate   // Certificate chain presented by the server
+	verifiedChains     [][]*x509.Certificate // Certificate chains we built for verification
+	receivedAt         time.Time             // When the session ticket was received from the server
+
+	// TLS 1.3 fields.
+	nonce  []byte    // Ticket nonce sent by the server, to derive PSK
+	useBy  time.Time // Expiration of the ticket lifetime as set by the server
+	ageAdd uint32    // Random obfuscation factor for sending the ticket age
+}

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -568,6 +568,10 @@ func (h *cryptoSetup) SetWriteKey(encLevel qtls.EncryptionLevel, suite *qtls.Cip
 		h.aead.SetWriteKey(suite, trafficSecret)
 		h.has1RTTSealer = true
 		h.logger.Debugf("Installed 1-RTT Write keys (using %s)", cipherSuiteName(suite.ID))
+		if h.zeroRTTSealer != nil {
+			h.zeroRTTSealer = nil
+			h.logger.Debugf("Dropping 0-RTT keys.")
+		}
 	default:
 		panic("unexpected write encryption level")
 	}

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -67,6 +67,7 @@ type cryptoSetup struct {
 	messageChan chan []byte
 
 	ourParams  *TransportParameters
+	peerParams *TransportParameters
 	paramsChan <-chan []byte
 
 	runner handshakeRunner
@@ -77,8 +78,9 @@ type cryptoSetup struct {
 	// is closed when Close() is called
 	closeChan chan struct{}
 
+	zeroRTTParameters      *TransportParameters
 	clientHelloWritten     bool
-	clientHelloWrittenChan chan struct{}
+	clientHelloWrittenChan chan *TransportParameters
 
 	receivedWriteKey chan struct{}
 	receivedReadKey  chan struct{}
@@ -131,7 +133,7 @@ func NewCryptoSetupClient(
 	enable0RTT bool,
 	rttStats *congestion.RTTStats,
 	logger utils.Logger,
-) (CryptoSetup, <-chan struct{} /* ClientHello written */) {
+) (CryptoSetup, <-chan *TransportParameters /* ClientHello written. Receive nil for non-0-RTT */) {
 	cs, clientHelloWritten := newCryptoSetup(
 		initialStream,
 		handshakeStream,
@@ -192,7 +194,7 @@ func newCryptoSetup(
 	rttStats *congestion.RTTStats,
 	logger utils.Logger,
 	perspective protocol.Perspective,
-) (*cryptoSetup, <-chan struct{} /* ClientHello written */) {
+) (*cryptoSetup, <-chan *TransportParameters /* ClientHello written. Receive nil for non-0-RTT */) {
 	initialSealer, initialOpener := NewInitialAEAD(connID, perspective)
 	extHandler := newExtensionHandler(tp.Marshal(), perspective)
 	cs := &cryptoSetup{
@@ -211,14 +213,14 @@ func newCryptoSetup(
 		perspective:            perspective,
 		handshakeDone:          make(chan struct{}),
 		alertChan:              make(chan uint8),
-		clientHelloWrittenChan: make(chan struct{}),
+		clientHelloWrittenChan: make(chan *TransportParameters, 1),
 		messageChan:            make(chan []byte, 100),
 		receivedReadKey:        make(chan struct{}),
 		receivedWriteKey:       make(chan struct{}),
 		writeRecord:            make(chan struct{}, 1),
 		closeChan:              make(chan struct{}),
 	}
-	qtlsConf := tlsConfigToQtlsConfig(tlsConf, cs, extHandler, cs.accept0RTT, enable0RTT)
+	qtlsConf := tlsConfigToQtlsConfig(tlsConf, cs, extHandler, cs.marshalPeerParamsForSessionState, cs.handlePeerParamsFromSessionState, cs.accept0RTT, enable0RTT)
 	cs.tlsConf = qtlsConf
 	return cs, cs.clientHelloWrittenChan
 }
@@ -436,7 +438,22 @@ func (h *cryptoSetup) handleTransportParameters(data []byte) {
 	if err := tp.Unmarshal(data, h.perspective.Opposite()); err != nil {
 		h.runner.OnError(qerr.Error(qerr.TransportParameterError, err.Error()))
 	}
-	h.runner.OnReceivedParams(&tp)
+	h.peerParams = &tp
+	h.runner.OnReceivedParams(h.peerParams)
+}
+
+// must be called after receiving the transport parameters
+func (h *cryptoSetup) marshalPeerParamsForSessionState() []byte {
+	return h.peerParams.MarshalForSessionTicket()
+}
+
+func (h *cryptoSetup) handlePeerParamsFromSessionState(data []byte) {
+	var tp TransportParameters
+	if err := tp.Unmarshal(data, protocol.PerspectiveServer); err != nil {
+		h.logger.Debugf("Restoring of transport parameters from session ticket failed: %s", err.Error())
+		return
+	}
+	h.zeroRTTParameters = &tp
 }
 
 // only valid for the server
@@ -569,7 +586,13 @@ func (h *cryptoSetup) WriteRecord(p []byte) (int, error) {
 		n, err := h.initialStream.Write(p)
 		if !h.clientHelloWritten && h.perspective == protocol.PerspectiveClient {
 			h.clientHelloWritten = true
-			close(h.clientHelloWrittenChan)
+			if h.zeroRTTSealer != nil && h.zeroRTTParameters != nil {
+				h.logger.Debugf("Doing 0-RTT.")
+				h.clientHelloWrittenChan <- h.zeroRTTParameters
+			} else {
+				h.logger.Debugf("Not doing 0-RTT. Has Sealer: %t, has params: %t", h.zeroRTTSealer != nil, h.zeroRTTParameters != nil)
+				h.clientHelloWrittenChan <- nil
+			}
 		} else {
 			// We need additional signaling to properly detect HelloRetryRequests.
 			// For servers: when the ServerHello is written.

--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -720,18 +720,6 @@ var _ = Describe("Crypto Setup TLS", func() {
 
 				Expect(server.ConnectionState().DidResume).To(BeTrue())
 				Expect(client.ConnectionState().DidResume).To(BeTrue())
-				opener, err := server.Get0RTTOpener()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(opener).ToNot(BeNil())
-				sealer, err := client.Get0RTTSealer()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(sealer).ToNot(BeNil())
-				// use the 0-RTT sealer and opener to encrypt and decrypt a message
-				plaintext := []byte("Lorem ipsum dolor sit amet")
-				msg := sealer.Seal(nil, plaintext, 0x1337, []byte("foobar"))
-				decrypted, err := opener.Open(nil, msg, 0x1337, []byte("foobar"))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(decrypted).To(Equal(plaintext))
 			})
 		})
 	})

--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			NewMockHandshakeRunner(mockCtrl),
 			tlsConf,
+			false,
 			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
@@ -126,6 +127,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			runner,
 			testdata.GetTLSConfig(),
+			false,
 			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
@@ -163,6 +165,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			runner,
 			testdata.GetTLSConfig(),
+			false,
 			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
@@ -203,6 +206,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			runner,
 			serverConf,
+			false,
 			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
@@ -236,6 +240,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&TransportParameters{},
 			NewMockHandshakeRunner(mockCtrl),
 			serverConf,
+			false,
 			&congestion.RTTStats{},
 			utils.DefaultLogger.WithPrefix("server"),
 		)
@@ -324,6 +329,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{},
 				cRunner,
 				clientConf,
+				false,
 				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("client"),
 			)
@@ -345,6 +351,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{StatelessResetToken: &token},
 				sRunner,
 				serverConf,
+				false,
 				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("server"),
 			)
@@ -397,6 +404,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&TransportParameters{},
 				runner,
 				&tls.Config{InsecureSkipVerify: true},
+				false,
 				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("client"),
 			)
@@ -437,6 +445,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				cTransportParameters,
 				cRunner,
 				clientConf,
+				false,
 				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("client"),
 			)
@@ -459,6 +468,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				sTransportParameters,
 				sRunner,
 				serverConf,
+				false,
 				&congestion.RTTStats{},
 				utils.DefaultLogger.WithPrefix("server"),
 			)
@@ -495,6 +505,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&TransportParameters{},
 					cRunner,
 					clientConf,
+					false,
 					&congestion.RTTStats{},
 					utils.DefaultLogger.WithPrefix("client"),
 				)
@@ -512,6 +523,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&TransportParameters{},
 					sRunner,
 					serverConf,
+					false,
 					&congestion.RTTStats{},
 					utils.DefaultLogger.WithPrefix("server"),
 				)
@@ -550,6 +562,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&TransportParameters{},
 					cRunner,
 					clientConf,
+					false,
 					&congestion.RTTStats{},
 					utils.DefaultLogger.WithPrefix("client"),
 				)
@@ -567,6 +580,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&TransportParameters{},
 					sRunner,
 					serverConf,
+					false,
 					&congestion.RTTStats{},
 					utils.DefaultLogger.WithPrefix("server"),
 				)

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -78,9 +78,11 @@ type CryptoSetup interface {
 
 	GetInitialOpener() (LongHeaderOpener, error)
 	GetHandshakeOpener() (LongHeaderOpener, error)
+	Get0RTTOpener() (LongHeaderOpener, error)
 	Get1RTTOpener() (ShortHeaderOpener, error)
 
 	GetInitialSealer() (LongHeaderSealer, error)
 	GetHandshakeSealer() (LongHeaderSealer, error)
+	Get0RTTSealer() (LongHeaderSealer, error)
 	Get1RTTSealer() (ShortHeaderSealer, error)
 }

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -59,7 +59,7 @@ type tlsExtensionHandler interface {
 }
 
 type handshakeRunner interface {
-	OnReceivedParams([]byte)
+	OnReceivedParams(*TransportParameters)
 	OnHandshakeComplete()
 	OnError(error)
 	DropKeys(protocol.EncryptionLevel)

--- a/internal/handshake/mock_handshake_runner_test.go
+++ b/internal/handshake/mock_handshake_runner_test.go
@@ -71,7 +71,7 @@ func (mr *MockHandshakeRunnerMockRecorder) OnHandshakeComplete() *gomock.Call {
 }
 
 // OnReceivedParams mocks base method
-func (m *MockHandshakeRunner) OnReceivedParams(arg0 []byte) {
+func (m *MockHandshakeRunner) OnReceivedParams(arg0 *TransportParameters) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnReceivedParams", arg0)
 }

--- a/internal/handshake/qtls.go
+++ b/internal/handshake/qtls.go
@@ -31,6 +31,8 @@ func tlsConfigToQtlsConfig(
 	c *tls.Config,
 	recordLayer qtls.RecordLayer,
 	extHandler tlsExtensionHandler,
+	getDataForSessionState func() []byte,
+	setDataFromSessionState func([]byte),
 	accept0RTT func([]byte) bool,
 	enable0RTT bool,
 ) *qtls.Config {
@@ -59,16 +61,12 @@ func tlsConfigToQtlsConfig(
 			if tlsConf == nil {
 				return nil, nil
 			}
-			return tlsConfigToQtlsConfig(tlsConf, recordLayer, extHandler, accept0RTT, enable0RTT), nil
+			return tlsConfigToQtlsConfig(tlsConf, recordLayer, extHandler, getDataForSessionState, setDataFromSessionState, accept0RTT, enable0RTT), nil
 		}
 	}
 	var csc qtls.ClientSessionCache
 	if c.ClientSessionCache != nil {
-		csc = newClientSessionCache(
-			c.ClientSessionCache,
-			func() []byte { return nil },
-			func([]byte) {},
-		)
+		csc = newClientSessionCache(c.ClientSessionCache, getDataForSessionState, setDataFromSessionState)
 	}
 	conf := &qtls.Config{
 		Rand:                        c.Rand,

--- a/internal/handshake/qtls_test.go
+++ b/internal/handshake/qtls_test.go
@@ -28,19 +28,19 @@ func (*mockExtensionHandler) TransportParameters() <-chan []byte { panic("not im
 var _ = Describe("qtls.Config generation", func() {
 	It("sets MinVersion and MaxVersion", func() {
 		tlsConf := &tls.Config{MinVersion: tls.VersionTLS11, MaxVersion: tls.VersionTLS12}
-		qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{})
+		qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
 		Expect(qtlsConf.MinVersion).To(BeEquivalentTo(tls.VersionTLS13))
 		Expect(qtlsConf.MaxVersion).To(BeEquivalentTo(tls.VersionTLS13))
 	})
 
 	It("works when called with a nil config", func() {
-		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{})
+		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, false)
 		Expect(qtlsConf).ToNot(BeNil())
 	})
 
 	It("sets the setter and getter function for TLS extensions", func() {
 		extHandler := &mockExtensionHandler{}
-		qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, extHandler)
+		qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, extHandler, nil, false)
 		Expect(extHandler.get).To(BeFalse())
 		qtlsConf.GetExtensions(10)
 		Expect(extHandler.get).To(BeTrue())
@@ -49,17 +49,33 @@ var _ = Describe("qtls.Config generation", func() {
 		Expect(extHandler.received).To(BeTrue())
 	})
 
+	It("sets the Accept0RTT callback", func() {
+		accept0RTT := func([]byte) bool { return true }
+		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, accept0RTT, false)
+		Expect(qtlsConf.Accept0RTT).ToNot(BeNil())
+		Expect(qtlsConf.Accept0RTT(nil)).To(BeTrue())
+	})
+
+	It("enables 0-RTT", func() {
+		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, false)
+		Expect(qtlsConf.Enable0RTT).To(BeFalse())
+		Expect(qtlsConf.MaxEarlyData).To(BeZero())
+		qtlsConf = tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, true)
+		Expect(qtlsConf.Enable0RTT).To(BeTrue())
+		Expect(qtlsConf.MaxEarlyData).To(Equal(uint32(0xffffffff)))
+	})
+
 	It("initializes such that the session ticket key remains constant", func() {
 		tlsConf := &tls.Config{}
-		qtlsConf1 := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{})
-		qtlsConf2 := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{})
+		qtlsConf1 := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
+		qtlsConf2 := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
 		Expect(qtlsConf1.SessionTicketKey).ToNot(BeZero()) // should now contain a random value
 		Expect(qtlsConf1.SessionTicketKey).To(Equal(qtlsConf2.SessionTicketKey))
 	})
 
 	Context("GetConfigForClient callback", func() {
 		It("doesn't set it if absent", func() {
-			qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, &mockExtensionHandler{})
+			qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, &mockExtensionHandler{}, nil, false)
 			Expect(qtlsConf.GetConfigForClient).To(BeNil())
 		})
 
@@ -70,7 +86,7 @@ var _ = Describe("qtls.Config generation", func() {
 				},
 			}
 			extHandler := &mockExtensionHandler{}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, extHandler)
+			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, extHandler, nil, false)
 			Expect(qtlsConf.GetConfigForClient).ToNot(BeNil())
 			confForClient, err := qtlsConf.GetConfigForClient(nil)
 			Expect(err).ToNot(HaveOccurred())
@@ -90,7 +106,7 @@ var _ = Describe("qtls.Config generation", func() {
 					return nil, testErr
 				},
 			}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{})
+			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
 			_, err := qtlsConf.GetConfigForClient(nil)
 			Expect(err).To(MatchError(testErr))
 		})
@@ -101,21 +117,21 @@ var _ = Describe("qtls.Config generation", func() {
 					return nil, nil
 				},
 			}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{})
+			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
 			Expect(qtlsConf.GetConfigForClient(nil)).To(BeNil())
 		})
 	})
 
 	Context("ClientSessionCache", func() {
 		It("doesn't set if absent", func() {
-			qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, &mockExtensionHandler{})
+			qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, &mockExtensionHandler{}, nil, false)
 			Expect(qtlsConf.ClientSessionCache).To(BeNil())
 		})
 
 		It("sets it, and puts and gets session states", func() {
 			csc := NewMockClientSessionCache(mockCtrl)
 			tlsConf := &tls.Config{ClientSessionCache: csc}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{})
+			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
 			Expect(qtlsConf.ClientSessionCache).ToNot(BeNil())
 			// put something
 			csc.EXPECT().Put("foobar", gomock.Any())
@@ -129,7 +145,7 @@ var _ = Describe("qtls.Config generation", func() {
 		It("puts a nil session state", func() {
 			csc := NewMockClientSessionCache(mockCtrl)
 			tlsConf := &tls.Config{ClientSessionCache: csc}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{})
+			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
 			// put something
 			csc.EXPECT().Put("foobar", nil)
 			qtlsConf.ClientSessionCache.Put("foobar", nil)

--- a/internal/handshake/qtls_test.go
+++ b/internal/handshake/qtls_test.go
@@ -28,19 +28,19 @@ func (*mockExtensionHandler) TransportParameters() <-chan []byte { panic("not im
 var _ = Describe("qtls.Config generation", func() {
 	It("sets MinVersion and MaxVersion", func() {
 		tlsConf := &tls.Config{MinVersion: tls.VersionTLS11, MaxVersion: tls.VersionTLS12}
-		qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
+		qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, nil, nil, false)
 		Expect(qtlsConf.MinVersion).To(BeEquivalentTo(tls.VersionTLS13))
 		Expect(qtlsConf.MaxVersion).To(BeEquivalentTo(tls.VersionTLS13))
 	})
 
 	It("works when called with a nil config", func() {
-		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, false)
+		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, nil, nil, false)
 		Expect(qtlsConf).ToNot(BeNil())
 	})
 
 	It("sets the setter and getter function for TLS extensions", func() {
 		extHandler := &mockExtensionHandler{}
-		qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, extHandler, nil, false)
+		qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, extHandler, nil, nil, nil, false)
 		Expect(extHandler.get).To(BeFalse())
 		qtlsConf.GetExtensions(10)
 		Expect(extHandler.get).To(BeTrue())
@@ -51,31 +51,31 @@ var _ = Describe("qtls.Config generation", func() {
 
 	It("sets the Accept0RTT callback", func() {
 		accept0RTT := func([]byte) bool { return true }
-		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, accept0RTT, false)
+		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, nil, accept0RTT, false)
 		Expect(qtlsConf.Accept0RTT).ToNot(BeNil())
 		Expect(qtlsConf.Accept0RTT(nil)).To(BeTrue())
 	})
 
 	It("enables 0-RTT", func() {
-		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, false)
+		qtlsConf := tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, nil, nil, false)
 		Expect(qtlsConf.Enable0RTT).To(BeFalse())
 		Expect(qtlsConf.MaxEarlyData).To(BeZero())
-		qtlsConf = tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, true)
+		qtlsConf = tlsConfigToQtlsConfig(nil, nil, &mockExtensionHandler{}, nil, nil, nil, true)
 		Expect(qtlsConf.Enable0RTT).To(BeTrue())
 		Expect(qtlsConf.MaxEarlyData).To(Equal(uint32(0xffffffff)))
 	})
 
 	It("initializes such that the session ticket key remains constant", func() {
 		tlsConf := &tls.Config{}
-		qtlsConf1 := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
-		qtlsConf2 := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
+		qtlsConf1 := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, nil, nil, false)
+		qtlsConf2 := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, nil, nil, false)
 		Expect(qtlsConf1.SessionTicketKey).ToNot(BeZero()) // should now contain a random value
 		Expect(qtlsConf1.SessionTicketKey).To(Equal(qtlsConf2.SessionTicketKey))
 	})
 
 	Context("GetConfigForClient callback", func() {
 		It("doesn't set it if absent", func() {
-			qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, &mockExtensionHandler{}, nil, false)
+			qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, &mockExtensionHandler{}, nil, nil, nil, false)
 			Expect(qtlsConf.GetConfigForClient).To(BeNil())
 		})
 
@@ -86,7 +86,7 @@ var _ = Describe("qtls.Config generation", func() {
 				},
 			}
 			extHandler := &mockExtensionHandler{}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, extHandler, nil, false)
+			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, extHandler, nil, nil, nil, false)
 			Expect(qtlsConf.GetConfigForClient).ToNot(BeNil())
 			confForClient, err := qtlsConf.GetConfigForClient(nil)
 			Expect(err).ToNot(HaveOccurred())
@@ -106,7 +106,7 @@ var _ = Describe("qtls.Config generation", func() {
 					return nil, testErr
 				},
 			}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
+			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, nil, nil, false)
 			_, err := qtlsConf.GetConfigForClient(nil)
 			Expect(err).To(MatchError(testErr))
 		})
@@ -117,35 +117,49 @@ var _ = Describe("qtls.Config generation", func() {
 					return nil, nil
 				},
 			}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
+			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, nil, nil, false)
 			Expect(qtlsConf.GetConfigForClient(nil)).To(BeNil())
 		})
 	})
 
 	Context("ClientSessionCache", func() {
 		It("doesn't set if absent", func() {
-			qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, &mockExtensionHandler{}, nil, false)
+			qtlsConf := tlsConfigToQtlsConfig(&tls.Config{}, nil, &mockExtensionHandler{}, nil, nil, nil, false)
 			Expect(qtlsConf.ClientSessionCache).To(BeNil())
 		})
 
 		It("sets it, and puts and gets session states", func() {
 			csc := NewMockClientSessionCache(mockCtrl)
 			tlsConf := &tls.Config{ClientSessionCache: csc}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
+			var appData []byte
+			qtlsConf := tlsConfigToQtlsConfig(
+				tlsConf,
+				nil,
+				&mockExtensionHandler{},
+				func() []byte { return []byte("foobar") },
+				func(p []byte) { appData = p },
+				nil,
+				false,
+			)
 			Expect(qtlsConf.ClientSessionCache).ToNot(BeNil())
+
+			var state *tls.ClientSessionState
 			// put something
-			csc.EXPECT().Put("foobar", gomock.Any())
-			qtlsConf.ClientSessionCache.Put("foobar", &qtls.ClientSessionState{})
+			csc.EXPECT().Put("localhost", gomock.Any()).Do(func(_ string, css *tls.ClientSessionState) {
+				state = css
+			})
+			qtlsConf.ClientSessionCache.Put("localhost", &qtls.ClientSessionState{})
 			// get something
-			csc.EXPECT().Get("raboof").Return(nil, true)
-			_, ok := qtlsConf.ClientSessionCache.Get("raboof")
+			csc.EXPECT().Get("localhost").Return(state, true)
+			_, ok := qtlsConf.ClientSessionCache.Get("localhost")
 			Expect(ok).To(BeTrue())
+			Expect(appData).To(Equal([]byte("foobar")))
 		})
 
 		It("puts a nil session state", func() {
 			csc := NewMockClientSessionCache(mockCtrl)
 			tlsConf := &tls.Config{ClientSessionCache: csc}
-			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, false)
+			qtlsConf := tlsConfigToQtlsConfig(tlsConf, nil, &mockExtensionHandler{}, nil, nil, nil, false)
 			// put something
 			csc.EXPECT().Put("foobar", nil)
 			qtlsConf.ClientSessionCache.Put("foobar", nil)

--- a/internal/handshake/unsafe.go
+++ b/internal/handshake/unsafe.go
@@ -19,6 +19,9 @@ func init() {
 	if !structsEqual(&tls.ClientSessionState{}, &qtls.ClientSessionState{}) {
 		panic("qtls.ClientSessionState not compatible with tls.ClientSessionState")
 	}
+	if !structsEqual(&tls.ClientSessionState{}, &clientSessionState{}) {
+		panic("clientSessionState not compatible with tls.ClientSessionState")
+	}
 }
 
 func structsEqual(a, b interface{}) bool {

--- a/internal/handshake/updatable_aead.go
+++ b/internal/handshake/updatable_aead.go
@@ -47,6 +47,7 @@ type updatableAEAD struct {
 
 	keyPhase          protocol.KeyPhase
 	largestAcked      protocol.PacketNumber
+	firstPacketNumber protocol.PacketNumber
 	keyUpdateInterval uint64
 
 	// Time when the keys should be dropped. Keys are dropped on the next call to Open().
@@ -83,6 +84,7 @@ var _ ShortHeaderSealer = &updatableAEAD{}
 
 func newUpdatableAEAD(rttStats *congestion.RTTStats, logger utils.Logger) *updatableAEAD {
 	return &updatableAEAD{
+		firstPacketNumber:       protocol.InvalidPacketNumber,
 		largestAcked:            protocol.InvalidPacketNumber,
 		firstRcvdWithCurrentKey: protocol.InvalidPacketNumber,
 		firstSentWithCurrentKey: protocol.InvalidPacketNumber,
@@ -199,6 +201,9 @@ func (a *updatableAEAD) Seal(dst, src []byte, pn protocol.PacketNumber, ad []byt
 	if a.firstSentWithCurrentKey == protocol.InvalidPacketNumber {
 		a.firstSentWithCurrentKey = pn
 	}
+	if a.firstPacketNumber == protocol.InvalidPacketNumber {
+		a.firstPacketNumber = pn
+	}
 	a.numSentWithCurrentKey++
 	binary.BigEndian.PutUint64(a.nonceBuf[len(a.nonceBuf)-8:], uint64(pn))
 	// The AEAD we're using here will be the qtls.aeadAESGCM13.
@@ -248,4 +253,8 @@ func (a *updatableAEAD) EncryptHeader(sample []byte, firstByte *byte, hdrBytes [
 
 func (a *updatableAEAD) DecryptHeader(sample []byte, firstByte *byte, hdrBytes []byte) {
 	a.headerDecrypter.DecryptHeader(sample, firstByte, hdrBytes)
+}
+
+func (a *updatableAEAD) FirstPacketNumber() protocol.PacketNumber {
+	return a.firstPacketNumber
 }

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -75,6 +75,13 @@ var _ = Describe("Updatable AEAD", func() {
 					Expect(opened).To(Equal(msg))
 				})
 
+				It("saves the first packet number", func() {
+					client.Seal(nil, msg, 0x1337, ad)
+					Expect(client.FirstPacketNumber()).To(Equal(protocol.PacketNumber(0x1337)))
+					client.Seal(nil, msg, 0x1338, ad)
+					Expect(client.FirstPacketNumber()).To(Equal(protocol.PacketNumber(0x1337)))
+				})
+
 				It("fails to open a message if the associated data is not the same", func() {
 					encrypted := client.Seal(nil, msg, 0x1337, ad)
 					_, err := server.Open(nil, encrypted, time.Now(), 0x1337, protocol.KeyPhaseZero, []byte("wrong ad"))

--- a/internal/mocks/ackhandler/received_packet_handler.go
+++ b/internal/mocks/ackhandler/received_packet_handler.go
@@ -89,9 +89,11 @@ func (mr *MockReceivedPacketHandlerMockRecorder) IgnoreBelow(arg0 interface{}) *
 }
 
 // ReceivedPacket mocks base method
-func (m *MockReceivedPacketHandler) ReceivedPacket(arg0 protocol.PacketNumber, arg1 protocol.EncryptionLevel, arg2 time.Time, arg3 bool) {
+func (m *MockReceivedPacketHandler) ReceivedPacket(arg0 protocol.PacketNumber, arg1 protocol.EncryptionLevel, arg2 time.Time, arg3 bool) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReceivedPacket", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "ReceivedPacket", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ReceivedPacket indicates an expected call of ReceivedPacket

--- a/internal/mocks/crypto_setup.go
+++ b/internal/mocks/crypto_setup.go
@@ -88,6 +88,36 @@ func (mr *MockCryptoSetupMockRecorder) DropHandshakeKeys() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropHandshakeKeys", reflect.TypeOf((*MockCryptoSetup)(nil).DropHandshakeKeys))
 }
 
+// Get0RTTOpener mocks base method
+func (m *MockCryptoSetup) Get0RTTOpener() (handshake.LongHeaderOpener, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get0RTTOpener")
+	ret0, _ := ret[0].(handshake.LongHeaderOpener)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get0RTTOpener indicates an expected call of Get0RTTOpener
+func (mr *MockCryptoSetupMockRecorder) Get0RTTOpener() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get0RTTOpener", reflect.TypeOf((*MockCryptoSetup)(nil).Get0RTTOpener))
+}
+
+// Get0RTTSealer mocks base method
+func (m *MockCryptoSetup) Get0RTTSealer() (handshake.LongHeaderSealer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get0RTTSealer")
+	ret0, _ := ret[0].(handshake.LongHeaderSealer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get0RTTSealer indicates an expected call of Get0RTTSealer
+func (mr *MockCryptoSetupMockRecorder) Get0RTTSealer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get0RTTSealer", reflect.TypeOf((*MockCryptoSetup)(nil).Get0RTTSealer))
+}
+
 // Get1RTTOpener mocks base method
 func (m *MockCryptoSetup) Get1RTTOpener() (handshake.ShortHeaderOpener, error) {
 	m.ctrl.T.Helper()

--- a/internal/protocol/encryption_level.go
+++ b/internal/protocol/encryption_level.go
@@ -11,6 +11,8 @@ const (
 	EncryptionInitial
 	// EncryptionHandshake is the Handshake encryption level
 	EncryptionHandshake
+	// Encryption0RTT is the 0-RTT encryption level
+	Encryption0RTT
 	// Encryption1RTT is the 1-RTT encryption level
 	Encryption1RTT
 )
@@ -21,6 +23,8 @@ func (e EncryptionLevel) String() string {
 		return "Initial"
 	case EncryptionHandshake:
 		return "Handshake"
+	case Encryption0RTT:
+		return "0-RTT"
 	case Encryption1RTT:
 		return "1-RTT"
 	}

--- a/internal/protocol/encryption_level_test.go
+++ b/internal/protocol/encryption_level_test.go
@@ -10,6 +10,7 @@ var _ = Describe("Encryption Level", func() {
 		Expect(EncryptionUnspecified.String()).To(Equal("unknown"))
 		Expect(EncryptionInitial.String()).To(Equal("Initial"))
 		Expect(EncryptionHandshake.String()).To(Equal("Handshake"))
+		Expect(Encryption0RTT.String()).To(Equal("0-RTT"))
 		Expect(Encryption1RTT.String()).To(Equal("1-RTT"))
 	})
 })

--- a/internal/wire/frame_parser.go
+++ b/internal/wire/frame_parser.go
@@ -106,11 +106,21 @@ func (p *frameParser) isAllowedAtEncLevel(f Frame, encLevel protocol.EncryptionL
 		switch f.(type) {
 		case *CryptoFrame, *AckFrame, *ConnectionCloseFrame, *PingFrame:
 			return true
+		default:
+			return false
+		}
+	case protocol.Encryption0RTT:
+		switch f.(type) {
+		case *CryptoFrame, *AckFrame, *ConnectionCloseFrame, *NewTokenFrame, *PathResponseFrame, *RetireConnectionIDFrame:
+			return false
+		default:
+			return true
 		}
 	case protocol.Encryption1RTT:
 		return true
+	default:
+		panic("unknown encryption level")
 	}
-	return false
 }
 
 func (p *frameParser) SetAckDelayExponent(exp uint8) {

--- a/internal/wire/frame_parser_test.go
+++ b/internal/wire/frame_parser_test.go
@@ -357,6 +357,19 @@ var _ = Describe("Frame parsing", func() {
 			}
 		})
 
+		It("rejects all frames but ACK, CRYPTO, CONNECTION_CLOSE, NEW_TOKEN, PATH_RESPONSE and RETIRE_CONNECTION_ID in 0-RTT packets", func() {
+			for i, b := range framesSerialized {
+				_, err := parser.ParseNext(bytes.NewReader(b), protocol.Encryption0RTT)
+				switch frames[i].(type) {
+				case *AckFrame, *ConnectionCloseFrame, *CryptoFrame, *NewTokenFrame, *PathResponseFrame, *RetireConnectionIDFrame:
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("not allowed at encryption level 0-RTT"))
+				default:
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+		})
+
 		It("accepts all frame types in 1-RTT packets", func() {
 			for _, b := range framesSerialized {
 				_, err := parser.ParseNext(bytes.NewReader(b), protocol.Encryption1RTT)

--- a/mock_sealing_manager_test.go
+++ b/mock_sealing_manager_test.go
@@ -34,6 +34,21 @@ func (m *MockSealingManager) EXPECT() *MockSealingManagerMockRecorder {
 	return m.recorder
 }
 
+// Get0RTTSealer mocks base method
+func (m *MockSealingManager) Get0RTTSealer() (handshake.LongHeaderSealer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get0RTTSealer")
+	ret0, _ := ret[0].(handshake.LongHeaderSealer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get0RTTSealer indicates an expected call of Get0RTTSealer
+func (mr *MockSealingManagerMockRecorder) Get0RTTSealer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get0RTTSealer", reflect.TypeOf((*MockSealingManager)(nil).Get0RTTSealer))
+}
+
 // Get1RTTSealer mocks base method
 func (m *MockSealingManager) Get1RTTSealer() (handshake.ShortHeaderSealer, error) {
 	m.ctrl.T.Helper()

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -65,6 +65,16 @@ func (u *packetUnpacker) Unpack(hdr *wire.Header, rcvTime time.Time, data []byte
 		if err != nil {
 			return nil, err
 		}
+	case protocol.PacketType0RTT:
+		encLevel = protocol.Encryption0RTT
+		opener, err := u.cs.Get0RTTOpener()
+		if err != nil {
+			return nil, err
+		}
+		extHdr, decrypted, err = u.unpackLongHeaderPacket(opener, hdr, data)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		if hdr.IsLongHeader {
 			return nil, fmt.Errorf("unknown packet type: %s", hdr.Type)

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -78,6 +78,29 @@ var _ = Describe("Packet Unpacker", func() {
 		Expect(packet.data).To(Equal([]byte("decrypted")))
 	})
 
+	It("opens 0-RTT packets", func() {
+		extHdr := &wire.ExtendedHeader{
+			Header: wire.Header{
+				IsLongHeader:     true,
+				Type:             protocol.PacketType0RTT,
+				Length:           3 + 6, // packet number len + payload
+				DestConnectionID: connID,
+				Version:          version,
+			},
+			PacketNumber:    2,
+			PacketNumberLen: 3,
+		}
+		hdr, hdrRaw := getHeader(extHdr)
+		opener := mocks.NewMockLongHeaderOpener(mockCtrl)
+		cs.EXPECT().Get0RTTOpener().Return(opener, nil)
+		opener.EXPECT().DecryptHeader(gomock.Any(), gomock.Any(), gomock.Any())
+		opener.EXPECT().Open(gomock.Any(), payload, extHdr.PacketNumber, hdrRaw).Return([]byte("decrypted"), nil)
+		packet, err := unpacker.Unpack(hdr, time.Now(), append(hdrRaw, payload...))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(packet.encryptionLevel).To(Equal(protocol.Encryption0RTT))
+		Expect(packet.data).To(Equal([]byte("decrypted")))
+	})
+
 	It("returns the error when getting the sealer fails", func() {
 		extHdr := &wire.ExtendedHeader{
 			Header:          wire.Header{DestConnectionID: connID},

--- a/server.go
+++ b/server.go
@@ -361,6 +361,7 @@ func (s *baseServer) handlePacketImpl(p *receivedPacket) bool /* was the packet 
 		// Drop long header packets.
 		// There's litte point in sending a Stateless Reset, since the client
 		// might not have received the token yet.
+		s.logger.Debugf("Dropping long header packet of type %s (%d bytes)", hdr.Type, len(p.data))
 		return false
 	}
 

--- a/session.go
+++ b/session.go
@@ -274,6 +274,7 @@ var newSession = func(
 			},
 		},
 		tlsConf,
+		true, // TODO: make 0-RTT support configurable
 		s.rttStats,
 		logger,
 	)
@@ -370,6 +371,7 @@ var newClientSession = func(
 			onHandshakeComplete: func() { close(s.handshakeCompleteChan) },
 		},
 		tlsConf,
+		true, // TODO: make 0-RTT support configurable
 		s.rttStats,
 		logger,
 	)

--- a/session.go
+++ b/session.go
@@ -683,8 +683,8 @@ func (s *session) handleSinglePacket(p *receivedPacket, hdr *wire.Header) bool /
 		s.logger.Debugf("Dropping %s packet with unexpected source connection ID: %s (expected %s)", hdr.PacketType(), hdr.SrcConnectionID, s.handshakeDestConnID)
 		return false
 	}
-	// drop 0-RTT packets
-	if hdr.Type == protocol.PacketType0RTT {
+	// drop 0-RTT packets, if we are a client
+	if s.perspective == protocol.PerspectiveClient && hdr.Type == protocol.PacketType0RTT {
 		return false
 	}
 

--- a/session.go
+++ b/session.go
@@ -821,8 +821,7 @@ func (s *session) handleUnpackedPacket(packet *unpackedPacket, rcvTime time.Time
 		})
 	}
 
-	s.receivedPacketHandler.ReceivedPacket(packet.packetNumber, packet.encryptionLevel, rcvTime, isAckEliciting)
-	return nil
+	return s.receivedPacketHandler.ReceivedPacket(packet.packetNumber, packet.encryptionLevel, rcvTime, isAckEliciting)
 }
 
 func (s *session) handleFrame(f wire.Frame, pn protocol.PacketNumber, encLevel protocol.EncryptionLevel) error {

--- a/session.go
+++ b/session.go
@@ -467,6 +467,7 @@ func (s *session) run() error {
 			s.scheduleSending()
 			if zeroRTTParams != nil {
 				s.processTransportParameters(zeroRTTParams)
+				close(s.earlySessionReadyChan)
 			}
 		case closeErr := <-s.closeChan:
 			// put the close error back into the channel, so that the run loop can receive it

--- a/session.go
+++ b/session.go
@@ -84,16 +84,16 @@ type sessionRunner interface {
 }
 
 type handshakeRunner struct {
-	onReceivedParams    func([]byte)
+	onReceivedParams    func(*handshake.TransportParameters)
 	onError             func(error)
 	dropKeys            func(protocol.EncryptionLevel)
 	onHandshakeComplete func()
 }
 
-func (r *handshakeRunner) OnReceivedParams(b []byte)            { r.onReceivedParams(b) }
-func (r *handshakeRunner) OnError(e error)                      { r.onError(e) }
-func (r *handshakeRunner) DropKeys(el protocol.EncryptionLevel) { r.dropKeys(el) }
-func (r *handshakeRunner) OnHandshakeComplete()                 { r.onHandshakeComplete() }
+func (r *handshakeRunner) OnReceivedParams(tp *handshake.TransportParameters) { r.onReceivedParams(tp) }
+func (r *handshakeRunner) OnError(e error)                                    { r.onError(e) }
+func (r *handshakeRunner) DropKeys(el protocol.EncryptionLevel)               { r.dropKeys(el) }
+func (r *handshakeRunner) OnHandshakeComplete()                               { r.onHandshakeComplete() }
 
 type closeError struct {
 	err       error
@@ -1092,19 +1092,13 @@ func (s *session) dropEncryptionLevel(encLevel protocol.EncryptionLevel) {
 	s.receivedPacketHandler.DropPackets(encLevel)
 }
 
-func (s *session) processTransportParameters(data []byte) {
-	var params *handshake.TransportParameters
-	var err error
-	switch s.perspective {
-	case protocol.PerspectiveClient:
-		params, err = s.processTransportParametersForClient(data)
-	case protocol.PerspectiveServer:
-		params, err = s.processTransportParametersForServer(data)
-	}
-	if err != nil {
-		s.closeLocal(err)
+func (s *session) processTransportParameters(params *handshake.TransportParameters) {
+	// check the Retry token
+	if s.perspective == protocol.PerspectiveClient && !params.OriginalConnectionID.Equal(s.origDestConnID) {
+		s.closeLocal(qerr.Error(qerr.TransportParameterError, fmt.Sprintf("expected original_connection_id to equal %s, is %s", s.origDestConnID, params.OriginalConnectionID)))
 		return
 	}
+
 	s.logger.Debugf("Received Transport Parameters: %s", params)
 	s.peerParams = params
 	// Our local idle timeout will always be > 0.
@@ -1122,36 +1116,15 @@ func (s *session) processTransportParameters(data []byte) {
 	if params.StatelessResetToken != nil {
 		s.connIDManager.SetStatelessResetToken(*params.StatelessResetToken)
 	}
-	// On the server side, the early session is ready as soon as we processed
-	// the client's transport parameters.
-	close(s.earlySessionReadyChan)
-}
-
-func (s *session) processTransportParametersForClient(data []byte) (*handshake.TransportParameters, error) {
-	params := &handshake.TransportParameters{}
-	if err := params.Unmarshal(data, s.perspective.Opposite()); err != nil {
-		return nil, err
-	}
-
-	// check the Retry token
-	if !params.OriginalConnectionID.Equal(s.origDestConnID) {
-		return nil, qerr.Error(qerr.TransportParameterError, fmt.Sprintf("expected original_connection_id to equal %s, is %s", s.origDestConnID, params.OriginalConnectionID))
-	}
 	// We don't support connection migration yet, so we don't have any use for the preferred_address.
 	if params.PreferredAddress != nil {
 		s.logger.Debugf("Server sent preferred_address. Retiring the preferred_address connection ID.")
 		// Retire the connection ID.
 		s.framer.QueueControlFrame(&wire.RetireConnectionIDFrame{SequenceNumber: 1})
 	}
-	return params, nil
-}
-
-func (s *session) processTransportParametersForServer(data []byte) (*handshake.TransportParameters, error) {
-	params := &handshake.TransportParameters{}
-	if err := params.Unmarshal(data, s.perspective.Opposite()); err != nil {
-		return nil, err
-	}
-	return params, nil
+	// On the server side, the early session is ready as soon as we processed
+	// the client's transport parameters.
+	close(s.earlySessionReadyChan)
 }
 
 func (s *session) sendPackets() error {


### PR DESCRIPTION
Fixes #438. Depends on https://github.com/marten-seemann/qtls/pull/6 (please also review that PR).

This PR only adds very basic support for 0-RTT. Although the 0-RTT handshake works in general, it should not be considered production-ready yet. I opened a few follow-up issues: #2065, #2066, #2067, #2068.