### PR TITLE
pass the role (client or server) to the GetLogWriter callback

### DIFF
--- a/client.go
+++ b/client.go
@@ -180,7 +180,7 @@ func dialContext(
 
 	var qlogger qlog.Tracer
 	if c.config.GetLogWriter != nil {
-		if w := c.config.GetLogWriter(c.destConnID); w != nil {
+		if w := c.config.GetLogWriter("client", c.destConnID); w != nil {
 			qlogger = qlog.NewTracer(w, protocol.PerspectiveClient, c.destConnID)
 		}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -65,11 +65,11 @@ var _ = Describe("Config", func() {
 			var calledAcceptToken, calledGetLogWriter bool
 			c1 := &Config{
 				AcceptToken:  func(_ net.Addr, _ *Token) bool { calledAcceptToken = true; return true },
-				GetLogWriter: func(connectionID []byte) io.WriteCloser { calledGetLogWriter = true; return nil },
+				GetLogWriter: func(role string, connectionID []byte) io.WriteCloser { calledGetLogWriter = true; return nil },
 			}
 			c2 := c1.Clone()
 			c2.AcceptToken(&net.UDPAddr{}, &Token{})
-			c2.GetLogWriter([]byte{1, 2, 3})
+			c2.GetLogWriter("role", []byte{1, 2, 3})
 			Expect(calledAcceptToken).To(BeTrue())
 			Expect(calledGetLogWriter).To(BeTrue())
 		})
@@ -98,11 +98,11 @@ var _ = Describe("Config", func() {
 			var calledAcceptToken, calledGetLogWriter bool
 			c1 := &Config{
 				AcceptToken:  func(_ net.Addr, _ *Token) bool { calledAcceptToken = true; return true },
-				GetLogWriter: func(connectionID []byte) io.WriteCloser { calledGetLogWriter = true; return nil },
+				GetLogWriter: func(role string, connectionID []byte) io.WriteCloser { calledGetLogWriter = true; return nil },
 			}
 			c2 := populateConfig(c1)
 			c2.AcceptToken(&net.UDPAddr{}, &Token{})
-			c2.GetLogWriter([]byte{1, 2, 3})
+			c2.GetLogWriter("role", []byte{1, 2, 3})
 			Expect(calledAcceptToken).To(BeTrue())
 			Expect(calledGetLogWriter).To(BeTrue())
 		})

--- a/interface.go
+++ b/interface.go
@@ -246,10 +246,11 @@ type Config struct {
 	// Warning: Experimental. This API should not be considered stable and will change soon.
 	QuicTracer quictrace.Tracer
 	// GetLogWriter is used to pass in a writer for the qlog.
+	// The role will either be "client" or "server".
 	// If it is nil, no qlog will be collected and exported.
 	// If it returns nil, no qlog will be collected and exported for the respective connection.
 	// It is recommended to use a buffered writer here.
-	GetLogWriter func(connectionID []byte) io.WriteCloser
+	GetLogWriter func(role string, connectionID []byte) io.WriteCloser
 }
 
 // A Listener for incoming QUIC connections

--- a/server.go
+++ b/server.go
@@ -423,7 +423,7 @@ func (s *baseServer) createNewSession(
 ) quicSession {
 	var qlogger qlog.Tracer
 	if s.config.GetLogWriter != nil {
-		if w := s.config.GetLogWriter(origDestConnID); w != nil {
+		if w := s.config.GetLogWriter("server", origDestConnID); w != nil {
 			qlogger = qlog.NewTracer(w, protocol.PerspectiveServer, origDestConnID)
 		}
 	}


### PR DESCRIPTION
@lucas-clemente Since this is a breaking API change, we'll have to bump the version number to v0.16 with the next release, right?