### PR TITLE
skip a packet number when sending a 1-RTT PTO packet

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -632,6 +632,8 @@ func (h *sentPacketHandler) onVerifiedLossDetectionTimeout() error {
 		case protocol.EncryptionHandshake:
 			h.ptoMode = SendPTOHandshake
 		case protocol.Encryption1RTT:
+			// skip a packet number in order to elicit an immediate ACK
+			_ = h.PopPacketNumber(protocol.Encryption1RTT)
 			h.ptoMode = SendPTOAppData
 		default:
 			return fmt.Errorf("PTO timer in unexpected encryption level: %s", encLevel)


### PR DESCRIPTION
Fixes #2426.
Depends on #2753.

This will make the peer send an immediate ACK.