### PR TITLE
Allow setting MTU on Session

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -187,6 +187,9 @@ type Session interface {
 	// It blocks until the handshake completes.
 	// Warning: This API should not be considered stable and might change soon.
 	ConnectionState() ConnectionState
+	// SetMaxPacketSize allows setting the maximum packet size for outgoing
+	// packets, only use if you know what you are doing.
+	SetMaxPacketSize(packetSize uint64)
 }
 
 // An EarlySession is a session that is handshaking.

--- a/internal/mocks/quic/early_session.go
+++ b/internal/mocks/quic/early_session.go
@@ -211,3 +211,15 @@ func (mr *MockEarlySessionMockRecorder) RemoteAddr() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteAddr", reflect.TypeOf((*MockEarlySession)(nil).RemoteAddr))
 }
+
+// SetMaxPacketSize mocks base method
+func (m *MockEarlySession) SetMaxPacketSize(arg0 uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMaxPacketSize", arg0)
+}
+
+// SetMaxPacketSize indicates an expected call of SetMaxPacketSize
+func (mr *MockEarlySessionMockRecorder) SetMaxPacketSize(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxPacketSize", reflect.TypeOf((*MockEarlySession)(nil).SetMaxPacketSize), arg0)
+}

--- a/mock_packer_test.go
+++ b/mock_packer_test.go
@@ -123,6 +123,18 @@ func (mr *MockPackerMockRecorder) PackPacket() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackPacket", reflect.TypeOf((*MockPacker)(nil).PackPacket))
 }
 
+// SetMaxPacketSize mocks base method
+func (m *MockPacker) SetMaxPacketSize(arg0 protocol.ByteCount) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMaxPacketSize", arg0)
+}
+
+// SetMaxPacketSize indicates an expected call of SetMaxPacketSize
+func (mr *MockPackerMockRecorder) SetMaxPacketSize(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxPacketSize", reflect.TypeOf((*MockPacker)(nil).SetMaxPacketSize), arg0)
+}
+
 // SetToken mocks base method
 func (m *MockPacker) SetToken(arg0 []byte) {
 	m.ctrl.T.Helper()

--- a/mock_quic_session_test.go
+++ b/mock_quic_session_test.go
@@ -225,6 +225,18 @@ func (mr *MockQuicSessionMockRecorder) RemoteAddr() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteAddr", reflect.TypeOf((*MockQuicSession)(nil).RemoteAddr))
 }
 
+// SetMaxPacketSize mocks base method
+func (m *MockQuicSession) SetMaxPacketSize(arg0 uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMaxPacketSize", arg0)
+}
+
+// SetMaxPacketSize indicates an expected call of SetMaxPacketSize
+func (mr *MockQuicSessionMockRecorder) SetMaxPacketSize(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxPacketSize", reflect.TypeOf((*MockQuicSession)(nil).SetMaxPacketSize), arg0)
+}
+
 // closeForRecreating mocks base method
 func (m *MockQuicSession) closeForRecreating() protocol.PacketNumber {
 	m.ctrl.T.Helper()

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -22,6 +22,7 @@ type packer interface {
 	MaybePackProbePacket(protocol.EncryptionLevel) (*packedPacket, error)
 	MaybePackAckPacket(handshakeConfirmed bool) (*packedPacket, error)
 	PackConnectionClose(*qerr.QuicError) (*coalescedPacket, error)
+	SetMaxPacketSize(packetSize protocol.ByteCount)
 
 	HandleTransportParameters(*wire.TransportParameters)
 	SetToken([]byte)
@@ -742,4 +743,8 @@ func (p *packetPacker) HandleTransportParameters(params *wire.TransportParameter
 	if params.MaxUDPPayloadSize != 0 {
 		p.maxPacketSize = utils.MinByteCount(p.maxPacketSize, params.MaxUDPPayloadSize)
 	}
+}
+
+func (p *packetPacker) SetMaxPacketSize(packetSize protocol.ByteCount) {
+	p.maxPacketSize = packetSize
 }

--- a/session.go
+++ b/session.go
@@ -1650,3 +1650,7 @@ func (s *session) getPerspective() protocol.Perspective {
 func (s *session) GetVersion() protocol.VersionNumber {
 	return s.version
 }
+
+func (s *session) SetMaxPacketSize(packetSize uint64) {
+	s.packer.SetMaxPacketSize(protocol.ByteCount(packetSize))
+}


### PR DESCRIPTION
This adds `SetMaxPacketSize(packetSize uint64)` to the Session interface, and allows setting outgoing maximum packet size in bytes.

See https://github.com/lucas-clemente/quic-go/issues/2511 for details.

Note that this sets the size of UDP payloads, the actual packet will also include the UDP header (8 bytes), IP header (40 bytes for IPv6, 20 bytes or more for IPv4), and possibly ethernet header (18 bytes).