### PR TITLE
avoid segfault when closing the client after dialing fails

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -123,6 +123,9 @@ func (c *client) setupSession() error {
 }
 
 func (c *client) Close() error {
+	if c.session == nil {
+		return nil
+	}
 	return c.session.Close()
 }
 

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -140,6 +140,19 @@ var _ = Describe("Client", func() {
 		Expect(err).To(MatchError(testErr))
 	})
 
+	It("Closing the client after dialing fails", func() {
+		testErr := errors.New("dial error")
+		client = newClient("localhost:1337", nil, &roundTripperOpts{}, nil, nil)
+		dialAddr = func(hostname string, _ *tls.Config, _ *quic.Config) (quic.Session, error) {
+			return nil, testErr
+		}
+		defer GinkgoRecover()
+		_, err := client.RoundTrip(req)
+		Expect(err).To(MatchError(testErr))
+		err = client.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	Context("Doing requests", func() {
 		var (
 			request *http.Request


### PR DESCRIPTION
Make it safe to call `defer client.Close()` just after creating the
client.