### PR TITLE
generate a self-signed certificate for the handshake fuzzer

### DIFF
--- a/fuzzing/internal/helper/helper.go
+++ b/fuzzing/internal/helper/helper.go
@@ -1,11 +1,18 @@
 package helper
 
 import (
+	"crypto"
+	"crypto/rand"
 	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/hex"
 	"io/ioutil"
+	"math/big"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // NthBit gets the n-th bit of a byte (counting starts at 0).
@@ -34,4 +41,33 @@ func WriteCorpusFile(path string, data []byte) error {
 // This function prepends n zero-bytes to the data.
 func WriteCorpusFileWithPrefix(path string, data []byte, n int) error {
 	return WriteCorpusFile(path, append(make([]byte, n), data...))
+}
+
+// GenerateCertificate generates a self-signed certificate.
+// It returns the certificate and a x509.CertPool containing that certificate.
+func GenerateCertificate(priv crypto.Signer) (*tls.Certificate, *x509.CertPool, error) {
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"quic-go fuzzer"}},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(30 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{"localhost"},
+		BasicConstraintsValid: true,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	certPool := x509.NewCertPool()
+	certPool.AddCert(cert)
+	return &tls.Certificate{
+		Certificate: [][]byte{derBytes},
+		PrivateKey:  priv,
+	}, certPool, nil
 }


### PR DESCRIPTION
https://github.com/google/oss-fuzz/pull/4404 fails because the fuzzer binary doesn't find the certificate. We can just generate a certificate in `init()`, so we don't have to rely on files on the file system.