### PR TITLE
speed up header encryption / decryption

### DIFF
--- a/internal/handshake/updatable_aead.go
+++ b/internal/handshake/updatable_aead.go
@@ -242,7 +242,7 @@ func (a *updatableAEAD) Overhead() int {
 }
 
 func (a *updatableAEAD) EncryptHeader(sample []byte, firstByte *byte, pnBytes []byte) {
-	if len(sample) != a.hpEncrypter.BlockSize() {
+	if len(sample) != len(a.hpMask) {
 		panic("invalid sample size")
 	}
 	a.hpEncrypter.Encrypt(a.hpMask, sample)
@@ -253,7 +253,7 @@ func (a *updatableAEAD) EncryptHeader(sample []byte, firstByte *byte, pnBytes []
 }
 
 func (a *updatableAEAD) DecryptHeader(sample []byte, firstByte *byte, pnBytes []byte) {
-	if len(sample) != a.hpDecrypter.BlockSize() {
+	if len(sample) != len(a.hpMask) {
 		panic("invalid sample size")
 	}
 	a.hpDecrypter.Encrypt(a.hpMask, sample)


### PR DESCRIPTION
For some reason, the call to `cipher.Block.BlockSize()` is insanely expensive:
```
    244         10ms       10ms           func (a *updatableAEAD) EncryptHeader(sample []byte, firstByte *byte, pnBytes []byte) { 
    245         30ms       30ms           	if len(sample) != a.hpEncrypter.BlockSize() { 
    246            .          .           		panic("invalid sample size") 
    247            .          .           	} 
    248         10ms       20ms           	a.hpEncrypter.Encrypt(a.hpMask, sample) 
    249            .          .           	*firstByte ^= a.hpMask[0] & 0x1f 
    250            .          .           	for i := range pnBytes { 
    251            .          .           		pnBytes[i] ^= a.hpMask[i+1] 
    252            .          .           	} 
    253            .          .           } 
```
My suspicion is that for some reason, the compiler doesn't inline the function call.
Replacing this function call by a comparison to the length of the `hpMask` slice serves the same purpose, since we allocate `hpMask` to have a length of `BlockSize()`.

```
BenchmarkHeaderEncryption-12       	50000000	        24.5 ns/op
BenchmarkHeaderEncryptionNew-12    	100000000	        21.9 ns/op
```