### PR TITLE
don't generate new packets when the send queue is full

### DIFF
--- a/send_queue.go
+++ b/send_queue.go
@@ -1,22 +1,49 @@
 package quic
 
+import (
+	"sync"
+)
+
+const sendQueueCapacity = 10
+
 type sendQueue struct {
+	mutex sync.Mutex
+
 	queue     chan *packedPacket
 	closeChan chan struct{}
 	conn      connection
+
+	available chan struct{}
+	blocked   bool
 }
 
-func newSendQueue(conn connection) *sendQueue {
+func newSendQueue(conn connection) (*sendQueue, <-chan struct{}) {
 	s := &sendQueue{
 		conn:      conn,
 		closeChan: make(chan struct{}),
-		queue:     make(chan *packedPacket, 1),
+		queue:     make(chan *packedPacket, sendQueueCapacity),
+		available: make(chan struct{}, 1),
 	}
-	return s
+	return s, s.available
+}
+
+// CanSend returns if a packet can be enqueued.
+func (h *sendQueue) CanSend() bool {
+	canSend := len(h.queue) < cap(h.queue)
+	if !canSend {
+		h.mutex.Lock()
+		h.blocked = true
+		h.mutex.Unlock()
+	}
+	return canSend
 }
 
 func (h *sendQueue) Send(p *packedPacket) {
-	h.queue <- p
+	select {
+	case h.queue <- p:
+	default:
+		panic("send would have blocked")
+	}
 }
 
 func (h *sendQueue) Run() error {
@@ -26,12 +53,32 @@ func (h *sendQueue) Run() error {
 		case <-h.closeChan:
 			return nil
 		case p = <-h.queue:
+			if err := h.sendPacket(p); err != nil {
+				return err
+			}
 		}
-		if err := h.conn.Write(p.raw); err != nil {
-			return err
-		}
-		p.buffer.Release()
 	}
+}
+
+func (h *sendQueue) sendPacket(p *packedPacket) error {
+	if len(h.queue) == cap(h.queue)-1 {
+		// If CanSend() indicated to the session that we're blocked, we need to unblock the session.
+		h.mutex.Lock()
+		if h.blocked {
+			select {
+			case h.available <- struct{}{}:
+			default:
+			}
+			h.blocked = false
+		}
+		h.mutex.Unlock()
+	}
+
+	if err := h.conn.Write(p.raw); err != nil {
+		return err
+	}
+	p.buffer.Release()
+	return nil
 }
 
 func (h *sendQueue) Close() {

--- a/send_queue_test.go
+++ b/send_queue_test.go
@@ -9,10 +9,12 @@ import (
 var _ = Describe("Send Queue", func() {
 	var q *sendQueue
 	var c *MockConnection
+	var availableChan <-chan struct{}
 
 	BeforeEach(func() {
 		c = NewMockConnection(mockCtrl)
-		q = newSendQueue(c)
+		q, availableChan = newSendQueue(c)
+		_ = availableChan
 	})
 
 	getPacket := func(b []byte) *packedPacket {
@@ -43,31 +45,55 @@ var _ = Describe("Send Queue", func() {
 		Eventually(done).Should(BeClosed())
 	})
 
-	It("blocks sending when too many packets are queued", func() {
-		q.Send(getPacket([]byte("foobar")))
+	It("says when the send queue is full", func() {
+		for i := 0; i < sendQueueCapacity; i++ {
+			Expect(q.CanSend()).To(BeTrue())
+			q.Send(getPacket([]byte("foobar")))
+		}
+		Expect(q.CanSend()).To(BeFalse())
+	})
 
-		written := make(chan []byte, 2)
-		c.EXPECT().Write(gomock.Any()).Do(func(p []byte) { written <- p }).Times(2)
-
-		sent := make(chan struct{})
-		go func() {
-			defer GinkgoRecover()
-			q.Send(getPacket([]byte("raboof")))
-			close(sent)
-		}()
-
-		Consistently(sent).ShouldNot(BeClosed())
-
+	It("notifies when the send queue frees up", func() {
 		done := make(chan struct{})
 		go func() {
 			defer GinkgoRecover()
+			defer close(done)
 			q.Run()
-			close(done)
 		}()
 
-		Eventually(written).Should(Receive(Equal([]byte("foobar"))))
-		Eventually(written).Should(Receive(Equal([]byte("raboof"))))
+		write := make(chan struct{}, 2)
+		unblockWrite := make(chan struct{})
+		c.EXPECT().Write(gomock.Any()).Do(func([]byte) {
+			write <- struct{}{}
+			<-unblockWrite
+		}).Times(2)
+		// send the first packet and make sure the write call blocks
+		q.Send(getPacket([]byte("foobar")))
+		Eventually(write).Should(HaveLen(1))
+		// now completely fill up the queue
+		for i := 0; i < sendQueueCapacity; i++ {
+			Eventually(q.CanSend()).Should(BeTrue())
+			q.Send(getPacket([]byte("foobar")))
+		}
+		Expect(q.CanSend()).To(BeFalse())
+		Expect(availableChan).ToNot(Receive())
+
+		// make the connection send out one packet
+		unblockWrite <- struct{}{}
+		Eventually(availableChan).Should(Receive())
+		Expect(q.CanSend()).To(BeTrue())
+
+		// make the go routine return
+		c.EXPECT().Write(gomock.Any()).AnyTimes()
+		unblockWrite <- struct{}{}
 		q.Close()
 		Eventually(done).Should(BeClosed())
+	})
+
+	It("panics a packet is enqueued when the queue is already full", func() {
+		for i := 0; i < sendQueueCapacity; i++ {
+			q.Send(getPacket([]byte("foobar")))
+		}
+		Expect(func() { q.Send(getPacket([]byte("foobar"))) }).To(Panic())
 	})
 })


### PR DESCRIPTION
Fixes #2258, which was deleted by Github. Depends on #2293.