### PR TITLE
fix determining of packet type from packet header in qlog

### DIFF
--- a/qlog/packet_header.go
+++ b/qlog/packet_header.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
+// PacketTypeFromHeader determines the packet type from a *wire.Header.
 func PacketTypeFromHeader(hdr *wire.Header) PacketType {
 	if !hdr.IsLongHeader {
 		return PacketType1RTT
@@ -24,7 +25,7 @@ func PacketTypeFromHeader(hdr *wire.Header) PacketType {
 	case protocol.PacketTypeRetry:
 		return PacketTypeRetry
 	default:
-		panic("unknown packet type")
+		return PacketTypeNotDetermined
 	}
 }
 

--- a/qlog/packet_header_test.go
+++ b/qlog/packet_header_test.go
@@ -61,6 +61,13 @@ var _ = Describe("Packet Header", func() {
 		It("recognizes 1-RTT packets", func() {
 			Expect(PacketTypeFromHeader(&wire.Header{})).To(Equal(PacketType1RTT))
 		})
+
+		It("handles unrecognized packet types", func() {
+			Expect(PacketTypeFromHeader(&wire.Header{
+				IsLongHeader: true,
+				Version:      protocol.VersionTLS,
+			})).To(Equal(PacketTypeNotDetermined))
+		})
 	})
 
 	Context("marshalling", func() {


### PR DESCRIPTION
Fixes #2431.