### PR TITLE
never send a value larger than 2^60 in MAX_STREAMS frames

### DIFF
--- a/streams_map_incoming_bidi.go
+++ b/streams_map_incoming_bidi.go
@@ -159,12 +159,15 @@ func (m *incomingBidiStreamsMap) deleteStream(num protocol.StreamNum) error {
 	delete(m.streams, num)
 	// queue a MAX_STREAM_ID frame, giving the peer the option to open a new stream
 	if m.maxNumStreams > uint64(len(m.streams)) {
-		numNewStreams := m.maxNumStreams - uint64(len(m.streams))
-		m.maxStream = m.nextStreamToOpen + protocol.StreamNum(numNewStreams) - 1
-		m.queueMaxStreamID(&wire.MaxStreamsFrame{
-			Type:         protocol.StreamTypeBidi,
-			MaxStreamNum: m.maxStream,
-		})
+		maxStream := m.nextStreamToOpen + protocol.StreamNum(m.maxNumStreams-uint64(len(m.streams))) - 1
+		// Never send a value larger than protocol.MaxStreamCount.
+		if maxStream <= protocol.MaxStreamCount {
+			m.maxStream = maxStream
+			m.queueMaxStreamID(&wire.MaxStreamsFrame{
+				Type:         protocol.StreamTypeBidi,
+				MaxStreamNum: m.maxStream,
+			})
+		}
 	}
 	return nil
 }

--- a/streams_map_incoming_generic.go
+++ b/streams_map_incoming_generic.go
@@ -157,12 +157,15 @@ func (m *incomingItemsMap) deleteStream(num protocol.StreamNum) error {
 	delete(m.streams, num)
 	// queue a MAX_STREAM_ID frame, giving the peer the option to open a new stream
 	if m.maxNumStreams > uint64(len(m.streams)) {
-		numNewStreams := m.maxNumStreams - uint64(len(m.streams))
-		m.maxStream = m.nextStreamToOpen + protocol.StreamNum(numNewStreams) - 1
-		m.queueMaxStreamID(&wire.MaxStreamsFrame{
-			Type:         streamTypeGeneric,
-			MaxStreamNum: m.maxStream,
-		})
+		maxStream := m.nextStreamToOpen + protocol.StreamNum(m.maxNumStreams-uint64(len(m.streams))) - 1
+		// Never send a value larger than protocol.MaxStreamCount.
+		if maxStream <= protocol.MaxStreamCount {
+			m.maxStream = maxStream
+			m.queueMaxStreamID(&wire.MaxStreamsFrame{
+				Type:         streamTypeGeneric,
+				MaxStreamNum: m.maxStream,
+			})
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #2709.