### PR TITLE
don't send write error in CONNECTION_CLOSE frames

### DIFF
--- a/session.go
+++ b/session.go
@@ -517,7 +517,7 @@ func (s *session) run() error {
 	go s.cryptoStreamHandler.RunHandshake()
 	go func() {
 		if err := s.sendQueue.Run(); err != nil {
-			s.closeLocal(err)
+			s.destroyImpl(err)
 		}
 	}()
 


### PR DESCRIPTION
If the send queue already failed, there's no point in trying to send out a CONNECTION_CLOSE.