### PR TITLE
rename the max_packet_size transport parameter to max_udp_payload_size

### DIFF
--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors when the max_packet_size is too small", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(maxPacketSizeParameterID))
+		utils.WriteVarInt(b, uint64(maxUDPPayloadSizeParameterID))
 		utils.WriteVarInt(b, uint64(utils.VarIntLen(1199)))
 		utils.WriteVarInt(b, 1199)
 		p := &TransportParameters{}

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -739,7 +739,7 @@ func (p *packetPacker) SetToken(token []byte) {
 }
 
 func (p *packetPacker) HandleTransportParameters(params *wire.TransportParameters) {
-	if params.MaxPacketSize != 0 {
-		p.maxPacketSize = utils.MinByteCount(p.maxPacketSize, params.MaxPacketSize)
+	if params.MaxUDPPayloadSize != 0 {
+		p.maxPacketSize = utils.MinByteCount(p.maxPacketSize, params.MaxUDPPayloadSize)
 	}
 }

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -732,7 +732,7 @@ var _ = Describe("Packet packer", func() {
 					Expect(err).ToNot(HaveOccurred())
 					// now reduce the maxPacketSize
 					packer.HandleTransportParameters(&wire.TransportParameters{
-						MaxPacketSize: maxPacketSize - 10,
+						MaxUDPPayloadSize: maxPacketSize - 10,
 					})
 					framer.EXPECT().AppendControlFrames(gomock.Any(), gomock.Any()).Do(func(_ []ackhandler.Frame, maxLen protocol.ByteCount) ([]ackhandler.Frame, protocol.ByteCount) {
 						Expect(maxLen).To(Equal(initialMaxPacketSize - 10))
@@ -757,7 +757,7 @@ var _ = Describe("Packet packer", func() {
 					Expect(err).ToNot(HaveOccurred())
 					// now try to increase the maxPacketSize
 					packer.HandleTransportParameters(&wire.TransportParameters{
-						MaxPacketSize: maxPacketSize + 10,
+						MaxUDPPayloadSize: maxPacketSize + 10,
 					})
 					framer.EXPECT().AppendControlFrames(gomock.Any(), gomock.Any()).Do(func(_ []ackhandler.Frame, maxLen protocol.ByteCount) ([]ackhandler.Frame, protocol.ByteCount) {
 						Expect(maxLen).To(Equal(initialMaxPacketSize))

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -277,7 +277,7 @@ type eventTransportParameters struct {
 	StatelessResetToken     *[16]byte
 	DisableActiveMigration  bool
 	MaxIdleTimeout          time.Duration
-	MaxPacketSize           protocol.ByteCount
+	MaxUDPPayloadSize       protocol.ByteCount
 	AckDelayExponent        uint8
 	MaxAckDelay             time.Duration
 	ActiveConnectionIDLimit uint64
@@ -306,7 +306,7 @@ func (e eventTransportParameters) MarshalJSONObject(enc *gojay.Encoder) {
 	}
 	enc.BoolKey("disable_active_migration", e.DisableActiveMigration)
 	enc.FloatKeyOmitEmpty("max_idle_timeout", milliseconds(e.MaxIdleTimeout))
-	enc.Uint64KeyNullEmpty("max_packet_size", uint64(e.MaxPacketSize))
+	enc.Uint64KeyNullEmpty("max_udp_payload_size", uint64(e.MaxUDPPayloadSize))
 	enc.Uint8KeyOmitEmpty("ack_delay_exponent", e.AckDelayExponent)
 	enc.FloatKeyOmitEmpty("max_ack_delay", milliseconds(e.MaxAckDelay))
 	enc.Uint64KeyOmitEmpty("active_connection_id_limit", e.ActiveConnectionIDLimit)

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -149,7 +149,7 @@ func (t *tracer) recordTransportParameters(time time.Time, owner owner, tp *wire
 			StatelessResetToken:            tp.StatelessResetToken,
 			DisableActiveMigration:         tp.DisableActiveMigration,
 			MaxIdleTimeout:                 tp.MaxIdleTimeout,
-			MaxPacketSize:                  tp.MaxPacketSize,
+			MaxUDPPayloadSize:              tp.MaxUDPPayloadSize,
 			AckDelayExponent:               tp.AckDelayExponent,
 			MaxAckDelay:                    tp.MaxAckDelay,
 			ActiveConnectionIDLimit:        tp.ActiveConnectionIDLimit,

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Tracer", func() {
 				MaxAckDelay:                    123 * time.Millisecond,
 				AckDelayExponent:               12,
 				DisableActiveMigration:         true,
-				MaxPacketSize:                  1234,
+				MaxUDPPayloadSize:              1234,
 				MaxIdleTimeout:                 321 * time.Millisecond,
 				StatelessResetToken:            &[16]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00},
 				OriginalConnectionID:           protocol.ConnectionID{0xde, 0xad, 0xc0, 0xde},
@@ -180,7 +180,7 @@ var _ = Describe("Tracer", func() {
 			Expect(ev).To(HaveKeyWithValue("original_connection_id", "deadc0de"))
 			Expect(ev).To(HaveKeyWithValue("stateless_reset_token", "112233445566778899aabbccddeeff00"))
 			Expect(ev).To(HaveKeyWithValue("max_idle_timeout", float64(321)))
-			Expect(ev).To(HaveKeyWithValue("max_packet_size", float64(1234)))
+			Expect(ev).To(HaveKeyWithValue("max_udp_payload_size", float64(1234)))
 			Expect(ev).To(HaveKeyWithValue("ack_delay_exponent", float64(12)))
 			Expect(ev).To(HaveKeyWithValue("active_connection_id_limit", float64(7)))
 			Expect(ev).To(HaveKeyWithValue("initial_max_data", float64(4000)))

--- a/session_test.go
+++ b/session_test.go
@@ -1436,7 +1436,7 @@ var _ = Describe("Session", func() {
 				InitialMaxData:                0x5000,
 				ActiveConnectionIDLimit:       3,
 				// marshaling always sets it to this value
-				MaxPacketSize: protocol.MaxReceivePacketSize,
+				MaxUDPPayloadSize: protocol.MaxReceivePacketSize,
 			}
 			streamManager.EXPECT().UpdateLimits(params)
 			packer.EXPECT().HandleTransportParameters(params)


### PR DESCRIPTION
See https://github.com/quicwg/base-drafts/pull/3473/, and the corresponding change to qlog: https://github.com/quiclog/internet-drafts/pull/67.