### PR TITLE
Revert "use Go 1.14's embedded interfaces, update CIs"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   test:
     docker:
-      - image: "circleci/golang:1.14"
+      - image: "circleci/golang:1.13"
     environment:
       runrace: true
   interop:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ group: travis_latest
 language: go
 
 go:
-  - "1.14.x"
+  - "1.13.x"
 
 # first part of the GOARCH workaround
 # setting the GOARCH directly doesn't work, since the value will be overwritten later

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to use quic-go as a library in other projects, please consider using
 
 ## Guides
 
-*We currently support Go 1.14+, with [Go modules](https://github.com/golang/go/wiki/Modules) support enabled.*
+*We currently support Go 1.13+, with [Go modules](https://github.com/golang/go/wiki/Modules) support enabled.*
 
 Running tests:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ clone_folder: c:\gopath\src\github.com\lucas-clemente\quic-go
 
 install:
   - rmdir c:\go /s /q
-  - appveyor-retry appveyor DownloadFile https://storage.googleapis.com/golang/go1.14.windows-amd64.zip
-  - 7z x go1.14.windows-amd64.zip -y -oC:\ > NUL
+  - appveyor-retry appveyor DownloadFile https://storage.googleapis.com/golang/go1.13.windows-amd64.zip
+  - 7z x go1.13.windows-amd64.zip -y -oC:\ > NUL
   - set PATH=%PATH%;%GOPATH%\bin\windows_%GOARCH%;%GOPATH%\bin
   - set GO111MODULE=on
   - echo %PATH%

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lucas-clemente/quic-go
 
-go 1.14
+go 1.13
 
 require (
 	github.com/alangpierce/go-forceexport v0.0.0-20160317203124-8f1d6941cd75

--- a/interface.go
+++ b/interface.go
@@ -50,16 +50,6 @@ type ErrorCode = protocol.ApplicationErrorCode
 
 // Stream is the interface implemented by QUIC streams
 type Stream interface {
-	ReceiveStream
-	SendStream
-	// SetDeadline sets the read and write deadlines associated
-	// with the connection. It is equivalent to calling both
-	// SetReadDeadline and SetWriteDeadline.
-	SetDeadline(t time.Time) error
-}
-
-// A ReceiveStream is a unidirectional Receive Stream.
-type ReceiveStream interface {
 	// StreamID returns the stream ID.
 	StreamID() StreamID
 	// Read reads data from the stream.
@@ -70,22 +60,6 @@ type ReceiveStream interface {
 	// If the session was closed due to a timeout, the error satisfies
 	// the net.Error interface, and Timeout() will be true.
 	io.Reader
-	// CancelRead aborts receiving on this stream.
-	// It will ask the peer to stop transmitting stream data.
-	// Read will unblock immediately, and future Read calls will fail.
-	// When called multiple times or after reading the io.EOF it is a no-op.
-	CancelRead(ErrorCode)
-	// SetReadDeadline sets the deadline for future Read calls and
-	// any currently-blocked Read call.
-	// A zero value for t means Read will not time out.
-
-	SetReadDeadline(t time.Time) error
-}
-
-// A SendStream is a unidirectional Send Stream.
-type SendStream interface {
-	// StreamID returns the stream ID.
-	StreamID() StreamID
 	// Write writes data to the stream.
 	// Write can be made to time out and return a net.Error with Timeout() == true
 	// after a fixed time limit; see SetDeadline and SetWriteDeadline.
@@ -104,16 +78,57 @@ type SendStream interface {
 	// Write will unblock immediately, and future calls to Write will fail.
 	// When called multiple times or after closing the stream it is a no-op.
 	CancelWrite(ErrorCode)
+	// CancelRead aborts receiving on this stream.
+	// It will ask the peer to stop transmitting stream data.
+	// Read will unblock immediately, and future Read calls will fail.
+	// When called multiple times or after reading the io.EOF it is a no-op.
+	CancelRead(ErrorCode)
 	// The context is canceled as soon as the write-side of the stream is closed.
 	// This happens when Close() or CancelWrite() is called, or when the peer
 	// cancels the read-side of their stream.
 	// Warning: This API should not be considered stable and might change soon.
 	Context() context.Context
+	// SetReadDeadline sets the deadline for future Read calls and
+	// any currently-blocked Read call.
+	// A zero value for t means Read will not time out.
+	SetReadDeadline(t time.Time) error
 	// SetWriteDeadline sets the deadline for future Write calls
 	// and any currently-blocked Write call.
 	// Even if write times out, it may return n > 0, indicating that
 	// some of the data was successfully written.
 	// A zero value for t means Write will not time out.
+	SetWriteDeadline(t time.Time) error
+	// SetDeadline sets the read and write deadlines associated
+	// with the connection. It is equivalent to calling both
+	// SetReadDeadline and SetWriteDeadline.
+	SetDeadline(t time.Time) error
+}
+
+// A ReceiveStream is a unidirectional Receive Stream.
+type ReceiveStream interface {
+	// see Stream.StreamID
+	StreamID() StreamID
+	// see Stream.Read
+	io.Reader
+	// see Stream.CancelRead
+	CancelRead(ErrorCode)
+	// see Stream.SetReadDealine
+	SetReadDeadline(t time.Time) error
+}
+
+// A SendStream is a unidirectional Send Stream.
+type SendStream interface {
+	// see Stream.StreamID
+	StreamID() StreamID
+	// see Stream.Write
+	io.Writer
+	// see Stream.Close
+	io.Closer
+	// see Stream.CancelWrite
+	CancelWrite(ErrorCode)
+	// see Stream.Context
+	Context() context.Context
+	// see Stream.SetWriteDeadline
 	SetWriteDeadline(t time.Time) error
 }
 

--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -2,9 +2,9 @@ FROM martenseemann/quic-network-simulator-endpoint:latest AS builder
 
 RUN apt-get update && apt-get install -y wget tar git
 
-RUN wget https://dl.google.com/go/go1.14.linux-amd64.tar.gz && \
-  tar xfz go1.14.linux-amd64.tar.gz && \
-  rm go1.14.linux-amd64.tar.gz
+RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
+  tar xfz go1.13.3.linux-amd64.tar.gz && \
+  rm go1.13.3.linux-amd64.tar.gz
 
 ENV PATH="/go/bin:${PATH}"
 


### PR DESCRIPTION
This reverts commit c88a69034d6b6d288a01578f5256e90aca95428a.

Unfortunately, go 1.14's new scheduler and timer changes have a few bugs that need to be ironed out before it's ready for production use.

See:
* https://github.com/libp2p/go-libp2p/issues/858
* https://github.com/golang/go/issues/38119