### PR TITLE
avoid converting to float64 when calculating receive window utilization

### DIFF
--- a/internal/flowcontrol/base_flow_controller.go
+++ b/internal/flowcontrol/base_flow_controller.go
@@ -76,7 +76,7 @@ func (c *baseFlowController) AddBytesRead(n protocol.ByteCount) {
 func (c *baseFlowController) hasWindowUpdate() bool {
 	bytesRemaining := c.receiveWindow - c.bytesRead
 	// update the window when more than the threshold was consumed
-	return bytesRemaining <= protocol.ByteCount((float64(c.receiveWindowSize) * float64((1 - protocol.WindowUpdateThreshold))))
+	return bytesRemaining <= c.receiveWindowSize-c.receiveWindowSize/protocol.WindowUpdateFraction
 }
 
 // getWindowUpdate updates the receive window, if necessary

--- a/internal/flowcontrol/base_flow_controller_test.go
+++ b/internal/flowcontrol/base_flow_controller_test.go
@@ -106,8 +106,8 @@ var _ = Describe("Base Flow controller", func() {
 		})
 
 		It("triggers a window update when necessary", func() {
-			bytesConsumed := float64(receiveWindowSize)*protocol.WindowUpdateThreshold + 1 // consumed 1 byte more than the threshold
-			bytesRemaining := receiveWindowSize - protocol.ByteCount(bytesConsumed)
+			bytesConsumed := receiveWindowSize/protocol.WindowUpdateFraction + 1 // consumed 1 byte more than the threshold
+			bytesRemaining := receiveWindowSize - bytesConsumed
 			readPosition := receiveWindow - bytesRemaining
 			controller.bytesRead = readPosition
 			offset := controller.getWindowUpdate()
@@ -116,8 +116,8 @@ var _ = Describe("Base Flow controller", func() {
 		})
 
 		It("doesn't trigger a window update when not necessary", func() {
-			bytesConsumed := float64(receiveWindowSize)*protocol.WindowUpdateThreshold - 1 // consumed 1 byte less than the threshold
-			bytesRemaining := receiveWindowSize - protocol.ByteCount(bytesConsumed)
+			bytesConsumed := receiveWindowSize/protocol.WindowUpdateFraction - 1 // consumed 1 byte less than the threshold
+			bytesRemaining := receiveWindowSize - bytesConsumed
 			readPosition := receiveWindow - bytesRemaining
 			controller.bytesRead = readPosition
 			offset := controller.getWindowUpdate()
@@ -173,7 +173,7 @@ var _ = Describe("Base Flow controller", func() {
 
 			It("doesn't increase the window size if data is read so fast that the window would be consumed in less than 4 RTTs, but less than half the window has been read", func() {
 				// this test only makes sense if a window update is triggered before half of the window has been consumed
-				Expect(protocol.WindowUpdateThreshold).To(BeNumerically(">", 1/3))
+				Expect(protocol.WindowUpdateFraction).To(BeNumerically(">", 3))
 				bytesRead := controller.bytesRead
 				rtt := scaleDuration(20 * time.Millisecond)
 				setRtt(rtt)

--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -30,8 +30,9 @@ const DefaultMaxReceiveStreamFlowControlWindow = 6 * (1 << 20) // 6 MB
 // DefaultMaxReceiveConnectionFlowControlWindow is the default connection-level flow control window for receiving data, for the server
 const DefaultMaxReceiveConnectionFlowControlWindow = 15 * (1 << 20) // 12 MB
 
-// WindowUpdateThreshold is the fraction of the receive window that has to be consumed before an higher offset is advertised to the client
-const WindowUpdateThreshold = 0.25
+// WindowUpdateFraction is the fraction of the receive window that has to be consumed before an higher offset is advertised.
+// For example, if this value is 3, then we'll grant higher flow control credit once 1/3 of the window has been consumed.
+const WindowUpdateFraction = 4
 
 // DefaultMaxIncomingStreams is the maximum number of streams that a peer may open
 const DefaultMaxIncomingStreams = 100


### PR DESCRIPTION
Maybe this is better than #2592?

Closes #2592.