### PR TITLE
fix conversion of qtls.ClientHelloInfo to tls.ClientHelloInfo

### DIFF
--- a/internal/handshake/qtls.go
+++ b/internal/handshake/qtls.go
@@ -62,7 +62,11 @@ func tlsConfigToQtlsConfig(
 	var getConfigForClient func(ch *qtls.ClientHelloInfo) (*qtls.Config, error)
 	if c.GetConfigForClient != nil {
 		getConfigForClient = func(ch *qtls.ClientHelloInfo) (*qtls.Config, error) {
-			tlsConf, err := c.GetConfigForClient((*tls.ClientHelloInfo)(unsafe.Pointer(ch)))
+			var chi *tls.ClientHelloInfo
+			if ch != nil {
+				chi = toTLSClientHelloInfo(ch)
+			}
+			tlsConf, err := c.GetConfigForClient(chi)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/handshake/unsafe.go
+++ b/internal/handshake/unsafe.go
@@ -81,6 +81,9 @@ type qtlsClientHelloInfo struct {
 }
 
 func toTLSClientHelloInfo(chi *qtls.ClientHelloInfo) *tls.ClientHelloInfo {
+	if chi == nil {
+		return nil
+	}
 	qtlsCHI := (*qtlsClientHelloInfo)(unsafe.Pointer(chi))
 	var config *tls.Config
 	if qtlsCHI.config != nil {

--- a/internal/handshake/unsafe.go
+++ b/internal/handshake/unsafe.go
@@ -82,6 +82,10 @@ type qtlsClientHelloInfo struct {
 
 func toTLSClientHelloInfo(chi *qtls.ClientHelloInfo) *tls.ClientHelloInfo {
 	qtlsCHI := (*qtlsClientHelloInfo)(unsafe.Pointer(chi))
+	var config *tls.Config
+	if qtlsCHI.config != nil {
+		config = qtlsConfigToTLSConfig((*qtls.Config)(unsafe.Pointer(qtlsCHI.config)))
+	}
 	return (*tls.ClientHelloInfo)(unsafe.Pointer(&clientHelloInfo{
 		CipherSuites:      chi.CipherSuites,
 		ServerName:        chi.ServerName,
@@ -91,6 +95,6 @@ func toTLSClientHelloInfo(chi *qtls.ClientHelloInfo) *tls.ClientHelloInfo {
 		SupportedProtos:   chi.SupportedProtos,
 		SupportedVersions: chi.SupportedVersions,
 		Conn:              chi.Conn,
-		config:            qtlsConfigToTLSConfig((*qtls.Config)(unsafe.Pointer(qtlsCHI.config))),
+		config:            config,
 	}))
 }

--- a/internal/handshake/unsafe_test.go
+++ b/internal/handshake/unsafe_test.go
@@ -95,4 +95,10 @@ var _ = Describe("Unsafe checks", func() {
 		Expect(c.config.MaxVersion).To(BeEquivalentTo(tls.VersionTLS12))
 		Expect(c.config.CurvePreferences).To(Equal([]tls.CurveID{19, 20, 21}))
 	})
+
+	It("converts a qtls.ClientHelloInfo to a tls.ClientHelloInfo, if no config is set", func() {
+		chi := &qtlsClientHelloInfo{CipherSuites: []uint16{13, 37}}
+		tlsCHI := toTLSClientHelloInfo((*qtls.ClientHelloInfo)(unsafe.Pointer(chi)))
+		Expect(tlsCHI.CipherSuites).To(Equal([]uint16{13, 37}))
+	})
 })


### PR DESCRIPTION
This happens when you use `unsafe`...