### PR TITLE
use 0-RTT to open the H3 client's control stream

### DIFF
--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -44,7 +44,7 @@ type RoundTripper struct {
 	// Dial specifies an optional dial function for creating QUIC
 	// connections for requests.
 	// If Dial is nil, quic.DialAddr will be used.
-	Dial func(network, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.Session, error)
+	Dial func(network, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlySession, error)
 
 	// MaxResponseHeaderBytes specifies a limit on how many response bytes are
 	// allowed in the server's response header.


### PR DESCRIPTION
This is a step towards #2311. Depends on #2312.