### PR TITLE
remove superflous case when queueing undecryptable packets

### DIFF
--- a/session.go
+++ b/session.go
@@ -1495,12 +1495,8 @@ func (s *session) scheduleSending() {
 }
 
 func (s *session) tryQueueingUndecryptablePacket(p *receivedPacket) {
-	if s.handshakeComplete {
-		s.logger.Debugf("Received undecryptable packet from %s after the handshake (%d bytes)", p.remoteAddr.String(), len(p.data))
-		return
-	}
 	if len(s.undecryptablePackets)+1 > protocol.MaxUndecryptablePackets {
-		s.logger.Infof("Dropping undecrytable packet (%d bytes). Undecryptable packet queue full.", len(p.data))
+		s.logger.Infof("Dropping undecryptable packet (%d bytes). Undecryptable packet queue full.", len(p.data))
 		return
 	}
 	s.logger.Infof("Queueing packet (%d bytes) for later decryption", len(p.data))


### PR DESCRIPTION
This was only needed in gQUIC. In IETF QUIC, we determine the keys from the packet header. The crypto setup will return an `ErrKeysDropped` if we already dropped the corresponding keys.