### PR TITLE
Replaced runtime.Caller with os.Executable

### DIFF
--- a/internal/testdata/cert.go
+++ b/internal/testdata/cert.go
@@ -5,19 +5,18 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
+	"os"
 	"path"
-	"runtime"
 )
 
 var certPath string
 
 func init() {
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("Failed to get current frame")
+	ex, err := os.Executable()
+	if err != nil {
+		panic(err)
 	}
-
-	certPath = path.Dir(filename)
+	certPath = path.Dir(ex)
 }
 
 // GetCertificatePaths returns the paths to certificate and key


### PR DESCRIPTION
**os.Executable** returns the path name for the executable that started the current process while **runtime.Caller** points to the path of the source file (cert.go) from the compilation phase and stays constant (so if you move the binary to another directory the path won't change and it will be always looking for SSL certificates in the source code tree related path, not in the current dir of the local filesystem).

Example test app:

```
MacBook-Pro-Piotr:tmp piotrszwed$ cat path.go
package main

import (
	"fmt"
	"os"
	"path"
	"runtime"
)

func main() {
	### case 1 ###
	_, filename, _, _ := runtime.Caller(0)
	fmt.Println("runtime.Caller:",path.Dir(filename))

	### case 2 ###
	ex, err := os.Executable()
	exPath := path.Dir(ex)
	fmt.Println("os.Executable:",exPath)
}
```

The actual test:
```
MacBook-Pro-Piotr:tmp piotrszwed$ go build path.go
MacBook-Pro-Piotr:tmp piotrszwed$ ./path
runtime.Caller: /tmp
os.Executable: /tmp

MacBook-Pro-Piotr:tmp piotrszwed$ mkdir dddd; cp path dddd/path
MacBook-Pro-Piotr:tmp piotrszwed$ ./dddd/path
runtime.Caller: /tmp
os.Executable: /tmp/dddd
```
