### PR TITLE
don't replace the ALPN in the tls.Config returned by GetConfigForClient

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -113,6 +113,7 @@ func (s *Server) serveImpl(tlsConf *tls.Config, conn net.PacketConn) error {
 			if err != nil || conf == nil {
 				return conf, err
 			}
+			conf = conf.Clone()
 			conf.NextProtos = []string{nextProtoH3}
 			return conf, nil
 		}


### PR DESCRIPTION
Fixes #2131.