### PR TITLE
remove nolint commands that show up in GoDoc

### DIFF
--- a/streams_map_generic_helper.go
+++ b/streams_map_generic_helper.go
@@ -1,4 +1,3 @@
-//nolint:unused
 package quic
 
 import (

--- a/streams_map_incoming_bidi.go
+++ b/streams_map_incoming_bidi.go
@@ -2,7 +2,6 @@
 // Any changes will be lost if this file is regenerated.
 // see https://github.com/cheekybits/genny
 
-//nolint:unused
 package quic
 
 import (

--- a/streams_map_incoming_generic.go
+++ b/streams_map_incoming_generic.go
@@ -1,4 +1,3 @@
-//nolint:unused
 package quic
 
 import (

--- a/streams_map_incoming_uni.go
+++ b/streams_map_incoming_uni.go
@@ -2,7 +2,6 @@
 // Any changes will be lost if this file is regenerated.
 // see https://github.com/cheekybits/genny
 
-//nolint:unused
 package quic
 
 import (

--- a/streams_map_outgoing_bidi.go
+++ b/streams_map_outgoing_bidi.go
@@ -2,7 +2,6 @@
 // Any changes will be lost if this file is regenerated.
 // see https://github.com/cheekybits/genny
 
-//nolint:unused
 package quic
 
 import (

--- a/streams_map_outgoing_generic.go
+++ b/streams_map_outgoing_generic.go
@@ -1,4 +1,3 @@
-//nolint:unused
 package quic
 
 import (

--- a/streams_map_outgoing_uni.go
+++ b/streams_map_outgoing_uni.go
@@ -2,7 +2,6 @@
 // Any changes will be lost if this file is regenerated.
 // see https://github.com/cheekybits/genny
 
-//nolint:unused
 package quic
 
 import (


### PR DESCRIPTION
Fixes #2220.

No idea why we had them in the first place.