### PR TITLE
update the contents of flow control frames when retransmitting

### DIFF
--- a/framer.go
+++ b/framer.go
@@ -12,7 +12,7 @@ import (
 type framer interface {
 	HasData() bool
 
-	QueueControlFrame(wire.Frame)
+	QueueControlFrame(ackhandler.Frame)
 	AppendControlFrames([]ackhandler.Frame, protocol.ByteCount) ([]ackhandler.Frame, protocol.ByteCount)
 
 	AddActiveStream(protocol.StreamID)
@@ -29,7 +29,7 @@ type framerI struct {
 	streamQueue   []protocol.StreamID
 
 	controlFrameMutex sync.Mutex
-	controlFrames     []wire.Frame
+	controlFrames     []ackhandler.Frame
 }
 
 var _ framer = &framerI{}
@@ -58,7 +58,7 @@ func (f *framerI) HasData() bool {
 	return hasData
 }
 
-func (f *framerI) QueueControlFrame(frame wire.Frame) {
+func (f *framerI) QueueControlFrame(frame ackhandler.Frame) {
 	f.controlFrameMutex.Lock()
 	f.controlFrames = append(f.controlFrames, frame)
 	f.controlFrameMutex.Unlock()
@@ -73,7 +73,7 @@ func (f *framerI) AppendControlFrames(frames []ackhandler.Frame, maxLen protocol
 		if length+frameLen > maxLen {
 			break
 		}
-		frames = append(frames, ackhandler.Frame{Frame: frame})
+		frames = append(frames, frame)
 		length += frameLen
 		f.controlFrames = f.controlFrames[:len(f.controlFrames)-1]
 	}

--- a/framer_test.go
+++ b/framer_test.go
@@ -40,8 +40,8 @@ var _ = Describe("Framer", func() {
 		It("adds control frames", func() {
 			mdf := &wire.MaxDataFrame{ByteOffset: 0x42}
 			msf := &wire.MaxStreamsFrame{MaxStreamNum: 0x1337}
-			framer.QueueControlFrame(mdf)
-			framer.QueueControlFrame(msf)
+			framer.QueueControlFrame(ackhandler.Frame{Frame: mdf})
+			framer.QueueControlFrame(ackhandler.Frame{Frame: msf})
 			frames, length := framer.AppendControlFrames(nil, 1000)
 			Expect(frames).To(HaveLen(2))
 			fs := []wire.Frame{frames[0].Frame, frames[1].Frame}
@@ -53,7 +53,7 @@ var _ = Describe("Framer", func() {
 		It("says if it has data", func() {
 			Expect(framer.HasData()).To(BeFalse())
 			f := &wire.MaxDataFrame{ByteOffset: 0x42}
-			framer.QueueControlFrame(f)
+			framer.QueueControlFrame(ackhandler.Frame{Frame: f})
 			Expect(framer.HasData()).To(BeTrue())
 			frames, _ := framer.AppendControlFrames(nil, 1000)
 			Expect(frames).To(HaveLen(1))
@@ -63,7 +63,7 @@ var _ = Describe("Framer", func() {
 		It("appends to the slice given", func() {
 			ping := &wire.PingFrame{}
 			mdf := &wire.MaxDataFrame{ByteOffset: 0x42}
-			framer.QueueControlFrame(mdf)
+			framer.QueueControlFrame(ackhandler.Frame{Frame: mdf})
 			frames, length := framer.AppendControlFrames([]ackhandler.Frame{{Frame: ping}}, 1000)
 			Expect(frames).To(HaveLen(2))
 			Expect(frames[0].Frame).To(Equal(ping))
@@ -77,7 +77,7 @@ var _ = Describe("Framer", func() {
 			bfLen := bf.Length(version)
 			numFrames := int(maxSize / bfLen) // max number of frames that fit into maxSize
 			for i := 0; i < numFrames+1; i++ {
-				framer.QueueControlFrame(bf)
+				framer.QueueControlFrame(ackhandler.Frame{Frame: bf})
 			}
 			frames, length := framer.AppendControlFrames(nil, maxSize)
 			Expect(frames).To(HaveLen(numFrames))

--- a/session.go
+++ b/session.go
@@ -577,7 +577,7 @@ runLoop:
 		if keepAliveTime := s.nextKeepAliveTime(); !keepAliveTime.IsZero() && !now.Before(keepAliveTime) {
 			// send a PING frame since there is no activity in the session
 			s.logger.Debugf("Sending a keep-alive PING to keep the connection alive.")
-			s.framer.QueueControlFrame(&wire.PingFrame{})
+			s.framer.QueueControlFrame(ackhandler.Frame{Frame: &wire.PingFrame{}})
 			s.keepAlivePingSent = true
 		} else if !s.handshakeComplete && now.Sub(s.sessionCreationTime) >= s.config.HandshakeTimeout {
 			if s.qlogger != nil {
@@ -1474,7 +1474,7 @@ func (s *session) sendProbePacket(encLevel protocol.EncryptionLevel) error {
 
 func (s *session) sendPacket() (bool, error) {
 	if isBlocked, offset := s.connFlowController.IsNewlyBlocked(); isBlocked {
-		s.framer.QueueControlFrame(&wire.DataBlockedFrame{DataLimit: offset})
+		s.framer.QueueControlFrame(ackhandler.Frame{Frame: &wire.DataBlockedFrame{DataLimit: offset}})
 	}
 	s.windowUpdateQueue.QueueAll()
 
@@ -1665,7 +1665,7 @@ func (s *session) tryDecryptingQueuedPackets() {
 }
 
 func (s *session) queueControlFrame(f wire.Frame) {
-	s.framer.QueueControlFrame(f)
+	s.framer.QueueControlFrame(ackhandler.Frame{Frame: f})
 	s.scheduleSending()
 }
 

--- a/window_update_queue.go
+++ b/window_update_queue.go
@@ -49,11 +49,15 @@ func (q *windowUpdateQueue) QueueAll() {
 	q.mutex.Lock()
 	// queue a connection-level window update
 	if q.queuedConn {
-		q.callback(ackhandler.Frame{Frame: &wire.MaxDataFrame{ByteOffset: q.connFlowController.GetWindowUpdate()}})
+		q.callback(ackhandler.Frame{
+			Frame:  &wire.MaxDataFrame{ByteOffset: q.connFlowController.GetWindowUpdate()},
+			OnLost: func(wire.Frame) { q.AddConnection() },
+		})
 		q.queuedConn = false
 	}
 	// queue all stream-level window updates
-	for id := range q.queue {
+	for s := range q.queue {
+		id := s // capture the loop variable
 		delete(q.queue, id)
 		str, err := q.streamGetter.GetOrOpenReceiveStream(id)
 		if err != nil || str == nil { // the stream can be nil if it was completed before dequeing the window update
@@ -63,10 +67,13 @@ func (q *windowUpdateQueue) QueueAll() {
 		if offset == 0 { // can happen if we received a final offset, right after queueing the window update
 			continue
 		}
-		q.callback(ackhandler.Frame{Frame: &wire.MaxStreamDataFrame{
-			StreamID:   id,
-			ByteOffset: offset,
-		}})
+		q.callback(ackhandler.Frame{
+			Frame: &wire.MaxStreamDataFrame{
+				StreamID:   id,
+				ByteOffset: offset,
+			},
+			OnLost: func(wire.Frame) { q.AddStream(id) },
+		})
 	}
 	q.mutex.Unlock()
 }

--- a/window_update_queue_test.go
+++ b/window_update_queue_test.go
@@ -1,6 +1,7 @@
 package quic
 
 import (
+	"github.com/lucas-clemente/quic-go/internal/ackhandler"
 	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/wire"
@@ -14,14 +15,14 @@ var _ = Describe("Window Update Queue", func() {
 		q            *windowUpdateQueue
 		streamGetter *MockStreamGetter
 		connFC       *mocks.MockConnectionFlowController
-		queuedFrames []wire.Frame
+		queuedFrames []ackhandler.Frame
 	)
 
 	BeforeEach(func() {
 		streamGetter = NewMockStreamGetter(mockCtrl)
 		connFC = mocks.NewMockConnectionFlowController(mockCtrl)
 		queuedFrames = queuedFrames[:0]
-		q = newWindowUpdateQueue(streamGetter, connFC, func(f wire.Frame) {
+		q = newWindowUpdateQueue(streamGetter, connFC, func(f ackhandler.Frame) {
 			queuedFrames = append(queuedFrames, f)
 		})
 	})
@@ -36,8 +37,10 @@ var _ = Describe("Window Update Queue", func() {
 		q.AddStream(3)
 		q.AddStream(1)
 		q.QueueAll()
-		Expect(queuedFrames).To(ContainElement(&wire.MaxStreamDataFrame{StreamID: 1, ByteOffset: 10}))
-		Expect(queuedFrames).To(ContainElement(&wire.MaxStreamDataFrame{StreamID: 3, ByteOffset: 30}))
+		Expect(queuedFrames).To(HaveLen(2))
+		frames := []wire.Frame{queuedFrames[0].Frame, queuedFrames[1].Frame}
+		Expect(frames).To(ContainElement(&wire.MaxStreamDataFrame{StreamID: 1, ByteOffset: 10}))
+		Expect(frames).To(ContainElement(&wire.MaxStreamDataFrame{StreamID: 3, ByteOffset: 30}))
 	})
 
 	It("deletes the entry after getting the MAX_STREAM_DATA frame", func() {
@@ -93,9 +96,8 @@ var _ = Describe("Window Update Queue", func() {
 		connFC.EXPECT().GetWindowUpdate().Return(protocol.ByteCount(0x1337))
 		q.AddConnection()
 		q.QueueAll()
-		Expect(queuedFrames).To(Equal([]wire.Frame{
-			&wire.MaxDataFrame{ByteOffset: 0x1337},
-		}))
+		Expect(queuedFrames).To(HaveLen(1))
+		Expect(queuedFrames[0].Frame).To(Equal(&wire.MaxDataFrame{ByteOffset: 0x1337}))
 	})
 
 	It("deduplicates", func() {
@@ -105,8 +107,7 @@ var _ = Describe("Window Update Queue", func() {
 		q.AddStream(10)
 		q.AddStream(10)
 		q.QueueAll()
-		Expect(queuedFrames).To(Equal([]wire.Frame{
-			&wire.MaxStreamDataFrame{StreamID: 10, ByteOffset: 200},
-		}))
+		Expect(queuedFrames).To(HaveLen(1))
+		Expect(queuedFrames[0].Frame).To(Equal(&wire.MaxStreamDataFrame{StreamID: 10, ByteOffset: 200}))
 	})
 })


### PR DESCRIPTION
This turned out to be a lot simpler than I expected.

What happens here is the following:

1. We set the `OnLost` callback (which is called when a packet is lost) for MAX_DATA and MAX_STREAM_DATA frames.
2. This `OnLost` callback uses the same function that a stream would use to notify the `windowUpdateQueue` that there's a MAX_STREAM_DATA to send for that stream. Analogously for the connection.

This gives us a few advantages over the current behavior (which was just dumbly retransmitting the frame):

1. The retransmission will carry the current value of the flow control window.
2. It deduplicates: If two frames for the same stream are lost, we'll only send one retransmission.
3. It doesn't send retransmissions for streams that have already been removed from the streams map.