### PR TITLE
Fix keepalive ping

### DIFF
--- a/session.go
+++ b/session.go
@@ -586,7 +586,7 @@ func (s *session) ConnectionState() tls.ConnectionState {
 // Time when the next keep-alive packet should be sent.
 // It returns a zero time if no keep-alive should be sent.
 func (s *session) nextKeepAliveTime() time.Time {
-	if !s.config.KeepAlive || s.keepAlivePingSent || s.firstAckElicitingPacketAfterIdleSentTime.IsZero() {
+	if !s.config.KeepAlive || s.keepAlivePingSent || !s.firstAckElicitingPacketAfterIdleSentTime.IsZero() {
 		return time.Time{}
 	}
 	return s.lastPacketReceivedTime.Add(s.keepAliveInterval / 2)

--- a/session_test.go
+++ b/session_test.go
@@ -1370,7 +1370,6 @@ var _ = Describe("Session", func() {
 		It("sends a PING as a keep-alive after half the idle timeout", func() {
 			setRemoteIdleTimeout(5 * time.Second)
 			sess.lastPacketReceivedTime = time.Now().Add(-5 * time.Second / 2)
-			sess.firstAckElicitingPacketAfterIdleSentTime = time.Now().Add(-5 * time.Second / 2)
 			sent := make(chan struct{})
 			packer.EXPECT().PackPacket().Do(func() (*packedPacket, error) {
 				close(sent)
@@ -1384,7 +1383,6 @@ var _ = Describe("Session", func() {
 			sess.config.MaxIdleTimeout = time.Hour
 			setRemoteIdleTimeout(time.Hour)
 			sess.lastPacketReceivedTime = time.Now().Add(-protocol.MaxKeepAliveInterval).Add(-time.Millisecond)
-			sess.firstAckElicitingPacketAfterIdleSentTime = time.Now().Add(-protocol.MaxKeepAliveInterval).Add(-time.Millisecond)
 			sent := make(chan struct{})
 			packer.EXPECT().PackPacket().Do(func() (*packedPacket, error) {
 				close(sent)


### PR DESCRIPTION
The firstAckElicitingPacketAfterIdleSendTime condition was inverted
in a recent PR, maybe just a typo.  This was causing only one ping
to be sent during periods of no activity.  The ack from the first
keepalive ping causes firstAckElicitingPacketAfterIdleSentTime
to be set to zero.  If there is no further activity, it will remain
zero and prevent further keepalive pings.

fixes https://github.com/lucas-clemente/quic-go/issues/2317