### PR TITLE
remove the INVALID_MIGRATION error

### DIFF
--- a/internal/qerr/error_codes.go
+++ b/internal/qerr/error_codes.go
@@ -22,7 +22,6 @@ const (
 	TransportParameterError ErrorCode = 0x8
 	VersionNegotiationError ErrorCode = 0x9
 	ProtocolViolation       ErrorCode = 0xa
-	InvalidMigration        ErrorCode = 0xc
 	CryptoBufferExceeded    ErrorCode = 0xd
 )
 
@@ -70,8 +69,6 @@ func (e ErrorCode) String() string {
 		return "VERSION_NEGOTIATION_ERROR"
 	case ProtocolViolation:
 		return "PROTOCOL_VIOLATION"
-	case InvalidMigration:
-		return "INVALID_MIGRATION"
 	case CryptoBufferExceeded:
 		return "CRYPTO_BUFFER_EXCEEDED"
 	default:


### PR DESCRIPTION
Not sure when exactly it was removed, but it's not there anymore in draft-24.