### PR TITLE
add server closed error

### DIFF
--- a/server.go
+++ b/server.go
@@ -19,6 +19,8 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
+var ErrServerClosed = errors.New("server closed")
+
 // packetHandler handles packets
 type packetHandler interface {
 	handlePacket(*receivedPacket)
@@ -308,7 +310,7 @@ func (s *baseServer) Close() error {
 	}
 	s.sessionHandler.CloseServer()
 	if s.serverError == nil {
-		s.serverError = errors.New("server closed")
+		s.serverError = ErrServerClosed
 	}
 	var err error
 	// If the server was started with ListenAddr, we created the packet conn.


### PR DESCRIPTION
hi, I'd like you to give me a chance to handle server error.

I read #1778 and checked your code snippets.  I'd like to handle error as below.
I think server closed error can be treaded as normal termination but I think it's a little hard for someone who is not familiar with quic-go internal. 

```

func (l *MyListener) Accept() error {
	for {
		sess, err := ln.Accept()
		if err == quic.ErrServerClosed {
			return nil
		}
		if err != nil {
			return err
		}
		go handleSession(sess)
	}
}
```