### PR TITLE
delete unacknowledged packets from the packet history after 3 PTOs

### DIFF
--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -18,6 +18,7 @@ type Packet struct {
 	SendTime        time.Time
 
 	includedInBytesInFlight bool
+	declaredLost            bool
 }
 
 // SentPacketHandler handles ACKs received for outgoing packets

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -35,9 +35,9 @@ type packetNumberSpace struct {
 	largestSent  protocol.PacketNumber
 }
 
-func newPacketNumberSpace(initialPN protocol.PacketNumber) *packetNumberSpace {
+func newPacketNumberSpace(initialPN protocol.PacketNumber, rttStats *utils.RTTStats) *packetNumberSpace {
 	return &packetNumberSpace{
-		history:      newSentPacketHistory(),
+		history:      newSentPacketHistory(rttStats),
 		pns:          newPacketNumberGenerator(initialPN, protocol.SkipPacketAveragePeriodLength),
 		largestSent:  protocol.InvalidPacketNumber,
 		largestAcked: protocol.InvalidPacketNumber,
@@ -109,9 +109,9 @@ func newSentPacketHandler(
 	return &sentPacketHandler{
 		peerCompletedAddressValidation: pers == protocol.PerspectiveServer,
 		peerAddressValidated:           pers == protocol.PerspectiveClient,
-		initialPackets:                 newPacketNumberSpace(initialPacketNumber),
-		handshakePackets:               newPacketNumberSpace(0),
-		appDataPackets:                 newPacketNumberSpace(0),
+		initialPackets:                 newPacketNumberSpace(initialPacketNumber, rttStats),
+		handshakePackets:               newPacketNumberSpace(0, rttStats),
+		appDataPackets:                 newPacketNumberSpace(0, rttStats),
 		rttStats:                       rttStats,
 		congestion:                     congestion,
 		perspective:                    pers,
@@ -131,6 +131,13 @@ func (h *sentPacketHandler) DropPackets(encLevel protocol.EncryptionLevel) {
 	h.dropPackets(encLevel)
 }
 
+func (h *sentPacketHandler) removeFromBytesInFlight(p *Packet) {
+	if p.includedInBytesInFlight {
+		h.bytesInFlight -= p.Length
+		p.includedInBytesInFlight = false
+	}
+}
+
 func (h *sentPacketHandler) dropPackets(encLevel protocol.EncryptionLevel) {
 	// The server won't await address validation after the handshake is confirmed.
 	// This applies even if we didn't receive an ACK for a Handshake packet.
@@ -141,9 +148,7 @@ func (h *sentPacketHandler) dropPackets(encLevel protocol.EncryptionLevel) {
 	if encLevel == protocol.EncryptionInitial || encLevel == protocol.EncryptionHandshake {
 		pnSpace := h.getPacketNumberSpace(encLevel)
 		pnSpace.history.Iterate(func(p *Packet) (bool, error) {
-			if p.includedInBytesInFlight {
-				h.bytesInFlight -= p.Length
-			}
+			h.removeFromBytesInFlight(p)
 			return true, nil
 		})
 	}
@@ -160,9 +165,7 @@ func (h *sentPacketHandler) dropPackets(encLevel protocol.EncryptionLevel) {
 				return false, nil
 			}
 			h.queueFramesForRetransmission(p)
-			if p.includedInBytesInFlight {
-				h.bytesInFlight -= p.Length
-			}
+			h.removeFromBytesInFlight(p)
 			h.appDataPackets.history.Remove(p.PacketNumber)
 			return true, nil
 		})
@@ -301,7 +304,7 @@ func (h *sentPacketHandler) ReceivedAck(ack *wire.AckFrame, encLevel protocol.En
 			}
 		}
 	}
-	lostPackets, err := h.detectAndRemoveLostPackets(rcvTime, encLevel)
+	lostPackets, err := h.detectLostPackets(rcvTime, encLevel)
 	if err != nil {
 		return err
 	}
@@ -309,9 +312,10 @@ func (h *sentPacketHandler) ReceivedAck(ack *wire.AckFrame, encLevel protocol.En
 		h.congestion.OnPacketLost(p.PacketNumber, p.Length, priorInFlight)
 	}
 	for _, p := range ackedPackets {
-		if p.includedInBytesInFlight {
+		if p.includedInBytesInFlight && !p.declaredLost {
 			h.congestion.OnPacketAcked(p.PacketNumber, p.Length, priorInFlight, rcvTime)
 		}
+		h.removeFromBytesInFlight(p)
 	}
 
 	// Reset the pto_count unless the client is unsure if the server has validated the client's address.
@@ -323,6 +327,7 @@ func (h *sentPacketHandler) ReceivedAck(ack *wire.AckFrame, encLevel protocol.En
 	}
 	h.numProbesToSend = 0
 
+	pnSpace.history.DeleteOldPackets(rcvTime)
 	h.setLossDetectionTimer()
 	return nil
 }
@@ -384,9 +389,6 @@ func (h *sentPacketHandler) detectAndRemoveAckedPackets(ack *wire.AckFrame, encL
 			if f.OnAcked != nil {
 				f.OnAcked(f.Frame)
 			}
-		}
-		if p.includedInBytesInFlight {
-			h.bytesInFlight -= p.Length
 		}
 		if err := pnSpace.history.Remove(p.PacketNumber); err != nil {
 			return nil, err
@@ -500,7 +502,7 @@ func (h *sentPacketHandler) setLossDetectionTimer() {
 	}
 }
 
-func (h *sentPacketHandler) detectAndRemoveLostPackets(now time.Time, encLevel protocol.EncryptionLevel) ([]*Packet, error) {
+func (h *sentPacketHandler) detectLostPackets(now time.Time, encLevel protocol.EncryptionLevel) ([]*Packet, error) {
 	pnSpace := h.getPacketNumberSpace(encLevel)
 	pnSpace.lossTime = time.Time{}
 
@@ -517,6 +519,9 @@ func (h *sentPacketHandler) detectAndRemoveLostPackets(now time.Time, encLevel p
 	if err := pnSpace.history.Iterate(func(packet *Packet) (bool, error) {
 		if packet.PacketNumber > pnSpace.largestAcked {
 			return false, nil
+		}
+		if packet.declaredLost {
+			return true, nil
 		}
 
 		if packet.SendTime.Before(lostSendTime) {
@@ -551,14 +556,10 @@ func (h *sentPacketHandler) detectAndRemoveLostPackets(now time.Time, encLevel p
 	}
 
 	for _, p := range lostPackets {
+		p.declaredLost = true
 		h.queueFramesForRetransmission(p)
 		// the bytes in flight need to be reduced no matter if this packet will be retransmitted
-		if p.includedInBytesInFlight {
-			h.bytesInFlight -= p.Length
-		}
-		if err := pnSpace.history.Remove(p.PacketNumber); err != nil {
-			return nil, err
-		}
+		h.removeFromBytesInFlight(p)
 		if h.traceCallback != nil {
 			frames := make([]wire.Frame, 0, len(p.Frames))
 			for _, f := range p.Frames {
@@ -603,7 +604,7 @@ func (h *sentPacketHandler) onVerifiedLossDetectionTimeout() error {
 		}
 		// Early retransmit or time loss detection
 		priorInFlight := h.bytesInFlight
-		lostPackets, err := h.detectAndRemoveLostPackets(time.Now(), encLevel)
+		lostPackets, err := h.detectLostPackets(time.Now(), encLevel)
 		if err != nil {
 			return err
 		}
@@ -740,22 +741,21 @@ func (h *sentPacketHandler) QueueProbePacket(encLevel protocol.EncryptionLevel) 
 		return false
 	}
 	h.queueFramesForRetransmission(p)
-	// TODO: don't remove the packet here
+	// TODO: don't declare the packet lost here.
 	// Keep track of acknowledged frames instead.
-	if p.includedInBytesInFlight {
-		h.bytesInFlight -= p.Length
-	}
-	if err := pnSpace.history.Remove(p.PacketNumber); err != nil {
-		// should never happen. We just got this packet from the history.
-		panic(err)
-	}
+	h.removeFromBytesInFlight(p)
+	p.declaredLost = true
 	return true
 }
 
 func (h *sentPacketHandler) queueFramesForRetransmission(p *Packet) {
+	if len(p.Frames) == 0 {
+		panic("no frames")
+	}
 	for _, f := range p.Frames {
 		f.OnLost(f.Frame)
 	}
+	p.Frames = nil
 }
 
 func (h *sentPacketHandler) ResetForRetry() error {
@@ -765,13 +765,18 @@ func (h *sentPacketHandler) ResetForRetry() error {
 		if firstPacketSendTime.IsZero() {
 			firstPacketSendTime = p.SendTime
 		}
+		if p.declaredLost {
+			return true, nil
+		}
 		h.queueFramesForRetransmission(p)
 		return true, nil
 	})
 	// All application data packets sent at this point are 0-RTT packets.
 	// In the case of a Retry, we can assume that the server dropped all of them.
 	h.appDataPackets.history.Iterate(func(p *Packet) (bool, error) {
-		h.queueFramesForRetransmission(p)
+		if !p.declaredLost {
+			h.queueFramesForRetransmission(p)
+		}
 		return true, nil
 	})
 
@@ -787,8 +792,8 @@ func (h *sentPacketHandler) ResetForRetry() error {
 			h.tracer.UpdatedMetrics(h.rttStats, h.congestion.GetCongestionWindow(), h.bytesInFlight, h.packetsInFlight())
 		}
 	}
-	h.initialPackets = newPacketNumberSpace(h.initialPackets.pns.Pop())
-	h.appDataPackets = newPacketNumberSpace(h.appDataPackets.pns.Pop())
+	h.initialPackets = newPacketNumberSpace(h.initialPackets.pns.Pop(), h.rttStats)
+	h.appDataPackets = newPacketNumberSpace(h.appDataPackets.pns.Pop(), h.rttStats)
 	oldAlarm := h.alarm
 	h.alarm = time.Time{}
 	if h.tracer != nil {


### PR DESCRIPTION
This is a fairly big change how we keep track of sent packets. We used to evict packets from the history once they got acknowledged or declared lost.
With this change, packets are only evicted when they are acknowledged. When a packet is declared lost, we still keep it in the history. This allows us generate RTT measurements for packets that were spuriously declared lost.
Packets are now deleted from the history after 3 PTOs (and only if they have been declared lost before).