### PR TITLE
use the optimized HKDF-Expand-Label everywhere

### DIFF
--- a/internal/handshake/aead.go
+++ b/internal/handshake/aead.go
@@ -9,8 +9,8 @@ import (
 )
 
 func createAEAD(suite *qtls.CipherSuiteTLS13, trafficSecret []byte) cipher.AEAD {
-	key := qtls.HkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, "quic key", suite.KeyLen)
-	iv := qtls.HkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, "quic iv", suite.IVLen())
+	key := hkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, "quic key", suite.KeyLen)
+	iv := hkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, "quic iv", suite.IVLen())
 	return suite.AEAD(key, iv)
 }
 

--- a/internal/handshake/updatable_aead.go
+++ b/internal/handshake/updatable_aead.go
@@ -115,7 +115,7 @@ func (a *updatableAEAD) rollKeys(now time.Time) {
 }
 
 func (a *updatableAEAD) getNextTrafficSecret(hash crypto.Hash, ts []byte) []byte {
-	return qtls.HkdfExpandLabel(hash, ts, []byte{}, "quic ku", hash.Size())
+	return hkdfExpandLabel(hash, ts, []byte{}, "quic ku", hash.Size())
 }
 
 // For the client, this function is called before SetWriteKey.


### PR DESCRIPTION
It's not performance critical here, but it doesn't hurt. And it makes things more consistent.