### PR TITLE
use GitHub Actions to build the interop runner Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,6 @@ executors:
       - image: "circleci/golang:1.14"
     environment:
       runrace: true
-  interop:
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    environment:
-      IMAGE_NAME: martenseemann/quic-go-interop
 
 jobs:
   "test": &test
@@ -45,49 +40,8 @@ jobs:
           command: ginkgo -v -randomizeAllSpecs -trace integrationtests/self -- -qlog -metrics
   go114:
     <<: *test
-  interop-build:
-    executor: interop
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Build docker image
-          command: cd interop && docker build . -t $IMAGE_NAME:latest --pull --build-arg CACHEBUST=$(date +%s)
-      - run:
-          name: Archive Docker image
-          command: docker save -o image.tar $IMAGE_NAME
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./image.tar
-  interop-publish:
-    executor: interop
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - setup_remote_docker
-      - run:
-          name: Load archived Docker image 
-          command: docker load -i /tmp/workspace/image.tar
-      - run:
-          name: Publish quic-go-interop
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push $IMAGE_NAME:latest
 
 workflows:
   workflow:
     jobs:
       - go114
-      - interop-build:
-          filters:
-            branches:
-              only: interop
-      - interop-publish:
-          requires:
-            - go114
-            - interop-build
-          filters:
-            branches:
-              only: interop

--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -1,0 +1,20 @@
+name: Build interop Docker image
+on: 
+  push:
+    branches: [ interop ]
+  
+jobs:
+  interop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          always_pull: true
+          path: interop/
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: martenseemann/quic-go-interop
+          tags: latest
+          tag_with_ref: true
+          add_git_labels: true


### PR DESCRIPTION
This feels like a lot cleaner way to do it. I've canceled my CircleCI subscription, which I mainly had for building Docker images.

@lucas-clemente: For this to work, we'll need to add two environment variables on this repository. Unfortunately, I don't have access to those:
<img width="784" alt="image" src="https://user-images.githubusercontent.com/1478487/89890167-198b7480-dbfd-11ea-9184-9021236ab33d.png">

I just shared you a document with the credentials. Can you please add them to the settings and then ping me here?