### PR TITLE
reset the PTO count when receiving a Retry

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -721,9 +721,13 @@ func (h *sentPacketHandler) ResetForRetry() error {
 	h.appDataPackets = newPacketNumberSpace(h.appDataPackets.pns.Pop())
 	oldAlarm := h.alarm
 	h.alarm = time.Time{}
-	if h.qlogger != nil && !oldAlarm.IsZero() {
-		h.qlogger.LossTimerCanceled()
+	if h.qlogger != nil {
+		h.qlogger.UpdatedPTOCount(0)
+		if !oldAlarm.IsZero() {
+			h.qlogger.LossTimerCanceled()
+		}
 	}
+	h.ptoCount = 0
 	return nil
 }
 

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -995,7 +995,7 @@ var _ = Describe("SentPacketHandler", func() {
 			perspective = protocol.PerspectiveClient
 		})
 
-		It("queues outstanding packets for retransmission and cancels alarms", func() {
+		It("queues outstanding packets for retransmission, cancels alarms and resets PTO count", func() {
 			handler.SentPacket(initialPacket(&Packet{PacketNumber: 42}))
 			Expect(handler.GetLossDetectionTimeout()).ToNot(BeZero())
 			Expect(handler.bytesInFlight).ToNot(BeZero())
@@ -1006,6 +1006,7 @@ var _ = Describe("SentPacketHandler", func() {
 			Expect(handler.bytesInFlight).To(BeZero())
 			Expect(handler.GetLossDetectionTimeout()).To(BeZero())
 			Expect(handler.SendMode()).To(Equal(SendAny))
+			Expect(handler.ptoCount).To(BeZero())
 		})
 
 		It("queues outstanding frames for retransmission and cancels alarms", func() {

--- a/session_test.go
+++ b/session_test.go
@@ -2077,6 +2077,9 @@ var _ = Describe("Client Session", func() {
 		}
 
 		It("handles Retry packets", func() {
+			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
+			sess.sentPacketHandler = sph
+			sph.EXPECT().ResetForRetry()
 			cryptoSetup.EXPECT().ChangeConnectionID(protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef})
 			packer.EXPECT().SetToken([]byte("foobar"))
 			qlogger.EXPECT().ReceivedRetry(gomock.Any()).Do(func(hdr *wire.Header) {
@@ -2307,6 +2310,9 @@ var _ = Describe("Client Session", func() {
 		// Illustrates that attacker who injects a Retry packet and changes the connection ID
 		// can cause subsequent real Initial packets to be ignored
 		It("ignores Initial packets which use original source id, after accepting a Retry", func() {
+			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
+			sess.sentPacketHandler = sph
+			sph.EXPECT().ResetForRetry()
 			newSrcConnID := protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef}
 			cryptoSetup.EXPECT().ChangeConnectionID(newSrcConnID)
 			packer.EXPECT().SetToken([]byte("foobar"))


### PR DESCRIPTION
As #2462, but this time with fixed tests.