### PR TITLE
use the application-specific variant of CONNECTION_CLOSE

### DIFF
--- a/internal/qerr/quic_error.go
+++ b/internal/qerr/quic_error.go
@@ -39,6 +39,7 @@ func CryptoError(tlsAlert uint8, errorMessage string) *QuicError {
 	}
 }
 
+// ApplicationError creates a new QuicError instance for an application error
 func ApplicationError(errorCode ErrorCode, errorMessage string) *QuicError {
 	return &QuicError{
 		ErrorCode:          errorCode,
@@ -63,6 +64,11 @@ func (e *QuicError) Error() string {
 // IsCryptoError says if this error is a crypto error
 func (e *QuicError) IsCryptoError() bool {
 	return e.ErrorCode.isCryptoError()
+}
+
+// IsApplicationError says if this error is an application error
+func (e *QuicError) IsApplicationError() bool {
+	return e.isApplicationError
 }
 
 // Temporary says if the error is temporary.

--- a/internal/qerr/quic_error_test.go
+++ b/internal/qerr/quic_error_test.go
@@ -11,6 +11,7 @@ var _ = Describe("QUIC Transport Errors", func() {
 	It("has a string representation", func() {
 		err := Error(FlowControlError, "foobar")
 		Expect(err.Timeout()).To(BeFalse())
+		Expect(err.IsApplicationError()).To(BeFalse())
 		Expect(err.Error()).To(Equal("FLOW_CONTROL_ERROR: foobar"))
 	})
 
@@ -38,13 +39,17 @@ var _ = Describe("QUIC Transport Errors", func() {
 
 		It("says if an error is a crypto error", func() {
 			Expect(Error(FlowControlError, "").IsCryptoError()).To(BeFalse())
-			Expect(CryptoError(42, "").IsCryptoError()).To(BeTrue())
+			err := CryptoError(42, "")
+			Expect(err.IsCryptoError()).To(BeTrue())
+			Expect(err.IsApplicationError()).To(BeFalse())
+
 		})
 	})
 
 	Context("application errors", func() {
 		It("has a string representation for errors with a message", func() {
 			err := ApplicationError(0x42, "foobar")
+			Expect(err.IsApplicationError()).To(BeTrue())
 			Expect(err.Error()).To(Equal("Application error 0x42: foobar"))
 		})
 

--- a/session.go
+++ b/session.go
@@ -1023,7 +1023,7 @@ func (s *session) Close() error {
 }
 
 func (s *session) CloseWithError(code protocol.ApplicationErrorCode, desc string) error {
-	s.closeLocal(qerr.Error(qerr.ErrorCode(code), desc))
+	s.closeLocal(qerr.ApplicationError(qerr.ErrorCode(code), desc))
 	<-s.ctx.Done()
 	return nil
 }
@@ -1250,8 +1250,9 @@ func (s *session) sendConnectionClose(quicErr *qerr.QuicError) ([]byte, error) {
 		reason = quicErr.ErrorMessage
 	}
 	packet, err := s.packer.PackConnectionClose(&wire.ConnectionCloseFrame{
-		ErrorCode:    quicErr.ErrorCode,
-		ReasonPhrase: reason,
+		IsApplicationError: quicErr.IsApplicationError(),
+		ErrorCode:          quicErr.ErrorCode,
+		ReasonPhrase:       reason,
 	})
 	if err != nil {
 		return nil, err

--- a/session.go
+++ b/session.go
@@ -1030,7 +1030,7 @@ func (s *session) CloseWithError(code protocol.ApplicationErrorCode, desc string
 
 func (s *session) handleCloseError(closeErr closeError) {
 	if closeErr.err == nil {
-		closeErr.err = qerr.NoError
+		closeErr.err = qerr.ApplicationError(0, "")
 	}
 
 	var quicErr *qerr.QuicError

--- a/session_test.go
+++ b/session_test.go
@@ -426,10 +426,16 @@ var _ = Describe("Session", func() {
 		})
 
 		It("shuts down without error", func() {
-			streamManager.EXPECT().CloseWithError(qerr.Error(qerr.NoError, ""))
+			streamManager.EXPECT().CloseWithError(qerr.ApplicationError(0, ""))
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{raw: []byte("connection close")}, nil)
+			packer.EXPECT().PackConnectionClose(gomock.Any()).DoAndReturn(func(f *wire.ConnectionCloseFrame) (*packedPacket, error) {
+				Expect(f.IsApplicationError).To(BeTrue())
+				Expect(f.ErrorCode).To(Equal(qerr.NoError))
+				Expect(f.FrameType).To(BeZero())
+				Expect(f.ReasonPhrase).To(BeEmpty())
+				return &packedPacket{raw: []byte("connection close")}, nil
+			})
 			Expect(sess.Close()).To(Succeed())
 			Eventually(areSessionsRunning).Should(BeFalse())
 			Expect(mconn.written).To(HaveLen(1))
@@ -438,7 +444,7 @@ var _ = Describe("Session", func() {
 		})
 
 		It("only closes once", func() {
-			streamManager.EXPECT().CloseWithError(qerr.Error(qerr.NoError, ""))
+			streamManager.EXPECT().CloseWithError(gomock.Any())
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
 			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)


### PR DESCRIPTION
Both `Session.Close` and `Session.CloseWithError` should send the application-specific variant of the CONNECTION_CLOSE frame, since in both cases it's the application that is requesting the transport to close.

Note that the NO_ERROR QUIC error code is unused now. According to the spec, the only use case for this error code is that you MAY use it to respond to a received CONNECTION_CLOSE frame (which we don't do).