### PR TITLE
update qtls to v0.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.3.1
 	github.com/marten-seemann/qpack v0.1.0
-	github.com/marten-seemann/qtls v0.7.1
+	github.com/marten-seemann/qtls v0.7.2
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/marten-seemann/qpack v0.1.0 h1:/0M7lkda/6mus9B8u34Asqm8ZhHAAt9Ho0vniNuVSVg=
 github.com/marten-seemann/qpack v0.1.0/go.mod h1:LFt1NU/Ptjip0C2CPkhimBz5CGE3WGDAUWqna+CNTrI=
-github.com/marten-seemann/qtls v0.7.1 h1:+jBCODo2UW86tVlc1HCxAG+ccD51CZquJunNPUsaPQU=
-github.com/marten-seemann/qtls v0.7.1/go.mod h1:2MdmPXnAOf1oOfu871hbP8oYrClgWsykCQvi0S96jnw=
+github.com/marten-seemann/qtls v0.7.2 h1:/Hq1sYrHGnoi+AZGAeFrrae4n401H5+B7/9ez0M/BMg=
+github.com/marten-seemann/qtls v0.7.2/go.mod h1:2MdmPXnAOf1oOfu871hbP8oYrClgWsykCQvi0S96jnw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
This version makes sure that the server first checks the ALPN, and only exports Handshake secrets after the application protocol was chosen.