### PR TITLE
copy error code from the STOP_SENDING frame to the RESET_STREAM frame

### DIFF
--- a/send_stream.go
+++ b/send_stream.go
@@ -296,7 +296,7 @@ func (s *sendStream) handleStopSendingFrameImpl(frame *wire.StopSendingFrame) bo
 		errorCode: frame.ErrorCode,
 		error:     fmt.Errorf("Stream %d was reset with error code %d", s.streamID, frame.ErrorCode),
 	}
-	return s.cancelWriteImpl(errorCodeStopping, writeErr)
+	return s.cancelWriteImpl(frame.ErrorCode, writeErr)
 }
 
 func (s *sendStream) Context() context.Context {

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -609,10 +609,10 @@ var _ = Describe("Send Stream", func() {
 		})
 
 		Context("receiving STOP_SENDING frames", func() {
-			It("queues a RESET_STREAM frames with error code Stopping", func() {
+			It("queues a RESET_STREAM frames, and copies the error code from the STOP_SENDING frame", func() {
 				mockSender.EXPECT().queueControlFrame(&wire.ResetStreamFrame{
 					StreamID:  streamID,
-					ErrorCode: errorCodeStopping,
+					ErrorCode: 101,
 				})
 				mockSender.EXPECT().onStreamCompleted(streamID)
 				str.handleStopSendingFrame(&wire.StopSendingFrame{

--- a/stream.go
+++ b/stream.go
@@ -10,8 +10,6 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
-const errorCodeStopping protocol.ApplicationErrorCode = 0
-
 // The streamSender is notified by the stream about various events.
 type streamSender interface {
 	queueControlFrame(wire.Frame)


### PR DESCRIPTION
[The spec](https://quicwg.org/base-drafts/draft-ietf-quic-transport.html#solicited-state-transitions) says:
> An endpoint SHOULD copy the error code from the STOP_SENDING frame to the RESET_STREAM frame it sends, but MAY use any application error code. The endpoint that sends a STOP_SENDING frame MAY ignore the error code carried in any RESET_STREAM frame it receives.