### PR TITLE
only call the onStreamCompleted callback once in the receiveStream

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -236,11 +236,13 @@ func (s *receiveStream) handleStreamFrameImpl(frame *wire.StreamFrame) (bool /* 
 	if err := s.flowController.UpdateHighestReceived(maxOffset, frame.FinBit); err != nil {
 		return false, err
 	}
+	var newlyRcvdFinalOffset bool
 	if frame.FinBit {
+		newlyRcvdFinalOffset = s.finalOffset == protocol.MaxByteCount
 		s.finalOffset = maxOffset
 	}
 	if s.canceledRead {
-		return frame.FinBit, nil
+		return newlyRcvdFinalOffset, nil
 	}
 	if err := s.frameQueue.Push(frame.Data, frame.Offset, frame.PutBack); err != nil {
 		return false, err

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -269,6 +269,7 @@ func (s *receiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame)
 	if err := s.flowController.UpdateHighestReceived(frame.ByteOffset, true); err != nil {
 		return false, err
 	}
+	newlyRcvdFinalOffset := s.finalOffset == protocol.MaxByteCount
 	s.finalOffset = frame.ByteOffset
 
 	// ignore duplicate RESET_STREAM frames for this stream (after checking their final offset)
@@ -281,7 +282,7 @@ func (s *receiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame)
 		error:     fmt.Errorf("stream %d was reset with error code %d", s.streamID, frame.ErrorCode),
 	}
 	s.signalRead()
-	return true, nil
+	return newlyRcvdFinalOffset, nil
 }
 
 func (s *receiveStream) CloseRemote(offset protocol.ByteCount) {

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -538,6 +538,25 @@ var _ = Describe("Receive Stream", func() {
 					FinBit: true,
 				})).To(Succeed())
 			})
+
+			It("handles duplicate FinBits after the stream was canceled", func() {
+				mockSender.EXPECT().queueControlFrame(gomock.Any())
+				str.CancelRead(1234)
+				gomock.InOrder(
+					mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(1000), true),
+					mockFC.EXPECT().Abandon(),
+					mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(1000), true),
+				)
+				mockSender.EXPECT().onStreamCompleted(streamID)
+				Expect(str.handleStreamFrame(&wire.StreamFrame{
+					Offset: 1000,
+					FinBit: true,
+				})).To(Succeed())
+				Expect(str.handleStreamFrame(&wire.StreamFrame{
+					Offset: 1000,
+					FinBit: true,
+				})).To(Succeed())
+			})
 		})
 
 		Context("receiving RESET_STREAM frames", func() {
@@ -564,7 +583,7 @@ var _ = Describe("Receive Stream", func() {
 					mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(42), true),
 					mockFC.EXPECT().Abandon(),
 				)
-				str.handleResetStreamFrame(rst)
+				Expect(str.handleResetStreamFrame(rst)).To(Succeed())
 				Eventually(done).Should(BeClosed())
 			})
 


### PR DESCRIPTION
Fixes #2212.