### PR TITLE
remove Session.Close()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## v0.15.0 (unreleased)
 
 - Add support for 0-RTT.
+- Remove `Session.Close()`. Applications need to pass an application error code to the transport using `Session.CloseWithError()`.
 
 ## v0.14.0 (2019-12-04)
 

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Benchmarks", func() {
 				b.RecordValue("transfer rate [MB/s]", float64(dataLen)/1e6/runtime.Seconds())
 
 				ln.Close()
-				sess.Close()
+				sess.CloseWithError(0, "")
 			}, 3)
 		})
 	}

--- a/client.go
+++ b/client.go
@@ -301,8 +301,7 @@ func (c *client) establishSecureConnection(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
-		// The session will send a PeerGoingAway error to the server.
-		c.session.Close()
+		c.session.shutdown()
 		return ctx.Err()
 	case err := <-errorChan:
 		return err
@@ -373,13 +372,13 @@ func (c *client) handleVersionNegotiationPacket(p *receivedPacket) {
 	c.initialPacketNumber = c.session.closeForRecreating()
 }
 
-func (c *client) Close() error {
+func (c *client) shutdown() {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	if c.session == nil {
-		return nil
+		return
 	}
-	return c.session.Close()
+	c.session.shutdown()
 }
 
 func (c *client) destroy(e error) {

--- a/client_test.go
+++ b/client_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Client", func() {
 
 	AfterEach(func() {
 		if s, ok := cl.session.(*session); ok {
-			s.Close()
+			s.shutdown()
 		}
 		Eventually(areSessionsRunning).Should(BeFalse())
 	})
@@ -387,7 +387,7 @@ var _ = Describe("Client", func() {
 				close(dialed)
 			}()
 			Consistently(dialed).ShouldNot(BeClosed())
-			sess.EXPECT().Close()
+			sess.EXPECT().shutdown()
 			cancel()
 			Eventually(dialed).Should(BeClosed())
 		})

--- a/closed_session.go
+++ b/closed_session.go
@@ -79,9 +79,8 @@ func (s *closedLocalSession) handlePacketImpl(_ *receivedPacket) {
 	}
 }
 
-func (s *closedLocalSession) Close() error {
+func (s *closedLocalSession) shutdown() {
 	s.destroy(nil)
-	return nil
 }
 
 func (s *closedLocalSession) destroy(error) {
@@ -108,6 +107,6 @@ func newClosedRemoteSession(pers protocol.Perspective) packetHandler {
 }
 
 func (s *closedRemoteSession) handlePacket(*receivedPacket)         {}
-func (s *closedRemoteSession) Close() error                         { return nil }
+func (s *closedRemoteSession) shutdown()                            {}
 func (s *closedRemoteSession) destroy(error)                        {}
 func (s *closedRemoteSession) getPerspective() protocol.Perspective { return s.perspective }

--- a/closed_session_test.go
+++ b/closed_session_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Closed local session", func() {
 	It("tells its perspective", func() {
 		Expect(sess.getPerspective()).To(Equal(protocol.PerspectiveClient))
 		// stop the session
-		Expect(sess.Close()).To(Succeed())
+		sess.shutdown()
 	})
 
 	It("repeats the packet containing the CONNECTION_CLOSE frame", func() {
@@ -45,7 +45,7 @@ var _ = Describe("Closed local session", func() {
 			}
 		}
 		// stop the session
-		Expect(sess.Close()).To(Succeed())
+		sess.shutdown()
 	})
 
 	It("destroys sessions", func() {

--- a/http3/client.go
+++ b/http3/client.go
@@ -123,7 +123,7 @@ func (c *client) setupSession() error {
 }
 
 func (c *client) Close() error {
-	return c.session.Close()
+	return c.session.CloseWithError(quic.ErrorCode(errorNoError), "")
 }
 
 func (c *client) maxHeaderBytes() uint64 {

--- a/integrationtests/self/cancelation_test.go
+++ b/integrationtests/self/cancelation_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Stream Cancelations", func() {
 
 			var serverCanceledCounter int32
 			Eventually(serverCanceledCounterChan).Should(Receive(&serverCanceledCounter))
-			Expect(sess.Close()).To(Succeed())
+			Expect(sess.CloseWithError(0, "")).To(Succeed())
 
 			clientCanceledCounter := atomic.LoadInt32(&canceledCounter)
 			// The server will only count a stream as being reset if learns about the cancelation before it finished writing all data.
@@ -141,7 +141,7 @@ var _ = Describe("Stream Cancelations", func() {
 
 			var serverCanceledCounter int32
 			Eventually(serverCanceledCounterChan).Should(Receive(&serverCanceledCounter))
-			Expect(sess.Close()).To(Succeed())
+			Expect(sess.CloseWithError(0, "")).To(Succeed())
 
 			clientCanceledCounter := atomic.LoadInt32(&canceledCounter)
 			// The server will only count a stream as being reset if learns about the cancelation before it finished writing all data.
@@ -185,7 +185,7 @@ var _ = Describe("Stream Cancelations", func() {
 			fmt.Fprintf(GinkgoWriter, "Canceled writing on %d of %d streams\n", streamCount, numStreams)
 			Expect(streamCount).To(BeNumerically(">", numStreams/10))
 			Expect(numStreams - streamCount).To(BeNumerically(">", numStreams/10))
-			Expect(sess.Close()).To(Succeed())
+			Expect(sess.CloseWithError(0, "")).To(Succeed())
 			Expect(server.Close()).To(Succeed())
 			return streamCount
 		}
@@ -326,7 +326,7 @@ var _ = Describe("Stream Cancelations", func() {
 			Expect(count).To(BeNumerically(">", numStreams/15))
 			fmt.Fprintf(GinkgoWriter, "Successfully read from %d of %d streams.\n", count, numStreams)
 
-			Expect(sess.Close()).To(Succeed())
+			Expect(sess.CloseWithError(0, "")).To(Succeed())
 			Eventually(done).Should(BeClosed())
 			Expect(server.Close()).To(Succeed())
 		})
@@ -414,7 +414,7 @@ var _ = Describe("Stream Cancelations", func() {
 			Expect(count).To(BeNumerically(">", numStreams/15))
 			fmt.Fprintf(GinkgoWriter, "Successfully read from %d of %d streams.\n", count, numStreams)
 
-			Expect(sess.Close()).To(Succeed())
+			Expect(sess.CloseWithError(0, "")).To(Succeed())
 			Eventually(done).Should(BeClosed())
 			Expect(server.Close()).To(Succeed())
 		})
@@ -484,7 +484,7 @@ var _ = Describe("Stream Cancelations", func() {
 			count := atomic.LoadInt32(&counter)
 			fmt.Fprintf(GinkgoWriter, "Canceled AcceptStream %d times\n", count)
 			Expect(count).To(BeNumerically(">", numStreams/2))
-			Expect(sess.Close()).To(Succeed())
+			Expect(sess.CloseWithError(0, "")).To(Succeed())
 			Expect(server.Close()).To(Succeed())
 		})
 
@@ -555,7 +555,7 @@ var _ = Describe("Stream Cancelations", func() {
 			count := atomic.LoadInt32(&numCanceled)
 			fmt.Fprintf(GinkgoWriter, "Canceled OpenStreamSync %d times\n", count)
 			Expect(count).To(BeNumerically(">", numStreams/5))
-			Expect(sess.Close()).To(Succeed())
+			Expect(sess.CloseWithError(0, "")).To(Succeed())
 			Expect(server.Close()).To(Succeed())
 		})
 	})

--- a/integrationtests/self/conn_id_test.go
+++ b/integrationtests/self/conn_id_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Connection ID lengths tests", func() {
 			conf,
 		)
 		Expect(err).ToNot(HaveOccurred())
-		defer cl.Close()
+		defer cl.CloseWithError(0, "")
 		str, err := cl.AcceptStream(context.Background())
 		Expect(err).ToNot(HaveOccurred())
 		data, err := ioutil.ReadAll(str)

--- a/integrationtests/self/drop_test.go
+++ b/integrationtests/self/drop_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Drop Tests", func() {
 								time.Sleep(messageInterval)
 							}
 							<-done
-							Expect(sess.Close()).To(Succeed())
+							Expect(sess.CloseWithError(0, "")).To(Succeed())
 						}()
 
 						sess, err := quic.DialAddr(
@@ -109,7 +109,7 @@ var _ = Describe("Drop Tests", func() {
 							&quic.Config{Versions: []protocol.VersionNumber{version}},
 						)
 						Expect(err).ToNot(HaveOccurred())
-						defer sess.Close()
+						defer sess.CloseWithError(0, "")
 						str, err := sess.AcceptStream(context.Background())
 						Expect(err).ToNot(HaveOccurred())
 						for i := uint8(1); i <= numMessages; i++ {

--- a/integrationtests/self/early_data_test.go
+++ b/integrationtests/self/early_data_test.go
@@ -64,7 +64,7 @@ var _ = Describe("early data", func() {
 				data, err := ioutil.ReadAll(str)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(data).To(Equal([]byte("early data")))
-				sess.Close()
+				sess.CloseWithError(0, "")
 				Eventually(done).Should(BeClosed())
 			})
 		})

--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Handshake drop tests", func() {
 				defer GinkgoRecover()
 				sess, err := ln.Accept(context.Background())
 				Expect(err).ToNot(HaveOccurred())
-				defer sess.Close()
+				defer sess.CloseWithError(0, "")
 				str, err := sess.AcceptStream(context.Background())
 				Expect(err).ToNot(HaveOccurred())
 				b := make([]byte, 6)
@@ -93,8 +93,8 @@ var _ = Describe("Handshake drop tests", func() {
 
 			var serverSession quic.Session
 			Eventually(serverSessionChan, timeout).Should(Receive(&serverSession))
-			sess.Close()
-			serverSession.Close()
+			sess.CloseWithError(0, "")
+			serverSession.CloseWithError(0, "")
 		},
 	}
 
@@ -131,8 +131,8 @@ var _ = Describe("Handshake drop tests", func() {
 
 			var serverSession quic.Session
 			Eventually(serverSessionChan, timeout).Should(Receive(&serverSession))
-			sess.Close()
-			serverSession.Close()
+			sess.CloseWithError(0, "")
+			serverSession.CloseWithError(0, "")
 		},
 	}
 
@@ -159,8 +159,8 @@ var _ = Describe("Handshake drop tests", func() {
 			var serverSession quic.Session
 			Eventually(serverSessionChan, timeout).Should(Receive(&serverSession))
 			// both server and client accepted a session. Close now.
-			sess.Close()
-			serverSession.Close()
+			sess.CloseWithError(0, "")
+			serverSession.CloseWithError(0, "")
 		},
 	}
 

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Handshake tests", func() {
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(sess.(versioner).GetVersion()).To(Equal(protocol.SupportedVersions[0]))
-				Expect(sess.Close()).To(Succeed())
+				Expect(sess.CloseWithError(0, "")).To(Succeed())
 			})
 
 			It("when the client supports more versions than the server supports", func() {
@@ -130,7 +130,7 @@ var _ = Describe("Handshake tests", func() {
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(sess.(versioner).GetVersion()).To(Equal(protocol.SupportedVersions[0]))
-				Expect(sess.Close()).To(Succeed())
+				Expect(sess.CloseWithError(0, "")).To(Succeed())
 			})
 		})
 	}
@@ -254,7 +254,7 @@ var _ = Describe("Handshake tests", func() {
 			for i := 0; i < protocol.MaxAcceptQueueSize; i++ {
 				sess, err := dial()
 				Expect(err).ToNot(HaveOccurred())
-				defer sess.Close()
+				defer sess.CloseWithError(0, "")
 			}
 			time.Sleep(25 * time.Millisecond) // wait a bit for the sessions to be queued
 
@@ -268,7 +268,7 @@ var _ = Describe("Handshake tests", func() {
 			// dial again, and expect that this dial succeeds
 			sess, err := dial()
 			Expect(err).ToNot(HaveOccurred())
-			defer sess.Close()
+			defer sess.CloseWithError(0, "")
 			time.Sleep(25 * time.Millisecond) // wait a bit for the session to be queued
 
 			_, err = dial()
@@ -283,7 +283,7 @@ var _ = Describe("Handshake tests", func() {
 			for i := 1; i < protocol.MaxAcceptQueueSize; i++ {
 				sess, err := dial()
 				Expect(err).ToNot(HaveOccurred())
-				defer sess.Close()
+				defer sess.CloseWithError(0, "")
 			}
 			time.Sleep(25 * time.Millisecond) // wait a bit for the sessions to be queued
 
@@ -293,7 +293,7 @@ var _ = Describe("Handshake tests", func() {
 
 			// Now close the one of the session that are waiting to be accepted.
 			// This should free one spot in the queue.
-			Expect(firstSess.Close())
+			Expect(firstSess.CloseWithError(0, ""))
 			time.Sleep(25 * time.Millisecond)
 
 			// dial again, and expect that this dial succeeds
@@ -330,7 +330,7 @@ var _ = Describe("Handshake tests", func() {
 				nil,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			defer sess.Close()
+			defer sess.CloseWithError(0, "")
 			cs := sess.ConnectionState()
 			Expect(cs.NegotiatedProtocol).To(Equal(alpn))
 			Expect(cs.NegotiatedProtocolIsMutual).To(BeTrue())
@@ -389,7 +389,7 @@ var _ = Describe("Handshake tests", func() {
 			Eventually(puts).Should(Receive())
 			Expect(tokenChan).ToNot(Receive())
 			// received a token. Close this session.
-			Expect(sess.Close()).To(Succeed())
+			Expect(sess.CloseWithError(0, "")).To(Succeed())
 
 			// dial the second session and verify that the token was used
 			done := make(chan struct{})
@@ -405,7 +405,7 @@ var _ = Describe("Handshake tests", func() {
 				quicConf,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			defer sess.Close()
+			defer sess.CloseWithError(0, "")
 			Expect(gets).To(Receive())
 			Expect(tokenChan).To(Receive())
 

--- a/integrationtests/self/key_update_test.go
+++ b/integrationtests/self/key_update_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Key Update tests", func() {
 			nil,
 		)
 		Expect(err).ToNot(HaveOccurred())
-		defer sess.Close()
+		defer sess.CloseWithError(0, "")
 		str, err := sess.AcceptUniStream(context.Background())
 		Expect(err).ToNot(HaveOccurred())
 		data, err := ioutil.ReadAll(str)

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -139,7 +139,7 @@ var _ = Describe("MITM test", func() {
 						data, err := ioutil.ReadAll(str)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(data).To(Equal(PRData))
-						Expect(sess.Close()).To(Succeed())
+						Expect(sess.CloseWithError(0, "")).To(Succeed())
 					}
 
 					It("downloads a message when the packets are injected towards the server", func() {
@@ -185,7 +185,7 @@ var _ = Describe("MITM test", func() {
 					data, err := ioutil.ReadAll(str)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(data).To(Equal(PRData))
-					Expect(sess.Close()).To(Succeed())
+					Expect(sess.CloseWithError(0, "")).To(Succeed())
 				}
 
 				Context("duplicating packets", func() {

--- a/integrationtests/self/multiplex_test.go
+++ b/integrationtests/self/multiplex_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Multiplexing", func() {
 					&quic.Config{Versions: []protocol.VersionNumber{version}},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				defer sess.Close()
+				defer sess.CloseWithError(0, "")
 				str, err := sess.AcceptStream(context.Background())
 				Expect(err).ToNot(HaveOccurred())
 				data, err := ioutil.ReadAll(str)

--- a/integrationtests/self/rtt_test.go
+++ b/integrationtests/self/rtt_test.go
@@ -72,7 +72,7 @@ var _ = Describe("non-zero RTT", func() {
 					data, err := ioutil.ReadAll(str)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(data).To(Equal(PRData))
-					sess.Close()
+					sess.CloseWithError(0, "")
 					Eventually(done).Should(BeClosed())
 				})
 			}

--- a/integrationtests/self/stream_test.go
+++ b/integrationtests/self/stream_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Bidirectional streams", func() {
 					sess, err := server.Accept(context.Background())
 					Expect(err).ToNot(HaveOccurred())
 					runSendingPeer(sess)
-					sess.Close()
+					sess.CloseWithError(0, "")
 				}()
 
 				client, err := quic.DialAddr(

--- a/integrationtests/self/uni_stream_test.go
+++ b/integrationtests/self/uni_stream_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Unidirectional Streams", func() {
 			sess, err := server.Accept(context.Background())
 			Expect(err).ToNot(HaveOccurred())
 			runReceivingPeer(sess)
-			sess.Close()
+			sess.CloseWithError(0, "")
 		}()
 
 		client, err := quic.DialAddr(

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -64,7 +64,7 @@ var _ = Describe("0-RTT", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(puts).Should(Receive())
 				// received the session ticket. We're done here.
-				Expect(sess.Close()).To(Succeed())
+				Expect(sess.CloseWithError(0, "")).To(Succeed())
 				return clientConf
 			}
 

--- a/interface.go
+++ b/interface.go
@@ -175,8 +175,6 @@ type Session interface {
 	LocalAddr() net.Addr
 	// RemoteAddr returns the address of the peer.
 	RemoteAddr() net.Addr
-	// Close the connection.
-	io.Closer
 	// Close the connection with an error.
 	// The error string will be sent to the peer.
 	CloseWithError(ErrorCode, string) error

--- a/internal/mocks/quic/session.go
+++ b/internal/mocks/quic/session.go
@@ -68,20 +68,6 @@ func (mr *MockSessionMockRecorder) AcceptUniStream(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptUniStream", reflect.TypeOf((*MockSession)(nil).AcceptUniStream), arg0)
 }
 
-// Close mocks base method
-func (m *MockSession) Close() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Close indicates an expected call of Close
-func (mr *MockSessionMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockSession)(nil).Close))
-}
-
 // CloseWithError mocks base method
 func (m *MockSession) CloseWithError(arg0 protocol.ApplicationErrorCode, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/interop/http09/client.go
+++ b/interop/http09/client.go
@@ -116,7 +116,7 @@ func (c *client) Close() error {
 	if c.sess == nil {
 		return nil
 	}
-	return c.sess.Close()
+	return c.sess.CloseWithError(0, "")
 }
 
 func hostnameFromRequest(req *http.Request) string {

--- a/mock_packet_handler_test.go
+++ b/mock_packet_handler_test.go
@@ -34,20 +34,6 @@ func (m *MockPacketHandler) EXPECT() *MockPacketHandlerMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
-func (m *MockPacketHandler) Close() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Close indicates an expected call of Close
-func (mr *MockPacketHandlerMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockPacketHandler)(nil).Close))
-}
-
 // destroy mocks base method
 func (m *MockPacketHandler) destroy(arg0 error) {
 	m.ctrl.T.Helper()
@@ -84,4 +70,16 @@ func (m *MockPacketHandler) handlePacket(arg0 *receivedPacket) {
 func (mr *MockPacketHandlerMockRecorder) handlePacket(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handlePacket", reflect.TypeOf((*MockPacketHandler)(nil).handlePacket), arg0)
+}
+
+// shutdown mocks base method
+func (m *MockPacketHandler) shutdown() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "shutdown")
+}
+
+// shutdown indicates an expected call of shutdown
+func (mr *MockPacketHandlerMockRecorder) shutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "shutdown", reflect.TypeOf((*MockPacketHandler)(nil).shutdown))
 }

--- a/mock_quic_session_test.go
+++ b/mock_quic_session_test.go
@@ -67,20 +67,6 @@ func (mr *MockQuicSessionMockRecorder) AcceptUniStream(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptUniStream", reflect.TypeOf((*MockQuicSession)(nil).AcceptUniStream), arg0)
 }
 
-// Close mocks base method
-func (m *MockQuicSession) Close() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Close indicates an expected call of Close
-func (mr *MockQuicSessionMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockQuicSession)(nil).Close))
-}
-
 // CloseWithError mocks base method
 func (m *MockQuicSession) CloseWithError(arg0 protocol.ApplicationErrorCode, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -317,4 +303,16 @@ func (m *MockQuicSession) run() error {
 func (mr *MockQuicSessionMockRecorder) run() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "run", reflect.TypeOf((*MockQuicSession)(nil).run))
+}
+
+// shutdown mocks base method
+func (m *MockQuicSession) shutdown() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "shutdown")
+}
+
+// shutdown indicates an expected call of shutdown
+func (mr *MockQuicSessionMockRecorder) shutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "shutdown", reflect.TypeOf((*MockQuicSession)(nil).shutdown))
 }

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -135,7 +135,7 @@ func (h *packetHandlerMap) ReplaceWithClosed(id protocol.ConnectionID, handler p
 
 	time.AfterFunc(h.deleteRetiredSessionsAfter, func() {
 		h.mutex.Lock()
-		handler.Close()
+		handler.shutdown()
 		delete(h.handlers, string(id))
 		h.mutex.Unlock()
 	})
@@ -175,8 +175,8 @@ func (h *packetHandlerMap) CloseServer() {
 		if handler.getPerspective() == protocol.PerspectiveServer {
 			wg.Add(1)
 			go func(handler packetHandler) {
-				// session.Close() blocks until the CONNECTION_CLOSE has been sent and the run-loop has stopped
-				_ = handler.Close()
+				// blocks until the CONNECTION_CLOSE has been sent and the run-loop has stopped
+				handler.shutdown()
 				wg.Done()
 			}(handler)
 		}

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -202,7 +202,7 @@ var _ = Describe("Packet Handler Map", func() {
 			clientSess.EXPECT().getPerspective().Return(protocol.PerspectiveClient)
 			serverSess := NewMockPacketHandler(mockCtrl)
 			serverSess.EXPECT().getPerspective().Return(protocol.PerspectiveServer)
-			serverSess.EXPECT().Close()
+			serverSess.EXPECT().shutdown()
 
 			handler.Add(protocol.ConnectionID{1, 1, 1, 1}, clientSess)
 			handler.Add(protocol.ConnectionID{2, 2, 2, 2}, serverSess)

--- a/server.go
+++ b/server.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -22,7 +21,7 @@ import (
 // packetHandler handles packets
 type packetHandler interface {
 	handlePacket(*receivedPacket)
-	io.Closer
+	shutdown()
 	destroy(error)
 	getPerspective() protocol.Perspective
 }
@@ -49,6 +48,7 @@ type quicSession interface {
 	getPerspective() protocol.Perspective
 	run() error
 	destroy(error)
+	shutdown()
 	closeForRecreating() protocol.PacketNumber
 }
 

--- a/session.go
+++ b/session.go
@@ -1063,12 +1063,11 @@ func (s *session) closeRemote(e error) {
 	})
 }
 
-// Close the connection. It sends a qerr.NoError.
+// Close the connection. It sends a NO_ERROR transport error.
 // It waits until the run loop has stopped before returning
-func (s *session) Close() error {
+func (s *session) shutdown() {
 	s.closeLocal(nil)
 	<-s.ctx.Done()
-	return nil
 }
 
 func (s *session) CloseWithError(code protocol.ApplicationErrorCode, desc string) error {

--- a/session_test.go
+++ b/session_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Session", func() {
 		sessionRunner.EXPECT().ReplaceWithClosed(clientDestConnID, gomock.Any()).MaxTimes(1)
 		sessionRunner.EXPECT().ReplaceWithClosed(srcConnID, gomock.Any()).Do(func(_ protocol.ConnectionID, s packetHandler) {
 			Expect(s).To(BeAssignableToTypeOf(&closedLocalSession{}))
-			Expect(s.Close()).To(Succeed())
+			s.shutdown()
 			Eventually(areClosedSessionsRunning).Should(BeFalse())
 		})
 	}
@@ -423,7 +423,7 @@ var _ = Describe("Session", func() {
 				return &packedPacket{raw: []byte("connection close")}, nil
 			})
 			mconn.EXPECT().Write([]byte("connection close"))
-			Expect(sess.Close()).To(Succeed())
+			sess.shutdown()
 			Eventually(areSessionsRunning).Should(BeFalse())
 			Expect(sess.Context().Done()).To(BeClosed())
 		})
@@ -434,8 +434,8 @@ var _ = Describe("Session", func() {
 			cryptoSetup.EXPECT().Close()
 			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)
 			mconn.EXPECT().Write(gomock.Any())
-			Expect(sess.Close()).To(Succeed())
-			Expect(sess.Close()).To(Succeed())
+			sess.shutdown()
+			sess.shutdown()
 			Eventually(areSessionsRunning).Should(BeFalse())
 			Expect(sess.Context().Done()).To(BeClosed())
 		})
@@ -527,7 +527,7 @@ var _ = Describe("Session", func() {
 			}()
 			Consistently(returned).ShouldNot(BeClosed())
 			mconn.EXPECT().Write(gomock.Any())
-			sess.Close()
+			sess.shutdown()
 			Eventually(returned).Should(BeClosed())
 		})
 	})
@@ -666,7 +666,7 @@ var _ = Describe("Session", func() {
 			Consistently(runErr).ShouldNot(Receive())
 			// make the go routine return
 			mconn.EXPECT().Write(gomock.Any())
-			sess.Close()
+			sess.shutdown()
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 
@@ -877,7 +877,7 @@ var _ = Describe("Session", func() {
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
-			sess.Close()
+			sess.shutdown()
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 
@@ -1004,7 +1004,7 @@ var _ = Describe("Session", func() {
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
-			Expect(sess.Close()).To(Succeed())
+			sess.shutdown()
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 
@@ -1118,7 +1118,7 @@ var _ = Describe("Session", func() {
 			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
-			sess.Close()
+			sess.shutdown()
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 
@@ -1206,7 +1206,7 @@ var _ = Describe("Session", func() {
 		packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
-		Expect(sess.Close()).To(Succeed())
+		sess.shutdown()
 		Eventually(sess.Context().Done()).Should(BeClosed())
 	})
 
@@ -1259,7 +1259,7 @@ var _ = Describe("Session", func() {
 		packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
-		Expect(sess.Close()).To(Succeed())
+		sess.shutdown()
 		Eventually(sess.Context().Done()).Should(BeClosed())
 	})
 
@@ -1276,7 +1276,7 @@ var _ = Describe("Session", func() {
 		packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
-		Expect(sess.Close()).To(Succeed())
+		sess.shutdown()
 		Eventually(done).Should(BeClosed())
 	})
 
@@ -1326,12 +1326,12 @@ var _ = Describe("Session", func() {
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			sessionRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any()).Do(func(_ protocol.ConnectionID, s packetHandler) {
 				Expect(s).To(BeAssignableToTypeOf(&closedLocalSession{}))
-				Expect(s.Close()).To(Succeed())
+				s.shutdown()
 			}).Times(4) // initial connection ID + initial client dest conn ID + 2 newly issued conn IDs
 			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
-			Expect(sess.Close()).To(Succeed())
+			sess.shutdown()
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 	})
@@ -1363,7 +1363,7 @@ var _ = Describe("Session", func() {
 			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil)
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
-			Expect(sess.Close()).To(Succeed())
+			sess.shutdown()
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 
@@ -1477,7 +1477,7 @@ var _ = Describe("Session", func() {
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
-			Expect(sess.Close()).To(Succeed())
+			sess.shutdown()
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 
@@ -1521,7 +1521,7 @@ var _ = Describe("Session", func() {
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
-			sess.Close()
+			sess.shutdown()
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 	})
@@ -1625,7 +1625,7 @@ var _ = Describe("Client Session", func() {
 
 	expectReplaceWithClosed := func() {
 		sessionRunner.EXPECT().ReplaceWithClosed(srcConnID, gomock.Any()).Do(func(_ protocol.ConnectionID, s packetHandler) {
-			Expect(s.Close()).To(Succeed())
+			s.shutdown()
 			Eventually(areClosedSessionsRunning).Should(BeFalse())
 		})
 	}
@@ -1695,7 +1695,7 @@ var _ = Describe("Client Session", func() {
 		expectReplaceWithClosed()
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
-		Expect(sess.Close()).To(Succeed())
+		sess.shutdown()
 		Eventually(sess.Context().Done()).Should(BeClosed())
 	})
 
@@ -1814,7 +1814,7 @@ var _ = Describe("Client Session", func() {
 			if !closed {
 				sessionRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any()).Do(func(_ protocol.ConnectionID, s packetHandler) {
 					Expect(s).To(BeAssignableToTypeOf(&closedLocalSession{}))
-					Expect(s.Close()).To(Succeed())
+					s.shutdown()
 				})
 				packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&packedPacket{}, nil).MaxTimes(1)
 				cryptoSetup.EXPECT().Close()
@@ -1825,7 +1825,7 @@ var _ = Describe("Client Session", func() {
 
 		AfterEach(func() {
 			expectClose()
-			sess.Close()
+			sess.shutdown()
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 


### PR DESCRIPTION
This might be controversial.

But this method doesn't really make sense: `Session.Close()` sends a transport-level error code. Applications should not be able to call this function, but use `CloseWithError()` instead, and specify an application-level error code.