### PR TITLE
always qlog the generation of 1-RTT key updates

### DIFF
--- a/qlog/event.go
+++ b/qlog/event.go
@@ -307,7 +307,9 @@ func (e eventKeyUpdated) IsNil() bool        { return false }
 func (e eventKeyUpdated) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("trigger", e.Trigger.String())
 	enc.StringKey("key_type", e.KeyType.String())
-	enc.Uint64KeyOmitEmpty("generation", uint64(e.Generation))
+	if e.KeyType == keyTypeClient1RTT || e.KeyType == keyTypeServer1RTT {
+		enc.Uint64Key("generation", uint64(e.Generation))
+	}
 }
 
 type eventKeyRetired struct {

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -560,6 +560,20 @@ var _ = Describe("Tracing", func() {
 				Expect(ev).ToNot(HaveKey("new"))
 			})
 
+			It("records TLS key updates, for 1-RTT keys", func() {
+				tracer.UpdatedKeyFromTLS(protocol.Encryption1RTT, protocol.PerspectiveServer)
+				entry := exportAndParseSingle()
+				Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+				Expect(entry.Category).To(Equal("security"))
+				Expect(entry.Name).To(Equal("key_updated"))
+				ev := entry.Event
+				Expect(ev).To(HaveKeyWithValue("key_type", "server_1rtt_secret"))
+				Expect(ev).To(HaveKeyWithValue("trigger", "tls"))
+				Expect(ev).To(HaveKeyWithValue("generation", float64(0)))
+				Expect(ev).ToNot(HaveKey("old"))
+				Expect(ev).ToNot(HaveKey("new"))
+			})
+
 			It("records QUIC key updates", func() {
 				tracer.UpdatedKey(1337, true)
 				entries := exportAndParse()


### PR DESCRIPTION
Not really a bug, but this will make things a little bit more specific (as 1-RTT keys have a generation).