### PR TITLE
log sent packets right before sending them out

### DIFF
--- a/session.go
+++ b/session.go
@@ -1508,9 +1508,9 @@ func (s *session) sendPackedPacket(packet *packedPacket) {
 	if s.firstAckElicitingPacketAfterIdleSentTime.IsZero() && packet.IsAckEliciting() {
 		s.firstAckElicitingPacketAfterIdleSentTime = now
 	}
-	s.logPacket(now, packet)
 	s.sentPacketHandler.SentPacket(packet.ToAckHandlerPacket(time.Now(), s.retransmissionQueue))
 	s.connIDManager.SentPacket()
+	s.logPacket(now, packet)
 	s.sendQueue.Send(packet.buffer)
 }
 


### PR DESCRIPTION
This means that the congestion stats logged will already include that packet.