### PR TITLE
refactor and add injection attacks

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -678,7 +678,7 @@ var _ = Describe("Client", func() {
 	})
 
 	Context("handling potentially injected packets", func() {
-		// NOTE: We hope these tests as written will fail once mitigations for injection adversaries are put in place.
+		// NOTE: We hope these tests as written will fail once mitigation for injection adversaries is put in place.
 
 		// Illustrates that adversary who injects any packet quickly can
 		// cause a real version negotiation packet to be ignored.

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -270,12 +270,17 @@ var _ = Describe("MITM test", func() {
 				})
 			})
 
-			Context("successful injection attacks", func() {
+			Context("early handshake injection attacks", func() {
 				// These tests demonstrate that the QUIC protocol is vulnerable to injection attacks before the handshake
 				// finishes. In particular, an adversary who can intercept packets coming from one endpoint and send a reply
 				// that arrives before the real reply can tear down the connection in multiple ways.
 
-				const rtt = 20 * time.Millisecond
+				const rtt = 5 * time.Millisecond
+
+				var delayCb func(dir quicproxy.Direction, raw []byte) time.Duration
+				var dropCb func(dir quicproxy.Direction, raw []byte) bool
+				var generateForgery func(hdr *wire.Header) []byte
+				var initialReceived bool
 
 				// AfterEach closes the proxy, but each function is responsible
 				// for closing client and server connections
@@ -285,54 +290,12 @@ var _ = Describe("MITM test", func() {
 					Expect(proxy.Close()).To(Succeed())
 				})
 
-				// sendForgedVersionNegotiationPacket sends a fake VN packet with no supported versions
-				// from serverConn to client's remoteAddr
-				// expects hdr from an Initial packet intercepted from client
-				sendForgedVersionNegotationPacket := func(conn net.PacketConn, remoteAddr net.Addr, hdr *wire.Header) {
-					// Create fake version negotiation packet with no supported versions
-					versions := []protocol.VersionNumber{}
-					packet, _ := wire.ComposeVersionNegotiation(hdr.SrcConnectionID, hdr.DestConnectionID, versions)
-
-					// Send the packet
-					_, err := conn.WriteTo(packet, remoteAddr)
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				// sendForgedRetryPacket sends a fake Retry packet with a modified srcConnID
-				// from serverConn to client's remoteAddr
-				// expects hdr from an Initial packet intercepted from client
-				sendForgedRetryPacket := func(conn net.PacketConn, remoteAddr net.Addr, hdr *wire.Header) {
-					var x byte = 0x12
-					fakeSrcConnID := protocol.ConnectionID{x, x, x, x, x, x, x, x}
-					retryPacket := testutils.ComposeRetryPacket(fakeSrcConnID, hdr.SrcConnectionID, hdr.DestConnectionID, []byte("token"), hdr.Version)
-
-					_, err := conn.WriteTo(retryPacket, remoteAddr)
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				// Send a forged Initial packet with no frames to client
-				// expects hdr from an Initial packet intercepted from client
-				sendForgedInitialPacket := func(conn net.PacketConn, remoteAddr net.Addr, hdr *wire.Header) {
-					initialPacket := testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, nil)
-					_, err := conn.WriteTo(initialPacket, remoteAddr)
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				// Send a forged Initial packet with ACK for random packet to client
-				// expects hdr from an Initial packet intercepted from client
-				sendForgedInitialPacketWithAck := func(conn net.PacketConn, remoteAddr net.Addr, hdr *wire.Header) {
-					// Fake Initial with ACK for packet 2 (unsent)
-					ackFrame := testutils.ComposeAckFrame(2, 2)
-					initialPacket := testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, []wire.Frame{ackFrame})
-					_, err := conn.WriteTo(initialPacket, remoteAddr)
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				runTest := func(delayCb quicproxy.DelayCallback) error {
-					startServerAndProxy(delayCb, nil)
+				// params dropCb and attackTimeout are for upcoming tests of attack mitigation
+				runTest := func(delayCb quicproxy.DelayCallback, dropCb quicproxy.DropCallback, attackTimeout time.Duration) error {
+					startServerAndProxy(delayCb, dropCb)
 					raddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", proxy.LocalPort()))
 					Expect(err).ToNot(HaveOccurred())
-					_, err = quic.Dial(
+					sess, err := quic.Dial(
 						clientConn,
 						raddr,
 						fmt.Sprintf("localhost:%d", proxy.LocalPort()),
@@ -343,103 +306,187 @@ var _ = Describe("MITM test", func() {
 							HandshakeTimeout:   2 * time.Second,
 						},
 					)
+					if err == nil {
+						str, err := sess.AcceptUniStream(context.Background())
+						Expect(err).ToNot(HaveOccurred())
+						data, err := ioutil.ReadAll(str)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(data).To(Equal(testserver.PRData))
+						Expect(sess.Close()).To(Succeed())
+					}
 					return err
 				}
 
-				// fails immediately because client connection closes when it can't find compatible version
-				It("fails when a forged version negotiation packet is sent to client", func() {
-					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
-						if dir == quicproxy.DirectionIncoming {
-							defer GinkgoRecover()
+				Context("intercept client Initial and reply with forged", func() {
+					JustBeforeEach(func() {
+						initialReceived = false
+						delayCb = func(dir quicproxy.Direction, raw []byte) time.Duration {
+							if dir == quicproxy.DirectionIncoming {
+								defer GinkgoRecover()
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
-							Expect(err).ToNot(HaveOccurred())
+								hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+								Expect(err).ToNot(HaveOccurred())
 
-							if hdr.Type != protocol.PacketTypeInitial {
-								return 0
+								if hdr.Type != protocol.PacketTypeInitial || initialReceived {
+									return 0
+								}
+
+								initialReceived = true
+								forgedPacket := generateForgery(hdr)
+								_, err = serverConn.WriteTo(forgedPacket, clientConn.LocalAddr())
+								Expect(err).ToNot(HaveOccurred())
 							}
-
-							sendForgedVersionNegotationPacket(serverConn, clientConn.LocalAddr(), hdr)
+							return rtt / 2
 						}
-						return rtt / 2
-					}
-					err := runTest(delayCb)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("No compatible QUIC version found."))
-				})
+						dropCb = func(dir quicproxy.Direction, raw []byte) bool {
+							return false
+						}
+					})
 
-				// times out, because client doesn't accept subsequent real retry packets from server
-				// as it has already accepted a retry.
-				// TODO: determine behavior when server does not send Retry packets
-				It("fails when a forged Retry packet with modified srcConnID is sent to client", func() {
-					var initialPacketIntercepted bool
-					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
-						if dir == quicproxy.DirectionIncoming && !initialPacketIntercepted {
-							defer GinkgoRecover()
-
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
-							Expect(err).ToNot(HaveOccurred())
-
-							if hdr.Type != protocol.PacketTypeInitial {
-								return 0
+					Context("version negotiation packet with unsupported versions", func() {
+						BeforeEach(func() {
+							generateForgery = func(hdr *wire.Header) []byte {
+								versions := []protocol.VersionNumber{0x22334455, 0x33445566}
+								packet, _ := wire.ComposeVersionNegotiation(hdr.SrcConnectionID, hdr.DestConnectionID, versions)
+								return packet
 							}
+						})
 
-							initialPacketIntercepted = true
-							sendForgedRetryPacket(serverConn, clientConn.LocalAddr(), hdr)
-						}
-						return rtt / 2
-					}
-					err := runTest(delayCb)
-					Expect(err).To(HaveOccurred())
-					Expect(err.(net.Error).Timeout()).To(BeTrue())
-				})
+						// fails immediately because client connection closes when it can't find compatible version
+						It("fails immediately", func() {
+							err := runTest(delayCb, dropCb, 0)
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring("No compatible QUIC version found."))
+						})
+					})
 
-				// times out, because client doesn't accept real retry packets from server because
-				// it has already accepted an initial.
-				// TODO: determine behavior when server does not send Retry packets
-				It("fails when a forged initial packet is sent to client", func() {
-					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
-						if dir == quicproxy.DirectionIncoming {
-							defer GinkgoRecover()
-
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
-							Expect(err).ToNot(HaveOccurred())
-
-							if hdr.Type != protocol.PacketTypeInitial {
-								return 0
+					Context("retry packet with modified srcConnID", func() {
+						BeforeEach(func() {
+							generateForgery = func(hdr *wire.Header) []byte {
+								var x byte = 0x12
+								fakeSrcConnID := protocol.ConnectionID{x, x, x, x, x, x, x, x}
+								return testutils.ComposeRetryPacket(fakeSrcConnID, hdr.SrcConnectionID, hdr.DestConnectionID, []byte("token"), hdr.Version)
 							}
+						})
 
-							sendForgedInitialPacket(serverConn, clientConn.LocalAddr(), hdr)
-						}
-						return rtt
-					}
-					err := runTest(delayCb)
-					Expect(err).To(HaveOccurred())
-					Expect(err.(net.Error).Timeout()).To(BeTrue())
-				})
+						// times out, because client doesn't accept subsequent real retry packets from server
+						// as it has already accepted a retry.
+						It("times out when server always sends retry packets", func() {
+							err := runTest(delayCb, dropCb, 0)
+							Expect(err).To(HaveOccurred())
+							Expect(err.(net.Error).Timeout()).To(BeTrue())
+						})
+					})
 
-				// client connection closes immediately on receiving ack for unsent packet
-				It("fails when a forged initial packet with ack for unsent packet is sent to client", func() {
-					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
-						if dir == quicproxy.DirectionIncoming {
-							defer GinkgoRecover()
-
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
-							Expect(err).ToNot(HaveOccurred())
-
-							if hdr.Type != protocol.PacketTypeInitial {
-								return 0
+					Context("empty initial packet", func() {
+						BeforeEach(func() {
+							generateForgery = func(hdr *wire.Header) []byte {
+								return testutils.ComposeInitialByPayload(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, nil)
 							}
+						})
 
-							sendForgedInitialPacketWithAck(serverConn, clientConn.LocalAddr(), hdr)
-						}
-						return rtt
-					}
-					err := runTest(delayCb)
-					Expect(err).To(HaveOccurred())
-					Expect(err).To(BeAssignableToTypeOf(&qerr.QuicError{}))
-					Expect(err.(*qerr.QuicError).ErrorCode).To(Equal(qerr.ProtocolViolation))
-					Expect(err.Error()).To(ContainSubstring("Received ACK for an unsent packet"))
+						// fails immediately because client closes when it receives an empty packet.
+						It("fails immediately", func() {
+							err := runTest(delayCb, dropCb, 0)
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring("empty packet"))
+						})
+					})
+
+					Context("initial packet with only padding", func() {
+						BeforeEach(func() {
+							generateForgery = func(hdr *wire.Header) []byte {
+								return testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, nil)
+							}
+						})
+
+						// times out, because client doesn't accept real retry packets from server because
+						// it has already accepted an initial.
+						It("fails due to handshake timeout", func() {
+							err := runTest(delayCb, dropCb, 0)
+							Expect(err).To(HaveOccurred())
+							Expect(err.(net.Error).Timeout()).To(BeTrue())
+						})
+					})
+
+					Context("initial packet with ack for unsent packet", func() {
+						BeforeEach(func() {
+							generateForgery = func(hdr *wire.Header) []byte {
+								// Initial with ACK for packet 2 (unsent)
+								ackFrame := testutils.ComposeAckFrame(2, 2)
+								return testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, []wire.Frame{ackFrame})
+							}
+						})
+
+						// client connection closes immediately on receiving ack for unsent packet
+						It("fails immediately", func() {
+							err := runTest(delayCb, dropCb, 0)
+							Expect(err).To(HaveOccurred())
+							Expect(err).To(BeAssignableToTypeOf(&qerr.QuicError{}))
+							Expect(err.(*qerr.QuicError).ErrorCode).To(Equal(qerr.ProtocolViolation))
+							Expect(err.Error()).To(ContainSubstring("Received ACK for an unsent packet"))
+						})
+
+					})
+
+					Context("initial packet with unparseable frame", func() {
+						BeforeEach(func() {
+							generateForgery = func(hdr *wire.Header) []byte {
+								// 42 is not a frame type
+								payload := make([]byte, protocol.MinInitialPacketSize)
+								payload[0] = byte(42)
+								return testutils.ComposeInitialByPayload(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, payload)
+							}
+						})
+
+						// client connection closes immediately on receiving unparseable frame
+						It("fails immediately", func() {
+							err := runTest(delayCb, dropCb, 0)
+							Expect(err).To(HaveOccurred())
+							Expect(err).To(BeAssignableToTypeOf(&qerr.QuicError{}))
+							Expect(err.(*qerr.QuicError).ErrorCode).To(Equal(qerr.FrameEncodingError))
+							Expect(err.Error()).To(ContainSubstring("unknown type byte"))
+						})
+
+					})
+
+					Context("initial packet with illegal frame", func() {
+						BeforeEach(func() {
+							generateForgery = func(hdr *wire.Header) []byte {
+								// ping frames are not allowed at Initial level
+								return testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, []wire.Frame{&wire.PingFrame{}})
+							}
+						})
+
+						// client connection closes immediately on receiving illegal frame
+						It("fails immediately", func() {
+							err := runTest(delayCb, dropCb, 0)
+							Expect(err).To(HaveOccurred())
+							Expect(err).To(BeAssignableToTypeOf(&qerr.QuicError{}))
+							Expect(err.(*qerr.QuicError).ErrorCode).To(Equal(qerr.FrameEncodingError))
+							Expect(err.Error()).To(ContainSubstring("PingFrame not allowed at encryption level Initial"))
+						})
+
+					})
+
+					Context("initial packet with CONNECTION_CLOSE", func() {
+						BeforeEach(func() {
+							generateForgery = func(hdr *wire.Header) []byte {
+								connCloseFrame := testutils.ComposeConnCloseFrame()
+								return testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, []wire.Frame{connCloseFrame})
+							}
+						})
+
+						// client connection closes immediately on receiving CONNECTION_CLOSE
+						It("closes immediately", func() {
+							err := runTest(delayCb, dropCb, 0)
+							Expect(err).To(HaveOccurred())
+							Expect(err).To(BeAssignableToTypeOf(&qerr.QuicError{}))
+							Expect(err.(*qerr.QuicError).ErrorCode).To(Equal(qerr.ErrorCode(0)))
+							Expect(err.Error()).To(ContainSubstring("mitm attacker"))
+						})
+
+					})
 				})
 
 			})

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/wire"
+	"github.com/lucas-clemente/quic-go/quictrace/pb"
 )
 
 // Utilities for simulating packet injection and man-in-the-middle (MITM) attacker tests.
@@ -41,6 +42,14 @@ func ComposeCryptoFrame(cft CryptoFrameType, size int) *wire.CryptoFrame {
 	}
 }
 
+// ComposeEmptyFrame returns a new raw frame of indicated length and type
+// composed of all zeroes
+func ComposeEmptyFrame(frameType pb.FrameType, length int) []byte {
+	frame := make([]byte, length)
+	frame[0] = byte(frameType)
+	return frame
+}
+
 // ComposeConnCloseFrame returns a new Connection Close frame with a generic error
 func ComposeConnCloseFrame() *wire.ConnectionCloseFrame {
 	return &wire.ConnectionCloseFrame{
@@ -62,18 +71,10 @@ func ComposeAckFrame(smallest protocol.PacketNumber, largest protocol.PacketNumb
 	}
 }
 
-// ComposeInitialPacket returns an Initial packet encrypted under key
-// (the original destination connection ID) containing specified frames
-func ComposeInitialPacket(srcConnID protocol.ConnectionID, destConnID protocol.ConnectionID, version protocol.VersionNumber, key protocol.ConnectionID, frames []wire.Frame) []byte {
+// ComposeInitialByPayload returns an Initial packet encrypted under key
+// (the original destination connection ID) containing specified raw payload
+func ComposeInitialByPayload(srcConnID protocol.ConnectionID, destConnID protocol.ConnectionID, version protocol.VersionNumber, key protocol.ConnectionID, payload []byte) []byte {
 	sealer, _, _ := handshake.NewInitialAEAD(key, protocol.PerspectiveServer)
-
-	// compose payload
-	var payload []byte
-	if len(frames) == 0 {
-		payload = make([]byte, protocol.MinInitialPacketSize)
-	} else {
-		payload = packRawPayload(version, frames)
-	}
 
 	// compose Initial header
 	payloadSize := len(payload)
@@ -107,6 +108,19 @@ func ComposeInitialPacket(srcConnID protocol.ConnectionID, destConnID protocol.C
 		encrypted[pnOffset:payloadOffset], // packet number bytes
 	)
 	return encrypted
+}
+
+// ComposeInitialPacket returns an Initial packet encrypted under key
+// (the original destination connection ID) containing specified frames
+// If frame list is empty, the payload will be all padding.
+func ComposeInitialPacket(srcConnID protocol.ConnectionID, destConnID protocol.ConnectionID, version protocol.VersionNumber, key protocol.ConnectionID, frames []wire.Frame) []byte {
+	var payload []byte
+	if len(frames) == 0 {
+		payload = make([]byte, protocol.MinInitialPacketSize)
+	} else {
+		payload = packRawPayload(version, frames)
+	}
+	return ComposeInitialByPayload(srcConnID, destConnID, version, key, payload)
 }
 
 // ComposeRetryPacket returns a new raw Retry Packet

--- a/session_test.go
+++ b/session_test.go
@@ -1797,6 +1797,20 @@ var _ = Describe("Client Session", func() {
 			Expect(sess.handlePacketImpl(wrapPacket(initialPacket))).To(BeFalse())
 		})
 
+		It("fails on Initial-level unparseable frames", func() {
+			sessionRunner.EXPECT().Retire(gomock.Any())
+			payload := make([]byte, protocol.MinInitialPacketSize)
+			payload[0] = byte(31)
+			initialPacket := testutils.ComposeInitialByPayload(sess.destConnID, sess.srcConnID, sess.version, sess.destConnID, payload)
+			Expect(sess.handlePacketImpl(wrapPacket(initialPacket))).To(BeFalse())
+		})
+
+		It("fails on Initial-level empty packets", func() {
+			sessionRunner.EXPECT().Retire(gomock.Any())
+			initialPacket := testutils.ComposeInitialByPayload(sess.destConnID, sess.srcConnID, sess.version, sess.destConnID, nil)
+			Expect(sess.handlePacketImpl(wrapPacket(initialPacket))).To(BeFalse())
+		})
+
 		// Illustrates that an injected Initial with a CONNECTION_CLOSE frame causes
 		// the connection to immediately break down
 		It("fails on Initial-level CONNECTION_CLOSE frame", func() {


### PR DESCRIPTION
Added more tests demonstrating injection attacks (including unparseable/illegal frames and empty packets), and refactored integration tests to allow for tests of attack mitigation

NOTE:  codecov comment is incorrect,coverage increases by .03%

@bemasc @lucas-clemente 