### PR TITLE
qlog the packet_type as part of the packet header, not the event itself

### DIFF
--- a/qlog/event.go
+++ b/qlog/event.go
@@ -105,7 +105,6 @@ func (e eventConnectionClosed) MarshalJSONObject(enc *gojay.Encoder) {
 }
 
 type eventPacketSent struct {
-	PacketType  packetType
 	Header      packetHeader
 	Frames      frames
 	IsCoalesced bool
@@ -119,7 +118,6 @@ func (e eventPacketSent) Name() string       { return "packet_sent" }
 func (e eventPacketSent) IsNil() bool        { return false }
 
 func (e eventPacketSent) MarshalJSONObject(enc *gojay.Encoder) {
-	enc.StringKey("packet_type", e.PacketType.String())
 	enc.ObjectKey("header", e.Header)
 	enc.ArrayKeyOmitEmpty("frames", e.Frames)
 	enc.BoolKeyOmitEmpty("is_coalesced", e.IsCoalesced)
@@ -127,7 +125,6 @@ func (e eventPacketSent) MarshalJSONObject(enc *gojay.Encoder) {
 }
 
 type eventPacketReceived struct {
-	PacketType  packetType
 	Header      packetHeader
 	Frames      frames
 	IsCoalesced bool
@@ -141,7 +138,6 @@ func (e eventPacketReceived) Name() string       { return "packet_received" }
 func (e eventPacketReceived) IsNil() bool        { return false }
 
 func (e eventPacketReceived) MarshalJSONObject(enc *gojay.Encoder) {
-	enc.StringKey("packet_type", e.PacketType.String())
 	enc.ObjectKey("header", e.Header)
 	enc.ArrayKeyOmitEmpty("frames", e.Frames)
 	enc.BoolKeyOmitEmpty("is_coalesced", e.IsCoalesced)
@@ -157,7 +153,6 @@ func (e eventRetryReceived) Name() string       { return "packet_received" }
 func (e eventRetryReceived) IsNil() bool        { return false }
 
 func (e eventRetryReceived) MarshalJSONObject(enc *gojay.Encoder) {
-	enc.StringKey("packet_type", packetType(logging.PacketTypeRetry).String())
 	enc.ObjectKey("header", e.Header)
 }
 
@@ -171,7 +166,6 @@ func (e eventVersionNegotiationReceived) Name() string       { return "packet_re
 func (e eventVersionNegotiationReceived) IsNil() bool        { return false }
 
 func (e eventVersionNegotiationReceived) MarshalJSONObject(enc *gojay.Encoder) {
-	enc.StringKey("packet_type", packetType(logging.PacketTypeVersionNegotiation).String())
 	enc.ObjectKey("header", e.Header)
 	enc.ArrayKey("supported_versions", versions(e.SupportedVersions))
 }

--- a/qlog/packet_header.go
+++ b/qlog/packet_header.go
@@ -1,10 +1,11 @@
 package qlog
 
 import (
-	"github.com/francoispqt/gojay"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 	"github.com/lucas-clemente/quic-go/logging"
+
+	"github.com/francoispqt/gojay"
 )
 
 func getPacketTypeFromEncryptionLevel(encLevel protocol.EncryptionLevel) packetType {
@@ -59,6 +60,7 @@ func transformExtendedHeader(hdr *wire.ExtendedHeader) *packetHeader {
 }
 
 func (h packetHeader) MarshalJSONObject(enc *gojay.Encoder) {
+	enc.StringKey("packet_type", packetType(h.PacketType).String())
 	if h.PacketType != logging.PacketTypeRetry && h.PacketType != logging.PacketTypeVersionNegotiation {
 		enc.Int64Key("packet_number", int64(h.PacketNumber))
 	}

--- a/qlog/packet_header_test.go
+++ b/qlog/packet_header_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Packet Header", func() {
 					KeyPhase:     protocol.KeyPhaseZero,
 				},
 				map[string]interface{}{
+					"packet_type":   "1RTT",
 					"packet_number": 42,
 					"dcil":          0,
 					"key_phase_bit": "0",
@@ -58,6 +59,7 @@ var _ = Describe("Packet Header", func() {
 					},
 				},
 				map[string]interface{}{
+					"packet_type":    "initial",
 					"packet_number":  42,
 					"payload_length": 123,
 					"dcil":           0,
@@ -78,6 +80,7 @@ var _ = Describe("Packet Header", func() {
 					},
 				},
 				map[string]interface{}{
+					"packet_type":   "handshake",
 					"packet_number": 0,
 					"dcil":          0,
 					"scil":          0,
@@ -98,6 +101,7 @@ var _ = Describe("Packet Header", func() {
 					},
 				},
 				map[string]interface{}{
+					"packet_type":   "handshake",
 					"packet_number": 42,
 					"dcil":          0,
 					"scil":          16,
@@ -115,6 +119,7 @@ var _ = Describe("Packet Header", func() {
 					KeyPhase:     protocol.KeyPhaseOne,
 				},
 				map[string]interface{}{
+					"packet_type":   "1RTT",
 					"packet_number": 42,
 					"dcil":          4,
 					"dcid":          "deadbeef",

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -240,9 +240,8 @@ func (t *connectionTracer) SentPacket(hdr *wire.ExtendedHeader, packetSize proto
 	header.PacketSize = packetSize
 	t.mutex.Lock()
 	t.recordEvent(time.Now(), &eventPacketSent{
-		PacketType: packetType(logging.PacketTypeFromHeader(&hdr.Header)),
-		Header:     header,
-		Frames:     fs,
+		Header: header,
+		Frames: fs,
 	})
 	t.mutex.Unlock()
 }
@@ -256,9 +255,8 @@ func (t *connectionTracer) ReceivedPacket(hdr *wire.ExtendedHeader, packetSize p
 	header.PacketSize = packetSize
 	t.mutex.Lock()
 	t.recordEvent(time.Now(), &eventPacketReceived{
-		PacketType: packetType(logging.PacketTypeFromHeader(&hdr.Header)),
-		Header:     header,
-		Frames:     fs,
+		Header: header,
+		Frames: fs,
 	})
 	t.mutex.Unlock()
 }

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -323,9 +323,9 @@ var _ = Describe("Tracing", func() {
 				Expect(entry.Category).To(Equal("transport"))
 				Expect(entry.Name).To(Equal("packet_sent"))
 				ev := entry.Event
-				Expect(ev).To(HaveKeyWithValue("packet_type", "handshake"))
 				Expect(ev).To(HaveKey("header"))
 				hdr := ev["header"].(map[string]interface{})
+				Expect(hdr).To(HaveKeyWithValue("packet_type", "handshake"))
 				Expect(hdr).To(HaveKeyWithValue("packet_size", float64(987)))
 				Expect(hdr).To(HaveKeyWithValue("packet_number", float64(1337)))
 				Expect(hdr).To(HaveKeyWithValue("scid", "04030201"))
@@ -348,8 +348,10 @@ var _ = Describe("Tracing", func() {
 				)
 				entry := exportAndParseSingle()
 				ev := entry.Event
-				Expect(ev).To(HaveKeyWithValue("packet_type", "1RTT"))
 				Expect(ev).To(HaveKey("header"))
+				hdr := ev["header"].(map[string]interface{})
+				Expect(hdr).To(HaveKeyWithValue("packet_type", "1RTT"))
+				Expect(hdr).To(HaveKeyWithValue("packet_number", float64(1337)))
 				Expect(ev).To(HaveKey("frames"))
 				frames := ev["frames"].([]interface{})
 				Expect(frames).To(HaveLen(2))
@@ -380,9 +382,9 @@ var _ = Describe("Tracing", func() {
 				Expect(entry.Category).To(Equal("transport"))
 				Expect(entry.Name).To(Equal("packet_received"))
 				ev := entry.Event
-				Expect(ev).To(HaveKeyWithValue("packet_type", "initial"))
 				Expect(ev).To(HaveKey("header"))
 				hdr := ev["header"].(map[string]interface{})
+				Expect(hdr).To(HaveKeyWithValue("packet_type", "initial"))
 				Expect(hdr).To(HaveKeyWithValue("packet_size", float64(789)))
 				Expect(hdr).To(HaveKeyWithValue("packet_number", float64(1337)))
 				Expect(hdr).To(HaveKeyWithValue("scid", "04030201"))
@@ -405,9 +407,9 @@ var _ = Describe("Tracing", func() {
 				Expect(entry.Category).To(Equal("transport"))
 				Expect(entry.Name).To(Equal("packet_received"))
 				ev := entry.Event
-				Expect(ev).To(HaveKeyWithValue("packet_type", "retry"))
 				Expect(ev).To(HaveKey("header"))
 				header := ev["header"]
+				Expect(header).To(HaveKeyWithValue("packet_type", "retry"))
 				Expect(header).ToNot(HaveKey("packet_number"))
 				Expect(header).To(HaveKey("version"))
 				Expect(header).To(HaveKey("dcid"))
@@ -430,12 +432,12 @@ var _ = Describe("Tracing", func() {
 				Expect(entry.Category).To(Equal("transport"))
 				Expect(entry.Name).To(Equal("packet_received"))
 				ev := entry.Event
-				Expect(ev).To(HaveKeyWithValue("packet_type", "version_negotiation"))
 				Expect(ev).To(HaveKey("header"))
 				Expect(ev).ToNot(HaveKey("frames"))
 				Expect(ev).To(HaveKey("supported_versions"))
 				Expect(ev["supported_versions"].([]interface{})).To(Equal([]interface{}{"deadbeef", "decafbad"}))
 				header := ev["header"]
+				Expect(header).To(HaveKeyWithValue("packet_type", "version_negotiation"))
 				Expect(header).ToNot(HaveKey("packet_number"))
 				Expect(header).ToNot(HaveKey("version"))
 				Expect(header).To(HaveKey("dcid"))


### PR DESCRIPTION
See https://github.com/quiclog/internet-drafts/commit/0cb1f02e3c8a60962bc39b387c5db9ba12210556.