### PR TITLE
implement a token-bucket pacing algorithm

### DIFF
--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -36,12 +36,8 @@ type SentPacketHandler interface {
 	// TimeUntilSend is the time when the next packet should be sent.
 	// It is used for pacing packets.
 	TimeUntilSend() time.Time
-	// ShouldSendNumPackets returns the number of packets that should be sent immediately.
-	// It always returns a number greater or equal than 1.
-	// A number greater than 1 is returned when the pacing delay is smaller than the minimum pacing delay.
-	// Note that the number of packets is only calculated based on the pacing algorithm.
-	// Before sending any packet, SendingAllowed() must be called to learn if we can actually send it.
-	ShouldSendNumPackets() int
+	// HasPacingBudget says if the pacer allows sending of a (full size) packet at this moment.
+	HasPacingBudget() bool
 
 	// only to be called once the handshake is complete
 	QueueProbePacket(protocol.EncryptionLevel) bool /* was a packet queued */

--- a/internal/congestion/interface.go
+++ b/internal/congestion/interface.go
@@ -8,7 +8,8 @@ import (
 
 // A SendAlgorithm performs congestion control
 type SendAlgorithm interface {
-	TimeUntilSend(bytesInFlight protocol.ByteCount) time.Duration
+	TimeUntilSend(bytesInFlight protocol.ByteCount) time.Time
+	HasPacingBudget() bool
 	OnPacketSent(sentTime time.Time, bytesInFlight protocol.ByteCount, packetNumber protocol.PacketNumber, bytes protocol.ByteCount, isRetransmittable bool)
 	CanSend(bytesInFlight protocol.ByteCount) bool
 	MaybeExitSlowStart()

--- a/internal/congestion/pacer.go
+++ b/internal/congestion/pacer.go
@@ -14,11 +14,14 @@ const maxBurstSize = 10 * maxDatagramSize
 type pacer struct {
 	budgetAtLastSent protocol.ByteCount
 	lastSentTime     time.Time
-	bandwidth        uint64 // in bytes / s
+	getBandwidth     func() uint64 // in bytes/s
 }
 
-func newPacer(bw uint64) *pacer {
-	p := &pacer{bandwidth: bw}
+func newPacer(getBandwidth func() Bandwidth) *pacer {
+	p := &pacer{getBandwidth: func() uint64 {
+		// Bandwidth is in bits/s. We need the value in bytes/s.
+		return uint64(getBandwidth() / BytesPerSecond)
+	}}
 	p.budgetAtLastSent = p.maxBurstSize()
 	return p
 }
@@ -33,24 +36,17 @@ func (p *pacer) SentPacket(sendTime time.Time, size protocol.ByteCount) {
 	p.lastSentTime = sendTime
 }
 
-func (p *pacer) SetBandwidth(bw uint64) {
-	if bw == 0 {
-		panic("zero bandwidth")
-	}
-	p.bandwidth = bw
-}
-
 func (p *pacer) Budget(now time.Time) protocol.ByteCount {
 	if p.lastSentTime.IsZero() {
 		return p.maxBurstSize()
 	}
-	budget := p.budgetAtLastSent + (protocol.ByteCount(p.bandwidth)*protocol.ByteCount(now.Sub(p.lastSentTime).Nanoseconds()))/1e9
+	budget := p.budgetAtLastSent + (protocol.ByteCount(p.getBandwidth())*protocol.ByteCount(now.Sub(p.lastSentTime).Nanoseconds()))/1e9
 	return utils.MinByteCount(p.maxBurstSize(), budget)
 }
 
 func (p *pacer) maxBurstSize() protocol.ByteCount {
 	return utils.MaxByteCount(
-		protocol.ByteCount(uint64((protocol.MinPacingDelay+protocol.TimerGranularity).Nanoseconds())*p.bandwidth)/1e9,
+		protocol.ByteCount(uint64((protocol.MinPacingDelay+protocol.TimerGranularity).Nanoseconds())*p.getBandwidth())/1e9,
 		maxBurstSize,
 	)
 }
@@ -62,6 +58,6 @@ func (p *pacer) TimeUntilSend() time.Time {
 	}
 	return p.lastSentTime.Add(utils.MaxDuration(
 		protocol.MinPacingDelay,
-		time.Duration(math.Ceil(float64(maxDatagramSize-p.budgetAtLastSent)*1e9/float64(p.bandwidth)))*time.Nanosecond,
+		time.Duration(math.Ceil(float64(maxDatagramSize-p.budgetAtLastSent)*1e9/float64(p.getBandwidth())))*time.Nanosecond,
 	))
 }

--- a/internal/congestion/pacer.go
+++ b/internal/congestion/pacer.go
@@ -1,0 +1,61 @@
+package congestion
+
+import (
+	"math"
+	"time"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+)
+
+const maxBurstSize = 10 * maxDatagramSize
+
+// The pacer implements a token bucket pacing algorithm.
+type pacer struct {
+	budgetAtLastSent protocol.ByteCount
+	lastSentTime     time.Time
+	bandwidth        uint64 // in bytes / s
+}
+
+func newPacer(bw uint64) *pacer {
+	return &pacer{
+		bandwidth:        bw,
+		budgetAtLastSent: maxBurstSize,
+	}
+}
+
+func (p *pacer) SentPacket(sendTime time.Time, size protocol.ByteCount) {
+	budget := p.Budget(sendTime)
+	if size > budget {
+		p.budgetAtLastSent = 0
+	} else {
+		p.budgetAtLastSent = budget - size
+	}
+	p.lastSentTime = sendTime
+}
+
+func (p *pacer) SetBandwidth(bw uint64) {
+	if bw == 0 {
+		panic("zero bandwidth")
+	}
+	p.bandwidth = bw
+}
+
+func (p *pacer) Budget(now time.Time) protocol.ByteCount {
+	if p.lastSentTime.IsZero() {
+		return p.budgetAtLastSent
+	}
+	return utils.MinByteCount(
+		maxBurstSize,
+		p.budgetAtLastSent+(protocol.ByteCount(p.bandwidth)*protocol.ByteCount(now.Sub(p.lastSentTime).Nanoseconds()))/1e9,
+	)
+}
+
+// TimeUntilSend returns when the next packet should be sent.
+func (p *pacer) TimeUntilSend() time.Time {
+	if p.budgetAtLastSent >= maxDatagramSize {
+		return time.Time{}
+	}
+	// TODO: don't allow pacing faster than MinPacingDelay
+	return p.lastSentTime.Add(time.Duration(math.Ceil(float64(maxDatagramSize-p.budgetAtLastSent)*1e9/float64(p.bandwidth))) * time.Nanosecond)
+}

--- a/internal/congestion/pacer.go
+++ b/internal/congestion/pacer.go
@@ -12,15 +12,20 @@ const maxBurstSize = 10 * maxDatagramSize
 
 // The pacer implements a token bucket pacing algorithm.
 type pacer struct {
-	budgetAtLastSent protocol.ByteCount
-	lastSentTime     time.Time
-	getBandwidth     func() uint64 // in bytes/s
+	budgetAtLastSent     protocol.ByteCount
+	lastSentTime         time.Time
+	getAdjustedBandwidth func() uint64 // in bytes/s
 }
 
 func newPacer(getBandwidth func() Bandwidth) *pacer {
-	p := &pacer{getBandwidth: func() uint64 {
+	p := &pacer{getAdjustedBandwidth: func() uint64 {
 		// Bandwidth is in bits/s. We need the value in bytes/s.
-		return uint64(getBandwidth() / BytesPerSecond)
+		bw := uint64(getBandwidth() / BytesPerSecond)
+		// Use a slightly higher value than the actual measured bandwidth.
+		// RTT variations then won't result in under-utilization of the congestion window.
+		// Ultimately, this will  result in sending packets as acknowledgments are received rather than when timers fire,
+		// provided the congestion window is fully utilized and acknowledgments arrive at regular intervals.
+		return bw * 5 / 4
 	}}
 	p.budgetAtLastSent = p.maxBurstSize()
 	return p
@@ -40,13 +45,13 @@ func (p *pacer) Budget(now time.Time) protocol.ByteCount {
 	if p.lastSentTime.IsZero() {
 		return p.maxBurstSize()
 	}
-	budget := p.budgetAtLastSent + (protocol.ByteCount(p.getBandwidth())*protocol.ByteCount(now.Sub(p.lastSentTime).Nanoseconds()))/1e9
+	budget := p.budgetAtLastSent + (protocol.ByteCount(p.getAdjustedBandwidth())*protocol.ByteCount(now.Sub(p.lastSentTime).Nanoseconds()))/1e9
 	return utils.MinByteCount(p.maxBurstSize(), budget)
 }
 
 func (p *pacer) maxBurstSize() protocol.ByteCount {
 	return utils.MaxByteCount(
-		protocol.ByteCount(uint64((protocol.MinPacingDelay+protocol.TimerGranularity).Nanoseconds())*p.getBandwidth())/1e9,
+		protocol.ByteCount(uint64((protocol.MinPacingDelay+protocol.TimerGranularity).Nanoseconds())*p.getAdjustedBandwidth())/1e9,
 		maxBurstSize,
 	)
 }
@@ -58,6 +63,6 @@ func (p *pacer) TimeUntilSend() time.Time {
 	}
 	return p.lastSentTime.Add(utils.MaxDuration(
 		protocol.MinPacingDelay,
-		time.Duration(math.Ceil(float64(maxDatagramSize-p.budgetAtLastSent)*1e9/float64(p.getBandwidth())))*time.Nanosecond,
+		time.Duration(math.Ceil(float64(maxDatagramSize-p.budgetAtLastSent)*1e9/float64(p.getAdjustedBandwidth())))*time.Nanosecond,
 	))
 }

--- a/internal/congestion/pacer_test.go
+++ b/internal/congestion/pacer_test.go
@@ -1,0 +1,91 @@
+package congestion
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Pacer", func() {
+	var p *pacer
+
+	const packetsPerSecond = 42
+
+	BeforeEach(func() {
+		p = newPacer(packetsPerSecond * uint64(maxDatagramSize)) // bandwidth: 42 full-size packets per second
+	})
+
+	It("allows a burst at the beginning", func() {
+		t := time.Now()
+		Expect(p.TimeUntilSend()).To(BeZero())
+		Expect(p.Budget(t)).To(BeEquivalentTo(maxBurstSize))
+	})
+
+	It("reduces the budget when sending packets", func() {
+		t := time.Now()
+		budget := p.Budget(t)
+		for budget > 0 {
+			Expect(p.TimeUntilSend()).To(BeZero())
+			Expect(p.Budget(t)).To(Equal(budget))
+			p.SentPacket(t, maxDatagramSize)
+			budget -= maxDatagramSize
+		}
+		Expect(p.Budget(t)).To(BeZero())
+		Expect(p.TimeUntilSend()).ToNot(BeZero())
+	})
+
+	sendBurst := func(t time.Time) {
+		for p.Budget(t) > 0 {
+			p.SentPacket(t, maxDatagramSize)
+		}
+	}
+
+	It("paces packets after a burst", func() {
+		t := time.Now()
+		sendBurst(t)
+		// send 100 exactly paced packets
+		for i := 0; i < 100; i++ {
+			t2 := p.TimeUntilSend()
+			Expect(t2.Sub(t)).To(BeNumerically("~", time.Second/packetsPerSecond, time.Nanosecond))
+			Expect(p.Budget(t2)).To(BeEquivalentTo(maxDatagramSize))
+			p.SentPacket(t2, maxDatagramSize)
+			t = t2
+		}
+	})
+
+	It("accounts for non-full-size packets", func() {
+		t := time.Now()
+		sendBurst(t)
+		t2 := p.TimeUntilSend()
+		Expect(t2.Sub(t)).To(BeNumerically("~", time.Second/packetsPerSecond, time.Nanosecond))
+		// send a half-full packet
+		Expect(p.Budget(t2)).To(BeEquivalentTo(maxDatagramSize))
+		size := maxDatagramSize / 2
+		p.SentPacket(t2, size)
+		Expect(p.Budget(t2)).To(Equal(maxDatagramSize - size))
+		Expect(p.TimeUntilSend()).To(BeTemporally("~", t2.Add(time.Second/packetsPerSecond/2), time.Nanosecond))
+	})
+
+	It("accumulates budget, if no packets are sent", func() {
+		t := time.Now()
+		sendBurst(t)
+		t2 := p.TimeUntilSend()
+		Expect(t2).To(BeTemporally(">", t))
+		// wait for 5 times the duration
+		Expect(p.Budget(t.Add(5 * t2.Sub(t)))).To(BeEquivalentTo(5 * maxDatagramSize))
+	})
+
+	It("never allows bursts larger than the maximum burst size", func() {
+		t := time.Now()
+		sendBurst(t)
+		Expect(p.Budget(t.Add(time.Hour))).To(BeEquivalentTo(maxBurstSize))
+	})
+
+	It("changes the bandwidth", func() {
+		t := time.Now()
+		sendBurst(t)
+		p.SetBandwidth(uint64(maxDatagramSize)) // reduce the bandwidth to 1 packet per second
+		Expect(p.TimeUntilSend()).To(Equal(t.Add(time.Second)))
+	})
+})

--- a/internal/congestion/pacer_test.go
+++ b/internal/congestion/pacer_test.go
@@ -13,9 +13,11 @@ var _ = Describe("Pacer", func() {
 	var p *pacer
 
 	const packetsPerSecond = 42
+	var bandwidth uint64 // in bytes/s
 
 	BeforeEach(func() {
-		p = newPacer(packetsPerSecond * uint64(maxDatagramSize)) // bandwidth: 42 full-size packets per second
+		bandwidth = uint64(packetsPerSecond * maxDatagramSize) // 42 full-size packets per second
+		p = newPacer(func() Bandwidth { return Bandwidth(bandwidth) * BytesPerSecond })
 	})
 
 	It("allows a burst at the beginning", func() {
@@ -26,7 +28,7 @@ var _ = Describe("Pacer", func() {
 
 	It("allows a big burst for high pacing rates", func() {
 		t := time.Now()
-		p.SetBandwidth(10000 * packetsPerSecond * uint64(maxDatagramSize))
+		bandwidth = uint64(10000 * packetsPerSecond * maxDatagramSize)
 		Expect(p.TimeUntilSend()).To(BeZero())
 		Expect(p.Budget(t)).To(BeNumerically(">", maxBurstSize))
 	})
@@ -94,14 +96,14 @@ var _ = Describe("Pacer", func() {
 	It("changes the bandwidth", func() {
 		t := time.Now()
 		sendBurst(t)
-		p.SetBandwidth(uint64(maxDatagramSize)) // reduce the bandwidth to 1 packet per second
+		bandwidth = uint64(maxDatagramSize) // reduce the bandwidth to 1 packet per second
 		Expect(p.TimeUntilSend()).To(Equal(t.Add(time.Second)))
 	})
 
 	It("doesn't pace faster than the minimum pacing duration", func() {
 		t := time.Now()
 		sendBurst(t)
-		p.SetBandwidth(1e6 * uint64(maxDatagramSize))
+		bandwidth = uint64(1e6 * maxDatagramSize)
 		Expect(p.TimeUntilSend()).To(Equal(t.Add(protocol.MinPacingDelay)))
 		Expect(p.Budget(t.Add(protocol.MinPacingDelay))).To(Equal(protocol.ByteCount(protocol.MinPacingDelay) * maxDatagramSize * 1e6 / 1e9))
 	})

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -92,6 +92,20 @@ func (mr *MockSentPacketHandlerMockRecorder) GetStats() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStats", reflect.TypeOf((*MockSentPacketHandler)(nil).GetStats))
 }
 
+// HasPacingBudget mocks base method
+func (m *MockSentPacketHandler) HasPacingBudget() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasPacingBudget")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasPacingBudget indicates an expected call of HasPacingBudget
+func (mr *MockSentPacketHandlerMockRecorder) HasPacingBudget() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPacingBudget", reflect.TypeOf((*MockSentPacketHandler)(nil).HasPacingBudget))
+}
+
 // OnLossDetectionTimeout mocks base method
 func (m *MockSentPacketHandler) OnLossDetectionTimeout() error {
 	m.ctrl.T.Helper()
@@ -225,20 +239,6 @@ func (m *MockSentPacketHandler) SetHandshakeComplete() {
 func (mr *MockSentPacketHandlerMockRecorder) SetHandshakeComplete() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHandshakeComplete", reflect.TypeOf((*MockSentPacketHandler)(nil).SetHandshakeComplete))
-}
-
-// ShouldSendNumPackets mocks base method
-func (m *MockSentPacketHandler) ShouldSendNumPackets() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ShouldSendNumPackets")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// ShouldSendNumPackets indicates an expected call of ShouldSendNumPackets
-func (mr *MockSentPacketHandlerMockRecorder) ShouldSendNumPackets() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSendNumPackets", reflect.TypeOf((*MockSentPacketHandler)(nil).ShouldSendNumPackets))
 }
 
 // TimeUntilSend mocks base method

--- a/internal/mocks/congestion.go
+++ b/internal/mocks/congestion.go
@@ -63,6 +63,20 @@ func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) GetCongestionWindow() *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCongestionWindow", reflect.TypeOf((*MockSendAlgorithmWithDebugInfos)(nil).GetCongestionWindow))
 }
 
+// HasPacingBudget mocks base method
+func (m *MockSendAlgorithmWithDebugInfos) HasPacingBudget() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasPacingBudget")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasPacingBudget indicates an expected call of HasPacingBudget
+func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) HasPacingBudget() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPacingBudget", reflect.TypeOf((*MockSendAlgorithmWithDebugInfos)(nil).HasPacingBudget))
+}
+
 // InRecovery mocks base method
 func (m *MockSendAlgorithmWithDebugInfos) InRecovery() bool {
 	m.ctrl.T.Helper()
@@ -152,10 +166,10 @@ func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) OnRetransmissionTimeout(a
 }
 
 // TimeUntilSend mocks base method
-func (m *MockSendAlgorithmWithDebugInfos) TimeUntilSend(arg0 protocol.ByteCount) time.Duration {
+func (m *MockSendAlgorithmWithDebugInfos) TimeUntilSend(arg0 protocol.ByteCount) time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TimeUntilSend", arg0)
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time.Time)
 	return ret0
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -1067,7 +1067,7 @@ var _ = Describe("Session", func() {
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
-			sph.EXPECT().ShouldSendNumPackets().Return(1000)
+			sph.EXPECT().HasPacingBudget().Return(true).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any())
 			sess.sentPacketHandler = sph
 			runSession()
@@ -1095,7 +1095,6 @@ var _ = Describe("Session", func() {
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAck)
-			sph.EXPECT().ShouldSendNumPackets().Return(1000)
 			done := make(chan struct{})
 			packer.EXPECT().MaybePackAckPacket(false).Do(func(bool) { close(done) })
 			sess.sentPacketHandler = sph
@@ -1110,7 +1109,7 @@ var _ = Describe("Session", func() {
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
-			sph.EXPECT().ShouldSendNumPackets().Return(1000)
+			sph.EXPECT().HasPacingBudget().Return(true).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any())
 			sess.sentPacketHandler = sph
 			fc := mocks.NewMockConnectionFlowController(mockCtrl)
@@ -1133,7 +1132,7 @@ var _ = Describe("Session", func() {
 		It("doesn't send when the SentPacketHandler doesn't allow it", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendNone)
+			sph.EXPECT().SendMode().Return(ackhandler.SendNone).AnyTimes()
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sess.sentPacketHandler = sph
 			runSession()
@@ -1167,7 +1166,7 @@ var _ = Describe("Session", func() {
 					sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 					sph.EXPECT().TimeUntilSend().AnyTimes()
 					sph.EXPECT().SendMode().Return(sendMode)
-					sph.EXPECT().ShouldSendNumPackets().Return(1)
+					sph.EXPECT().SendMode().Return(ackhandler.SendNone)
 					sph.EXPECT().QueueProbePacket(encLevel)
 					p := getPacket(123)
 					packer.EXPECT().MaybePackProbePacket(encLevel).Return(p, nil)
@@ -1188,7 +1187,7 @@ var _ = Describe("Session", func() {
 					sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 					sph.EXPECT().TimeUntilSend().AnyTimes()
 					sph.EXPECT().SendMode().Return(sendMode)
-					sph.EXPECT().ShouldSendNumPackets().Return(1)
+					sph.EXPECT().SendMode().Return(ackhandler.SendNone)
 					sph.EXPECT().QueueProbePacket(encLevel).Return(false)
 					p := getPacket(123)
 					packer.EXPECT().MaybePackProbePacket(encLevel).Return(p, nil)
@@ -1218,6 +1217,7 @@ var _ = Describe("Session", func() {
 			sph = mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sess.handshakeConfirmed = true
+			sess.handshakeComplete = true
 			sess.sentPacketHandler = sph
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 		})
@@ -1235,10 +1235,10 @@ var _ = Describe("Session", func() {
 
 		It("sends multiple packets one by one immediately", func() {
 			sph.EXPECT().SentPacket(gomock.Any()).Times(2)
-			sph.EXPECT().ShouldSendNumPackets().Return(1).Times(2)
-			sph.EXPECT().TimeUntilSend().Return(time.Now()).Times(2)
+			sph.EXPECT().HasPacingBudget().Return(true).Times(2)
+			sph.EXPECT().HasPacingBudget()
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(2) // allow 2 packets...
+			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(3)
 			packer.EXPECT().PackPacket().Return(getPacket(10), nil)
 			packer.EXPECT().PackPacket().Return(getPacket(11), nil)
 			mconn.EXPECT().Write(gomock.Any()).Times(2)
@@ -1255,8 +1255,7 @@ var _ = Describe("Session", func() {
 		// we shouldn't send the ACK in the same run
 		It("doesn't send an ACK right after becoming congestion limited", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().ShouldSendNumPackets().Return(1000)
-			sph.EXPECT().TimeUntilSend().Return(time.Now())
+			sph.EXPECT().HasPacingBudget().Return(true)
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
 			sph.EXPECT().SendMode().Return(ackhandler.SendAck)
 			packer.EXPECT().PackPacket().Return(getPacket(100), nil)
@@ -1272,14 +1271,19 @@ var _ = Describe("Session", func() {
 
 		It("paces packets", func() {
 			pacingDelay := scaleDuration(100 * time.Millisecond)
-			sph.EXPECT().SentPacket(gomock.Any()).Times(2)
-			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(-time.Minute)) // send one packet immediately
-			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(pacingDelay))  // send one
-			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
-			sph.EXPECT().ShouldSendNumPackets().Times(2).Return(1)
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
-			packer.EXPECT().PackPacket().Return(getPacket(100), nil)
-			packer.EXPECT().PackPacket().Return(getPacket(101), nil)
+			gomock.InOrder(
+				sph.EXPECT().HasPacingBudget().Return(true),
+				packer.EXPECT().PackPacket().Return(getPacket(100), nil),
+				sph.EXPECT().SentPacket(gomock.Any()),
+				sph.EXPECT().HasPacingBudget(),
+				sph.EXPECT().TimeUntilSend().Return(time.Now().Add(pacingDelay)),
+				sph.EXPECT().HasPacingBudget().Return(true),
+				packer.EXPECT().PackPacket().Return(getPacket(101), nil),
+				sph.EXPECT().SentPacket(gomock.Any()),
+				sph.EXPECT().HasPacingBudget(),
+				sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour)),
+			)
 			written := make(chan struct{}, 2)
 			mconn.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
 				written <- struct{}{}
@@ -1298,10 +1302,10 @@ var _ = Describe("Session", func() {
 
 		It("sends multiple packets at once", func() {
 			sph.EXPECT().SentPacket(gomock.Any()).Times(3)
-			sph.EXPECT().ShouldSendNumPackets().Return(3)
-			sph.EXPECT().TimeUntilSend().Return(time.Now())
+			sph.EXPECT().HasPacingBudget().Return(true).Times(3)
+			sph.EXPECT().HasPacingBudget()
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(3)
+			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(4)
 			packer.EXPECT().PackPacket().Return(getPacket(1000), nil)
 			packer.EXPECT().PackPacket().Return(getPacket(1001), nil)
 			packer.EXPECT().PackPacket().Return(getPacket(1002), nil)
@@ -1320,8 +1324,7 @@ var _ = Describe("Session", func() {
 		})
 
 		It("doesn't set a pacing timer when there is no data to send", func() {
-			sph.EXPECT().TimeUntilSend().Return(time.Now())
-			sph.EXPECT().ShouldSendNumPackets().Return(1)
+			sph.EXPECT().HasPacingBudget().Return(true)
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
 			packer.EXPECT().PackPacket()
 			// don't EXPECT any calls to mconn.Write()
@@ -1357,10 +1360,11 @@ var _ = Describe("Session", func() {
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
-			sph.EXPECT().ShouldSendNumPackets().AnyTimes().Return(1)
+			sph.EXPECT().HasPacingBudget().Return(true).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any())
 			sess.sentPacketHandler = sph
 			packer.EXPECT().PackPacket().Return(getPacket(1), nil)
+			packer.EXPECT().PackPacket().Return(nil, nil)
 
 			go func() {
 				defer GinkgoRecover()
@@ -1379,12 +1383,11 @@ var _ = Describe("Session", func() {
 
 		It("sets the timer to the ack timer", func() {
 			packer.EXPECT().PackPacket().Return(getPacket(1234), nil)
+			packer.EXPECT().PackPacket().Return(nil, nil)
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
-			sph.EXPECT().TimeUntilSend().Return(time.Now())
-			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
-			sph.EXPECT().ShouldSendNumPackets().Return(1)
+			sph.EXPECT().HasPacingBudget().Return(true).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any()).Do(func(p *ackhandler.Packet) {
 				Expect(p.PacketNumber).To(Equal(protocol.PacketNumber(1234)))
 			})
@@ -1408,6 +1411,7 @@ var _ = Describe("Session", func() {
 	})
 
 	It("sends coalesced packets before the handshake is confirmed", func() {
+		sess.handshakeComplete = false
 		sess.handshakeConfirmed = false
 		sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 		const window protocol.ByteCount = 321
@@ -1445,7 +1449,6 @@ var _ = Describe("Session", func() {
 		sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 		sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
 		sph.EXPECT().TimeUntilSend().Return(time.Now()).AnyTimes()
-		sph.EXPECT().ShouldSendNumPackets().Return(1).AnyTimes()
 		gomock.InOrder(
 			sph.EXPECT().SentPacket(gomock.Any()).Do(func(p *ackhandler.Packet) {
 				Expect(p.EncryptionLevel).To(Equal(protocol.EncryptionInitial))
@@ -1597,7 +1600,7 @@ var _ = Describe("Session", func() {
 		sph.EXPECT().SetHandshakeComplete()
 		sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 		sph.EXPECT().TimeUntilSend().AnyTimes()
-		sph.EXPECT().ShouldSendNumPackets().AnyTimes().Return(10)
+		sph.EXPECT().HasPacingBudget().Return(true)
 		sess.sentPacketHandler = sph
 		done := make(chan struct{})
 		sessionRunner.EXPECT().Retire(clientDestConnID)


### PR DESCRIPTION
Fixes #2606. cc @Stebalien

The bucket accumulates "tokens" (bytes that can be sent out immediately). Every time we send a packet, we check if there are enough tokens in the bucket to send out a (full-size) packet.

Once the tokens in the bucket are depleted, we need to wait for enough new tokens to accumulate, before we can send out another packet. `TimeUntilSend` can be used to query when this will be the case. To avoid setting too short timers (this would both be computationally inefficient, and timers have a limited resolution anyway), this function will never return a duration smaller than `MinPacingDelay` (1ms).

When sending out packets, we arm a pacing timer if the bucket runs out of tokens **and** we're not congestion limited. If we're congestion limited, but still have enough tokens in the bucket, there's no need to arm a timer, as the only way we'll be allowed to send more packets is by receiving an ACK from the peer that frees up the congestion window.

To avoid sending large bursts into the network, the bucket size is limited to maximum of a constant `maxBurstSize` (10 full-size packets) and the number of packets that we're supposed to send out during `MinPacingDelay + TimerGranularity` (both 1ms).

As recommended in the [recovery draft](https://tools.ietf.org/html/draft-ietf-quic-recovery-29#section-7.9), the pacer fills the bucket with a slightly higher rate than the actual bandwidth (`N = 1.25`). This allows us to completely fill the congestion window even when the RTT varies. More importantly, it also means that in the case of a continuous transfer, we become congestion limited shortly **before** depleting the bucket. As described above, in this case we don't need to arm a pacing timer, as packets are effectively paced by receiving acknowledgements. This greatly reduces the number of times we need to arm the session timer.

In my tests, this PR reduces the number of times we arm a pacing timer by 2/3 on the sending side, and eliminates the setting of pacing timers completely on the receiving side (as it should, there's nothing to pace when you're just acknowledging incoming packets).