### PR TITLE
disable TLS 1.3 compatibility mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.3.1
 	github.com/marten-seemann/qpack v0.1.0
-	github.com/marten-seemann/qtls v0.9.0
+	github.com/marten-seemann/qtls v0.9.1
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/marten-seemann/qpack v0.1.0 h1:/0M7lkda/6mus9B8u34Asqm8ZhHAAt9Ho0vniNuVSVg=
 github.com/marten-seemann/qpack v0.1.0/go.mod h1:LFt1NU/Ptjip0C2CPkhimBz5CGE3WGDAUWqna+CNTrI=
-github.com/marten-seemann/qtls v0.9.0 h1:8Zguhc72eS+DH5EAb0BpAPIy3HDXYcihQi4xoDZOnjQ=
-github.com/marten-seemann/qtls v0.9.0/go.mod h1:T1MmAdDPyISzxlK6kjRr0pcZFBVd1OZbBb/j3cvzHhk=
+github.com/marten-seemann/qtls v0.9.1 h1:O0YKQxNVPaiFgMng0suWEOY2Sb4LT2sRn9Qimq3Z1IQ=
+github.com/marten-seemann/qtls v0.9.1/go.mod h1:T1MmAdDPyISzxlK6kjRr0pcZFBVd1OZbBb/j3cvzHhk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
This PR includes https://github.com/marten-seemann/qtls/commit/6c6a0ec9e44166407c8d2f6724d0e02c1204325d.

The Go standard library uses [TLS 1.3 compatiblity mode](), which means that it
1. set the `legacy_session_id` in the ClientHello and
2. sends ChangeCipherSpec records.

ChangeCipherSpec records are already filtered out, but so far we'd still send a `legacy_session_id`.

Compatibility mode is not required for QUIC, and https://github.com/quicwg/base-drafts/pull/3595 aims to forbid its usage. With this PR, we'll not send the `legacy_session_id` any more. The validation that the client actually doesn't send it would break interoperability, and therefore has to be postponed until the next QUIC draft is released.
