### PR TITLE
throw FRAME_ENCODING_ERRORs when MAX_STREAMs and STREAMS_BLOCKED frame exceed the maximum stream count

### DIFF
--- a/internal/protocol/stream_test.go
+++ b/internal/protocol/stream_test.go
@@ -56,5 +56,15 @@ var _ = Describe("Stream ID", func() {
 			Expect(StreamNum(100).StreamID(StreamTypeUni, PerspectiveClient)).To(Equal(StreamID(398)))
 			Expect(StreamNum(100).StreamID(StreamTypeUni, PerspectiveServer)).To(Equal(StreamID(399)))
 		})
+
+		It("has the right value for MaxStreamCount", func() {
+			const maxStreamID = StreamID(1<<62 - 1)
+			for _, dir := range []StreamType{StreamTypeUni, StreamTypeBidi} {
+				for _, pers := range []Perspective{PerspectiveClient, PerspectiveServer} {
+					Expect(MaxStreamCount.StreamID(dir, pers)).To(BeNumerically("<=", maxStreamID))
+					Expect((MaxStreamCount + 1).StreamID(dir, pers)).To(BeNumerically(">", maxStreamID))
+				}
+			}
+		})
 	})
 })

--- a/internal/wire/max_streams_frame.go
+++ b/internal/wire/max_streams_frame.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
@@ -31,6 +32,9 @@ func parseMaxStreamsFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxStream
 		return nil, err
 	}
 	f.MaxStreamNum = protocol.StreamNum(streamID)
+	if f.MaxStreamNum > protocol.MaxStreamCount {
+		return nil, fmt.Errorf("%d exceeds the maximum stream count", f.MaxStreamNum)
+	}
 	return f, nil
 }
 

--- a/internal/wire/streams_blocked_frame.go
+++ b/internal/wire/streams_blocked_frame.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
@@ -31,7 +32,9 @@ func parseStreamsBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*Strea
 		return nil, err
 	}
 	f.StreamLimit = protocol.StreamNum(streamLimit)
-
+	if f.StreamLimit > protocol.MaxStreamCount {
+		return nil, fmt.Errorf("%d exceeds the maximum stream count", f.StreamLimit)
+	}
 	return f, nil
 }
 

--- a/streams_map.go
+++ b/streams_map.go
@@ -214,9 +214,6 @@ func (m *streamsMap) getOrOpenSendStream(id protocol.StreamID) (sendStreamI, err
 }
 
 func (m *streamsMap) HandleMaxStreamsFrame(f *wire.MaxStreamsFrame) error {
-	if f.MaxStreamNum > protocol.MaxStreamCount {
-		return qerr.StreamLimitError
-	}
 	switch f.Type {
 	case protocol.StreamTypeUni:
 		m.outgoingUniStreams.SetMaxStream(f.MaxStreamNum)

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -381,13 +381,6 @@ var _ = Describe("Streams Map", func() {
 					_, err = m.OpenUniStream()
 					expectTooManyStreamsError(err)
 				})
-
-				It("rejects MAX_STREAMS frames with too large values", func() {
-					Expect(m.HandleMaxStreamsFrame(&wire.MaxStreamsFrame{
-						Type:         protocol.StreamTypeBidi,
-						MaxStreamNum: protocol.MaxStreamCount + 1,
-					})).To(MatchError(qerr.StreamLimitError))
-				})
 			})
 
 			Context("sending MAX_STREAMS frames", func() {


### PR DESCRIPTION
As outlined in https://github.com/quicwg/base-drafts/pull/3042, we can throw an error as early as possible.