### PR TITLE
reset the PTO when dropping a packet number space

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -164,6 +164,7 @@ func (h *sentPacketHandler) dropPackets(encLevel protocol.EncryptionLevel) {
 		h.qlogger.UpdatedPTOCount(0)
 	}
 	h.ptoCount = 0
+	h.numProbesToSend = 0
 	h.ptoMode = SendNone
 }
 


### PR DESCRIPTION
If `numProbesToSend != 0`, then 
https://github.com/lucas-clemente/quic-go/blob/c0b6d4e141d6dca43023a8c9ae0f437bb943f182/internal/ackhandler/sent_packet_handler.go#L647-L649
will return `SendNone` as send mode. That means that if `numProbesToSend` was `> 0`, and we drop the packet number space, we'd be unable to send out any packet, leading to a stall of the connection.