### PR TITLE
handle rejection of 0-RTT, expose 0-RTT information in the ConnectionState

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/protobuf v1.3.0
 	github.com/marten-seemann/chacha20 v0.2.0
 	github.com/marten-seemann/qpack v0.1.0
-	github.com/marten-seemann/qtls v0.5.0
+	github.com/marten-seemann/qtls v0.6.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/marten-seemann/chacha20 v0.2.0 h1:f40vqzzx+3GdOmzQoItkLX5WLvHgPgyYqFF
 github.com/marten-seemann/chacha20 v0.2.0/go.mod h1:HSdjFau7GzYRj+ahFNwsO3ouVJr1HFkWoEwNDb4TMtE=
 github.com/marten-seemann/qpack v0.1.0 h1:/0M7lkda/6mus9B8u34Asqm8ZhHAAt9Ho0vniNuVSVg=
 github.com/marten-seemann/qpack v0.1.0/go.mod h1:LFt1NU/Ptjip0C2CPkhimBz5CGE3WGDAUWqna+CNTrI=
-github.com/marten-seemann/qtls v0.5.0 h1:psje4bHl6372lku0pTIt2PZ9HcVJyBIuW9pZn+u2vhY=
-github.com/marten-seemann/qtls v0.5.0/go.mod h1:pxVXcHHw1pNIt8Qo0pwSYQEoZ8yYOOPXTCZLQQunvRc=
+github.com/marten-seemann/qtls v0.6.0 h1:iCN+BD2aSP23uY5Gb3COVlQeOIWmKTOgD2FPIE2KjQ4=
+github.com/marten-seemann/qtls v0.6.0/go.mod h1:pxVXcHHw1pNIt8Qo0pwSYQEoZ8yYOOPXTCZLQQunvRc=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -68,7 +68,13 @@ var _ = Describe("0-RTT", func() {
 				return clientConf
 			}
 
-			transfer0RTTData := func(ln quic.EarlyListener, proxyPort int, clientConf *tls.Config, testdata []byte) {
+			transfer0RTTData := func(
+				ln quic.EarlyListener,
+				proxyPort int,
+				clientConf *tls.Config,
+				testdata []byte, // data to transfer
+				expect0RTT bool, // do we expect that 0-RTT is actually used
+			) {
 				// now dial the second session, and use 0-RTT to send some data
 				done := make(chan struct{})
 				go func() {
@@ -80,6 +86,7 @@ var _ = Describe("0-RTT", func() {
 					data, err := ioutil.ReadAll(str)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(data).To(Equal(testdata))
+					Expect(sess.ConnectionState().Used0RTT).To(Equal(expect0RTT))
 					close(done)
 				}()
 
@@ -94,6 +101,7 @@ var _ = Describe("0-RTT", func() {
 				_, err = str.Write(testdata)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(str.Close()).To(Succeed())
+				Expect(sess.ConnectionState().Used0RTT).To(Equal(expect0RTT))
 				Eventually(done).Should(BeClosed())
 			}
 
@@ -113,7 +121,7 @@ var _ = Describe("0-RTT", func() {
 				defer proxy.Close()
 
 				clientConf := dialAndReceiveSessionTicket(ln, proxy.LocalPort())
-				transfer0RTTData(ln, proxy.LocalPort(), clientConf, PRData)
+				transfer0RTTData(ln, proxy.LocalPort(), clientConf, PRData, true)
 
 				num0RTT := atomic.LoadUint32(num0RTTPackets)
 				fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
@@ -239,7 +247,7 @@ var _ = Describe("0-RTT", func() {
 				defer proxy.Close()
 
 				clientConf := dialAndReceiveSessionTicket(ln, proxy.LocalPort())
-				transfer0RTTData(ln, proxy.LocalPort(), clientConf, PRData)
+				transfer0RTTData(ln, proxy.LocalPort(), clientConf, PRData, true)
 
 				num0RTT := atomic.LoadUint32(&num0RTTPackets)
 				numDropped := atomic.LoadUint32(&num0RTTDropped)
@@ -293,12 +301,49 @@ var _ = Describe("0-RTT", func() {
 				defer proxy.Close()
 
 				clientConf := dialAndReceiveSessionTicket(ln, proxy.LocalPort())
-				transfer0RTTData(ln, proxy.LocalPort(), clientConf, GeneratePRData(5*1100)) // ~5 packets
+				transfer0RTTData(ln, proxy.LocalPort(), clientConf, GeneratePRData(5*1100), true) // ~5 packets
 
 				mutex.Lock()
 				defer mutex.Unlock()
 				Expect(firstCounter).To(BeNumerically("~", 5, 1)) // the FIN bit might be sent extra
 				Expect(secondCounter).To(Equal(firstCounter))
+			})
+
+			It("rejects 0-RTT when the server's transport parameters changed", func() {
+				const maxStreams = 42
+				ln, err := quic.ListenAddrEarly(
+					"localhost:0",
+					getTLSConfig(),
+					&quic.Config{
+						Versions:           []protocol.VersionNumber{version},
+						AcceptToken:        func(_ net.Addr, _ *quic.Token) bool { return true },
+						MaxIncomingStreams: maxStreams,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				clientConf := dialAndReceiveSessionTicket(ln, ln.Addr().(*net.UDPAddr).Port)
+
+				// now close the listener and restart it with a different config
+				Expect(ln.Close()).To(Succeed())
+				ln, err = quic.ListenAddrEarly(
+					"localhost:0",
+					getTLSConfig(),
+					&quic.Config{
+						Versions:           []protocol.VersionNumber{version},
+						AcceptToken:        func(_ net.Addr, _ *quic.Token) bool { return true },
+						MaxIncomingStreams: maxStreams + 1,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				proxy, num0RTTPackets := runCountingProxy(ln.Addr().(*net.UDPAddr).Port)
+				defer proxy.Close()
+				transfer0RTTData(ln, proxy.LocalPort(), clientConf, PRData, false)
+
+				// The client should send 0-RTT packets, but the server doesn't process them.
+				num0RTT := atomic.LoadUint32(num0RTTPackets)
+				fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
+				Expect(num0RTT).ToNot(BeZero())
 			})
 		})
 	}

--- a/interface.go
+++ b/interface.go
@@ -2,11 +2,11 @@ package quic
 
 import (
 	"context"
-	"crypto/tls"
 	"io"
 	"net"
 	"time"
 
+	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/quictrace"
 )
@@ -139,6 +139,8 @@ type StreamError interface {
 	ErrorCode() ErrorCode
 }
 
+type ConnectionState = handshake.ConnectionState
+
 // A Session is a QUIC connection between two peers.
 type Session interface {
 	// AcceptStream returns the next stream opened by the peer, blocking until one is available.
@@ -182,8 +184,9 @@ type Session interface {
 	// Warning: This API should not be considered stable and might change soon.
 	Context() context.Context
 	// ConnectionState returns basic details about the QUIC connection.
+	// It blocks until the handshake completes.
 	// Warning: This API should not be considered stable and might change soon.
-	ConnectionState() tls.ConnectionState
+	ConnectionState() ConnectionState
 }
 
 // An EarlySession is a session that is handshaking.

--- a/internal/ackhandler/received_packet_handler.go
+++ b/internal/ackhandler/received_packet_handler.go
@@ -93,6 +93,9 @@ func (h *receivedPacketHandler) DropPackets(encLevel protocol.EncryptionLevel) {
 		h.initialPackets = nil
 	case protocol.EncryptionHandshake:
 		h.handshakePackets = nil
+	case protocol.Encryption0RTT:
+		// Nothing to do here.
+		// If we are rejecting 0-RTT, no 0-RTT packets will have been decrypted.
 	default:
 		panic(fmt.Sprintf("Cannot drop keys for encryption level %s", encLevel))
 	}

--- a/internal/ackhandler/received_packet_handler_test.go
+++ b/internal/ackhandler/received_packet_handler_test.go
@@ -91,4 +91,8 @@ var _ = Describe("Received Packet Handler", func() {
 		Expect(handler.GetAckFrame(protocol.EncryptionHandshake)).To(BeNil())
 		Expect(handler.GetAckFrame(protocol.Encryption1RTT)).ToNot(BeNil())
 	})
+
+	It("does nothing when droping 0-RTT packets", func() {
+		handler.DropPackets(protocol.Encryption0RTT)
+	})
 })

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net"
 	"sync"
-	"unsafe"
 
 	"github.com/lucas-clemente/quic-go/internal/congestion"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
@@ -782,12 +781,6 @@ func (h *cryptoSetup) Get1RTTOpener() (ShortHeaderOpener, error) {
 	return h.aead, nil
 }
 
-func (h *cryptoSetup) ConnectionState() tls.ConnectionState {
-	cs := h.conn.ConnectionState()
-	// h.conn is a qtls.Conn, which returns a qtls.ConnectionState.
-	// qtls.ConnectionState is identical to the tls.ConnectionState.
-	// It contains an unexported field which is used ExportKeyingMaterial().
-	// The only way to return a tls.ConnectionState is to use unsafe.
-	// In unsafe.go we check that the two objects are actually identical.
-	return *(*tls.ConnectionState)(unsafe.Pointer(&cs))
+func (h *cryptoSetup) ConnectionState() ConnectionState {
+	return h.conn.ConnectionState()
 }

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -1,7 +1,6 @@
 package handshake
 
 import (
-	"crypto/tls"
 	"errors"
 	"io"
 	"time"
@@ -21,6 +20,9 @@ var (
 	// ErrDecryptionFailed is returned when the AEAD fails to open the packet.
 	ErrDecryptionFailed = errors.New("decryption failed")
 )
+
+// ConnectionState contains information about the state of the connection.
+type ConnectionState = qtls.ConnectionState
 
 type headerDecryptor interface {
 	DecryptHeader(sample []byte, firstByte *byte, pnBytes []byte)
@@ -74,7 +76,7 @@ type CryptoSetup interface {
 	HandleMessage([]byte, protocol.EncryptionLevel) bool
 	SetLargest1RTTAcked(protocol.PacketNumber)
 	DropHandshakeKeys()
-	ConnectionState() tls.ConnectionState
+	ConnectionState() ConnectionState
 
 	GetInitialOpener() (LongHeaderOpener, error)
 	GetHandshakeOpener() (LongHeaderOpener, error)

--- a/internal/handshake/qtls.go
+++ b/internal/handshake/qtls.go
@@ -34,6 +34,7 @@ func tlsConfigToQtlsConfig(
 	getDataForSessionState func() []byte,
 	setDataFromSessionState func([]byte),
 	accept0RTT func([]byte) bool,
+	rejected0RTT func(),
 	enable0RTT bool,
 ) *qtls.Config {
 	if c == nil {
@@ -61,7 +62,7 @@ func tlsConfigToQtlsConfig(
 			if tlsConf == nil {
 				return nil, nil
 			}
-			return tlsConfigToQtlsConfig(tlsConf, recordLayer, extHandler, getDataForSessionState, setDataFromSessionState, accept0RTT, enable0RTT), nil
+			return tlsConfigToQtlsConfig(tlsConf, recordLayer, extHandler, getDataForSessionState, setDataFromSessionState, accept0RTT, rejected0RTT, enable0RTT), nil
 		}
 	}
 	var csc qtls.ClientSessionCache
@@ -99,6 +100,7 @@ func tlsConfigToQtlsConfig(
 		GetExtensions:          extHandler.GetExtensions,
 		ReceivedExtensions:     extHandler.ReceivedExtensions,
 		Accept0RTT:             accept0RTT,
+		Rejected0RTT:           rejected0RTT,
 	}
 	if enable0RTT {
 		conf.Enable0RTT = true

--- a/internal/handshake/unsafe.go
+++ b/internal/handshake/unsafe.go
@@ -13,9 +13,6 @@ import (
 )
 
 func init() {
-	if !structsEqual(&tls.ConnectionState{}, &qtls.ConnectionState{}) {
-		panic("qtls.ConnectionState not compatible with tls.ConnectionState")
-	}
 	if !structsEqual(&tls.ClientSessionState{}, &qtls.ClientSessionState{}) {
 		panic("qtls.ClientSessionState not compatible with tls.ClientSessionState")
 	}

--- a/internal/mocks/crypto_setup.go
+++ b/internal/mocks/crypto_setup.go
@@ -5,12 +5,12 @@
 package mocks
 
 import (
-	tls "crypto/tls"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	handshake "github.com/lucas-clemente/quic-go/internal/handshake"
 	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
+	qtls "github.com/marten-seemann/qtls"
 )
 
 // MockCryptoSetup is a mock of CryptoSetup interface
@@ -63,10 +63,10 @@ func (mr *MockCryptoSetupMockRecorder) Close() *gomock.Call {
 }
 
 // ConnectionState mocks base method
-func (m *MockCryptoSetup) ConnectionState() tls.ConnectionState {
+func (m *MockCryptoSetup) ConnectionState() qtls.ConnectionState {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectionState")
-	ret0, _ := ret[0].(tls.ConnectionState)
+	ret0, _ := ret[0].(qtls.ConnectionState)
 	return ret0
 }
 

--- a/internal/mocks/quic/early_session.go
+++ b/internal/mocks/quic/early_session.go
@@ -6,13 +6,13 @@ package mockquic
 
 import (
 	context "context"
-	tls "crypto/tls"
 	net "net"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	quic "github.com/lucas-clemente/quic-go"
 	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
+	qtls "github.com/marten-seemann/qtls"
 )
 
 // MockEarlySession is a mock of EarlySession interface
@@ -83,10 +83,10 @@ func (mr *MockEarlySessionMockRecorder) CloseWithError(arg0, arg1 interface{}) *
 }
 
 // ConnectionState mocks base method
-func (m *MockEarlySession) ConnectionState() tls.ConnectionState {
+func (m *MockEarlySession) ConnectionState() qtls.ConnectionState {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectionState")
-	ret0, _ := ret[0].(tls.ConnectionState)
+	ret0, _ := ret[0].(qtls.ConnectionState)
 	return ret0
 }
 

--- a/mock_quic_session_test.go
+++ b/mock_quic_session_test.go
@@ -6,12 +6,12 @@ package quic
 
 import (
 	context "context"
-	tls "crypto/tls"
 	net "net"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
+	qtls "github.com/marten-seemann/qtls"
 )
 
 // MockQuicSession is a mock of QuicSession interface
@@ -82,10 +82,10 @@ func (mr *MockQuicSessionMockRecorder) CloseWithError(arg0, arg1 interface{}) *g
 }
 
 // ConnectionState mocks base method
-func (m *MockQuicSession) ConnectionState() tls.ConnectionState {
+func (m *MockQuicSession) ConnectionState() qtls.ConnectionState {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectionState")
-	ret0, _ := ret[0].(tls.ConnectionState)
+	ret0, _ := ret[0].(qtls.ConnectionState)
 	return ret0
 }
 

--- a/session.go
+++ b/session.go
@@ -53,7 +53,7 @@ type cryptoStreamHandler interface {
 	SetLargest1RTTAcked(protocol.PacketNumber)
 	DropHandshakeKeys()
 	io.Closer
-	ConnectionState() tls.ConnectionState
+	ConnectionState() handshake.ConnectionState
 }
 
 type receivedPacket struct {
@@ -579,7 +579,7 @@ func (s *session) Context() context.Context {
 	return s.ctx
 }
 
-func (s *session) ConnectionState() tls.ConnectionState {
+func (s *session) ConnectionState() ConnectionState {
 	return s.cryptoStreamHandler.ConnectionState()
 }
 


### PR DESCRIPTION
Fixes #2276.

Note that this doesn't implement #2067 yet, which is the correct way to handle 0-RTT rejection.