### PR TITLE
Fix alt-svc header

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -334,7 +334,7 @@ func (s *Server) SetQuicHeaders(hdr http.Header) error {
 		s.supportedVersionsAsString = strings.Join(versions, ",")
 	}
 
-	hdr.Add("Alt-Svc", fmt.Sprintf(`quic=":%d"; ma=2592000; v="%s"`, port, s.supportedVersionsAsString))
+	hdr.Add("Alt-Svc", fmt.Sprintf(`%s=":%d"; ma=2592000; quic="%s"`, nextProtoH3, port, s.supportedVersionsAsString))
 
 	return nil
 }

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -334,12 +334,12 @@ var _ = Describe("Server", func() {
 				versionsAsString = append(versionsAsString, v.ToAltSvc())
 			}
 			return http.Header{
-				"Alt-Svc": {fmt.Sprintf(`quic=":443"; ma=2592000; v="%s"`, strings.Join(versionsAsString, ","))},
+				"Alt-Svc": {fmt.Sprintf(`%s=":443"; ma=2592000; quic="%s"`, nextProtoH3, strings.Join(versionsAsString, ","))},
 			}
 		}
 
 		BeforeEach(func() {
-			Expect(getExpectedHeader([]protocol.VersionNumber{99, 90, 9})).To(Equal(http.Header{"Alt-Svc": {`quic=":443"; ma=2592000; v="99,90,9"`}}))
+			Expect(getExpectedHeader([]protocol.VersionNumber{99, 90, 9})).To(Equal(http.Header{"Alt-Svc": {nextProtoH3 + `=":443"; ma=2592000; quic="99,90,9"`}}))
 			expected = getExpectedHeader(protocol.SupportedVersions)
 		})
 

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -339,7 +339,7 @@ var _ = Describe("Server", func() {
 		}
 
 		BeforeEach(func() {
-			Expect(getExpectedHeader([]protocol.VersionNumber{99, 90, 9})).To(Equal(http.Header{"Alt-Svc": {nextProtoH3 + `=":443"; ma=2592000; quic="99,90,9"`}}))
+			Expect(getExpectedHeader([]protocol.VersionNumber{0x00000001, 0x1abadaba})).To(Equal(http.Header{"Alt-Svc": {nextProtoH3 + `=":443"; ma=2592000; quic="1,1abadaba"`}}))
 			expected = getExpectedHeader(protocol.SupportedVersions)
 		})
 

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -50,7 +50,7 @@ func (vn VersionNumber) String() string {
 
 // ToAltSvc returns the representation of the version for the H2 Alt-Svc parameters
 func (vn VersionNumber) ToAltSvc() string {
-	return fmt.Sprintf("%d", vn)
+	return fmt.Sprintf("%x", uint32(vn))
 }
 
 func (vn VersionNumber) isGQUIC() bool {


### PR DESCRIPTION
### What does this PR do?
This PR changes the `alt-svc` header format.

### Motivation
as specified https://quicwg.org/base-drafts/draft-ietf-quic-http.html#rfc.section.3.1, we need to send `h3-#draft-version#=:#port#` instead of `quic=:#port#`

and

as specified https://quicwg.org/base-drafts/draft-ietf-quic-http.html#rfc.appendix.B.22, we need to send supported version in `quic=#supported#` instead of `v=#supported#`


### More
- [x] Added/updated tests

