### PR TITLE
fix flaky server test on Travis

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -645,7 +645,10 @@ var _ = Describe("Server", func() {
 				wg.Wait()
 
 				close(acceptSession)
-				Eventually(func() uint32 { return atomic.LoadUint32(&counter) }).Should(BeEquivalentTo(protocol.MaxServerUnprocessedPackets + 1))
+				Eventually(
+					func() uint32 { return atomic.LoadUint32(&counter) },
+					scaleDuration(100*time.Millisecond),
+				).Should(BeEquivalentTo(protocol.MaxServerUnprocessedPackets + 1))
 				Consistently(func() uint32 { return atomic.LoadUint32(&counter) }).Should(BeEquivalentTo(protocol.MaxServerUnprocessedPackets + 1))
 			})
 


### PR DESCRIPTION
In this test, the server receives 3072 packets. When running with race detector on Travis, the `Eventually` timeout is sometimes too short.