### PR TITLE
put the session in the packet handler map directly (for client sessions)

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -634,9 +634,4 @@ var _ = Describe("Client", func() {
 			Expect(counter).To(Equal(2))
 		})
 	})
-
-	It("tells its version", func() {
-		Expect(cl.version).ToNot(BeZero())
-		Expect(cl.GetVersion()).To(Equal(cl.version))
-	})
 })


### PR DESCRIPTION
As of #2640, Version Negotiation packets are now handled in the session. This allows us to put the `session` in the packet handler map directly, without the need to route packets through the `client` first.