### PR TITLE
add the exhaustive linter, replace panics by return values in logging stringers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - asciicheck
     - deadcode
     - depguard
+    - exhaustive
     - exportloopref
     - goconst
     - goimports

--- a/crypto_stream_manager.go
+++ b/crypto_stream_manager.go
@@ -35,6 +35,7 @@ func newCryptoStreamManager(
 
 func (m *cryptoStreamManager) HandleCryptoFrame(frame *wire.CryptoFrame, encLevel protocol.EncryptionLevel) (bool /* encryption level changed */, error) {
 	var str cryptoStream
+	//nolint:exhaustive // CRYPTO frames cannot be sent in 0-RTT packets.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		str = m.initialStream

--- a/fuzzing/handshake/fuzz.go
+++ b/fuzzing/handshake/fuzz.go
@@ -205,6 +205,7 @@ func toEncryptionLevel(n uint8) protocol.EncryptionLevel {
 }
 
 func maxEncLevel(cs handshake.CryptoSetup, encLevel protocol.EncryptionLevel) protocol.EncryptionLevel {
+	//nolint:exhaustive
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		return protocol.EncryptionInitial

--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -203,6 +203,7 @@ var _ = Describe("Handshake drop tests", func() {
 											var incoming, outgoing int32
 											startListenerAndProxy(func(d quicproxy.Direction, _ []byte) bool {
 												var p int32
+												//nolint:exhaustive
 												switch d {
 												case quicproxy.DirectionIncoming:
 													p = atomic.AddInt32(&incoming, 1)
@@ -218,6 +219,7 @@ var _ = Describe("Handshake drop tests", func() {
 											var incoming, outgoing int32
 											startListenerAndProxy(func(d quicproxy.Direction, _ []byte) bool {
 												var p int32
+												//nolint:exhaustive
 												switch d {
 												case quicproxy.DirectionIncoming:
 													p = atomic.AddInt32(&incoming, 1)

--- a/integrationtests/self/packetization_test.go
+++ b/integrationtests/self/packetization_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Packetization", func() {
 		proxy, err = quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
 			RemoteAddr: serverAddr,
 			DelayPacket: func(dir quicproxy.Direction, _ []byte) time.Duration {
+				//nolint:exhaustive
 				switch dir {
 				case quicproxy.DirectionIncoming:
 					atomic.AddUint32(&incoming, 1)

--- a/internal/ackhandler/received_packet_handler.go
+++ b/internal/ackhandler/received_packet_handler.go
@@ -67,6 +67,7 @@ func (h *receivedPacketHandler) ReceivedPacket(
 }
 
 func (h *receivedPacketHandler) DropPackets(encLevel protocol.EncryptionLevel) {
+	//nolint:exhaustive // 1-RTT packet number space is never dropped.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		h.initialPackets = nil
@@ -94,6 +95,7 @@ func (h *receivedPacketHandler) GetAlarmTimeout() time.Time {
 
 func (h *receivedPacketHandler) GetAckFrame(encLevel protocol.EncryptionLevel, onlyIfQueued bool) *wire.AckFrame {
 	var ack *wire.AckFrame
+	//nolint:exhaustive // 0-RTT packets can't contain ACK frames.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		if h.initialPackets != nil {

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -156,6 +156,7 @@ func (h *sentPacketHandler) dropPackets(encLevel protocol.EncryptionLevel) {
 		})
 	}
 	// drop the packet history
+	//nolint:exhaustive // Not every packet number space can be dropped.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		h.initialPackets = nil
@@ -629,6 +630,7 @@ func (h *sentPacketHandler) onVerifiedLossDetectionTimeout() error {
 			h.tracer.UpdatedPTOCount(h.ptoCount)
 		}
 		h.numProbesToSend += 2
+		//nolint:exhaustive // We never arm a PTO timer for 0-RTT packets.
 		switch encLevel {
 		case protocol.EncryptionInitial:
 			h.ptoMode = SendPTOInitial

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -42,7 +42,7 @@ var _ = Describe("SentPacketHandler", func() {
 	}
 
 	ackElicitingPacket := func(p *Packet) *Packet {
-		if p.EncryptionLevel == protocol.EncryptionUnspecified {
+		if p.EncryptionLevel == 0 {
 			p.EncryptionLevel = protocol.Encryption1RTT
 		}
 		if p.Length == 0 {

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -612,6 +612,7 @@ func (h *cryptoSetup) WriteRecord(p []byte) (int, error) {
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
 
+	//nolint:exhaustive // LS records can only be written for Initial and Handshake.
 	switch h.writeEncLevel {
 	case protocol.EncryptionInitial:
 		// assume that the first WriteRecord call contains the ClientHello

--- a/internal/protocol/encryption_level.go
+++ b/internal/protocol/encryption_level.go
@@ -5,10 +5,8 @@ package protocol
 type EncryptionLevel uint8
 
 const (
-	// EncryptionUnspecified is a not specified encryption level
-	EncryptionUnspecified EncryptionLevel = iota
 	// EncryptionInitial is the Initial encryption level
-	EncryptionInitial
+	EncryptionInitial EncryptionLevel = 1 + iota
 	// EncryptionHandshake is the Handshake encryption level
 	EncryptionHandshake
 	// Encryption0RTT is the 0-RTT encryption level

--- a/internal/protocol/encryption_level_test.go
+++ b/internal/protocol/encryption_level_test.go
@@ -6,8 +6,12 @@ import (
 )
 
 var _ = Describe("Encryption Level", func() {
+	It("doesn't use 0 as a value", func() {
+		// 0 is used in some tests
+		Expect(EncryptionInitial * EncryptionHandshake * Encryption0RTT * Encryption1RTT).ToNot(BeZero())
+	})
+
 	It("has the correct string representation", func() {
-		Expect(EncryptionUnspecified.String()).To(Equal("unknown"))
 		Expect(EncryptionInitial.String()).To(Equal("Initial"))
 		Expect(EncryptionHandshake.String()).To(Equal("Handshake"))
 		Expect(Encryption0RTT.String()).To(Equal("0-RTT"))

--- a/internal/protocol/packet_number.go
+++ b/internal/protocol/packet_number.go
@@ -11,8 +11,6 @@ const InvalidPacketNumber PacketNumber = -1
 type PacketNumberLen uint8
 
 const (
-	// PacketNumberLenInvalid is the default value and not a valid length for a packet number
-	PacketNumberLenInvalid PacketNumberLen = 0
 	// PacketNumberLen1 is a packet number length of 1 byte
 	PacketNumberLen1 PacketNumberLen = 1
 	// PacketNumberLen2 is a packet number length of 2 bytes

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -128,6 +128,7 @@ func (h *ExtendedHeader) Write(b *bytes.Buffer, ver protocol.VersionNumber) erro
 
 func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	var packetType uint8
+	//nolint:exhaustive
 	switch h.Type {
 	case protocol.PacketTypeInitial:
 		packetType = 0x0
@@ -151,6 +152,7 @@ func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, _ protocol.VersionNumb
 	b.WriteByte(uint8(h.SrcConnectionID.Len()))
 	b.Write(h.SrcConnectionID.Bytes())
 
+	//nolint:exhaustive
 	switch h.Type {
 	case protocol.PacketTypeRetry:
 		b.Write(h.Token)

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -268,6 +268,7 @@ func (p *TransportParameters) readNumericTransportParameter(
 	if remainingLen-r.Len() != expectedLen {
 		return fmt.Errorf("inconsistent transport parameter length for %d", paramID)
 	}
+	//nolint:exhaustive // This only covers the numeric transport parameters.
 	switch paramID {
 	case initialMaxStreamDataBidiLocalParameterID:
 		p.InitialMaxStreamDataBidiLocal = protocol.ByteCount(val)

--- a/logging/interface.go
+++ b/logging/interface.go
@@ -69,8 +69,6 @@ const (
 	Encryption1RTT EncryptionLevel = protocol.Encryption1RTT
 	// Encryption0RTT is the 0-RTT encryption level
 	Encryption0RTT EncryptionLevel = protocol.Encryption0RTT
-	// EncryptionNone is no encryption
-	EncryptionNone EncryptionLevel = protocol.EncryptionUnspecified
 )
 
 const (

--- a/metrics/types.go
+++ b/metrics/types.go
@@ -11,7 +11,7 @@ func (p perspective) String() string {
 	case logging.PerspectiveServer:
 		return "server"
 	default:
-		panic("unknown perspective")
+		return "unknown perspective"
 	}
 }
 
@@ -28,7 +28,7 @@ func (e encryptionLevel) String() string {
 	case logging.Encryption1RTT:
 		return "1-RTT"
 	default:
-		panic("unknown encryption level")
+		return "unknown encryption level"
 	}
 }
 
@@ -41,7 +41,7 @@ func (r packetLossReason) String() string {
 	case logging.PacketLossReorderingThreshold:
 		return "reordering_threshold"
 	default:
-		panic("unknown packet loss reason")
+		return "unknown packet loss reason"
 	}
 }
 
@@ -62,7 +62,7 @@ func (t packetType) String() string {
 	case logging.PacketType1RTT:
 		return "1-RTT"
 	default:
-		panic("unknown packet type")
+		return "unknown packet type"
 	}
 }
 
@@ -75,6 +75,6 @@ func (r timeoutReason) String() string {
 	case logging.TimeoutReasonIdle:
 		return "idle_timeout"
 	default:
-		panic("unknown timeout reason")
+		return "unknown timeout reason"
 	}
 }

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -60,6 +60,7 @@ func (p *packetContents) EncryptionLevel() protocol.EncryptionLevel {
 	if !p.header.IsLongHeader {
 		return protocol.Encryption1RTT
 	}
+	//nolint:exhaustive // Will never be called for Retry packets (and they don't have encrypted data).
 	switch p.header.Type {
 	case protocol.PacketTypeInitial:
 		return protocol.EncryptionInitial
@@ -410,6 +411,7 @@ func (p *packetPacker) maybeAppendCryptoPacket(buffer *packetBuffer, maxPacketSi
 	var sealer sealer
 	var s cryptoStream
 	var hasRetransmission bool
+	//nolint:exhaustive // Initial and Handshake are the only two encryption levels here.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		s = p.initialStream
@@ -452,6 +454,7 @@ func (p *packetPacker) maybeAppendCryptoPacket(buffer *packetBuffer, maxPacketSi
 	if hasRetransmission {
 		for {
 			var f wire.Frame
+			//nolint:exhaustive // 0-RTT packets can't contain any retransmission.s
 			switch encLevel {
 			case protocol.EncryptionInitial:
 				f = p.retransmissionQueue.GetInitialFrame(remainingLen)
@@ -567,6 +570,7 @@ func (p *packetPacker) MaybePackProbePacket(encLevel protocol.EncryptionLevel) (
 	var contents *packetContents
 	var err error
 	buffer := getPacketBuffer()
+	//nolint:exhaustive Probe packets are never sent for 0-RTT.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		contents, err = p.maybeAppendCryptoPacket(buffer, p.maxPacketSize, protocol.EncryptionInitial)
@@ -649,6 +653,7 @@ func (p *packetPacker) getLongHeader(encLevel protocol.EncryptionLevel) *wire.Ex
 	hdr.PacketNumber = pn
 	hdr.PacketNumberLen = pnLen
 
+	//nolint:exhaustive // 1-RTT packets are not long header packets.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		hdr.Type = protocol.PacketTypeInitial

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -68,7 +68,7 @@ func (p *packetContents) EncryptionLevel() protocol.EncryptionLevel {
 	case protocol.PacketType0RTT:
 		return protocol.Encryption0RTT
 	default:
-		return protocol.EncryptionUnspecified
+		panic("can't determine encryption level")
 	}
 }
 

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -65,6 +65,7 @@ func (u *packetUnpacker) Unpack(hdr *wire.Header, rcvTime time.Time, data []byte
 	var encLevel protocol.EncryptionLevel
 	var extHdr *wire.ExtendedHeader
 	var decrypted []byte
+	//nolint:exhaustive // Retry packets can't be unpacked.
 	switch hdr.Type {
 	case protocol.PacketTypeInitial:
 		encLevel = protocol.EncryptionInitial

--- a/qlog/types.go
+++ b/qlog/types.go
@@ -22,7 +22,7 @@ func (o owner) String() string {
 	case ownerRemote:
 		return "remote"
 	default:
-		panic("unknown owner")
+		return "unknown owner"
 	}
 }
 
@@ -35,7 +35,7 @@ func (s streamType) String() string {
 	case protocol.StreamTypeBidi:
 		return "bidirectional"
 	default:
-		panic("unknown stream type")
+		return "unknown stream type"
 	}
 }
 
@@ -66,7 +66,7 @@ func (c category) String() string {
 	case categoryRecovery:
 		return "recovery"
 	default:
-		panic("unknown category")
+		return "unknown category"
 	}
 }
 
@@ -87,14 +87,14 @@ func encLevelToPacketNumberSpace(encLevel protocol.EncryptionLevel) string {
 	case protocol.Encryption0RTT, protocol.Encryption1RTT:
 		return "application_data"
 	default:
-		panic("unknown encryption level")
+		return "unknown encryption level"
 	}
 }
 
 type keyType uint8
 
 const (
-	keyTypeServerInitial keyType = iota
+	keyTypeServerInitial keyType = 1 + iota
 	keyTypeClientInitial
 	keyTypeServerHandshake
 	keyTypeClientHandshake
@@ -116,7 +116,7 @@ func encLevelToKeyType(encLevel protocol.EncryptionLevel, pers protocol.Perspect
 		case protocol.Encryption1RTT:
 			return keyTypeServer1RTT
 		default:
-			panic("unknown encryption level")
+			return 0
 		}
 	}
 	switch encLevel {
@@ -129,7 +129,7 @@ func encLevelToKeyType(encLevel protocol.EncryptionLevel, pers protocol.Perspect
 	case protocol.Encryption1RTT:
 		return keyTypeClient1RTT
 	default:
-		panic("unknown encryption level")
+		return 0
 	}
 }
 
@@ -152,7 +152,7 @@ func (t keyType) String() string {
 	case keyTypeClient1RTT:
 		return "client_1rtt_secret"
 	default:
-		panic("unknown key type")
+		return "unknown key type"
 	}
 }
 
@@ -173,7 +173,7 @@ func (t keyUpdateTrigger) String() string {
 	case keyUpdateLocal:
 		return "local_update"
 	default:
-		panic("unknown key update trigger")
+		return "unknown key update trigger"
 	}
 }
 
@@ -239,7 +239,7 @@ func (t packetType) String() string {
 	case logging.PacketTypeNotDetermined:
 		return ""
 	default:
-		panic("unknown packet type")
+		return "unknown packet type"
 	}
 }
 
@@ -252,7 +252,7 @@ func (r packetLossReason) String() string {
 	case logging.PacketLossTimeThreshold:
 		return "time_threshold"
 	default:
-		panic("unknown loss reason")
+		return "unknown loss reason"
 	}
 }
 
@@ -283,7 +283,7 @@ func (r packetDropReason) String() string {
 	case logging.PacketDropDuplicate:
 		return "duplicate"
 	default:
-		panic("unknown packet drop reason")
+		return "unknown packet drop reason"
 	}
 }
 
@@ -296,7 +296,7 @@ func (t timerType) String() string {
 	case logging.TimerTypePTO:
 		return "pto"
 	default:
-		panic("unknown timer type")
+		return "unknown timer type"
 	}
 }
 
@@ -309,7 +309,7 @@ func (r timeoutReason) String() string {
 	case logging.TimeoutReasonIdle:
 		return "idle_timeout"
 	default:
-		panic("unknown close reason")
+		return "unknown close reason"
 	}
 }
 
@@ -326,6 +326,6 @@ func (s congestionState) String() string {
 	case logging.CongestionStateApplicationLimited:
 		return "application_limited"
 	default:
-		panic("unknown congestion state")
+		return "unknown congestion state"
 	}
 }

--- a/quictrace/tracer.go
+++ b/quictrace/tracer.go
@@ -124,6 +124,8 @@ func getEncryptionLevel(encLevel protocol.EncryptionLevel) *pb.EncryptionLevel {
 		enc = pb.EncryptionLevel_ENCRYPTION_INITIAL
 	case protocol.EncryptionHandshake:
 		enc = pb.EncryptionLevel_ENCRYPTION_HANDSHAKE
+	case protocol.Encryption0RTT:
+		enc = pb.EncryptionLevel_ENCRYPTION_0RTT
 	case protocol.Encryption1RTT:
 		enc = pb.EncryptionLevel_ENCRYPTION_1RTT
 	}

--- a/retransmission_queue.go
+++ b/retransmission_queue.go
@@ -117,6 +117,7 @@ func (q *retransmissionQueue) GetAppDataFrame(maxLen protocol.ByteCount) wire.Fr
 }
 
 func (q *retransmissionQueue) DropPackets(encLevel protocol.EncryptionLevel) {
+	//nolint:exhaustive // Can only drop Initial and Handshake packet number space.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		q.initial = nil

--- a/session.go
+++ b/session.go
@@ -1515,6 +1515,7 @@ func (s *session) sendProbePacket(encLevel protocol.EncryptionLevel) error {
 		}
 	}
 	if packet == nil {
+		//nolint:exhaustive // Cannot send probe packets for 0-RTT.
 		switch encLevel {
 		case protocol.EncryptionInitial:
 			s.retransmissionQueue.AddInitial(&wire.PingFrame{})

--- a/session_test.go
+++ b/session_test.go
@@ -1278,6 +1278,7 @@ var _ = Describe("Session", func() {
 				var getFrame func(protocol.ByteCount) wire.Frame
 
 				BeforeEach(func() {
+					//nolint:exhaustive
 					switch encLevel {
 					case protocol.EncryptionInitial:
 						sendMode = ackhandler.SendPTOInitial

--- a/session_test.go
+++ b/session_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Session", func() {
 				Expect(sess.handleFrame(&wire.ResetStreamFrame{
 					StreamID:  3,
 					ErrorCode: 42,
-				}, protocol.EncryptionUnspecified, protocol.ConnectionID{})).To(Succeed())
+				}, protocol.Encryption1RTT, protocol.ConnectionID{})).To(Succeed())
 			})
 		})
 
@@ -236,7 +236,7 @@ var _ = Describe("Session", func() {
 				Expect(sess.handleFrame(&wire.MaxStreamDataFrame{
 					StreamID:          10,
 					MaximumStreamData: 1337,
-				}, protocol.EncryptionUnspecified, protocol.ConnectionID{})).To(Succeed())
+				}, protocol.Encryption1RTT, protocol.ConnectionID{})).To(Succeed())
 			})
 		})
 
@@ -278,7 +278,7 @@ var _ = Describe("Session", func() {
 				Expect(sess.handleFrame(&wire.StopSendingFrame{
 					StreamID:  3,
 					ErrorCode: 1337,
-				}, protocol.EncryptionUnspecified, protocol.ConnectionID{})).To(Succeed())
+				}, protocol.Encryption1RTT, protocol.ConnectionID{})).To(Succeed())
 			})
 		})
 
@@ -291,18 +291,18 @@ var _ = Describe("Session", func() {
 		})
 
 		It("handles PING frames", func() {
-			err := sess.handleFrame(&wire.PingFrame{}, protocol.EncryptionUnspecified, protocol.ConnectionID{})
+			err := sess.handleFrame(&wire.PingFrame{}, protocol.Encryption1RTT, protocol.ConnectionID{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("rejects PATH_RESPONSE frames", func() {
-			err := sess.handleFrame(&wire.PathResponseFrame{Data: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}}, protocol.EncryptionUnspecified, protocol.ConnectionID{})
+			err := sess.handleFrame(&wire.PathResponseFrame{Data: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}}, protocol.Encryption1RTT, protocol.ConnectionID{})
 			Expect(err).To(MatchError("unexpected PATH_RESPONSE frame"))
 		})
 
 		It("handles PATH_CHALLENGE frames", func() {
 			data := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
-			err := sess.handleFrame(&wire.PathChallengeFrame{Data: data}, protocol.EncryptionUnspecified, protocol.ConnectionID{})
+			err := sess.handleFrame(&wire.PathChallengeFrame{Data: data}, protocol.Encryption1RTT, protocol.ConnectionID{})
 			Expect(err).ToNot(HaveOccurred())
 			frames, _ := sess.framer.AppendControlFrames(nil, 1000)
 			Expect(frames).To(Equal([]ackhandler.Frame{{Frame: &wire.PathResponseFrame{Data: data}}}))
@@ -316,17 +316,17 @@ var _ = Describe("Session", func() {
 		})
 
 		It("handles BLOCKED frames", func() {
-			err := sess.handleFrame(&wire.DataBlockedFrame{}, protocol.EncryptionUnspecified, protocol.ConnectionID{})
+			err := sess.handleFrame(&wire.DataBlockedFrame{}, protocol.Encryption1RTT, protocol.ConnectionID{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("handles STREAM_BLOCKED frames", func() {
-			err := sess.handleFrame(&wire.StreamDataBlockedFrame{}, protocol.EncryptionUnspecified, protocol.ConnectionID{})
+			err := sess.handleFrame(&wire.StreamDataBlockedFrame{}, protocol.Encryption1RTT, protocol.ConnectionID{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("handles STREAM_ID_BLOCKED frames", func() {
-			err := sess.handleFrame(&wire.StreamsBlockedFrame{}, protocol.EncryptionUnspecified, protocol.ConnectionID{})
+			err := sess.handleFrame(&wire.StreamsBlockedFrame{}, protocol.Encryption1RTT, protocol.ConnectionID{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -358,7 +358,7 @@ var _ = Describe("Session", func() {
 			Expect(sess.handleFrame(&wire.ConnectionCloseFrame{
 				ErrorCode:    qerr.StreamLimitError,
 				ReasonPhrase: "foobar",
-			}, protocol.EncryptionUnspecified, protocol.ConnectionID{})).To(Succeed())
+			}, protocol.Encryption1RTT, protocol.ConnectionID{})).To(Succeed())
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 
@@ -392,7 +392,7 @@ var _ = Describe("Session", func() {
 				ReasonPhrase:       "foobar",
 				IsApplicationError: true,
 			}
-			Expect(sess.handleFrame(ccf, protocol.EncryptionUnspecified, protocol.ConnectionID{})).To(Succeed())
+			Expect(sess.handleFrame(ccf, protocol.Encryption1RTT, protocol.ConnectionID{})).To(Succeed())
 			Eventually(sess.Context().Done()).Should(BeClosed())
 		})
 


### PR DESCRIPTION
Depends on #2728.

A while back, @lanzafame suggested to replace the `panic`s in the `Stringer`s of logging types by "unknown" return values. Of course, he was right with that suggestion. Logging is not a good enough reason to panic.

Turns out that there's an even better solution for this: the [exhaustive](https://github.com/nishanths/exhaustive) linter, which even is part of the golangci-lint suite. This linter allows us to check that `switch` statement for enum types cover all values defined for that enum.

There are a few cases in our code where we deliberately don't do an exhaustive check, and I've added a `nolint:exhaustive` statement there. This is fine, at least it forces us to be explicit about this. In fact, activating this linter actually caught a bug in the packet packer (#2728).