### PR TITLE
fix deadlock when the crypto setup is closed while qtls writes messages

### DIFF
--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -70,7 +70,6 @@ type cryptoSetup struct {
 
 	runner handshakeRunner
 
-	closed    bool
 	alertChan chan uint8
 	// handshakeDone is closed as soon as the go routine running qtls.Handshake() returns
 	handshakeDone chan struct{}
@@ -283,19 +282,13 @@ func (h *cryptoSetup) RunHandshake() {
 }
 
 func (h *cryptoSetup) onError(alert uint8, message string) {
-
 	h.runner.OnError(qerr.CryptoError(alert, message))
 }
 
+// Close closes the crypto setup.
+// It aborts the handshake, if it is still running.
+// It must only be called once.
 func (h *cryptoSetup) Close() error {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
-
-	if h.closed {
-		return nil
-	}
-	h.closed = true
-
 	close(h.closeChan)
 	// wait until qtls.Handshake() actually returned
 	<-h.handshakeDone


### PR DESCRIPTION
Fixes #2097. @Stebalien, thanks for finding this issue.

Closing the `cryptoSetup` was more complicated than it needs to be. In particular, it only held the mutex to protect against concurrent calls of `Close()`. However, we're only ever closing the crypto setup once, so this was unnecessary. We can simplify this code a bit by only handling a single call to `Close`.

The `io.Closer` documentation says
> The behavior of Close after the first call is undefined. Specific implementations may document their own behavior.

Therefore I'm documenting here that closing the `cryptoSetup` twice is not allowed (and will result in a panic because it would close a closed channel).
