### PR TITLE
don't log a metrics_update when sending a non-ack-eliciting packet

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -187,7 +187,7 @@ func (h *sentPacketHandler) SentPacket(packet *Packet) {
 	if isAckEliciting {
 		h.getPacketNumberSpace(packet.EncryptionLevel).history.SentPacket(packet)
 	}
-	if h.qlogger != nil {
+	if h.qlogger != nil && isAckEliciting {
 		h.qlogger.UpdatedMetrics(h.rttStats, h.congestion.GetCongestionWindow(), h.bytesInFlight, h.packetsInFlight())
 	}
 	if isAckEliciting || !h.peerCompletedAddressValidation {


### PR DESCRIPTION
Non-ack-eliciting are not considered "in-flight", i.e. they don't increase the `bytes_in_flight`.