### PR TITLE
make sure that quic-go builds with Go 1.13 and Go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
 version: 2.1
 executors:
-  test:
+  test-go114:
     docker:
       - image: "circleci/golang:1.14"
+    environment:
+      runrace: true
+  test-go113:
+    docker:
+      - image: "circleci/golang:1.13"
     environment:
       runrace: true
   interop:
@@ -12,8 +17,8 @@ executors:
       IMAGE_NAME: martenseemann/quic-go-interop
 
 jobs:
-  test:
-    executor: test
+  "test": &test
+    executor: test-go114
     working_directory: /go/src/github.com/lucas-clemente/quic-go
     steps:
       - checkout
@@ -43,6 +48,11 @@ jobs:
       - run:
           name: "Run self integration tests with qlog"
           command: ginkgo -v -randomizeAllSpecs -trace integrationtests/self -- -qlog
+  go114:
+    <<: *test
+  go113:
+    <<: *test
+    executor: test-go113
   interop-build:
     executor: interop
     steps:
@@ -77,14 +87,15 @@ jobs:
 workflows:
   workflow:
     jobs:
-      - test
+      - go114
+      - go113
       - interop-build:
           filters:
             branches:
               only: interop
       - interop-publish:
           requires:
-            - test
+            - go114
             - interop-build
           filters:
             branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: go
 
 go:
   - "1.14.x"
+  - "1.13.x"
 
 # first part of the GOARCH workaround
 # setting the GOARCH directly doesn't work, since the value will be overwritten later
@@ -23,6 +24,10 @@ env:
     - TRAVIS_GOARCH=386 TESTMODE=unit
     - TRAVIS_GOARCH=386 TESTMODE=integration
 
+jobs:
+  exclude:
+    - go: "1.13.x"
+      env: TRAVIS_GOARCH=amd64 TESTMODE=fuzz
 
 # second part of the GOARCH workaround
 # now actually set the GOARCH env variable to the value of the temporary variable set earlier

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to use quic-go as a library in other projects, please consider using
 
 ## Guides
 
-*We currently support Go 1.14+, with [Go modules](https://github.com/golang/go/wiki/Modules) support enabled.*
+*We currently support both Go 1.13.x and Go 1.14+, with [Go modules](https://github.com/golang/go/wiki/Modules) support enabled.*
 
 Running tests:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lucas-clemente/quic-go
 
-go 1.14
+go 1.13
 
 require (
 	github.com/alangpierce/go-forceexport v0.0.0-20160317203124-8f1d6941cd75
@@ -9,7 +9,7 @@ require (
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.3.1
 	github.com/marten-seemann/qpack v0.1.0
-	github.com/marten-seemann/qtls v0.8.0
+	github.com/marten-seemann/qtls v0.9.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/marten-seemann/qpack v0.1.0 h1:/0M7lkda/6mus9B8u34Asqm8ZhHAAt9Ho0vniNuVSVg=
 github.com/marten-seemann/qpack v0.1.0/go.mod h1:LFt1NU/Ptjip0C2CPkhimBz5CGE3WGDAUWqna+CNTrI=
-github.com/marten-seemann/qtls v0.8.0 h1:aj+MPLibzKByw8CmG0WvWgbtBkctYPAXeB11cQJC8mo=
-github.com/marten-seemann/qtls v0.8.0/go.mod h1:Lao6jDqlCfxyLKYFmZXGm2LSHBgVn+P+ROOex6YkT+k=
+github.com/marten-seemann/qtls v0.9.0 h1:8Zguhc72eS+DH5EAb0BpAPIy3HDXYcihQi4xoDZOnjQ=
+github.com/marten-seemann/qtls v0.9.0/go.mod h1:T1MmAdDPyISzxlK6kjRr0pcZFBVd1OZbBb/j3cvzHhk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/interface.go
+++ b/interface.go
@@ -50,16 +50,6 @@ type ErrorCode = protocol.ApplicationErrorCode
 
 // Stream is the interface implemented by QUIC streams
 type Stream interface {
-	ReceiveStream
-	SendStream
-	// SetDeadline sets the read and write deadlines associated
-	// with the connection. It is equivalent to calling both
-	// SetReadDeadline and SetWriteDeadline.
-	SetDeadline(t time.Time) error
-}
-
-// A ReceiveStream is a unidirectional Receive Stream.
-type ReceiveStream interface {
 	// StreamID returns the stream ID.
 	StreamID() StreamID
 	// Read reads data from the stream.
@@ -70,22 +60,6 @@ type ReceiveStream interface {
 	// If the session was closed due to a timeout, the error satisfies
 	// the net.Error interface, and Timeout() will be true.
 	io.Reader
-	// CancelRead aborts receiving on this stream.
-	// It will ask the peer to stop transmitting stream data.
-	// Read will unblock immediately, and future Read calls will fail.
-	// When called multiple times or after reading the io.EOF it is a no-op.
-	CancelRead(ErrorCode)
-	// SetReadDeadline sets the deadline for future Read calls and
-	// any currently-blocked Read call.
-	// A zero value for t means Read will not time out.
-
-	SetReadDeadline(t time.Time) error
-}
-
-// A SendStream is a unidirectional Send Stream.
-type SendStream interface {
-	// StreamID returns the stream ID.
-	StreamID() StreamID
 	// Write writes data to the stream.
 	// Write can be made to time out and return a net.Error with Timeout() == true
 	// after a fixed time limit; see SetDeadline and SetWriteDeadline.
@@ -104,16 +78,57 @@ type SendStream interface {
 	// Write will unblock immediately, and future calls to Write will fail.
 	// When called multiple times or after closing the stream it is a no-op.
 	CancelWrite(ErrorCode)
+	// CancelRead aborts receiving on this stream.
+	// It will ask the peer to stop transmitting stream data.
+	// Read will unblock immediately, and future Read calls will fail.
+	// When called multiple times or after reading the io.EOF it is a no-op.
+	CancelRead(ErrorCode)
 	// The context is canceled as soon as the write-side of the stream is closed.
 	// This happens when Close() or CancelWrite() is called, or when the peer
 	// cancels the read-side of their stream.
 	// Warning: This API should not be considered stable and might change soon.
 	Context() context.Context
+	// SetReadDeadline sets the deadline for future Read calls and
+	// any currently-blocked Read call.
+	// A zero value for t means Read will not time out.
+	SetReadDeadline(t time.Time) error
 	// SetWriteDeadline sets the deadline for future Write calls
 	// and any currently-blocked Write call.
 	// Even if write times out, it may return n > 0, indicating that
 	// some of the data was successfully written.
 	// A zero value for t means Write will not time out.
+	SetWriteDeadline(t time.Time) error
+	// SetDeadline sets the read and write deadlines associated
+	// with the connection. It is equivalent to calling both
+	// SetReadDeadline and SetWriteDeadline.
+	SetDeadline(t time.Time) error
+}
+
+// A ReceiveStream is a unidirectional Receive Stream.
+type ReceiveStream interface {
+	// see Stream.StreamID
+	StreamID() StreamID
+	// see Stream.Read
+	io.Reader
+	// see Stream.CancelRead
+	CancelRead(ErrorCode)
+	// see Stream.SetReadDealine
+	SetReadDeadline(t time.Time) error
+}
+
+// A SendStream is a unidirectional Send Stream.
+type SendStream interface {
+	// see Stream.StreamID
+	StreamID() StreamID
+	// see Stream.Write
+	io.Writer
+	// see Stream.Close
+	io.Closer
+	// see Stream.CancelWrite
+	CancelWrite(ErrorCode)
+	// see Stream.Context
+	Context() context.Context
+	// see Stream.SetWriteDeadline
 	SetWriteDeadline(t time.Time) error
 }
 

--- a/internal/handshake/aead_test.go
+++ b/internal/handshake/aead_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/marten-seemann/qtls"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,7 +16,7 @@ var _ = Describe("Long Header AEAD", func() {
 	for i := range cipherSuites {
 		cs := cipherSuites[i]
 
-		Context(fmt.Sprintf("using %s", qtls.CipherSuiteName(cs.ID)), func() {
+		Context(fmt.Sprintf("using %s", cipherSuiteName(cs.ID)), func() {
 			getSealerAndOpener := func() (LongHeaderSealer, LongHeaderOpener) {
 				key := make([]byte, 16)
 				hpKey := make([]byte, 16)

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -571,7 +571,7 @@ func (h *cryptoSetup) SetReadKey(encLevel qtls.EncryptionLevel, suite *qtls.Ciph
 			newHeaderProtector(suite, trafficSecret, true),
 		)
 		h.mutex.Unlock()
-		h.logger.Debugf("Installed 0-RTT Read keys (using %s)", qtls.CipherSuiteName(suite.ID))
+		h.logger.Debugf("Installed 0-RTT Read keys (using %s)", cipherSuiteName(suite.ID))
 		if h.qlogger != nil {
 			h.qlogger.UpdatedKeyFromTLS(protocol.Encryption0RTT, h.perspective.Opposite())
 		}
@@ -584,12 +584,12 @@ func (h *cryptoSetup) SetReadKey(encLevel qtls.EncryptionLevel, suite *qtls.Ciph
 			h.dropInitialKeys,
 			h.perspective,
 		)
-		h.logger.Debugf("Installed Handshake Read keys (using %s)", qtls.CipherSuiteName(suite.ID))
+		h.logger.Debugf("Installed Handshake Read keys (using %s)", cipherSuiteName(suite.ID))
 	case qtls.EncryptionApplication:
 		h.readEncLevel = protocol.Encryption1RTT
 		h.aead.SetReadKey(suite, trafficSecret)
 		h.has1RTTOpener = true
-		h.logger.Debugf("Installed 1-RTT Read keys (using %s)", qtls.CipherSuiteName(suite.ID))
+		h.logger.Debugf("Installed 1-RTT Read keys (using %s)", cipherSuiteName(suite.ID))
 	default:
 		panic("unexpected read encryption level")
 	}
@@ -612,7 +612,7 @@ func (h *cryptoSetup) SetWriteKey(encLevel qtls.EncryptionLevel, suite *qtls.Cip
 			newHeaderProtector(suite, trafficSecret, true),
 		)
 		h.mutex.Unlock()
-		h.logger.Debugf("Installed 0-RTT Write keys (using %s)", qtls.CipherSuiteName(suite.ID))
+		h.logger.Debugf("Installed 0-RTT Write keys (using %s)", cipherSuiteName(suite.ID))
 		if h.qlogger != nil {
 			h.qlogger.UpdatedKeyFromTLS(protocol.Encryption0RTT, h.perspective)
 		}
@@ -625,12 +625,12 @@ func (h *cryptoSetup) SetWriteKey(encLevel qtls.EncryptionLevel, suite *qtls.Cip
 			h.dropInitialKeys,
 			h.perspective,
 		)
-		h.logger.Debugf("Installed Handshake Write keys (using %s)", qtls.CipherSuiteName(suite.ID))
+		h.logger.Debugf("Installed Handshake Write keys (using %s)", cipherSuiteName(suite.ID))
 	case qtls.EncryptionApplication:
 		h.writeEncLevel = protocol.Encryption1RTT
 		h.aead.SetWriteKey(suite, trafficSecret)
 		h.has1RTTSealer = true
-		h.logger.Debugf("Installed 1-RTT Write keys (using %s)", qtls.CipherSuiteName(suite.ID))
+		h.logger.Debugf("Installed 1-RTT Write keys (using %s)", cipherSuiteName(suite.ID))
 		if h.zeroRTTSealer != nil {
 			h.zeroRTTSealer = nil
 			h.logger.Debugf("Dropping 0-RTT keys.")

--- a/internal/handshake/go_1-13.go
+++ b/internal/handshake/go_1-13.go
@@ -1,0 +1,24 @@
+// +build !go1.14
+
+package handshake
+
+import (
+	"crypto/tls"
+
+	"github.com/marten-seemann/qtls"
+)
+
+func cipherSuiteName(id uint16) string {
+	switch id {
+	case qtls.TLS_AES_128_GCM_SHA256:
+		return "TLS_AES_128_GCM_SHA256"
+	case qtls.TLS_CHACHA20_POLY1305_SHA256:
+		return "TLS_CHACHA20_POLY1305_SHA256"
+	case qtls.TLS_AES_256_GCM_SHA384:
+		return "TLS_AES_256_GCM_SHA384"
+	default:
+		return "unknown cipher suite"
+	}
+}
+
+func toTLSClientHelloInfo(c *qtls.ClientHelloInfo) *tls.ClientHelloInfo { return c }

--- a/internal/handshake/go_1-14.go
+++ b/internal/handshake/go_1-14.go
@@ -1,0 +1,82 @@
+// +build go1.14
+
+package handshake
+
+import (
+	"crypto/tls"
+	"net"
+	"unsafe"
+
+	"github.com/marten-seemann/qtls"
+)
+
+func init() {
+	if !structsEqual(&tls.ClientHelloInfo{}, &clientHelloInfo{}) {
+		panic("clientHelloInfo not compatible with tls.ClientHelloInfo")
+	}
+	if !structsEqual(&qtls.ClientHelloInfo{}, &qtlsClientHelloInfo{}) {
+		panic("qtlsClientHelloInfo not compatible with qtls.ClientHelloInfo")
+	}
+}
+
+func cipherSuiteName(id uint16) string { return qtls.CipherSuiteName(id) }
+
+type clientHelloInfo struct {
+	CipherSuites      []uint16
+	ServerName        string
+	SupportedCurves   []tls.CurveID
+	SupportedPoints   []uint8
+	SignatureSchemes  []tls.SignatureScheme
+	SupportedProtos   []string
+	SupportedVersions []uint16
+	Conn              net.Conn
+
+	config *tls.Config
+}
+
+type qtlsClientHelloInfo struct {
+	CipherSuites      []uint16
+	ServerName        string
+	SupportedCurves   []tls.CurveID
+	SupportedPoints   []uint8
+	SignatureSchemes  []tls.SignatureScheme
+	SupportedProtos   []string
+	SupportedVersions []uint16
+	Conn              net.Conn
+
+	config *qtls.Config
+}
+
+func toTLSClientHelloInfo(chi *qtls.ClientHelloInfo) *tls.ClientHelloInfo {
+	if chi == nil {
+		return nil
+	}
+	qtlsCHI := (*qtlsClientHelloInfo)(unsafe.Pointer(chi))
+	var config *tls.Config
+	if qtlsCHI.config != nil {
+		config = qtlsConfigToTLSConfig((*qtls.Config)(unsafe.Pointer(qtlsCHI.config)))
+	}
+	return (*tls.ClientHelloInfo)(unsafe.Pointer(&clientHelloInfo{
+		CipherSuites:      chi.CipherSuites,
+		ServerName:        chi.ServerName,
+		SupportedCurves:   chi.SupportedCurves,
+		SupportedPoints:   chi.SupportedPoints,
+		SignatureSchemes:  chi.SignatureSchemes,
+		SupportedProtos:   chi.SupportedProtos,
+		SupportedVersions: chi.SupportedVersions,
+		Conn:              chi.Conn,
+		config:            config,
+	}))
+}
+
+// qtlsConfigToTLSConfig is used to transform a qtls.Config to a tls.Config.
+// It is used to create the tls.Config in the ClientHelloInfo.
+// It doesn't copy all values, but only those used by ClientHelloInfo.SupportsCertificate.
+func qtlsConfigToTLSConfig(config *qtls.Config) *tls.Config {
+	return &tls.Config{
+		MinVersion:       config.MinVersion,
+		MaxVersion:       config.MaxVersion,
+		CipherSuites:     config.CipherSuites,
+		CurvePreferences: config.CurvePreferences,
+	}
+}

--- a/internal/handshake/go_1-14_test.go
+++ b/internal/handshake/go_1-14_test.go
@@ -1,0 +1,55 @@
+// +build go1.14
+
+package handshake
+
+import (
+	"crypto/tls"
+	"net"
+	"unsafe"
+
+	"github.com/marten-seemann/qtls"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Unsafe checks, for Go 1.14+", func() {
+	It("converts a qtls.ClientHelloInfo to a tls.ClientHelloInfo", func() {
+		chi := &qtlsClientHelloInfo{
+			CipherSuites:      []uint16{1, 2, 3},
+			ServerName:        "foo.bar",
+			SupportedCurves:   []qtls.CurveID{4, 5, 6},
+			SupportedPoints:   []uint8{7, 8, 9},
+			SignatureSchemes:  []qtls.SignatureScheme{10, 11, 12},
+			SupportedProtos:   []string{"foo", "bar"},
+			SupportedVersions: []uint16{13, 14, 15},
+			Conn:              &net.UDPConn{},
+			config: &qtls.Config{
+				MinVersion:       tls.VersionTLS10,
+				MaxVersion:       tls.VersionTLS12,
+				CipherSuites:     []uint16{16, 17, 18},
+				CurvePreferences: []qtls.CurveID{19, 20, 21},
+			},
+		}
+		tlsCHI := toTLSClientHelloInfo((*qtls.ClientHelloInfo)(unsafe.Pointer(chi)))
+		Expect(tlsCHI.CipherSuites).To(Equal([]uint16{1, 2, 3}))
+		Expect(tlsCHI.ServerName).To(Equal("foo.bar"))
+		Expect(tlsCHI.SupportedCurves).To(Equal([]tls.CurveID{4, 5, 6}))
+		Expect(tlsCHI.SupportedPoints).To(Equal([]uint8{7, 8, 9}))
+		Expect(tlsCHI.SignatureSchemes).To(Equal([]tls.SignatureScheme{10, 11, 12}))
+		Expect(tlsCHI.SupportedProtos).To(Equal([]string{"foo", "bar"}))
+		Expect(tlsCHI.SupportedVersions).To(Equal([]uint16{13, 14, 15}))
+		Expect(tlsCHI.Conn).To(Equal(&net.UDPConn{}))
+		c := (*clientHelloInfo)(unsafe.Pointer(tlsCHI))
+		Expect(c.config.CipherSuites).To(Equal([]uint16{16, 17, 18}))
+		Expect(c.config.MinVersion).To(BeEquivalentTo(tls.VersionTLS10))
+		Expect(c.config.MaxVersion).To(BeEquivalentTo(tls.VersionTLS12))
+		Expect(c.config.CurvePreferences).To(Equal([]tls.CurveID{19, 20, 21}))
+	})
+
+	It("converts a qtls.ClientHelloInfo to a tls.ClientHelloInfo, if no config is set", func() {
+		chi := &qtlsClientHelloInfo{CipherSuites: []uint16{13, 37}}
+		tlsCHI := toTLSClientHelloInfo((*qtls.ClientHelloInfo)(unsafe.Pointer(chi)))
+		Expect(tlsCHI.CipherSuites).To(Equal([]uint16{13, 37}))
+	})
+})

--- a/internal/handshake/qtls.go
+++ b/internal/handshake/qtls.go
@@ -130,15 +130,3 @@ func tlsConfigToQtlsConfig(
 	}
 	return conf
 }
-
-// qtlsConfigToTLSConfig is used to transform a qtls.Config to a tls.Config.
-// It is used to create the tls.Config in the ClientHelloInfo.
-// It doesn't copy all values, but only those used by ClientHelloInfo.SupportsCertificate.
-func qtlsConfigToTLSConfig(config *qtls.Config) *tls.Config {
-	return &tls.Config{
-		MinVersion:       config.MinVersion,
-		MaxVersion:       config.MaxVersion,
-		CipherSuites:     config.CipherSuites,
-		CurvePreferences: config.CurvePreferences,
-	}
-}

--- a/internal/handshake/unsafe.go
+++ b/internal/handshake/unsafe.go
@@ -10,9 +10,7 @@ package handshake
 
 import (
 	"crypto/tls"
-	"net"
 	"reflect"
-	"unsafe"
 
 	"github.com/marten-seemann/qtls"
 )
@@ -30,12 +28,6 @@ func init() {
 	if !structsEqual(&tls.ClientSessionState{}, &clientSessionState{}) {
 		panic("clientSessionState not compatible with tls.ClientSessionState")
 	}
-	if !structsEqual(&tls.ClientHelloInfo{}, &clientHelloInfo{}) {
-		panic("clientHelloInfo not compatible with tls.ClientHelloInfo")
-	}
-	if !structsEqual(&qtls.ClientHelloInfo{}, &qtlsClientHelloInfo{}) {
-		panic("qtlsClientHelloInfo not compatible with qtls.ClientHelloInfo")
-	}
 }
 
 func structsEqual(a, b interface{}) bool {
@@ -52,52 +44,4 @@ func structsEqual(a, b interface{}) bool {
 		}
 	}
 	return true
-}
-
-type clientHelloInfo struct {
-	CipherSuites      []uint16
-	ServerName        string
-	SupportedCurves   []tls.CurveID
-	SupportedPoints   []uint8
-	SignatureSchemes  []tls.SignatureScheme
-	SupportedProtos   []string
-	SupportedVersions []uint16
-	Conn              net.Conn
-
-	config *tls.Config
-}
-
-type qtlsClientHelloInfo struct {
-	CipherSuites      []uint16
-	ServerName        string
-	SupportedCurves   []tls.CurveID
-	SupportedPoints   []uint8
-	SignatureSchemes  []tls.SignatureScheme
-	SupportedProtos   []string
-	SupportedVersions []uint16
-	Conn              net.Conn
-
-	config *qtls.Config
-}
-
-func toTLSClientHelloInfo(chi *qtls.ClientHelloInfo) *tls.ClientHelloInfo {
-	if chi == nil {
-		return nil
-	}
-	qtlsCHI := (*qtlsClientHelloInfo)(unsafe.Pointer(chi))
-	var config *tls.Config
-	if qtlsCHI.config != nil {
-		config = qtlsConfigToTLSConfig((*qtls.Config)(unsafe.Pointer(qtlsCHI.config)))
-	}
-	return (*tls.ClientHelloInfo)(unsafe.Pointer(&clientHelloInfo{
-		CipherSuites:      chi.CipherSuites,
-		ServerName:        chi.ServerName,
-		SupportedCurves:   chi.SupportedCurves,
-		SupportedPoints:   chi.SupportedPoints,
-		SignatureSchemes:  chi.SignatureSchemes,
-		SupportedProtos:   chi.SupportedProtos,
-		SupportedVersions: chi.SupportedVersions,
-		Conn:              chi.Conn,
-		config:            config,
-	}))
 }

--- a/internal/handshake/unsafe_test.go
+++ b/internal/handshake/unsafe_test.go
@@ -1,11 +1,6 @@
 package handshake
 
 import (
-	"crypto/tls"
-	"net"
-	"unsafe"
-
-	"github.com/marten-seemann/qtls"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -61,44 +56,5 @@ var _ = Describe("Unsafe checks", func() {
 		Expect(structsEqual(&target{}, &additionalField{})).To(BeFalse())
 		Expect(structsEqual(&target{}, &interchangedFields{})).To(BeFalse())
 		Expect(structsEqual(&target{}, &renamedCallbackFunctionParams{})).To(BeTrue())
-	})
-
-	It("converts a qtls.ClientHelloInfo to a tls.ClientHelloInfo", func() {
-		chi := &qtlsClientHelloInfo{
-			CipherSuites:      []uint16{1, 2, 3},
-			ServerName:        "foo.bar",
-			SupportedCurves:   []qtls.CurveID{4, 5, 6},
-			SupportedPoints:   []uint8{7, 8, 9},
-			SignatureSchemes:  []qtls.SignatureScheme{10, 11, 12},
-			SupportedProtos:   []string{"foo", "bar"},
-			SupportedVersions: []uint16{13, 14, 15},
-			Conn:              &net.UDPConn{},
-			config: &qtls.Config{
-				MinVersion:       tls.VersionTLS10,
-				MaxVersion:       tls.VersionTLS12,
-				CipherSuites:     []uint16{16, 17, 18},
-				CurvePreferences: []qtls.CurveID{19, 20, 21},
-			},
-		}
-		tlsCHI := toTLSClientHelloInfo((*qtls.ClientHelloInfo)(unsafe.Pointer(chi)))
-		Expect(tlsCHI.CipherSuites).To(Equal([]uint16{1, 2, 3}))
-		Expect(tlsCHI.ServerName).To(Equal("foo.bar"))
-		Expect(tlsCHI.SupportedCurves).To(Equal([]tls.CurveID{4, 5, 6}))
-		Expect(tlsCHI.SupportedPoints).To(Equal([]uint8{7, 8, 9}))
-		Expect(tlsCHI.SignatureSchemes).To(Equal([]tls.SignatureScheme{10, 11, 12}))
-		Expect(tlsCHI.SupportedProtos).To(Equal([]string{"foo", "bar"}))
-		Expect(tlsCHI.SupportedVersions).To(Equal([]uint16{13, 14, 15}))
-		Expect(tlsCHI.Conn).To(Equal(&net.UDPConn{}))
-		c := (*clientHelloInfo)(unsafe.Pointer(tlsCHI))
-		Expect(c.config.CipherSuites).To(Equal([]uint16{16, 17, 18}))
-		Expect(c.config.MinVersion).To(BeEquivalentTo(tls.VersionTLS10))
-		Expect(c.config.MaxVersion).To(BeEquivalentTo(tls.VersionTLS12))
-		Expect(c.config.CurvePreferences).To(Equal([]tls.CurveID{19, 20, 21}))
-	})
-
-	It("converts a qtls.ClientHelloInfo to a tls.ClientHelloInfo, if no config is set", func() {
-		chi := &qtlsClientHelloInfo{CipherSuites: []uint16{13, 37}}
-		tlsCHI := toTLSClientHelloInfo((*qtls.ClientHelloInfo)(unsafe.Pointer(chi)))
-		Expect(tlsCHI.CipherSuites).To(Equal([]uint16{13, 37}))
 	})
 })

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/congestion"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
-	"github.com/marten-seemann/qtls"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,8 +18,7 @@ var _ = Describe("Updatable AEAD", func() {
 	for i := range cipherSuites {
 		cs := cipherSuites[i]
 
-		Context(fmt.Sprintf("using %s", qtls.CipherSuiteName(cs.ID)), func() {
-
+		Context(fmt.Sprintf("using %s", cipherSuiteName(cs.ID)), func() {
 			getPeers := func(rttStats *congestion.RTTStats) (client, server *updatableAEAD) {
 				trafficSecret1 := make([]byte, 16)
 				trafficSecret2 := make([]byte, 16)


### PR DESCRIPTION
Depends on #2475. Closes #2446.

cc @Stebalien.

As outlined in #2446, quic-go will need to build with Go 1.13 for the foreseeable future for libp2p and IPFS. This makes things pretty complicated because Go 1.14 introduced a bunch of changes to `crypto/tls`, which are reflected in qtls. In order to provide users of quic-go with all the `crypto/tls` functionality they expect, we basically have to provide two copies of qtls.

This is achieved in [v0.9.0](https://github.com/marten-seemann/qtls/releases/tag/v0.9.0) by adding the `// +build go1.14` build tag to all `.go` files, and then copying all the latest qtls release under Go 1.13, this time with `// +build !go1.14`.

quic-go also needs a few build switches at the interface with qtls, but fortunately these are just a few functions.