### PR TITLE
Fix nil pointer crash in http3.client.Close()

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -120,6 +120,9 @@ func (c *client) setupSession() error {
 }
 
 func (c *client) Close() error {
+	if c.session == nil {
+		return nil
+	}
 	return c.session.Close()
 }
 


### PR DESCRIPTION
client.session would be nil when handshake err. So it's better to check `session != nil` in client.Close() function.