### PR TITLE
don't create a new session for invalid Initial packets

### DIFF
--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -88,10 +88,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 				return &tls.Config{ServerName: ch.ServerName}, nil
 			},
 		}
+		initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 		server := NewCryptoSetupServer(
 			&bytes.Buffer{},
 			&bytes.Buffer{},
-			protocol.ConnectionID{},
+			initialSealer,
+			initialOpener,
 			nil,
 			nil,
 			&wire.TransportParameters{},
@@ -121,10 +123,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 		runner := NewMockHandshakeRunner(mockCtrl)
 		runner.EXPECT().OnError(gomock.Any()).Do(func(e error) { sErrChan <- e })
 		_, sInitialStream, sHandshakeStream := initStreams()
+		initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 		server := NewCryptoSetupServer(
 			sInitialStream,
 			sHandshakeStream,
-			protocol.ConnectionID{},
+			initialSealer,
+			initialOpener,
 			nil,
 			nil,
 			&wire.TransportParameters{},
@@ -160,10 +164,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 		_, sInitialStream, sHandshakeStream := initStreams()
 		runner := NewMockHandshakeRunner(mockCtrl)
 		runner.EXPECT().OnError(gomock.Any()).Do(func(e error) { sErrChan <- e })
+		initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 		server := NewCryptoSetupServer(
 			sInitialStream,
 			sHandshakeStream,
-			protocol.ConnectionID{},
+			initialSealer,
+			initialOpener,
 			nil,
 			nil,
 			&wire.TransportParameters{},
@@ -202,10 +208,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 		_, sInitialStream, sHandshakeStream := initStreams()
 		runner := NewMockHandshakeRunner(mockCtrl)
 		runner.EXPECT().OnError(gomock.Any()).Do(func(e error) { sErrChan <- e })
+		initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 		server := NewCryptoSetupServer(
 			sInitialStream,
 			sHandshakeStream,
-			protocol.ConnectionID{},
+			initialSealer,
+			initialOpener,
 			nil,
 			nil,
 			&wire.TransportParameters{},
@@ -237,10 +245,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 
 	It("returns Handshake() when it is closed", func() {
 		_, sInitialStream, sHandshakeStream := initStreams()
+		initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 		server := NewCryptoSetupServer(
 			sInitialStream,
 			sHandshakeStream,
-			protocol.ConnectionID{},
+			initialSealer,
+			initialOpener,
 			nil,
 			nil,
 			&wire.TransportParameters{},
@@ -355,10 +365,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 			sRunner.EXPECT().OnError(gomock.Any()).Do(func(e error) { sErrChan <- e }).MaxTimes(1)
 			sRunner.EXPECT().OnHandshakeComplete().Do(func() { sHandshakeComplete = true }).MaxTimes(1)
 			var token [16]byte
+			initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 			server := NewCryptoSetupServer(
 				sInitialStream,
 				sHandshakeStream,
-				protocol.ConnectionID{},
+				initialSealer,
+				initialOpener,
 				nil,
 				nil,
 				&wire.TransportParameters{StatelessResetToken: &token},
@@ -475,10 +487,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 				MaxIdleTimeout:      0x1337 * time.Second,
 				StatelessResetToken: &token,
 			}
+			initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 			server := NewCryptoSetupServer(
 				sInitialStream,
 				sHandshakeStream,
-				protocol.ConnectionID{},
+				initialSealer,
+				initialOpener,
 				nil,
 				nil,
 				sTransportParameters,
@@ -527,10 +541,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 				sRunner := NewMockHandshakeRunner(mockCtrl)
 				sRunner.EXPECT().OnReceivedParams(gomock.Any())
 				sRunner.EXPECT().OnHandshakeComplete()
+				initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 				server := NewCryptoSetupServer(
 					sInitialStream,
 					sHandshakeStream,
-					protocol.ConnectionID{},
+					initialSealer,
+					initialOpener,
 					nil,
 					nil,
 					&wire.TransportParameters{},
@@ -586,10 +602,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 				sRunner := NewMockHandshakeRunner(mockCtrl)
 				sRunner.EXPECT().OnReceivedParams(gomock.Any())
 				sRunner.EXPECT().OnHandshakeComplete()
+				initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 				server := NewCryptoSetupServer(
 					sInitialStream,
 					sHandshakeStream,
-					protocol.ConnectionID{},
+					initialSealer,
+					initialOpener,
 					nil,
 					nil,
 					&wire.TransportParameters{},
@@ -717,10 +735,12 @@ var _ = Describe("Crypto Setup TLS", func() {
 				sRunner := NewMockHandshakeRunner(mockCtrl)
 				sRunner.EXPECT().OnReceivedParams(gomock.Any())
 				sRunner.EXPECT().OnHandshakeComplete()
+				initialSealer, initialOpener := NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 				server = NewCryptoSetupServer(
 					sInitialStream,
 					sHandshakeStream,
-					protocol.ConnectionID{},
+					initialSealer,
+					initialOpener,
 					nil,
 					nil,
 					&wire.TransportParameters{},

--- a/server_test.go
+++ b/server_test.go
@@ -14,18 +14,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/lucas-clemente/quic-go/internal/qerr"
-
-	"github.com/lucas-clemente/quic-go/qlog"
-
-	"github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/testdata"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 	"github.com/lucas-clemente/quic-go/quictrace"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -421,7 +418,6 @@ var _ = Describe("Server", func() {
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
 					enable0RTT bool,
-					_ qlog.Tracer,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -491,7 +487,6 @@ var _ = Describe("Server", func() {
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
 					_ bool,
-					_ qlog.Tracer,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -527,7 +522,6 @@ var _ = Describe("Server", func() {
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
 					_ bool,
-					_ qlog.Tracer,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -569,7 +563,6 @@ var _ = Describe("Server", func() {
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
 					_ bool,
-					_ qlog.Tracer,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -599,7 +592,6 @@ var _ = Describe("Server", func() {
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
 					_ bool,
-					_ qlog.Tracer,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -660,7 +652,6 @@ var _ = Describe("Server", func() {
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
 					_ bool,
-					_ qlog.Tracer,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -764,7 +755,6 @@ var _ = Describe("Server", func() {
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
 					_ bool,
-					_ qlog.Tracer,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -827,7 +817,6 @@ var _ = Describe("Server", func() {
 				_ *tls.Config,
 				_ *handshake.TokenGenerator,
 				enable0RTT bool,
-				_ qlog.Tracer,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -861,7 +850,6 @@ var _ = Describe("Server", func() {
 				_ *tls.Config,
 				_ *handshake.TokenGenerator,
 				_ bool,
-				_ qlog.Tracer,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -916,7 +904,6 @@ var _ = Describe("Server", func() {
 				_ *tls.Config,
 				_ *handshake.TokenGenerator,
 				_ bool,
-				_ qlog.Tracer,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {

--- a/session.go
+++ b/session.go
@@ -205,6 +205,8 @@ var newSession = func(
 	destConnID protocol.ConnectionID,
 	srcConnID protocol.ConnectionID,
 	statelessResetToken [16]byte,
+	initialSealer handshake.LongHeaderSealer,
+	initialOpener handshake.LongHeaderOpener,
 	conf *Config,
 	tlsConf *tls.Config,
 	tokenGenerator *handshake.TokenGenerator,
@@ -291,7 +293,8 @@ var newSession = func(
 	cs := handshake.NewCryptoSetupServer(
 		initialStream,
 		handshakeStream,
-		clientDestConnID,
+		initialSealer,
+		initialOpener,
 		conn.LocalAddr(),
 		conn.RemoteAddr(),
 		params,

--- a/session_test.go
+++ b/session_test.go
@@ -93,7 +93,6 @@ var _ = Describe("Session", func() {
 			nil, // tls.Config
 			tokenGenerator,
 			false,
-			nil,
 			utils.DefaultLogger,
 			protocol.VersionTLS,
 		).(*session)

--- a/session_test.go
+++ b/session_test.go
@@ -81,6 +81,7 @@ var _ = Describe("Session", func() {
 		mconn.EXPECT().LocalAddr().Return(&net.UDPAddr{})
 		tokenGenerator, err := handshake.NewTokenGenerator()
 		Expect(err).ToNot(HaveOccurred())
+		initialSealer, initialOpener := handshake.NewInitialAEAD(protocol.ConnectionID{}, protocol.PerspectiveServer)
 		sess = newSession(
 			mconn,
 			sessionRunner,
@@ -89,6 +90,8 @@ var _ = Describe("Session", func() {
 			destConnID,
 			srcConnID,
 			[16]byte{},
+			initialSealer,
+			initialOpener,
 			populateServerConfig(&Config{}),
 			nil, // tls.Config
 			tokenGenerator,


### PR DESCRIPTION
@ptrd reported the following error: When we receive an Initial packet with a corrupted SCID, we'd still create a new session (and drop the Initial packet, since it doesn't get past the AEAD). However, the session is still created, and once we receive (the retransmission of) a valid Initial packet, we'd then use the corrupted SCID to reply to it.

This PR implements a check before creating the session. Basically, we create the AEAD in the server and decrypt the packet there. Only if it decrypts, we create the session. This is based on the realization that creating the AEAD is an order of magnitude more expensive than an AEAD operation (#2467 doesn't change this significantly):
```
BenchmarkAEADCreation-16    	  720339	     17222 ns/op	   10488 B/op	     171 allocs/op
BenchmarkAEADOpen-16        	13196452	       923 ns/op	    2696 B/op	       2 allocs/op
```

The sad thing is that we'll still decrypt the packet twice (and we have to copy all the packet data into a new buffer, to avoid touching the packet, which will have to be decrypted later). That means we're taking a (small) performance hit in the common case, in order to catch a problem in a corner case.
