### PR TITLE
fix incorrect documentation of sentPacketHistory.Iterate

### DIFF
--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -31,7 +31,6 @@ func (h *sentPacketHistory) GetPacket(p protocol.PacketNumber) *Packet {
 }
 
 // Iterate iterates through all packets.
-// The callback must not modify the history.
 func (h *sentPacketHistory) Iterate(cb func(*Packet) (cont bool, err error)) error {
 	cont := true
 	for el := h.packetList.Front(); cont && el != nil; el = el.Next() {
@@ -45,8 +44,6 @@ func (h *sentPacketHistory) Iterate(cb func(*Packet) (cont bool, err error)) err
 }
 
 // FirstOutStanding returns the first outstanding packet.
-// It must not be modified (e.g. retransmitted).
-// Use DequeueFirstPacketForRetransmission() to retransmit it.
 func (h *sentPacketHistory) FirstOutstanding() *Packet {
 	if !h.HasOutstandingPackets() {
 		return nil

--- a/internal/ackhandler/sent_packet_history_test.go
+++ b/internal/ackhandler/sent_packet_history_test.go
@@ -90,36 +90,43 @@ var _ = Describe("SentPacketHistory", func() {
 
 		It("iterates over all packets", func() {
 			var iterations []protocol.PacketNumber
-			err := hist.Iterate(func(p *Packet) (bool, error) {
+			Expect(hist.Iterate(func(p *Packet) (bool, error) {
 				iterations = append(iterations, p.PacketNumber)
 				return true, nil
-			})
-			Expect(err).ToNot(HaveOccurred())
+			})).To(Succeed())
 			Expect(iterations).To(Equal([]protocol.PacketNumber{10, 14, 18}))
 		})
 
 		It("stops iterating", func() {
 			var iterations []protocol.PacketNumber
-			err := hist.Iterate(func(p *Packet) (bool, error) {
+			Expect(hist.Iterate(func(p *Packet) (bool, error) {
 				iterations = append(iterations, p.PacketNumber)
 				return p.PacketNumber != 14, nil
-			})
-			Expect(err).ToNot(HaveOccurred())
+			})).To(Succeed())
 			Expect(iterations).To(Equal([]protocol.PacketNumber{10, 14}))
 		})
 
 		It("returns the error", func() {
 			testErr := errors.New("test error")
 			var iterations []protocol.PacketNumber
-			err := hist.Iterate(func(p *Packet) (bool, error) {
+			Expect(hist.Iterate(func(p *Packet) (bool, error) {
 				iterations = append(iterations, p.PacketNumber)
 				if p.PacketNumber == 14 {
 					return false, testErr
 				}
 				return true, nil
-			})
-			Expect(err).To(MatchError(testErr))
+			})).To(MatchError(testErr))
 			Expect(iterations).To(Equal([]protocol.PacketNumber{10, 14}))
+		})
+
+		It("allows deletions", func() {
+			Expect(hist.Iterate(func(p *Packet) (bool, error) {
+				if p.PacketNumber == 14 {
+					Expect(hist.Remove(14)).To(Succeed())
+				}
+				return true, nil
+			})).To(Succeed())
+			expectInHistory([]protocol.PacketNumber{10, 18})
 		})
 	})
 


### PR DESCRIPTION
We've been using this in https://github.com/lucas-clemente/quic-go/blob/bed802aee5732c8fe373bf4f71e789bea2f7f11f/internal/ackhandler/sent_packet_handler.go#L158-L166

I thought this was not a safe thing to do, but it turns out to be. Therefore, we can revise the documentation, and add a test case to make sure we don't introduce a regression at some point.