### PR TITLE
pad short Long Header packets to 4 bytes

### DIFF
--- a/packet_packer.go
+++ b/packet_packer.go
@@ -677,10 +677,11 @@ func (p *packetPacker) appendPacket(
 ) (*packetContents, error) {
 	var paddingLen protocol.ByteCount
 	pnLen := protocol.ByteCount(header.PacketNumberLen)
-	if encLevel != protocol.Encryption1RTT {
-		header.Length = pnLen + protocol.ByteCount(sealer.Overhead()) + payload.length
-	} else if payload.length < 4-pnLen {
+	if payload.length < 4-pnLen {
 		paddingLen = 4 - pnLen - payload.length
+	}
+	if header.IsLongHeader {
+		header.Length = pnLen + protocol.ByteCount(sealer.Overhead()) + payload.length + paddingLen
 	}
 
 	hdrOffset := buffer.Len()


### PR DESCRIPTION
Fixes #2399.

This is required for header protection to work.