### PR TITLE
don't fake-implement the http.CloseNotifier interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 run:
   skip-files:
-    - http3/response_writer_closenotifier.go
     - internal/handshake/unsafe_test.go
 
 linters-settings:

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -81,9 +81,6 @@ func (w *responseWriter) Write(p []byte) (int, error) {
 
 func (w *responseWriter) Flush() {}
 
-// This is a NOP. Use http.Request.Context
-func (w *responseWriter) CloseNotify() <-chan bool { return make(<-chan bool) }
-
 // test that we implement http.Flusher
 var _ http.Flusher = &responseWriter{}
 

--- a/http3/response_writer_closenotifier.go
+++ b/http3/response_writer_closenotifier.go
@@ -1,9 +1,0 @@
-package http3
-
-import "net/http"
-
-// The CloseNotifier is a deprecated interface, and staticcheck will report that from Go 1.11.
-// By defining it in a separate file, we can exclude this file from staticcheck.
-
-// test that we implement http.CloseNotifier
-var _ http.CloseNotifier = &responseWriter{}


### PR DESCRIPTION
Not sure why we ever introduced this. Providing a fake implementation of an interfacing seems like a bad idea, since this means we're pretending to support a function that's actually not supported.
Or am I missing something here?