### PR TITLE
remove stray GinkgoRecover(), add a lint script to check that

### DIFF
--- a/.travis/no_ginkgo.sh
+++ b/.travis/no_ginkgo.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Verify that no non-test files import Ginkgo or Gomega.
+
+set -e
+
+HAS_TESTING=false
+
+cd ..
+for f in $(find . -name "*.go" ! -name "*_test.go"); do
+	if grep -q "github.com/onsi/ginkgo" $f; then
+    echo "$f imports github.com/onsi/ginkgo"
+    HAS_TESTING=true
+	fi
+	if grep -q "github.com/onsi/gomega" $f; then
+    echo "$f imports github.com/onsi/gomega"
+    HAS_TESTING=true
+	fi
+done
+
+if "$HAS_TESTING"; then
+	exit 1
+fi
+exit 0

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -3,6 +3,7 @@
 set -ex
 
 if [ ${TESTMODE} == "lint" ]; then
+  .travis/no_ginkgo.sh
   ./bin/golangci-lint run ./...
 fi
 

--- a/http3/server.go
+++ b/http3/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/marten-seemann/qpack"
-	"github.com/onsi/ginkgo"
 )
 
 // allows mocking of quic.Listen and quic.ListenAddr
@@ -198,7 +197,6 @@ func (s *Server) handleConn(sess quic.EarlySession) {
 			return
 		}
 		go func() {
-			defer ginkgo.GinkgoRecover()
 			rerr := s.handleRequest(sess, str, decoder, func() {
 				sess.CloseWithError(quic.ErrorCode(errorFrameUnexpected), "")
 			})


### PR DESCRIPTION
Sometimes this is useful for debugging, but we really need to make sure we don't commit something like this.