### PR TITLE
Do not ignore loss timer

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -372,6 +372,7 @@ func (h *sentPacketHandler) setLossDetectionTimer() {
 	if lossTime, _ := h.getEarliestLossTimeAndSpace(); !lossTime.IsZero() {
 		// Early retransmit timer or time loss detection.
 		h.alarm = lossTime
+		return
 	}
 
 	// Cancel the alarm if no packets are outstanding


### PR DESCRIPTION
In _setLossDetectionTimer_ the first assignment to _h.alarm_ is redundant, since it is going to be overwritten.