### PR TITLE
fix closing of the http.Request.Body

### DIFF
--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -155,13 +155,6 @@ var _ = Describe("Body", func() {
 				Expect(errorCbCalled).To(BeTrue())
 			})
 
-			if bodyType == bodyTypeRequest {
-				It("closes requests", func() {
-					str.EXPECT().Close()
-					Expect(rb.Close()).To(Succeed())
-				})
-			}
-
 			if bodyType == bodyTypeResponse {
 				It("closes the reqDone channel when Read errors", func() {
 					buf.Write([]byte("invalid"))

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -122,6 +122,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
 				return len(p), nil
 			}).AnyTimes()
+			str.EXPECT().CancelRead(gomock.Any())
 
 			Expect(s.handleRequest(sess, str, qpackDecoder, nil)).To(Equal(requestError{}))
 			var req *http.Request
@@ -140,6 +141,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
 				return responseBuf.Write(p)
 			}).AnyTimes()
+			str.EXPECT().CancelRead(gomock.Any())
 
 			serr := s.handleRequest(sess, str, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fixes #2551.

On the server side, the `http.Request` is consumed by the HTTP handler. The HTTP handler may close the body (it doesn't have to though). In any case, closing the stream is the wrong thing to do, since that closes the write side of the stream. All we want to do is cancel the stream (if the
EOF hasn't been read yet).

On the client side (for the `http.Response`) the same logic applies: When the application calls `Body.Close()`, all we want to do is cancel the stream (if the EOF hasn't been read yet).