### PR TITLE
make sure to only pass handshake messages that keys are available for

### DIFF
--- a/fuzzing/handshake/fuzz.go
+++ b/fuzzing/handshake/fuzz.go
@@ -135,6 +135,27 @@ func toEncryptionLevel(n uint8) protocol.EncryptionLevel {
 	}
 }
 
+func maxEncLevel(cs handshake.CryptoSetup, encLevel protocol.EncryptionLevel) protocol.EncryptionLevel {
+	switch encLevel {
+	case protocol.EncryptionInitial:
+		return protocol.EncryptionInitial
+	case protocol.EncryptionHandshake:
+		// Handshake opener not available. We can't possibly read a Handshake handshake message.
+		if opener, err := cs.GetHandshakeOpener(); err != nil || opener == nil {
+			return protocol.EncryptionInitial
+		}
+		return protocol.EncryptionHandshake
+	case protocol.Encryption1RTT:
+		// 1-RTT opener not available. We can't possibly read a post-handshake message.
+		if opener, err := cs.Get1RTTOpener(); err != nil || opener == nil {
+			return maxEncLevel(cs, protocol.EncryptionHandshake)
+		}
+		return protocol.Encryption1RTT
+	default:
+		panic("unexpected encryption level")
+	}
+}
+
 // PrefixLen is the number of bytes used for configuration
 const PrefixLen = 2
 
@@ -230,7 +251,7 @@ messageLoop:
 			if len(b) > 0 && b[0] == messageToReplace {
 				fmt.Println("replacing message to the server", messageType(b[0]).String())
 				b = data
-				encLevel = messageToReplaceEncLevel
+				encLevel = maxEncLevel(server, messageToReplaceEncLevel)
 			}
 			server.HandleMessage(b, encLevel)
 		case c := <-sChunkChan:
@@ -239,7 +260,7 @@ messageLoop:
 			if len(b) > 0 && b[0] == messageToReplace {
 				fmt.Println("replacing message to the client", messageType(b[0]).String())
 				b = data
-				encLevel = messageToReplaceEncLevel
+				encLevel = maxEncLevel(client, messageToReplaceEncLevel)
 			}
 			client.HandleMessage(b, encLevel)
 		case <-done: // test done


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25397.

What's happening here is that we're replacing the EncryptedExtensions message with a NewSessionTicket message (at the correct encryption level: 1-RTT). At this point, the handshake hasn't completed yet, so the client would wait for that.
This can never happen in practice: As the handshake is not yet complete, we wouldn't even be able to open a 1-RTT packet.

The fix for the fuzz-test is straightforward: Check if the corresponding AEAD opener is available before injecting a message at a given encryption level.