### PR TITLE
gracefully handle concurrent stream writes and cancellations

### DIFF
--- a/send_stream.go
+++ b/send_stream.go
@@ -173,6 +173,9 @@ func (s *sendStream) Write(p []byte) (int, error) {
 		s.mutex.Lock()
 	}
 
+	if bytesWritten == len(p) {
+		return bytesWritten, nil
+	}
 	if s.closeForShutdownErr != nil {
 		return bytesWritten, s.closeForShutdownErr
 	} else if s.cancelWriteErr != nil {


### PR DESCRIPTION
If the complete slice passed to `Stream.Write()` is sent out, and the stream is canceled concurrently (either by calling `Stream.CancelWrite()`or by receiving a STOP_SENDING frame), we don't need to return an error for the `Write()` call.

This PR fixes #2593. What was happening in that test is the following: The client would send a GET request to the server. In some rare cases, the FIN is not bundled with the STREAM frame. The server then receives the HTTP request and writes the response. The HTTP handler returns before the FIN is received, and the server therefore calls `CancelRead()` on the stream, which sends a STOP_SENDING frame. The client then receives and processes the STOP_SENDING before the `Write()` call (that sent the request in the first place) had a chance to return.