### PR TITLE
remove unneccessary destroy of the session when retiring a connection ID

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -72,25 +72,14 @@ func (h *packetHandlerMap) Add(id protocol.ConnectionID, handler packetHandler) 
 
 func (h *packetHandlerMap) Remove(id protocol.ConnectionID) {
 	h.mutex.Lock()
-	h.removeByConnectionIDAsString(string(id))
+	delete(h.handlers, string(id))
 	h.mutex.Unlock()
 }
 
-func (h *packetHandlerMap) removeByConnectionIDAsString(id string) {
-	delete(h.handlers, id)
-}
-
 func (h *packetHandlerMap) Retire(id protocol.ConnectionID) {
-	h.retireByConnectionIDAsString(string(id))
-}
-
-func (h *packetHandlerMap) retireByConnectionIDAsString(id string) {
 	time.AfterFunc(h.deleteRetiredSessionsAfter, func() {
 		h.mutex.Lock()
-		if sess, ok := h.handlers[id]; ok {
-			sess.destroy(errors.New("deleting"))
-		}
-		h.removeByConnectionIDAsString(id)
+		delete(h.handlers, string(id))
 		h.mutex.Unlock()
 	})
 }

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -139,7 +139,6 @@ var _ = Describe("Packet Handler Map", func() {
 			connID := protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}
 			sess := NewMockPacketHandler(mockCtrl)
 			handler.Add(connID, sess)
-			sess.EXPECT().destroy(gomock.Any())
 			handler.Retire(connID)
 			time.Sleep(scaleDuration(30 * time.Millisecond))
 			handler.handlePacket(nil, nil, getPacket(connID))


### PR DESCRIPTION
The only time `packetHandlerMap.Retire` is called is from `session.handleCloseError` https://github.com/lucas-clemente/quic-go/blob/afc7c1091896219294a0b6754c3de302c1244d43/session.go#L976.
At this point, the session should already be closed, so there's no need to call `session.destroy`.
