### PR TITLE
move the transport parameters from the handshake to the wire package

### DIFF
--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -11,13 +11,15 @@ import (
 	"math/big"
 	"time"
 
-	gomock "github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go/internal/congestion"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/testdata"
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/internal/wire"
 	"github.com/marten-seemann/qtls"
+
+	"github.com/golang/mock/gomock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -92,7 +94,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			protocol.ConnectionID{},
 			nil,
 			nil,
-			&TransportParameters{},
+			&wire.TransportParameters{},
 			NewMockHandshakeRunner(mockCtrl),
 			tlsConf,
 			false,
@@ -125,7 +127,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			protocol.ConnectionID{},
 			nil,
 			nil,
-			&TransportParameters{},
+			&wire.TransportParameters{},
 			runner,
 			testdata.GetTLSConfig(),
 			false,
@@ -164,7 +166,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			protocol.ConnectionID{},
 			nil,
 			nil,
-			&TransportParameters{},
+			&wire.TransportParameters{},
 			runner,
 			testdata.GetTLSConfig(),
 			false,
@@ -206,7 +208,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			protocol.ConnectionID{},
 			nil,
 			nil,
-			&TransportParameters{},
+			&wire.TransportParameters{},
 			runner,
 			serverConf,
 			false,
@@ -241,7 +243,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			protocol.ConnectionID{},
 			nil,
 			nil,
-			&TransportParameters{},
+			&wire.TransportParameters{},
 			NewMockHandshakeRunner(mockCtrl),
 			serverConf,
 			false,
@@ -336,7 +338,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				protocol.ConnectionID{},
 				nil,
 				nil,
-				&TransportParameters{},
+				&wire.TransportParameters{},
 				cRunner,
 				clientConf,
 				enable0RTT,
@@ -359,7 +361,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				protocol.ConnectionID{},
 				nil,
 				nil,
-				&TransportParameters{StatelessResetToken: &token},
+				&wire.TransportParameters{StatelessResetToken: &token},
 				sRunner,
 				serverConf,
 				enable0RTT,
@@ -413,7 +415,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				protocol.ConnectionID{},
 				nil,
 				nil,
-				&TransportParameters{},
+				&wire.TransportParameters{},
 				runner,
 				&tls.Config{InsecureSkipVerify: true},
 				false,
@@ -443,11 +445,11 @@ var _ = Describe("Crypto Setup TLS", func() {
 		})
 
 		It("receives transport parameters", func() {
-			var cTransportParametersRcvd, sTransportParametersRcvd *TransportParameters
+			var cTransportParametersRcvd, sTransportParametersRcvd *wire.TransportParameters
 			cChunkChan, cInitialStream, cHandshakeStream := initStreams()
-			cTransportParameters := &TransportParameters{MaxIdleTimeout: 0x42 * time.Second}
+			cTransportParameters := &wire.TransportParameters{MaxIdleTimeout: 0x42 * time.Second}
 			cRunner := NewMockHandshakeRunner(mockCtrl)
-			cRunner.EXPECT().OnReceivedParams(gomock.Any()).Do(func(tp *TransportParameters) { sTransportParametersRcvd = tp })
+			cRunner.EXPECT().OnReceivedParams(gomock.Any()).Do(func(tp *wire.TransportParameters) { sTransportParametersRcvd = tp })
 			cRunner.EXPECT().OnHandshakeComplete()
 			client, _ := NewCryptoSetupClient(
 				cInitialStream,
@@ -467,9 +469,9 @@ var _ = Describe("Crypto Setup TLS", func() {
 			sChunkChan, sInitialStream, sHandshakeStream := initStreams()
 			var token [16]byte
 			sRunner := NewMockHandshakeRunner(mockCtrl)
-			sRunner.EXPECT().OnReceivedParams(gomock.Any()).Do(func(tp *TransportParameters) { cTransportParametersRcvd = tp })
+			sRunner.EXPECT().OnReceivedParams(gomock.Any()).Do(func(tp *wire.TransportParameters) { cTransportParametersRcvd = tp })
 			sRunner.EXPECT().OnHandshakeComplete()
-			sTransportParameters := &TransportParameters{
+			sTransportParameters := &wire.TransportParameters{
 				MaxIdleTimeout:      0x1337 * time.Second,
 				StatelessResetToken: &token,
 			}
@@ -512,7 +514,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					protocol.ConnectionID{},
 					nil,
 					nil,
-					&TransportParameters{},
+					&wire.TransportParameters{},
 					cRunner,
 					clientConf,
 					false,
@@ -531,7 +533,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					protocol.ConnectionID{},
 					nil,
 					nil,
-					&TransportParameters{},
+					&wire.TransportParameters{},
 					sRunner,
 					serverConf,
 					false,
@@ -571,7 +573,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					protocol.ConnectionID{},
 					nil,
 					nil,
-					&TransportParameters{},
+					&wire.TransportParameters{},
 					cRunner,
 					clientConf,
 					false,
@@ -590,7 +592,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					protocol.ConnectionID{},
 					nil,
 					nil,
-					&TransportParameters{},
+					&wire.TransportParameters{},
 					sRunner,
 					serverConf,
 					false,
@@ -702,7 +704,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					protocol.ConnectionID{},
 					nil,
 					nil,
-					&TransportParameters{},
+					&wire.TransportParameters{},
 					cRunner,
 					clientConf,
 					true,
@@ -721,7 +723,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					protocol.ConnectionID{},
 					nil,
 					nil,
-					&TransportParameters{},
+					&wire.TransportParameters{},
 					sRunner,
 					serverConf,
 					true,

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/wire"
 	"github.com/marten-seemann/qtls"
 )
 
@@ -61,7 +62,7 @@ type tlsExtensionHandler interface {
 }
 
 type handshakeRunner interface {
-	OnReceivedParams(*TransportParameters)
+	OnReceivedParams(*wire.TransportParameters)
 	OnHandshakeComplete()
 	OnError(error)
 	DropKeys(protocol.EncryptionLevel)

--- a/internal/handshake/mock_handshake_runner_test.go
+++ b/internal/handshake/mock_handshake_runner_test.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
+	wire "github.com/lucas-clemente/quic-go/internal/wire"
 )
 
 // MockHandshakeRunner is a mock of HandshakeRunner interface
@@ -71,7 +72,7 @@ func (mr *MockHandshakeRunnerMockRecorder) OnHandshakeComplete() *gomock.Call {
 }
 
 // OnReceivedParams mocks base method
-func (m *MockHandshakeRunner) OnReceivedParams(arg0 *TransportParameters) {
+func (m *MockHandshakeRunner) OnReceivedParams(arg0 *wire.TransportParameters) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnReceivedParams", arg0)
 }

--- a/internal/handshake/session_ticket.go
+++ b/internal/handshake/session_ticket.go
@@ -7,12 +7,13 @@ import (
 	"time"
 
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
 const sessionTicketRevision = 2
 
 type sessionTicket struct {
-	Parameters *TransportParameters
+	Parameters *wire.TransportParameters
 	RTT        time.Duration // to be encoded in mus
 }
 
@@ -37,7 +38,7 @@ func (t *sessionTicket) Unmarshal(b []byte) error {
 	if err != nil {
 		return errors.New("failed to read RTT")
 	}
-	var tp TransportParameters
+	var tp wire.TransportParameters
 	if err := tp.UnmarshalFromSessionTicket(b[len(b)-r.Len():]); err != nil {
 		return fmt.Errorf("unmarshaling transport parameters from session ticket failed: %s", err.Error())
 	}

--- a/internal/handshake/session_ticket_test.go
+++ b/internal/handshake/session_ticket_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/internal/wire"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,7 +14,7 @@ import (
 var _ = Describe("Session Ticket", func() {
 	It("marshals and unmarshals a session ticket", func() {
 		ticket := &sessionTicket{
-			Parameters: &TransportParameters{
+			Parameters: &wire.TransportParameters{
 				InitialMaxStreamDataBidiLocal:  1,
 				InitialMaxStreamDataBidiRemote: 2,
 			},

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -1,4 +1,4 @@
-package handshake
+package wire
 
 import (
 	"bytes"
@@ -39,7 +39,7 @@ var _ = Describe("Transport Parameters", func() {
 			StatelessResetToken:            &[16]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00},
 			ActiveConnectionIDLimit:        123,
 		}
-		Expect(p.String()).To(Equal("&handshake.TransportParameters{OriginalConnectionID: 0xdeadbeef, InitialMaxStreamDataBidiLocal: 0x1234, InitialMaxStreamDataBidiRemote: 0x2345, InitialMaxStreamDataUni: 0x3456, InitialMaxData: 0x4567, MaxBidiStreamNum: 1337, MaxUniStreamNum: 7331, MaxIdleTimeout: 42s, AckDelayExponent: 14, MaxAckDelay: 37ms, ActiveConnectionIDLimit: 123, StatelessResetToken: 0x112233445566778899aabbccddeeff00}"))
+		Expect(p.String()).To(Equal("&wire.TransportParameters{OriginalConnectionID: 0xdeadbeef, InitialMaxStreamDataBidiLocal: 0x1234, InitialMaxStreamDataBidiRemote: 0x2345, InitialMaxStreamDataUni: 0x3456, InitialMaxData: 0x4567, MaxBidiStreamNum: 1337, MaxUniStreamNum: 7331, MaxIdleTimeout: 42s, AckDelayExponent: 14, MaxAckDelay: 37ms, ActiveConnectionIDLimit: 123, StatelessResetToken: 0x112233445566778899aabbccddeeff00}"))
 	})
 
 	It("has a string representation, if there's no stateless reset token", func() {
@@ -56,7 +56,7 @@ var _ = Describe("Transport Parameters", func() {
 			MaxAckDelay:                    37 * time.Second,
 			ActiveConnectionIDLimit:        89,
 		}
-		Expect(p.String()).To(Equal("&handshake.TransportParameters{OriginalConnectionID: 0xdeadbeef, InitialMaxStreamDataBidiLocal: 0x1234, InitialMaxStreamDataBidiRemote: 0x2345, InitialMaxStreamDataUni: 0x3456, InitialMaxData: 0x4567, MaxBidiStreamNum: 1337, MaxUniStreamNum: 7331, MaxIdleTimeout: 42s, AckDelayExponent: 14, MaxAckDelay: 37s, ActiveConnectionIDLimit: 89}"))
+		Expect(p.String()).To(Equal("&wire.TransportParameters{OriginalConnectionID: 0xdeadbeef, InitialMaxStreamDataBidiLocal: 0x1234, InitialMaxStreamDataBidiRemote: 0x2345, InitialMaxStreamDataUni: 0x3456, InitialMaxData: 0x4567, MaxBidiStreamNum: 1337, MaxUniStreamNum: 7331, MaxIdleTimeout: 42s, AckDelayExponent: 14, MaxAckDelay: 37s, ActiveConnectionIDLimit: 89}"))
 	})
 
 	It("marshals and unmarshals", func() {

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -1,4 +1,4 @@
-package handshake
+package wire
 
 import (
 	"bytes"
@@ -413,7 +413,7 @@ func (p *TransportParameters) ValidFor0RTT(tp *TransportParameters) bool {
 
 // String returns a string representation, intended for logging.
 func (p *TransportParameters) String() string {
-	logString := "&handshake.TransportParameters{OriginalConnectionID: %s, InitialMaxStreamDataBidiLocal: %#x, InitialMaxStreamDataBidiRemote: %#x, InitialMaxStreamDataUni: %#x, InitialMaxData: %#x, MaxBidiStreamNum: %d, MaxUniStreamNum: %d, MaxIdleTimeout: %s, AckDelayExponent: %d, MaxAckDelay: %s, ActiveConnectionIDLimit: %d"
+	logString := "&wire.TransportParameters{OriginalConnectionID: %s, InitialMaxStreamDataBidiLocal: %#x, InitialMaxStreamDataBidiRemote: %#x, InitialMaxStreamDataUni: %#x, InitialMaxData: %#x, MaxBidiStreamNum: %d, MaxUniStreamNum: %d, MaxIdleTimeout: %s, AckDelayExponent: %d, MaxAckDelay: %s, ActiveConnectionIDLimit: %d"
 	logParams := []interface{}{p.OriginalConnectionID, p.InitialMaxStreamDataBidiLocal, p.InitialMaxStreamDataBidiRemote, p.InitialMaxStreamDataUni, p.InitialMaxData, p.MaxBidiStreamNum, p.MaxUniStreamNum, p.MaxIdleTimeout, p.AckDelayExponent, p.MaxAckDelay, p.ActiveConnectionIDLimit}
 	if p.StatelessResetToken != nil { // the client never sends a stateless reset token
 		logString += ", StatelessResetToken: %#x"

--- a/mock_packer_test.go
+++ b/mock_packer_test.go
@@ -8,9 +8,9 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	handshake "github.com/lucas-clemente/quic-go/internal/handshake"
 	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
 	qerr "github.com/lucas-clemente/quic-go/internal/qerr"
+	wire "github.com/lucas-clemente/quic-go/internal/wire"
 )
 
 // MockPacker is a mock of Packer interface
@@ -37,7 +37,7 @@ func (m *MockPacker) EXPECT() *MockPackerMockRecorder {
 }
 
 // HandleTransportParameters mocks base method
-func (m *MockPacker) HandleTransportParameters(arg0 *handshake.TransportParameters) {
+func (m *MockPacker) HandleTransportParameters(arg0 *wire.TransportParameters) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "HandleTransportParameters", arg0)
 }

--- a/mock_stream_manager_test.go
+++ b/mock_stream_manager_test.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	handshake "github.com/lucas-clemente/quic-go/internal/handshake"
 	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
 	wire "github.com/lucas-clemente/quic-go/internal/wire"
 )
@@ -198,7 +197,7 @@ func (mr *MockStreamManagerMockRecorder) OpenUniStreamSync(arg0 interface{}) *go
 }
 
 // UpdateLimits mocks base method
-func (m *MockStreamManager) UpdateLimits(arg0 *handshake.TransportParameters) error {
+func (m *MockStreamManager) UpdateLimits(arg0 *wire.TransportParameters) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateLimits", arg0)
 	ret0, _ := ret[0].(error)

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -23,7 +23,7 @@ type packer interface {
 	MaybePackAckPacket(handshakeConfirmed bool) (*packedPacket, error)
 	PackConnectionClose(*qerr.QuicError) (*coalescedPacket, error)
 
-	HandleTransportParameters(*handshake.TransportParameters)
+	HandleTransportParameters(*wire.TransportParameters)
 	SetToken([]byte)
 }
 
@@ -738,7 +738,7 @@ func (p *packetPacker) SetToken(token []byte) {
 	p.token = token
 }
 
-func (p *packetPacker) HandleTransportParameters(params *handshake.TransportParameters) {
+func (p *packetPacker) HandleTransportParameters(params *wire.TransportParameters) {
 	if params.MaxPacketSize != 0 {
 		p.maxPacketSize = utils.MinByteCount(p.maxPacketSize, params.MaxPacketSize)
 	}

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -731,7 +731,7 @@ var _ = Describe("Packet packer", func() {
 					_, err := packer.PackPacket()
 					Expect(err).ToNot(HaveOccurred())
 					// now reduce the maxPacketSize
-					packer.HandleTransportParameters(&handshake.TransportParameters{
+					packer.HandleTransportParameters(&wire.TransportParameters{
 						MaxPacketSize: maxPacketSize - 10,
 					})
 					framer.EXPECT().AppendControlFrames(gomock.Any(), gomock.Any()).Do(func(_ []ackhandler.Frame, maxLen protocol.ByteCount) ([]ackhandler.Frame, protocol.ByteCount) {
@@ -756,7 +756,7 @@ var _ = Describe("Packet packer", func() {
 					_, err := packer.PackPacket()
 					Expect(err).ToNot(HaveOccurred())
 					// now try to increase the maxPacketSize
-					packer.HandleTransportParameters(&handshake.TransportParameters{
+					packer.HandleTransportParameters(&wire.TransportParameters{
 						MaxPacketSize: maxPacketSize + 10,
 					})
 					framer.EXPECT().AppendControlFrames(gomock.Any(), gomock.Any()).Do(func(_ []ackhandler.Frame, maxLen protocol.ByteCount) ([]ackhandler.Frame, protocol.ByteCount) {

--- a/server_test.go
+++ b/server_test.go
@@ -295,7 +295,7 @@ var _ = Describe("Server", func() {
 				destConnID := protocol.ConnectionID{1, 2, 3, 4, 5, 6}
 				packet := getPacket(&wire.Header{
 					IsLongHeader:     true,
-					Type:             protocol.PacketTypeInitial,
+					Type:             protocol.PacketTypeHandshake,
 					SrcConnectionID:  srcConnID,
 					DestConnectionID: destConnID,
 					Version:          0x42,

--- a/session_test.go
+++ b/session_test.go
@@ -1430,7 +1430,7 @@ var _ = Describe("Session", func() {
 				cryptoSetup.EXPECT().RunHandshake().MaxTimes(1)
 				sess.run()
 			}()
-			params := &handshake.TransportParameters{
+			params := &wire.TransportParameters{
 				MaxIdleTimeout:                90 * time.Second,
 				InitialMaxStreamDataBidiLocal: 0x5000,
 				InitialMaxData:                0x5000,
@@ -1465,7 +1465,7 @@ var _ = Describe("Session", func() {
 		setRemoteIdleTimeout := func(t time.Duration) {
 			streamManager.EXPECT().UpdateLimits(gomock.Any())
 			packer.EXPECT().HandleTransportParameters(gomock.Any())
-			sess.processTransportParameters(&handshake.TransportParameters{MaxIdleTimeout: t})
+			sess.processTransportParameters(&wire.TransportParameters{MaxIdleTimeout: t})
 		}
 
 		runSession := func() {
@@ -1956,8 +1956,8 @@ var _ = Describe("Client Session", func() {
 		})
 
 		It("uses the preferred_address connection ID", func() {
-			params := &handshake.TransportParameters{
-				PreferredAddress: &handshake.PreferredAddress{
+			params := &wire.TransportParameters{
+				PreferredAddress: &wire.PreferredAddress{
 					IPv4:                net.IPv4(127, 0, 0, 1),
 					IPv6:                net.IP{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 					ConnectionID:        protocol.ConnectionID{1, 2, 3, 4},
@@ -1979,7 +1979,7 @@ var _ = Describe("Client Session", func() {
 
 		It("uses the minimum of the peers' idle timeouts", func() {
 			sess.config.MaxIdleTimeout = 19 * time.Second
-			params := &handshake.TransportParameters{
+			params := &wire.TransportParameters{
 				MaxIdleTimeout: 18 * time.Second,
 			}
 			packer.EXPECT().HandleTransportParameters(gomock.Any())
@@ -1989,7 +1989,7 @@ var _ = Describe("Client Session", func() {
 
 		It("errors if the TransportParameters contain an original_connection_id, although no Retry was performed", func() {
 			expectClose()
-			sess.processTransportParameters(&handshake.TransportParameters{
+			sess.processTransportParameters(&wire.TransportParameters{
 				OriginalConnectionID: protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad},
 				StatelessResetToken:  &[16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			})
@@ -1999,7 +1999,7 @@ var _ = Describe("Client Session", func() {
 		It("errors if the TransportParameters contain a wrong original_connection_id", func() {
 			sess.origDestConnID = protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef}
 			expectClose()
-			sess.processTransportParameters(&handshake.TransportParameters{
+			sess.processTransportParameters(&wire.TransportParameters{
 				OriginalConnectionID: protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad},
 				StatelessResetToken:  &[16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 			})

--- a/streams_map.go
+++ b/streams_map.go
@@ -7,7 +7,6 @@ import (
 	"net"
 
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
-	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
@@ -223,7 +222,7 @@ func (m *streamsMap) HandleMaxStreamsFrame(f *wire.MaxStreamsFrame) error {
 	return nil
 }
 
-func (m *streamsMap) UpdateLimits(p *handshake.TransportParameters) error {
+func (m *streamsMap) UpdateLimits(p *wire.TransportParameters) error {
 	if p.MaxBidiStreamNum > protocol.MaxStreamCount ||
 		p.MaxUniStreamNum > protocol.MaxStreamCount {
 		return qerr.StreamLimitError

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
-	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qerr"
@@ -81,7 +80,7 @@ var _ = Describe("Streams Map", func() {
 			)
 
 			allowUnlimitedStreams := func() {
-				m.UpdateLimits(&handshake.TransportParameters{
+				m.UpdateLimits(&wire.TransportParameters{
 					MaxBidiStreamNum: protocol.MaxStreamCount,
 					MaxUniStreamNum:  protocol.MaxStreamCount,
 				})
@@ -331,7 +330,7 @@ var _ = Describe("Streams Map", func() {
 						m.perspective = pers
 						_, err := m.OpenStream()
 						expectTooManyStreamsError(err)
-						Expect(m.UpdateLimits(&handshake.TransportParameters{
+						Expect(m.UpdateLimits(&wire.TransportParameters{
 							MaxBidiStreamNum: 5,
 							MaxUniStreamNum:  8,
 						})).To(Succeed())
@@ -357,13 +356,13 @@ var _ = Describe("Streams Map", func() {
 				}
 
 				It("rejects parameters with too large unidirectional stream counts", func() {
-					Expect(m.UpdateLimits(&handshake.TransportParameters{
+					Expect(m.UpdateLimits(&wire.TransportParameters{
 						MaxUniStreamNum: protocol.MaxStreamCount + 1,
 					})).To(MatchError(qerr.StreamLimitError))
 				})
 
 				It("rejects parameters with too large unidirectional stream counts", func() {
-					Expect(m.UpdateLimits(&handshake.TransportParameters{
+					Expect(m.UpdateLimits(&wire.TransportParameters{
 						MaxBidiStreamNum: protocol.MaxStreamCount + 1,
 					})).To(MatchError(qerr.StreamLimitError))
 				})


### PR DESCRIPTION
Arguably, this is where they belong.

Also, we need this if we want to qlog them (to avoid an import cycle, since `handshake` imports `qlog`, but `wire` doesn't.