### PR TITLE
document that closing a http3.Server created by Serve doesn't close the conn

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -73,6 +73,8 @@ func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {
 }
 
 // Serve an existing UDP connection.
+// It is possible to reuse the same connection for outgoing connections.
+// Closing the server does not close the packet conn.
 func (s *Server) Serve(conn net.PacketConn) error {
 	return s.serveImpl(s.TLSConfig, conn)
 }


### PR DESCRIPTION
As mentioned in #2103.