### PR TITLE
stop the deadline timer in Stream.Read and Write

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -132,6 +132,7 @@ func (s *receiveStream) readImpl(p []byte) (bool /*stream completed */, int, err
 				}
 				if deadlineTimer == nil {
 					deadlineTimer = utils.NewTimer()
+					defer deadlineTimer.Stop()
 				}
 				deadlineTimer.Reset(deadline)
 			}

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -104,6 +104,7 @@ func (s *receiveStream) readImpl(p []byte) (bool /*stream completed */, int, err
 	}
 
 	bytesRead := 0
+	var deadlineTimer *utils.Timer
 	for bytesRead < len(p) {
 		if s.currentFrame == nil || s.readPosInFrame >= len(s.currentFrame) {
 			s.dequeueNextFrame()
@@ -112,7 +113,6 @@ func (s *receiveStream) readImpl(p []byte) (bool /*stream completed */, int, err
 			return false, bytesRead, s.closeForShutdownErr
 		}
 
-		var deadlineTimer *utils.Timer
 		for {
 			// Stop waiting on errors
 			if s.closedForShutdown {

--- a/send_stream.go
+++ b/send_stream.go
@@ -137,6 +137,7 @@ func (s *sendStream) Write(p []byte) (int, error) {
 				}
 				if deadlineTimer == nil {
 					deadlineTimer = utils.NewTimer()
+					defer deadlineTimer.Stop()
 				}
 				deadlineTimer.Reset(deadline)
 			}


### PR DESCRIPTION
When a deadline is set on a stream, the `time.Time` is saved in the `deadline` member variable.
When `Read` or `Write` are called, and `deadline` is set, we start a timer in order to return these calls on timer expiration. In the common case, deadlines don't expire, and `Read` and `Write` calls return before expiration of the timer. We need to make sure to stop this timer, otherwise it will leak.

This is the more probable reason for the performance issue reported in https://github.com/ipfs/go-ipfs/issues/7263, as every single `Read` and `Write` call that returns before the deadline leaks a new timer. This will accumulate a lot more timers than the timer leak that happened when closing a session, or when we received a duplicate Initial, which was fixed in #2516.

cc @Stebalien