### PR TITLE
don't send application-level errors before completion of the handshake

### DIFF
--- a/internal/qerr/quic_error.go
+++ b/internal/qerr/quic_error.go
@@ -16,6 +16,10 @@ type QuicError struct {
 
 var _ net.Error = &QuicError{}
 
+// UserCanceledError is used if the application closes the connection
+// before the handshake completes.
+var UserCanceledError = &QuicError{ErrorCode: 0x15a}
+
 // Error creates a new QuicError instance
 func Error(errorCode ErrorCode, errorMessage string) *QuicError {
 	return &QuicError{

--- a/session.go
+++ b/session.go
@@ -1282,6 +1282,10 @@ func (s *session) sendPackedPacket(packet *packedPacket) {
 }
 
 func (s *session) sendConnectionClose(quicErr *qerr.QuicError) ([]byte, error) {
+	// don't send application errors in Initial or Handshake packets
+	if quicErr.IsApplicationError() && !s.handshakeComplete {
+		quicErr = qerr.UserCanceledError
+	}
 	var reason string
 	// don't send details of crypto errors
 	if !quicErr.IsCryptoError() {


### PR DESCRIPTION
Fixes #2231.