### PR TITLE
Read timeout value from http.Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ main
 mockgen_tmp.go
 *.qtr
 *.qlog
+.DS_Store
+*~
 
 fuzzing/*/*.zip
 fuzzing/*/coverprofile
@@ -14,3 +16,4 @@ fuzzing/*/corpus/
 !fuzzing/frames/single-frame*
 !fuzzing/frames/multiple-frame*
 !fuzzing/header/header*
+

--- a/http3/server.go
+++ b/http3/server.go
@@ -137,6 +137,12 @@ func (s *Server) serveImpl(tlsConf *tls.Config, conn net.PacketConn) error {
 		}
 	}
 
+	// Update QUIC MaxIdleTimeout to server IdleTimeout
+	if s.IdleTimeout > 0 {
+		s.QuicConfig.MaxIdleTimeout = s.IdleTimeout
+		s.logger.Debugf("Updated QUIC MaxIdleTimeout to IdleTimeout: %v", s.IdleTimeout)
+	}
+
 	var ln quic.EarlyListener
 	var err error
 	if conn == nil {
@@ -230,6 +236,37 @@ func (s *Server) maxHeaderBytes() uint64 {
 }
 
 func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpack.Decoder, onFrameError func()) requestError {
+
+	var (
+		wholeReadDeadline time.Time
+		hdrDeadline       time.Time
+
+		setReadDeadline bool
+	)
+	t0 := time.Now()
+	// set read timeout
+	if d := s.ReadTimeout; d != 0 {
+		wholeReadDeadline = t0.Add(d)
+		err := str.SetReadDeadline(wholeReadDeadline)
+		if err != nil {
+			s.logger.Errorf("failed to SetReadDeadline on stream %v: %s", str.StreamID(), err)
+			return newStreamError(errorInternalError, err)
+		}
+		s.logger.Debugf("Set read deadline to the ReadTimeout %v on StreamID %v", d, str.StreamID())
+		setReadDeadline = true
+	}
+	// set header timeout
+	if d := s.ReadHeaderTimeout; d != 0 {
+		hdrDeadline = t0.Add(d)
+		err := str.SetReadDeadline(hdrDeadline)
+		if err != nil {
+			s.logger.Errorf("failed to SetReadDeadline on stream %v: %s", str.StreamID(), err)
+			return newStreamError(errorInternalError, err)
+		}
+		s.logger.Debugf("Set read deadline to the ReadHeaderTimeout %v on stream %v", d, str.StreamID())
+		setReadDeadline = true
+	}
+
 	frame, err := parseNextFrame(str)
 	if err != nil {
 		return newStreamError(errorRequestIncomplete, err)
@@ -265,6 +302,16 @@ func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpac
 		s.logger.Infof("%s %s%s", req.Method, req.Host, req.RequestURI)
 	}
 
+	// Adjust the read deadline if necessary
+	if setReadDeadline && !hdrDeadline.Equal(wholeReadDeadline) {
+		err := str.SetReadDeadline(wholeReadDeadline)
+		if err != nil {
+			s.logger.Errorf("failed to SetReadDeadline on stream %v: %s", str.StreamID(), err)
+			return newStreamError(errorInternalError, err)
+		}
+		s.logger.Debugf("Adjusted read deadline to the ReadTimeout %v on StreamID %v", s.ReadTimeout, str.StreamID())
+	}
+
 	ctx := str.Context()
 	ctx = context.WithValue(ctx, ServerContextKey, s)
 	ctx = context.WithValue(ctx, http.LocalAddrContextKey, sess.LocalAddr())
@@ -274,6 +321,16 @@ func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpac
 	handler := s.Handler
 	if handler == nil {
 		handler = http.DefaultServeMux
+	}
+
+	// Done with header, now set the write timeout
+	if d := s.WriteTimeout; d != 0 {
+		err = str.SetWriteDeadline(time.Now().Add(d))
+		if err != nil {
+			s.logger.Errorf("failed to SetWriteDeadline on stream %v: %s", str.StreamID(), err)
+			return newStreamError(errorInternalError, err)
+		}
+		s.logger.Debugf("Set write deadline to %v on stream %v", d, str.StreamID())
 	}
 
 	var panicked, readEOF bool
@@ -304,6 +361,7 @@ func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpac
 	if !readEOF {
 		str.CancelRead(quic.ErrorCode(errorEarlyResponse))
 	}
+
 	return requestError{}
 }
 


### PR DESCRIPTION
Server considers timeout values from http.Server in handleRequest.

Most of the changes is quite similar to the way net/http/server.go deals with timeouts.

Addresses server side of #410 .