### PR TITLE
use the correct return values in Fuzz() functions

### DIFF
--- a/fuzzing/frames/fuzz.go
+++ b/fuzzing/frames/fuzz.go
@@ -75,5 +75,5 @@ func Fuzz(data []byte) int {
 	if b.Len() > parsedLen {
 		panic(fmt.Sprintf("Serialized length (%d) is longer than parsed length (%d)", b.Len(), parsedLen))
 	}
-	return 0
+	return 1
 }

--- a/fuzzing/header/fuzz.go
+++ b/fuzzing/header/fuzz.go
@@ -60,7 +60,7 @@ func Fuzz(data []byte) int {
 			panic(fmt.Sprintf("inconsistent header length: %#v. Expected %d, got %d", extHdr, expLen, b.Len()))
 		}
 	}
-	return 0
+	return 1
 }
 
 func fuzzVNP(data []byte) int {
@@ -81,5 +81,5 @@ func fuzzVNP(data []byte) int {
 	if _, err := wire.ComposeVersionNegotiation(hdr.SrcConnectionID, hdr.DestConnectionID, versions); err != nil {
 		panic(err)
 	}
-	return 0
+	return 1
 }


### PR DESCRIPTION
The [docs](https://github.com/dvyukov/go-fuzz#usage) say:
> Data is a random input generated by go-fuzz, note that in most cases it is invalid. The function must return 1 if the fuzzer should increase priority of the given input during subsequent fuzzing (for example, the input is lexically correct and was parsed successfully); -1 if the input must not be added to corpus even if gives new coverage; and 0 otherwise; other values are reserved for future use.