### PR TITLE
use the parsed header length when unpacking packets

### DIFF
--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -241,7 +241,15 @@ func (h *Header) ParsedLen() protocol.ByteCount {
 // ParseExtended parses the version dependent part of the header.
 // The Reader has to be set such that it points to the first byte of the header.
 func (h *Header) ParseExtended(b *bytes.Reader, ver protocol.VersionNumber) (*ExtendedHeader, error) {
-	return h.toExtendedHeader().parse(b, ver)
+	extHdr := h.toExtendedHeader()
+	reservedBitsValid, err := extHdr.parse(b, ver)
+	if err != nil {
+		return nil, err
+	}
+	if !reservedBitsValid {
+		return extHdr, ErrInvalidReservedBits
+	}
+	return extHdr, nil
 }
 
 func (h *Header) toExtendedHeader() *ExtendedHeader {

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -188,6 +188,7 @@ var _ = Describe("Header Parsing", func() {
 			Expect(extHdr.PacketNumberLen).To(Equal(protocol.PacketNumberLen4))
 			Expect(b.Len()).To(Equal(6)) // foobar
 			Expect(hdr.ParsedLen()).To(BeEquivalentTo(hdrLen))
+			Expect(extHdr.ParsedLen()).To(Equal(hdr.ParsedLen() + 4))
 		})
 
 		It("errors if 0x40 is not set", func() {
@@ -382,6 +383,7 @@ var _ = Describe("Header Parsing", func() {
 				Expect(data).To(Equal(append(hdrRaw, []byte("foobar")...)))
 				Expect(rest).To(Equal([]byte("raboof")))
 			})
+
 			It("errors on packets that are smaller than the length in the packet header, for too small packet number", func() {
 				buf := &bytes.Buffer{}
 				Expect((&ExtendedHeader{
@@ -438,6 +440,8 @@ var _ = Describe("Header Parsing", func() {
 			Expect(extHdr.DestConnectionID).To(Equal(connID))
 			Expect(extHdr.SrcConnectionID).To(BeEmpty())
 			Expect(extHdr.PacketNumber).To(Equal(protocol.PacketNumber(0x42)))
+			Expect(hdr.ParsedLen()).To(BeEquivalentTo(len(data) - 1))
+			Expect(extHdr.ParsedLen()).To(Equal(hdr.ParsedLen() + 1))
 			Expect(pdata).To(Equal(data))
 			Expect(rest).To(BeEmpty())
 		})


### PR DESCRIPTION
Fixes #2259.
Thanks to @Zeymo for debugging this!