### PR TITLE
don't allow a HTTP/3 server to create bidirectional streams

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -19,7 +19,10 @@ import (
 const defaultUserAgent = "quic-go HTTP/3"
 const defaultMaxResponseHeaderBytes = 10 * 1 << 20 // 10 MB
 
-var defaultQuicConfig = &quic.Config{KeepAlive: true}
+var defaultQuicConfig = &quic.Config{
+	MaxIncomingStreams: -1, // don't allow the server to create bidirectional streams
+	KeepAlive:          true,
+}
 
 var dialAddr = quic.DialAddr
 


### PR DESCRIPTION
The HTTP/3 spec says:
>  Clients MUST treat receipt of a server-initiated bidirectional stream as a connection error of type HTTP_STREAM_CREATION_ERROR unless such an extension has been negotiated.

By not allowing the server to create any bidirectional streams on the QUIC layer, we don't need to implement this check in the HTTP/3 layer (which would consume one go-routine, and add additional complexity).