### PR TITLE
add a metric for closed connections

### DIFF
--- a/metrics/types.go
+++ b/metrics/types.go
@@ -65,3 +65,16 @@ func (t packetType) String() string {
 		panic("unknown packet type")
 	}
 }
+
+type timeoutReason logging.TimeoutReason
+
+func (r timeoutReason) String() string {
+	switch logging.TimeoutReason(r) {
+	case logging.TimeoutReasonHandshake:
+		return "handshake_timeout"
+	case logging.TimeoutReasonIdle:
+		return "idle_timeout"
+	default:
+		panic("unknown timeout reason")
+	}
+}


### PR DESCRIPTION
I'm not really happy with this PR. This seems overly complicated (and converting a bool to string is not pretty either).

The reason this is so complicated is that there are many reasons a QUIC connection can be closed:
1. It can run into a (handshake or post-handshake) timeout
2. It can receive a stateless reset because the peer lost state
3. The application can close the connection, in which case we want to log which side did it and which error code was used
4. The transport can close the connection, in which case we also want to log which side did it and which error code was used

@lanzafame Does this look ok to you?