### PR TITLE
add a command line option to export qlogs from the integration tests

### DIFF
--- a/integrationtests/self/cancelation_test.go
+++ b/integrationtests/self/cancelation_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Stream Cancelations", func() {
 		runServer := func() <-chan int32 {
 			numCanceledStreamsChan := make(chan int32)
 			var err error
-			server, err = quic.ListenAddr("localhost:0", getTLSConfig(), nil)
+			server, err = quic.ListenAddr("localhost:0", getTLSConfig(), getQuicConfigForServer(nil))
 			Expect(err).ToNot(HaveOccurred())
 
 			var canceledCounter int32
@@ -65,7 +65,7 @@ var _ = Describe("Stream Cancelations", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 				getTLSClientConfig(),
-				&quic.Config{MaxIncomingUniStreams: numStreams / 2},
+				getQuicConfigForClient(&quic.Config{MaxIncomingUniStreams: numStreams / 2}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -109,7 +109,7 @@ var _ = Describe("Stream Cancelations", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 				getTLSClientConfig(),
-				&quic.Config{MaxIncomingUniStreams: numStreams / 2},
+				getQuicConfigForClient(&quic.Config{MaxIncomingUniStreams: numStreams / 2}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -157,7 +157,7 @@ var _ = Describe("Stream Cancelations", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 				getTLSClientConfig(),
-				&quic.Config{MaxIncomingUniStreams: numStreams / 2},
+				getQuicConfigForClient(&quic.Config{MaxIncomingUniStreams: numStreams / 2}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -293,7 +293,7 @@ var _ = Describe("Stream Cancelations", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 				getTLSClientConfig(),
-				&quic.Config{MaxIncomingUniStreams: numStreams / 2},
+				getQuicConfigForClient(&quic.Config{MaxIncomingUniStreams: numStreams / 2}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -371,7 +371,7 @@ var _ = Describe("Stream Cancelations", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 				getTLSClientConfig(),
-				&quic.Config{MaxIncomingUniStreams: numStreams / 2},
+				getQuicConfigForClient(&quic.Config{MaxIncomingUniStreams: numStreams / 2}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -446,7 +446,7 @@ var _ = Describe("Stream Cancelations", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 				getTLSClientConfig(),
-				&quic.Config{MaxIncomingUniStreams: numStreams / 3},
+				getQuicConfigForClient(&quic.Config{MaxIncomingUniStreams: numStreams / 3}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -529,9 +529,7 @@ var _ = Describe("Stream Cancelations", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 				getTLSClientConfig(),
-				&quic.Config{
-					MaxIncomingUniStreams: 5,
-				},
+				getQuicConfigForClient(&quic.Config{MaxIncomingUniStreams: 5}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/integrationtests/self/conn_id_test.go
+++ b/integrationtests/self/conn_id_test.go
@@ -60,13 +60,13 @@ var _ = Describe("Connection ID lengths tests", func() {
 	}
 
 	It("downloads a file using a 0-byte connection ID for the client", func() {
-		serverConf := &quic.Config{
+		serverConf := getQuicConfigForServer(&quic.Config{
 			ConnectionIDLength: randomConnIDLen(),
 			Versions:           []protocol.VersionNumber{protocol.VersionTLS},
-		}
-		clientConf := &quic.Config{
+		})
+		clientConf := getQuicConfigForClient(&quic.Config{
 			Versions: []protocol.VersionNumber{protocol.VersionTLS},
-		}
+		})
 
 		ln := runServer(serverConf)
 		defer ln.Close()
@@ -74,14 +74,14 @@ var _ = Describe("Connection ID lengths tests", func() {
 	})
 
 	It("downloads a file when both client and server use a random connection ID length", func() {
-		serverConf := &quic.Config{
+		serverConf := getQuicConfigForServer(&quic.Config{
 			ConnectionIDLength: randomConnIDLen(),
 			Versions:           []protocol.VersionNumber{protocol.VersionTLS},
-		}
-		clientConf := &quic.Config{
+		})
+		clientConf := getQuicConfigForClient(&quic.Config{
 			ConnectionIDLength: randomConnIDLen(),
 			Versions:           []protocol.VersionNumber{protocol.VersionTLS},
-		}
+		})
 
 		ln := runServer(serverConf)
 		defer ln.Close()

--- a/integrationtests/self/drop_test.go
+++ b/integrationtests/self/drop_test.go
@@ -31,9 +31,7 @@ var _ = Describe("Drop Tests", func() {
 		ln, err = quic.ListenAddr(
 			"localhost:0",
 			getTLSConfig(),
-			&quic.Config{
-				Versions: []protocol.VersionNumber{version},
-			},
+			getQuicConfigForServer(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		serverPort := ln.Addr().(*net.UDPAddr).Port
@@ -106,7 +104,7 @@ var _ = Describe("Drop Tests", func() {
 						sess, err := quic.DialAddr(
 							fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 							getTLSClientConfig(),
-							&quic.Config{Versions: []protocol.VersionNumber{version}},
+							getQuicConfigForClient(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 						)
 						Expect(err).ToNot(HaveOccurred())
 						defer sess.CloseWithError(0, "")

--- a/integrationtests/self/early_data_test.go
+++ b/integrationtests/self/early_data_test.go
@@ -25,7 +25,7 @@ var _ = Describe("early data", func() {
 				ln, err := quic.ListenAddrEarly(
 					"localhost:0",
 					getTLSConfig(),
-					&quic.Config{Versions: []protocol.VersionNumber{version}},
+					getQuicConfigForServer(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				done := make(chan struct{})
@@ -56,7 +56,7 @@ var _ = Describe("early data", func() {
 				sess, err := quic.DialAddr(
 					fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 					getTLSClientConfig(),
-					&quic.Config{Versions: []protocol.VersionNumber{version}},
+					getQuicConfigForClient(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				str, err := sess.AcceptUniStream(context.Background())

--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -33,11 +33,11 @@ var _ = Describe("Handshake drop tests", func() {
 	const timeout = 10 * time.Minute
 
 	startListenerAndProxy := func(dropCallback quicproxy.DropCallback, doRetry bool, version protocol.VersionNumber) {
-		conf := &quic.Config{
+		conf := getQuicConfigForServer(&quic.Config{
 			MaxIdleTimeout:   timeout,
 			HandshakeTimeout: timeout,
 			Versions:         []protocol.VersionNumber{version},
-		}
+		})
 		if !doRetry {
 			conf.AcceptToken = func(net.Addr, *quic.Token) bool { return true }
 		}
@@ -79,11 +79,11 @@ var _ = Describe("Handshake drop tests", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 				getTLSClientConfig(),
-				&quic.Config{
+				getQuicConfigForClient(&quic.Config{
 					MaxIdleTimeout:   timeout,
 					HandshakeTimeout: timeout,
 					Versions:         []protocol.VersionNumber{version},
-				},
+				}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			str, err := sess.OpenStream()
@@ -115,11 +115,11 @@ var _ = Describe("Handshake drop tests", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 				getTLSClientConfig(),
-				&quic.Config{
+				getQuicConfigForClient(&quic.Config{
 					MaxIdleTimeout:   timeout,
 					HandshakeTimeout: timeout,
 					Versions:         []protocol.VersionNumber{version},
-				},
+				}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			str, err := sess.AcceptStream(context.Background())
@@ -149,11 +149,11 @@ var _ = Describe("Handshake drop tests", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 				getTLSClientConfig(),
-				&quic.Config{
+				getQuicConfigForClient(&quic.Config{
 					MaxIdleTimeout:   timeout,
 					HandshakeTimeout: timeout,
 					Versions:         []protocol.VersionNumber{version},
-				},
+				}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			var serverSession quic.Session

--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Handshake RTT tests", func() {
 
 	BeforeEach(func() {
 		acceptStopped = make(chan struct{})
-		serverConfig = &quic.Config{}
+		serverConfig = getQuicConfigForServer(nil)
 		serverTLSConfig = getTLSConfig()
 	})
 
@@ -79,9 +79,7 @@ var _ = Describe("Handshake RTT tests", func() {
 		}
 		serverConfig.Versions = protocol.SupportedVersions[:1]
 		runServerAndProxy()
-		clientConfig := &quic.Config{
-			Versions: protocol.SupportedVersions[1:2],
-		}
+		clientConfig := getQuicConfigForClient(&quic.Config{Versions: protocol.SupportedVersions[1:2]})
 		_, err := quic.DialAddr(
 			proxy.LocalAddr().String(),
 			getTLSClientConfig(),
@@ -96,7 +94,7 @@ var _ = Describe("Handshake RTT tests", func() {
 
 	BeforeEach(func() {
 		serverConfig.Versions = []protocol.VersionNumber{protocol.VersionTLS}
-		clientConfig = &quic.Config{Versions: []protocol.VersionNumber{protocol.VersionTLS}}
+		clientConfig = getQuicConfigForClient(&quic.Config{Versions: []protocol.VersionNumber{protocol.VersionTLS}})
 		clientConfig := getTLSClientConfig()
 		clientConfig.InsecureSkipVerify = true
 	})

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -76,7 +76,7 @@ var _ = Describe("HTTP tests", func() {
 				Handler:   mux,
 				TLSConfig: testdata.GetTLSConfig(),
 			},
-			QuicConfig: &quic.Config{Versions: versions},
+			QuicConfig: getQuicConfigForServer(&quic.Config{Versions: versions}),
 		}
 
 		addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:0")
@@ -110,10 +110,10 @@ var _ = Describe("HTTP tests", func() {
 							RootCAs: testdata.GetRootCA(),
 						},
 						DisableCompression: true,
-						QuicConfig: &quic.Config{
+						QuicConfig: getQuicConfigForClient(&quic.Config{
 							Versions:       []protocol.VersionNumber{version},
 							MaxIdleTimeout: 10 * time.Second,
-						},
+						}),
 					},
 				}
 			})

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -63,10 +63,10 @@ var _ = Describe("MITM test", func() {
 			}
 
 			BeforeEach(func() {
-				serverConfig = &quic.Config{
+				serverConfig = getQuicConfigForServer(&quic.Config{
 					Versions:           []protocol.VersionNumber{version},
 					ConnectionIDLength: connIDLen,
-				}
+				})
 				addr, err := net.ResolveUDPAddr("udp", "localhost:0")
 				Expect(err).ToNot(HaveOccurred())
 				clientConn, err = net.ListenUDP("udp", addr)
@@ -128,10 +128,10 @@ var _ = Describe("MITM test", func() {
 							raddr,
 							fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 							getTLSClientConfig(),
-							&quic.Config{
+							getQuicConfigForClient(&quic.Config{
 								Versions:           []protocol.VersionNumber{version},
 								ConnectionIDLength: connIDLen,
-							},
+							}),
 						)
 						Expect(err).ToNot(HaveOccurred())
 						str, err := sess.AcceptUniStream(context.Background())
@@ -174,10 +174,10 @@ var _ = Describe("MITM test", func() {
 						raddr,
 						fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 						getTLSClientConfig(),
-						&quic.Config{
+						getQuicConfigForClient(&quic.Config{
 							Versions:           []protocol.VersionNumber{version},
 							ConnectionIDLength: connIDLen,
-						},
+						}),
 					)
 					Expect(err).ToNot(HaveOccurred())
 					str, err := sess.AcceptUniStream(context.Background())
@@ -335,11 +335,11 @@ var _ = Describe("MITM test", func() {
 						raddr,
 						fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 						getTLSClientConfig(),
-						&quic.Config{
+						getQuicConfigForClient(&quic.Config{
 							Versions:           []protocol.VersionNumber{version},
 							ConnectionIDLength: connIDLen,
 							HandshakeTimeout:   2 * time.Second,
-						},
+						}),
 					)
 					return err
 				}

--- a/integrationtests/self/multiplex_test.go
+++ b/integrationtests/self/multiplex_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Multiplexing", func() {
 					addr,
 					fmt.Sprintf("localhost:%d", addr.(*net.UDPAddr).Port),
 					getTLSClientConfig(),
-					&quic.Config{Versions: []protocol.VersionNumber{version}},
+					getQuicConfigForClient(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				defer sess.CloseWithError(0, "")
@@ -62,7 +62,7 @@ var _ = Describe("Multiplexing", func() {
 					ln, err := quic.ListenAddr(
 						"localhost:0",
 						getTLSConfig(),
-						&quic.Config{Versions: []protocol.VersionNumber{version}},
+						getQuicConfigForServer(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 					)
 					Expect(err).ToNot(HaveOccurred())
 					return ln
@@ -145,7 +145,7 @@ var _ = Describe("Multiplexing", func() {
 					server, err := quic.Listen(
 						conn,
 						getTLSConfig(),
-						&quic.Config{Versions: []protocol.VersionNumber{version}},
+						getQuicConfigForServer(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 					)
 					Expect(err).ToNot(HaveOccurred())
 					runServer(server)
@@ -181,7 +181,7 @@ var _ = Describe("Multiplexing", func() {
 					server1, err := quic.Listen(
 						conn1,
 						getTLSConfig(),
-						&quic.Config{Versions: []protocol.VersionNumber{version}},
+						getQuicConfigForServer(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 					)
 					Expect(err).ToNot(HaveOccurred())
 					runServer(server1)
@@ -190,7 +190,7 @@ var _ = Describe("Multiplexing", func() {
 					server2, err := quic.Listen(
 						conn2,
 						getTLSConfig(),
-						&quic.Config{Versions: []protocol.VersionNumber{version}},
+						getQuicConfigForServer(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 					)
 					Expect(err).ToNot(HaveOccurred())
 					runServer(server2)

--- a/integrationtests/self/rtt_test.go
+++ b/integrationtests/self/rtt_test.go
@@ -23,9 +23,7 @@ var _ = Describe("non-zero RTT", func() {
 			ln, err := quic.ListenAddr(
 				"localhost:0",
 				getTLSConfig(),
-				&quic.Config{
-					Versions: []protocol.VersionNumber{version},
-				},
+				getQuicConfigForServer(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			go func() {
@@ -45,7 +43,7 @@ var _ = Describe("non-zero RTT", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", port),
 				getTLSClientConfig(),
-				&quic.Config{Versions: []protocol.VersionNumber{version}},
+				getQuicConfigForClient(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			str, err := sess.AcceptStream(context.Background())
@@ -81,7 +79,7 @@ var _ = Describe("non-zero RTT", func() {
 					sess, err := quic.DialAddr(
 						fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 						getTLSClientConfig(),
-						&quic.Config{Versions: []protocol.VersionNumber{version}},
+						getQuicConfigForClient(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 					)
 					Expect(err).ToNot(HaveOccurred())
 					str, err := sess.AcceptStream(context.Background())

--- a/integrationtests/self/stateless_reset_test.go
+++ b/integrationtests/self/stateless_reset_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Stateless Resets", func() {
 		It(fmt.Sprintf("sends and recognizes stateless resets, for %d byte connection IDs", connIDLen), func() {
 			statelessResetKey := make([]byte, 32)
 			rand.Read(statelessResetKey)
-			serverConfig := &quic.Config{StatelessResetKey: statelessResetKey}
+			serverConfig := getQuicConfigForServer(&quic.Config{StatelessResetKey: statelessResetKey})
 
 			ln, err := quic.ListenAddr("localhost:0", getTLSConfig(), serverConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -58,10 +58,10 @@ var _ = Describe("Stateless Resets", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 				getTLSClientConfig(),
-				&quic.Config{
+				getQuicConfigForClient(&quic.Config{
 					ConnectionIDLength: connIDLen,
 					MaxIdleTimeout:     2 * time.Second,
-				},
+				}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			str, err := sess.AcceptStream(context.Background())

--- a/integrationtests/self/stream_test.go
+++ b/integrationtests/self/stream_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Bidirectional streams", func() {
 					Versions:           []protocol.VersionNumber{version},
 					MaxIncomingStreams: 0,
 				}
-				server, err = quic.ListenAddr("localhost:0", getTLSConfig(), qconf)
+				server, err = quic.ListenAddr("localhost:0", getTLSConfig(), getQuicConfigForServer(qconf))
 				Expect(err).ToNot(HaveOccurred())
 				serverAddr = fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port)
 			})
@@ -100,7 +100,7 @@ var _ = Describe("Bidirectional streams", func() {
 				client, err := quic.DialAddr(
 					serverAddr,
 					getTLSClientConfig(),
-					qconf,
+					getQuicConfigForClient(qconf),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				runSendingPeer(client)
@@ -118,7 +118,7 @@ var _ = Describe("Bidirectional streams", func() {
 				client, err := quic.DialAddr(
 					serverAddr,
 					getTLSClientConfig(),
-					qconf,
+					getQuicConfigForClient(qconf),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				runReceivingPeer(client)
@@ -145,7 +145,7 @@ var _ = Describe("Bidirectional streams", func() {
 				client, err := quic.DialAddr(
 					serverAddr,
 					getTLSClientConfig(),
-					qconf,
+					getQuicConfigForClient(qconf),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				done2 := make(chan struct{})

--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Timeout tests", func() {
 			_, err := quic.DialAddr(
 				"localhost:12345",
 				getTLSClientConfig(),
-				&quic.Config{HandshakeTimeout: 10 * time.Millisecond},
+				getQuicConfigForClient(&quic.Config{HandshakeTimeout: 10 * time.Millisecond}),
 			)
 			errChan <- err
 		}()
@@ -47,7 +47,7 @@ var _ = Describe("Timeout tests", func() {
 				ctx,
 				"localhost:12345",
 				getTLSClientConfig(),
-				nil,
+				getQuicConfigForClient(nil),
 			)
 			errChan <- err
 		}()
@@ -63,7 +63,7 @@ var _ = Describe("Timeout tests", func() {
 		server, err := quic.ListenAddr(
 			"localhost:0",
 			getTLSConfig(),
-			nil,
+			getQuicConfigForServer(nil),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		defer server.Close()
@@ -92,7 +92,7 @@ var _ = Describe("Timeout tests", func() {
 		sess, err := quic.DialAddr(
 			fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 			getTLSClientConfig(),
-			&quic.Config{MaxIdleTimeout: idleTimeout},
+			getQuicConfigForClient(&quic.Config{MaxIdleTimeout: idleTimeout}),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		strIn, err := sess.AcceptStream(context.Background())
@@ -139,7 +139,11 @@ var _ = Describe("Timeout tests", func() {
 		})
 
 		It("times out after inactivity", func() {
-			server, err := quic.ListenAddr("localhost:0", getTLSConfig(), nil)
+			server, err := quic.ListenAddr(
+				"localhost:0",
+				getTLSConfig(),
+				getQuicConfigForServer(nil),
+			)
 			Expect(err).ToNot(HaveOccurred())
 			defer server.Close()
 
@@ -155,7 +159,7 @@ var _ = Describe("Timeout tests", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 				getTLSClientConfig(),
-				&quic.Config{MaxIdleTimeout: idleTimeout},
+				getQuicConfigForClient(&quic.Config{MaxIdleTimeout: idleTimeout}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			startTime := time.Now()
@@ -180,7 +184,11 @@ var _ = Describe("Timeout tests", func() {
 		})
 
 		It("times out after sending a packet", func() {
-			server, err := quic.ListenAddr("localhost:0", getTLSConfig(), nil)
+			server, err := quic.ListenAddr(
+				"localhost:0",
+				getTLSConfig(),
+				getQuicConfigForServer(nil),
+			)
 			Expect(err).ToNot(HaveOccurred())
 			defer server.Close()
 
@@ -196,7 +204,7 @@ var _ = Describe("Timeout tests", func() {
 			sess, err := quic.DialAddr(
 				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 				getTLSClientConfig(),
-				&quic.Config{MaxIdleTimeout: idleTimeout},
+				getQuicConfigForClient(&quic.Config{MaxIdleTimeout: idleTimeout}),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -236,7 +244,7 @@ var _ = Describe("Timeout tests", func() {
 		server, err := quic.ListenAddr(
 			"localhost:0",
 			getTLSConfig(),
-			nil,
+			getQuicConfigForServer(nil),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		defer server.Close()
@@ -264,10 +272,10 @@ var _ = Describe("Timeout tests", func() {
 		sess, err := quic.DialAddr(
 			fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 			getTLSClientConfig(),
-			&quic.Config{
+			getQuicConfigForClient(&quic.Config{
 				MaxIdleTimeout: idleTimeout,
 				KeepAlive:      true,
-			},
+			}),
 		)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/integrationtests/self/uni_stream_test.go
+++ b/integrationtests/self/uni_stream_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Unidirectional Streams", func() {
 	BeforeEach(func() {
 		var err error
 		qconf = &quic.Config{Versions: []protocol.VersionNumber{protocol.VersionTLS}}
-		server, err = quic.ListenAddr("localhost:0", getTLSConfig(), qconf)
+		server, err = quic.ListenAddr("localhost:0", getTLSConfig(), getQuicConfigForServer(qconf))
 		Expect(err).ToNot(HaveOccurred())
 		serverAddr = fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port)
 	})
@@ -81,7 +81,7 @@ var _ = Describe("Unidirectional Streams", func() {
 		client, err := quic.DialAddr(
 			serverAddr,
 			getTLSClientConfig(),
-			qconf,
+			getQuicConfigForClient(qconf),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		runSendingPeer(client)
@@ -99,7 +99,7 @@ var _ = Describe("Unidirectional Streams", func() {
 		client, err := quic.DialAddr(
 			serverAddr,
 			getTLSClientConfig(),
-			qconf,
+			getQuicConfigForClient(qconf),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		runReceivingPeer(client)
@@ -125,7 +125,7 @@ var _ = Describe("Unidirectional Streams", func() {
 		client, err := quic.DialAddr(
 			serverAddr,
 			getTLSClientConfig(),
-			qconf,
+			getQuicConfigForClient(qconf),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		done2 := make(chan struct{})

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -59,7 +59,7 @@ var _ = Describe("0-RTT", func() {
 				sess, err := quic.DialAddr(
 					fmt.Sprintf("localhost:%d", proxyPort),
 					clientConf,
-					&quic.Config{Versions: []protocol.VersionNumber{version}},
+					getQuicConfigForClient(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(puts).Should(Receive())
@@ -93,7 +93,7 @@ var _ = Describe("0-RTT", func() {
 				sess, err := quic.DialAddrEarly(
 					fmt.Sprintf("localhost:%d", proxyPort),
 					clientConf,
-					&quic.Config{Versions: []protocol.VersionNumber{version}},
+					getQuicConfigForClient(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				str, err := sess.OpenUniStream()
@@ -109,10 +109,10 @@ var _ = Describe("0-RTT", func() {
 				ln, err := quic.ListenAddrEarly(
 					"localhost:0",
 					getTLSConfig(),
-					&quic.Config{
+					getQuicConfigForServer(&quic.Config{
 						Versions:    []protocol.VersionNumber{version},
 						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-					},
+					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				defer ln.Close()
@@ -171,7 +171,7 @@ var _ = Describe("0-RTT", func() {
 				sess, err := quic.DialAddrEarly(
 					fmt.Sprintf("localhost:%d", proxy.LocalPort()),
 					clientConf,
-					&quic.Config{Versions: []protocol.VersionNumber{version}},
+					getQuicConfigForClient(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				sent0RTT := make(chan struct{})
@@ -210,10 +210,10 @@ var _ = Describe("0-RTT", func() {
 				ln, err := quic.ListenAddrEarly(
 					"localhost:0",
 					getTLSConfig(),
-					&quic.Config{
+					getQuicConfigForServer(&quic.Config{
 						Versions:    []protocol.VersionNumber{version},
 						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-					},
+					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				defer ln.Close()
@@ -264,7 +264,7 @@ var _ = Describe("0-RTT", func() {
 				ln, err := quic.ListenAddrEarly(
 					"localhost:0",
 					getTLSConfig(),
-					&quic.Config{Versions: []protocol.VersionNumber{version}},
+					getQuicConfigForServer(&quic.Config{Versions: []protocol.VersionNumber{version}}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				defer ln.Close()
@@ -330,11 +330,11 @@ var _ = Describe("0-RTT", func() {
 				ln, err := quic.ListenAddrEarly(
 					"localhost:0",
 					tlsConf,
-					&quic.Config{
+					getQuicConfigForServer(&quic.Config{
 						Versions:           []protocol.VersionNumber{version},
 						AcceptToken:        func(_ net.Addr, _ *quic.Token) bool { return true },
 						MaxIncomingStreams: maxStreams,
-					},
+					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -345,11 +345,11 @@ var _ = Describe("0-RTT", func() {
 				ln, err = quic.ListenAddrEarly(
 					"localhost:0",
 					tlsConf,
-					&quic.Config{
+					getQuicConfigForServer(&quic.Config{
 						Versions:           []protocol.VersionNumber{version},
 						AcceptToken:        func(_ net.Addr, _ *quic.Token) bool { return true },
 						MaxIncomingStreams: maxStreams + 1,
-					},
+					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				proxy, num0RTTPackets := runCountingProxy(ln.Addr().(*net.UDPAddr).Port)
@@ -367,10 +367,10 @@ var _ = Describe("0-RTT", func() {
 				ln, err := quic.ListenAddrEarly(
 					"localhost:0",
 					tlsConf,
-					&quic.Config{
+					getQuicConfigForServer(&quic.Config{
 						Versions:    []protocol.VersionNumber{version},
 						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-					},
+					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -383,10 +383,10 @@ var _ = Describe("0-RTT", func() {
 				ln, err = quic.ListenAddrEarly(
 					"localhost:0",
 					tlsConf,
-					&quic.Config{
+					getQuicConfigForServer(&quic.Config{
 						Versions:    []protocol.VersionNumber{version},
 						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-					},
+					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				proxy, num0RTTPackets := runCountingProxy(ln.Addr().(*net.UDPAddr).Port)


### PR DESCRIPTION
Depends on #2438.