### PR TITLE
only close the handshake fuzz runner once

### DIFF
--- a/fuzzing/handshake/fuzz.go
+++ b/fuzzing/handshake/fuzz.go
@@ -116,6 +116,9 @@ func newRunner(client, server *handshake.CryptoSetup, role string) *runner {
 func (r *runner) OnReceivedParams(*wire.TransportParameters) {}
 func (r *runner) OnHandshakeComplete()                       {}
 func (r *runner) OnError(err error) {
+	if r.errored {
+		return
+	}
 	r.errored = true
 	(*r.client).Close()
 	(*r.server).Close()


### PR DESCRIPTION
This should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25400.

What's happening here is the following: The client receives an EncryptedExtensions message that contains an invalid QUIC Transport Parameter extension as well as an invalid ALPN. The TLS stack therefore sends a TLS alert, while the QUIC stack at the same time throws a TRANSPORT_PARAMETER error.

As the TLS handshake is running in its own Go routine, which of these errors occurs first is undefined, and the QUIC specification doesn't require any order here. The important thing here is that only the first of these errors should be processed (in the case of a QUIC connection, it would be sent out in a CONNECTION_CLOSE frame). The fuzz setup should reflect this.