### PR TITLE
rename packetHandlerMap.Close() to Destroy()

### DIFF
--- a/client.go
+++ b/client.go
@@ -287,7 +287,7 @@ func (c *client) establishSecureConnection(ctx context.Context) error {
 	go func() {
 		err := c.session.run() // returns as soon as the session is closed
 		if err != errCloseForRecreating && c.createdPacketConn {
-			c.packetHandlers.Close()
+			c.packetHandlers.Destroy()
 		}
 		errorChan <- err
 	}()

--- a/client_test.go
+++ b/client_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Client", func() {
 
 			manager := NewMockPacketHandlerManager(mockCtrl)
 			manager.EXPECT().Add(gomock.Any(), gomock.Any())
-			manager.EXPECT().Close()
+			manager.EXPECT().Destroy()
 			mockMultiplexer.EXPECT().AddConn(gomock.Any(), gomock.Any(), gomock.Any()).Return(manager, nil)
 
 			remoteAddrChan := make(chan string, 1)
@@ -159,7 +159,7 @@ var _ = Describe("Client", func() {
 		It("uses the tls.Config.ServerName as the hostname, if present", func() {
 			manager := NewMockPacketHandlerManager(mockCtrl)
 			manager.EXPECT().Add(gomock.Any(), gomock.Any())
-			manager.EXPECT().Close()
+			manager.EXPECT().Destroy()
 			mockMultiplexer.EXPECT().AddConn(gomock.Any(), gomock.Any(), gomock.Any()).Return(manager, nil)
 
 			hostnameChan := make(chan string, 1)
@@ -440,7 +440,7 @@ var _ = Describe("Client", func() {
 			// check that the connection is not closed
 			Expect(conn.Write([]byte("foobar"))).To(Succeed())
 
-			manager.EXPECT().Close()
+			manager.EXPECT().Destroy()
 			close(run)
 			time.Sleep(50 * time.Millisecond)
 

--- a/mock_packet_handler_manager_test.go
+++ b/mock_packet_handler_manager_test.go
@@ -74,20 +74,6 @@ func (mr *MockPacketHandlerManagerMockRecorder) AddResetToken(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddResetToken", reflect.TypeOf((*MockPacketHandlerManager)(nil).AddResetToken), arg0, arg1)
 }
 
-// Close mocks base method
-func (m *MockPacketHandlerManager) Close() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Close indicates an expected call of Close
-func (mr *MockPacketHandlerManagerMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockPacketHandlerManager)(nil).Close))
-}
-
 // CloseServer mocks base method
 func (m *MockPacketHandlerManager) CloseServer() {
 	m.ctrl.T.Helper()
@@ -98,6 +84,20 @@ func (m *MockPacketHandlerManager) CloseServer() {
 func (mr *MockPacketHandlerManagerMockRecorder) CloseServer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseServer", reflect.TypeOf((*MockPacketHandlerManager)(nil).CloseServer))
+}
+
+// Destroy mocks base method
+func (m *MockPacketHandlerManager) Destroy() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Destroy")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Destroy indicates an expected call of Destroy
+func (mr *MockPacketHandlerManagerMockRecorder) Destroy() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockPacketHandlerManager)(nil).Destroy))
 }
 
 // GetStatelessResetToken mocks base method

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -185,8 +185,9 @@ func (h *packetHandlerMap) CloseServer() {
 	wg.Wait()
 }
 
-// Close the underlying connection and wait until listen() has returned.
-func (h *packetHandlerMap) Close() error {
+// Destroy the underlying connection and wait until listen() has returned.
+// It does not close active sessions.
+func (h *packetHandlerMap) Destroy() error {
 	if err := h.conn.Close(); err != nil {
 		return err
 	}

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Packet Handler Map", func() {
 		}
 		handler.server = nil
 		handler.mutex.Unlock()
-		handler.Close()
+		handler.Destroy()
 		Eventually(handler.listening).Should(BeClosed())
 	})
 

--- a/server.go
+++ b/server.go
@@ -33,7 +33,7 @@ type unknownPacketHandler interface {
 }
 
 type packetHandlerManager interface {
-	io.Closer
+	Destroy() error
 	SetServer(unknownPacketHandler)
 	CloseServer()
 	sessionRunner
@@ -305,7 +305,7 @@ func (s *baseServer) Close() error {
 	// If the server was started with ListenAddr, we created the packet conn.
 	// We need to close it in order to make the go routine reading from that conn return.
 	if s.createdPacketConn {
-		err = s.sessionHandler.Close()
+		err = s.sessionHandler.Destroy()
 	}
 	s.closed = true
 	close(s.errorChan)


### PR DESCRIPTION
`Destroy()` captures better what's going on: We're closing the connection, without closing any sessions that might be still be running on top.
In practice, we only use `Destroy()` when quic-go created the packet conn, and after all session have already been closed.