### PR TITLE
refactor handling of closed session

### DIFF
--- a/closed_session_test.go
+++ b/closed_session_test.go
@@ -1,40 +1,30 @@
 package quic
 
 import (
-	"errors"
 	"time"
 
-	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Closed local session", func() {
+var _ = Describe("closed local session", func() {
 	var (
-		sess  packetHandler
-		mconn *mockConnection
+		sess            closedSession
+		mconn           *mockConnection
+		receivedPackets chan *receivedPacket
 	)
 
 	BeforeEach(func() {
 		mconn = newMockConnection()
-		sess = newClosedLocalSession(mconn, []byte("close"), protocol.PerspectiveClient, utils.DefaultLogger)
-	})
-
-	AfterEach(func() {
-		Eventually(areClosedSessionsRunning).Should(BeFalse())
-	})
-
-	It("tells its perspective", func() {
-		Expect(sess.getPerspective()).To(Equal(protocol.PerspectiveClient))
-		// stop the session
-		Expect(sess.Close()).To(Succeed())
+		receivedPackets = make(chan *receivedPacket, 10)
+		sess = newClosedLocalSession(mconn, receivedPackets, []byte("close"), utils.DefaultLogger)
 	})
 
 	It("repeats the packet containing the CONNECTION_CLOSE frame", func() {
 		for i := 1; i <= 20; i++ {
-			sess.handlePacket(&receivedPacket{})
+			receivedPackets <- &receivedPacket{}
 			if i == 1 || i == 2 || i == 4 || i == 8 || i == 16 {
 				Eventually(mconn.written).Should(Receive(Equal([]byte("close")))) // receive the CONNECTION_CLOSE
 			} else {
@@ -42,12 +32,40 @@ var _ = Describe("Closed local session", func() {
 			}
 		}
 		// stop the session
-		Expect(sess.Close()).To(Succeed())
+		sess.destroy()
+		Eventually(areClosedSessionsRunning).Should(BeFalse())
 	})
 
 	It("destroys sessions", func() {
 		Expect(areClosedSessionsRunning()).To(BeTrue())
-		sess.destroy(errors.New("destroy"))
+		sess.destroy()
+		Eventually(areClosedSessionsRunning).Should(BeFalse())
+	})
+})
+
+var _ = Describe("closed remote session", func() {
+	var (
+		sess            closedSession
+		receivedPackets chan *receivedPacket
+	)
+
+	BeforeEach(func() {
+		receivedPackets = make(chan *receivedPacket, 10)
+		sess = newClosedRemoteSession(receivedPackets)
+	})
+
+	It("discards packets", func() {
+		for i := 0; i < 1000; i++ {
+			receivedPackets <- &receivedPacket{}
+		}
+		// stop the session
+		sess.destroy()
+		Eventually(areClosedSessionsRunning).Should(BeFalse())
+	})
+
+	It("destroys sessions", func() {
+		Expect(areClosedSessionsRunning()).To(BeTrue())
+		sess.destroy()
 		Eventually(areClosedSessionsRunning).Should(BeFalse())
 	})
 })

--- a/mock_packet_handler_manager_test.go
+++ b/mock_packet_handler_manager_test.go
@@ -122,18 +122,6 @@ func (mr *MockPacketHandlerManagerMockRecorder) RemoveResetToken(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveResetToken", reflect.TypeOf((*MockPacketHandlerManager)(nil).RemoveResetToken), arg0)
 }
 
-// ReplaceWithClosed mocks base method
-func (m *MockPacketHandlerManager) ReplaceWithClosed(arg0 protocol.ConnectionID, arg1 packetHandler) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReplaceWithClosed", arg0, arg1)
-}
-
-// ReplaceWithClosed indicates an expected call of ReplaceWithClosed
-func (mr *MockPacketHandlerManagerMockRecorder) ReplaceWithClosed(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceWithClosed", reflect.TypeOf((*MockPacketHandlerManager)(nil).ReplaceWithClosed), arg0, arg1)
-}
-
 // Retire mocks base method
 func (m *MockPacketHandlerManager) Retire(arg0 protocol.ConnectionID) {
 	m.ctrl.T.Helper()

--- a/mock_session_runner_test.go
+++ b/mock_session_runner_test.go
@@ -70,18 +70,6 @@ func (mr *MockSessionRunnerMockRecorder) RemoveResetToken(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveResetToken", reflect.TypeOf((*MockSessionRunner)(nil).RemoveResetToken), arg0)
 }
 
-// ReplaceWithClosed mocks base method
-func (m *MockSessionRunner) ReplaceWithClosed(arg0 protocol.ConnectionID, arg1 packetHandler) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReplaceWithClosed", arg0, arg1)
-}
-
-// ReplaceWithClosed indicates an expected call of ReplaceWithClosed
-func (mr *MockSessionRunnerMockRecorder) ReplaceWithClosed(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceWithClosed", reflect.TypeOf((*MockSessionRunner)(nil).ReplaceWithClosed), arg0, arg1)
-}
-
 // Retire mocks base method
 func (m *MockSessionRunner) Retire(arg0 protocol.ConnectionID) {
 	m.ctrl.T.Helper()

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -86,6 +86,9 @@ func (h *packetHandlerMap) Retire(id protocol.ConnectionID) {
 func (h *packetHandlerMap) retireByConnectionIDAsString(id string) {
 	time.AfterFunc(h.deleteRetiredSessionsAfter, func() {
 		h.mutex.Lock()
+		if sess, ok := h.handlers[id]; ok {
+			sess.destroy(errors.New("deleting"))
+		}
 		h.removeByConnectionIDAsString(id)
 		h.mutex.Unlock()
 	})

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -65,26 +65,14 @@ func newPacketHandlerMap(
 
 func (h *packetHandlerMap) Add(id protocol.ConnectionID, handler packetHandler) {
 	h.mutex.Lock()
-	h.addLocked(id, handler)
-	h.mutex.Unlock()
-}
-
-func (h *packetHandlerMap) addLocked(id protocol.ConnectionID, handler packetHandler) {
 	h.handlers[string(id)] = handler
+	h.mutex.Unlock()
 }
 
 func (h *packetHandlerMap) Remove(id protocol.ConnectionID) {
 	h.mutex.Lock()
 	h.removeByConnectionIDAsString(string(id))
 	h.mutex.Unlock()
-}
-
-func (h *packetHandlerMap) ReplaceWithClosed(id protocol.ConnectionID, handler packetHandler) {
-	h.mutex.Lock()
-	h.removeByConnectionIDAsString(string(id))
-	h.addLocked(id, handler)
-	h.mutex.Unlock()
-	h.retireByConnectionIDAsString(string(id))
 }
 
 func (h *packetHandlerMap) removeByConnectionIDAsString(id string) {

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -137,7 +137,9 @@ var _ = Describe("Packet Handler Map", func() {
 		It("deletes retired session entries after a wait time", func() {
 			handler.deleteRetiredSessionsAfter = scaleDuration(10 * time.Millisecond)
 			connID := protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}
-			handler.Add(connID, NewMockPacketHandler(mockCtrl))
+			sess := NewMockPacketHandler(mockCtrl)
+			handler.Add(connID, sess)
+			sess.EXPECT().destroy(gomock.Any())
 			handler.Retire(connID)
 			time.Sleep(scaleDuration(30 * time.Millisecond))
 			handler.handlePacket(nil, nil, getPacket(connID))

--- a/server.go
+++ b/server.go
@@ -37,7 +37,6 @@ type packetHandlerManager interface {
 	Add(protocol.ConnectionID, packetHandler)
 	Retire(protocol.ConnectionID)
 	Remove(protocol.ConnectionID)
-	ReplaceWithClosed(protocol.ConnectionID, packetHandler)
 	AddResetToken([16]byte, packetHandler)
 	RemoveResetToken([16]byte)
 	GetStatelessResetToken(protocol.ConnectionID) [16]byte
@@ -60,7 +59,6 @@ type quicSession interface {
 type sessionRunner interface {
 	Retire(protocol.ConnectionID)
 	Remove(protocol.ConnectionID)
-	ReplaceWithClosed(protocol.ConnectionID, packetHandler)
 	AddResetToken([16]byte, packetHandler)
 	RemoveResetToken([16]byte)
 }

--- a/streams_map_incoming_bidi.go
+++ b/streams_map_incoming_bidi.go
@@ -2,6 +2,7 @@
 // Any changes will be lost if this file is regenerated.
 // see https://github.com/cheekybits/genny
 
+//nolint:unused
 package quic
 
 import (

--- a/streams_map_incoming_uni.go
+++ b/streams_map_incoming_uni.go
@@ -2,6 +2,7 @@
 // Any changes will be lost if this file is regenerated.
 // see https://github.com/cheekybits/genny
 
+//nolint:unused
 package quic
 
 import (

--- a/streams_map_outgoing_bidi.go
+++ b/streams_map_outgoing_bidi.go
@@ -2,6 +2,7 @@
 // Any changes will be lost if this file is regenerated.
 // see https://github.com/cheekybits/genny
 
+//nolint:unused
 package quic
 
 import (

--- a/streams_map_outgoing_uni.go
+++ b/streams_map_outgoing_uni.go
@@ -2,6 +2,7 @@
 // Any changes will be lost if this file is regenerated.
 // see https://github.com/cheekybits/genny
 
+//nolint:unused
 package quic
 
 import (


### PR DESCRIPTION
This partly reverts #2105. Turns out that replacing closed sessions in the packet handler map doesn't really work when every session can have a bunch of connection IDs, some of which might already be retired by the peer.