### PR TITLE
simplify (and speed up) IsFrameAckEliciting

### DIFF
--- a/internal/ackhandler/ack_eliciting.go
+++ b/internal/ackhandler/ack_eliciting.go
@@ -4,12 +4,8 @@ import "github.com/lucas-clemente/quic-go/internal/wire"
 
 // IsFrameAckEliciting returns true if the frame is ack-eliciting.
 func IsFrameAckEliciting(f wire.Frame) bool {
-	switch f.(type) {
-	case *wire.AckFrame:
-		return false
-	default:
-		return true
-	}
+	_, ok := f.(*wire.AckFrame)
+	return !ok
 }
 
 // HasAckElicitingFrames returns true if at least one frame is ack-eliciting.


### PR DESCRIPTION
Turns out that the `switch` is really slow.

```
BenchmarkIsAckEliciting-12       	1000000000	         2.27 ns/op
BenchmarkIsAckElicitingNew-12    	2000000000	         1.08 ns/op
```