### PR TITLE
add a flag to disable conn ID generation and the check for retired conn IDs

### DIFF
--- a/conn_id_generator.go
+++ b/conn_id_generator.go
@@ -76,7 +76,7 @@ func (m *connIDGenerator) Retire(seq uint64, sentWithDestConnID protocol.Connect
 	if !ok {
 		return nil
 	}
-	if connID.Equal(sentWithDestConnID) {
+	if connID.Equal(sentWithDestConnID) && !RetireBugBackwardsCompatibilityMode {
 		return qerr.NewError(qerr.ProtocolViolation, fmt.Sprintf("tried to retire connection ID %d (%s), which was used as the Destination Connection ID on this packet", seq, connID))
 	}
 	m.retireConnectionID(connID)
@@ -89,6 +89,9 @@ func (m *connIDGenerator) Retire(seq uint64, sentWithDestConnID protocol.Connect
 }
 
 func (m *connIDGenerator) issueNewConnID() error {
+	if RetireBugBackwardsCompatibilityMode {
+		return nil
+	}
 	connID, err := protocol.GenerateConnectionID(m.connIDLen)
 	if err != nil {
 		return err

--- a/interface.go
+++ b/interface.go
@@ -13,6 +13,16 @@ import (
 	"github.com/lucas-clemente/quic-go/quictrace"
 )
 
+// RetireBugBackwardsCompatibilityMode controls a backwards compatibility mode, necessary due to a bug in
+// quic-go v0.17.2 (and earlier), where under certain circumstances, an endpoint would retire the connection
+// ID it is currently using. See https://github.com/lucas-clemente/quic-go/issues/2658.
+// The bug has now been fixed, and new deployments have nothing to worry about.
+// Deployments that already have quic-go <= v0.17.2 deployed should active RetireBugBackwardsCompatibilityMode.
+// If activated, quic-go will take steps to avoid the bug from triggering when connected to endpoints that are still
+// running quic-go <= v0.17.2.
+// This flag will be removed in a future version of quic-go.
+var RetireBugBackwardsCompatibilityMode bool
+
 // The StreamID is the ID of a QUIC stream.
 type StreamID = protocol.StreamID
 


### PR DESCRIPTION
This PR implements the proposed flag mentioned in https://github.com/ipfs/go-ipfs/issues/7526.