### PR TITLE
fix dropping of 0-RTT packets

### DIFF
--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -1036,7 +1036,7 @@ var _ = Describe("SentPacketHandler", func() {
 					EncryptionLevel: protocol.Encryption0RTT,
 				}))
 			}
-			for i := protocol.PacketNumber(0); i < 6; i++ {
+			for i := protocol.PacketNumber(6); i < 12; i++ {
 				handler.SentPacket(ackElicitingPacket(&Packet{PacketNumber: i}))
 			}
 			Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(12)))

--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -31,11 +31,12 @@ func (h *sentPacketHistory) GetPacket(p protocol.PacketNumber) *Packet {
 }
 
 // Iterate iterates through all packets.
-// The callback must not modify the history.
 func (h *sentPacketHistory) Iterate(cb func(*Packet) (cont bool, err error)) error {
 	cont := true
-	for el := h.packetList.Front(); cont && el != nil; el = el.Next() {
+	var next *PacketElement
+	for el := h.packetList.Front(); cont && el != nil; el = next {
 		var err error
+		next = el.Next()
 		cont, err = cb(&el.Value)
 		if err != nil {
 			return err
@@ -45,8 +46,6 @@ func (h *sentPacketHistory) Iterate(cb func(*Packet) (cont bool, err error)) err
 }
 
 // FirstOutStanding returns the first outstanding packet.
-// It must not be modified (e.g. retransmitted).
-// Use DequeueFirstPacketForRetransmission() to retransmit it.
 func (h *sentPacketHistory) FirstOutstanding() *Packet {
 	if !h.HasOutstandingPackets() {
 		return nil


### PR DESCRIPTION
Fixed version of #2749.

`Iterate` so far didn't allow to remove packets from the packet history, but we still did that for removing 0-RTT packets:
https://github.com/lucas-clemente/quic-go/blob/bed802aee5732c8fe373bf4f71e789bea2f7f11f/internal/ackhandler/sent_packet_handler.go#L158-L166
