### PR TITLE
correctly set anti-deadlock timer after the Initial space was dropped

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -441,6 +441,12 @@ func (h *sentPacketHandler) setLossDetectionTimer() {
 
 	// PTO alarm
 	sentTime, encLevel := h.getEarliestSentTimeAndSpace()
+	if sentTime.IsZero() {
+		if h.peerCompletedAddressValidation {
+			panic("didn't expect sentTime to be zero")
+		}
+		sentTime = time.Now()
+	}
 	h.alarm = sentTime.Add(h.rttStats.PTO(encLevel == protocol.Encryption1RTT) << h.ptoCount)
 }
 


### PR DESCRIPTION
Depends on #2452.
See https://github.com/quicwg/base-drafts/pull/3556.