### PR TITLE
Read Timeout Value from http.Server 

### DIFF
--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go"
 	mockquic "github.com/lucas-clemente/quic-go/internal/mocks/quic"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/testdata"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/marten-seemann/qpack"
@@ -288,6 +289,74 @@ var _ = Describe("Server", func() {
 				s.handleConn(sess)
 				Eventually(done).Should(BeClosed())
 			})
+
+			It("sets timeout on ReadHeaderTimeout and ReadTimeout", func() {
+				s.Server.ReadHeaderTimeout = 5 * time.Second
+				s.Server.ReadTimeout = 10 * time.Second
+
+				handlerCalled := make(chan struct{})
+				s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					close(handlerCalled)
+				})
+
+				str.EXPECT().Context().Return(reqContext)
+				str.EXPECT().StreamID().Return(protocol.StreamID(1)).AnyTimes()
+
+				// read timeout
+				str.EXPECT().SetReadDeadline(gomock.Any()).Return(nil)
+				// header timeout
+				str.EXPECT().SetReadDeadline(gomock.Any()).Return(nil)
+				// adjust read timeout
+				str.EXPECT().SetReadDeadline(gomock.Any()).Return(nil)
+
+				buf := bytes.NewBuffer(encodeRequest(exampleGetRequest))
+				str.EXPECT().Read(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
+					if buf.Len() == 0 {
+						return 0, io.EOF
+					}
+					return buf.Read(p)
+				}).AnyTimes()
+				str.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
+					return len(p), nil
+				}).AnyTimes()
+				str.EXPECT().CancelRead(gomock.Any())
+
+				done := make(chan struct{})
+				str.EXPECT().Close().Do(func() {
+					close(done)
+				})
+
+				s.handleConn(sess)
+				Eventually(handlerCalled).Should(BeClosed())
+				Eventually(done).Should(BeClosed())
+			})
+
+		})
+
+		It("cancels write on write timeout", func() {
+			s.Server.WriteTimeout = 50 * time.Millisecond
+			ctxDone := make(chan struct{})
+			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ctx := r.Context()
+				select {
+				case <-time.After(100 * time.Millisecond):
+					fmt.Fprint(w, "done")
+				case <-ctx.Done():
+					close(ctxDone)
+				}
+			})
+
+			setRequest(encodeRequest(exampleGetRequest))
+			str.EXPECT().Context().Return(reqContext)
+			str.EXPECT().StreamID().Return(protocol.StreamID(1)).AnyTimes()
+			str.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
+				return len(p), nil
+			}).AnyTimes()
+			str.EXPECT().CancelWrite(protocol.ApplicationErrorCode(errorInternalError))
+			str.EXPECT().CancelRead(gomock.Any())
+
+			serr := s.handleRequest(sess, str, qpackDecoder, nil)
+			Expect(serr.err).ToNot(HaveOccurred())
 		})
 
 		It("resets the stream when the body of POST request is not read, and the request handler replaces the request.Body", func() {


### PR DESCRIPTION
Issue: #410

Server timeout implementation, mostly following http2 implementation.

Also two extra HandleFunc has been added to `example/main.go` server, to test the write timeout.

Thanks,
Omid.