### PR TITLE
Make http3.client.Close() succeed if session was not started

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -127,6 +127,9 @@ func (c *client) setupSession() error {
 }
 
 func (c *client) Close() error {
+	if c.session == nil {
+		return nil
+	}
 	return c.session.CloseWithError(quic.ErrorCode(errorNoError), "")
 }
 

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -146,6 +146,12 @@ var _ = Describe("Client", func() {
 		Expect(err).To(MatchError(testErr))
 	})
 
+	It("closes correctly if session was not created", func() {
+		client = newClient("localhost:1337", nil, &roundTripperOpts{}, nil, nil)
+		err := client.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	Context("Doing requests", func() {
 		var (
 			request *http.Request


### PR DESCRIPTION
Invoking `http3.client.Close()` before `client.dial()` is invoked causes a segmentation fault. That occurs because, in this circumstance, invoking `client.Close()` results in invoking `client.session.CloseWithError(...)` while `client.session` is `nil`.

This pull request changes the behavior of `http3.client.Close()` to return `nil` if `client.session` is `nil` and adds an associated test case.