### PR TITLE
only set the 0x80 bit to 1 for version negotiation packets

### DIFF
--- a/internal/wire/version_negotiation.go
+++ b/internal/wire/version_negotiation.go
@@ -15,7 +15,7 @@ func ComposeVersionNegotiation(destConnID, srcConnID protocol.ConnectionID, vers
 	buf := bytes.NewBuffer(make([]byte, 0, expectedLen))
 	r := make([]byte, 1)
 	_, _ = rand.Read(r) // ignore the error here. It is not critical to have perfect random here.
-	buf.WriteByte(r[0] | 0xc0)
+	buf.WriteByte(r[0] | 0x80)
 	utils.BigEndian.WriteUint32(buf, 0) // version 0
 	buf.WriteByte(uint8(destConnID.Len()))
 	buf.Write(destConnID)

--- a/internal/wire/version_negotiation_test.go
+++ b/internal/wire/version_negotiation_test.go
@@ -14,7 +14,6 @@ var _ = Describe("Version Negotiation Packets", func() {
 		data, err := ComposeVersionNegotiation(destConnID, srcConnID, versions)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(data[0] & 0x80).ToNot(BeZero())
-		Expect(data[0] & 0x40).ToNot(BeZero())
 		hdr, _, rest, err := ParsePacket(data, 4)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hdr.DestConnectionID).To(Equal(destConnID))


### PR DESCRIPTION
See https://tools.ietf.org/html/draft-ietf-quic-invariants-07#section-5.