### PR TITLE
remember the value of the active_connection_id_limit transport parameter

### DIFF
--- a/internal/handshake/client_session_cache.go
+++ b/internal/handshake/client_session_cache.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
-const clientSessionStateRevision = 1
+const clientSessionStateRevision = 2
 
 type clientSessionCache struct {
 	tls.ClientSessionCache

--- a/internal/handshake/session_ticket.go
+++ b/internal/handshake/session_ticket.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
-const sessionTicketRevision = 1
+const sessionTicketRevision = 2
 
 type sessionTicket struct {
 	Parameters *TransportParameters

--- a/internal/handshake/transport_parameter_test.go
+++ b/internal/handshake/transport_parameter_test.go
@@ -316,6 +316,7 @@ var _ = Describe("Transport Parameters", func() {
 				InitialMaxData:                 protocol.ByteCount(getRandomValue()),
 				MaxBidiStreamNum:               protocol.StreamNum(getRandomValue()),
 				MaxUniStreamNum:                protocol.StreamNum(getRandomValue()),
+				ActiveConnectionIDLimit:        getRandomValue(),
 			}
 			Expect(params.ValidFor0RTT(params)).To(BeTrue())
 			b := &bytes.Buffer{}
@@ -328,6 +329,7 @@ var _ = Describe("Transport Parameters", func() {
 			Expect(tp.InitialMaxData).To(Equal(params.InitialMaxData))
 			Expect(tp.MaxBidiStreamNum).To(Equal(params.MaxBidiStreamNum))
 			Expect(tp.MaxUniStreamNum).To(Equal(params.MaxUniStreamNum))
+			Expect(tp.ActiveConnectionIDLimit).To(Equal(params.ActiveConnectionIDLimit))
 		})
 
 		It("rejects the parameters if it can't parse them", func() {

--- a/internal/handshake/transport_parameters.go
+++ b/internal/handshake/transport_parameters.go
@@ -384,6 +384,8 @@ func (p *TransportParameters) MarshalForSessionTicket(b *bytes.Buffer) {
 	p.marshalVarintParam(b, initialMaxStreamsBidiParameterID, uint64(p.MaxBidiStreamNum))
 	// initial_max_uni_streams
 	p.marshalVarintParam(b, initialMaxStreamsUniParameterID, uint64(p.MaxUniStreamNum))
+	// active_connection_id_limit
+	p.marshalVarintParam(b, activeConnectionIDLimitParameterID, p.ActiveConnectionIDLimit)
 }
 
 // UnmarshalFromSessionTicket unmarshals transport parameters from a session ticket.


### PR DESCRIPTION
Fixes #2404.