### PR TITLE
don't block sendQueue.Send() if the runloop already exited.

### DIFF
--- a/send_queue.go
+++ b/send_queue.go
@@ -18,7 +18,10 @@ func newSendQueue(conn connection) *sendQueue {
 }
 
 func (h *sendQueue) Send(p *packetBuffer) {
-	h.queue <- p
+	select {
+	case h.queue <- p:
+	case <-h.runStopped:
+	}
 }
 
 func (h *sendQueue) Run() error {


### PR DESCRIPTION
This can lead to a deadlock where session.shutdown() never exits
because it is blocked on a Send() but the sendQueue has exited due to
a write error.

Fixes #2655 but needs consideration for other consequences ...