### PR TITLE
simplify server shutdown

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -117,7 +117,6 @@ func (h *packetHandlerMap) CloseServer() {
 			go func(id string, handler packetHandler) {
 				// session.Close() blocks until the CONNECTION_CLOSE has been sent and the run-loop has stopped
 				_ = handler.Close()
-				h.retireByConnectionIDAsString(id)
 				wg.Done()
 			}(id, handler)
 		}


### PR DESCRIPTION
When the server is closed, it calls `Session.Close()`. The session already retires the connection ID when it is closed locally: https://github.com/lucas-clemente/quic-go/blob/d1489e5045f4270ebd7be356fee9951a12c0b450/session.go#L941-L952
So we don't need to do that in the packet handler map.