### PR TITLE
use the os.ErrDeadlineExceeded for stream deadline errors on Go 1.15

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -1,7 +1,6 @@
 package quic
 
 import (
-	"net"
 	"sync"
 	"time"
 
@@ -73,14 +72,6 @@ type stream struct {
 }
 
 var _ Stream = &stream{}
-
-type deadlineError struct{}
-
-func (deadlineError) Error() string   { return "deadline exceeded" }
-func (deadlineError) Temporary() bool { return true }
-func (deadlineError) Timeout() bool   { return true }
-
-var errDeadline net.Error = &deadlineError{}
 
 type streamCanceledError struct {
 	error

--- a/stream_deadline_error.go
+++ b/stream_deadline_error.go
@@ -1,0 +1,11 @@
+package quic
+
+import "net"
+
+type deadlineError struct{}
+
+func (deadlineError) Error() string   { return "deadline exceeded" }
+func (deadlineError) Temporary() bool { return true }
+func (deadlineError) Timeout() bool   { return true }
+
+var errDeadline net.Error = &deadlineError{}

--- a/stream_deadline_error_go115.go
+++ b/stream_deadline_error_go115.go
@@ -1,0 +1,9 @@
+// +build go1.15
+
+package quic
+
+import (
+	"os"
+)
+
+func (deadlineError) Unwrap() error { return os.ErrDeadlineExceeded }

--- a/stream_deadline_error_test.go
+++ b/stream_deadline_error_test.go
@@ -1,0 +1,21 @@
+// +build go1.15
+
+package quic
+
+import (
+	"errors"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Deadline Error", func() {
+	It("is a net.Error that wraps os.ErrDeadlineError", func() {
+		err := deadlineError{}
+		Expect(err.Temporary()).To(BeTrue())
+		Expect(err.Timeout()).To(BeTrue())
+		Expect(errors.Is(err, os.ErrDeadlineExceeded)).To(BeTrue())
+		Expect(errors.Unwrap(err)).To(Equal(os.ErrDeadlineExceeded))
+	})
+})


### PR DESCRIPTION
Fixes #2552.