### PR TITLE
reset the PTO count when receiving a Retry

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -721,9 +721,13 @@ func (h *sentPacketHandler) ResetForRetry() error {
 	h.appDataPackets = newPacketNumberSpace(h.appDataPackets.pns.Pop())
 	oldAlarm := h.alarm
 	h.alarm = time.Time{}
-	if h.qlogger != nil && !oldAlarm.IsZero() {
-		h.qlogger.LossTimerCanceled()
+	if h.qlogger != nil {
+		h.qlogger.UpdatedPTOCount(0)
+		if !oldAlarm.IsZero() {
+			h.qlogger.LossTimerCanceled()
+		}
 	}
+	h.ptoCount = 0
 	return nil
 }
 

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -995,7 +995,7 @@ var _ = Describe("SentPacketHandler", func() {
 			perspective = protocol.PerspectiveClient
 		})
 
-		It("queues outstanding packets for retransmission and cancels alarms", func() {
+		It("queues outstanding packets for retransmission, cancels alarms and resets PTO count", func() {
 			handler.SentPacket(initialPacket(&Packet{PacketNumber: 42}))
 			Expect(handler.GetLossDetectionTimeout()).ToNot(BeZero())
 			Expect(handler.bytesInFlight).ToNot(BeZero())
@@ -1006,6 +1006,7 @@ var _ = Describe("SentPacketHandler", func() {
 			Expect(handler.bytesInFlight).To(BeZero())
 			Expect(handler.GetLossDetectionTimeout()).To(BeZero())
 			Expect(handler.SendMode()).To(Equal(SendAny))
+			Expect(handler.ptoCount).To(BeZero())
 		})
 
 		It("queues outstanding frames for retransmission and cancels alarms", func() {


### PR DESCRIPTION
Not sure if this is the right thing to do, but it would prevent this failure:
![Screenshot_2020-04-04 qvis tools and visualizations for QUIC and HTTP 3](https://user-images.githubusercontent.com/1478487/78422100-084abe00-7687-11ea-8725-172c9c988960.png)
The test fails because the server receives the token more than `protocol.RetryTokenValidity` (10s) after it was issued.