### PR TITLE
implement the limit of unsuccessful decryptions for the AEADs

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -75,3 +75,10 @@ const MaxMaxAckDelay = (1<<14 - 1) * time.Millisecond
 
 // MaxConnIDLen is the maximum length of the connection ID
 const MaxConnIDLen = 20
+
+// InvalidPacketLimitAES is the maximum number of packets that we can fail to decrypt when using
+// AEAD_AES_128_GCM or AEAD_AES_265_GCM.
+const InvalidPacketLimitAES = 1 << 54
+
+// InvalidPacketLimitChaCha is the maximum number of packets that we can fail to decrypt when using AEAD_CHACHA20_POLY1305.
+const InvalidPacketLimitChaCha = 1 << 36

--- a/internal/qerr/error_codes.go
+++ b/internal/qerr/error_codes.go
@@ -26,6 +26,7 @@ const (
 	ApplicationError        ErrorCode = 0xc
 	CryptoBufferExceeded    ErrorCode = 0xd
 	KeyUpdateError          ErrorCode = 0xe
+	AEADLimitReached        ErrorCode = 0xf
 )
 
 func (e ErrorCode) isCryptoError() bool {
@@ -80,6 +81,8 @@ func (e ErrorCode) String() string {
 		return "CRYPTO_BUFFER_EXCEEDED"
 	case KeyUpdateError:
 		return "KEY_UPDATE_ERROR"
+	case AEADLimitReached:
+		return "AEAD_LIMIT_REACHED"
 	default:
 		if e.isCryptoError() {
 			return "CRYPTO_ERROR"

--- a/qlog/types.go
+++ b/qlog/types.go
@@ -211,6 +211,8 @@ func (e transportError) String() string {
 		return "crypto_buffer_exceeded"
 	case qerr.KeyUpdateError:
 		return "key_update_error"
+	case qerr.AEADLimitReached:
+		return "aead_limit_reached"
 	default:
 		return ""
 	}


### PR DESCRIPTION
Fixes #2530.

This counts the number of unsuccessful decryption attempts over the lifetime of the connection and closes it once it exceeds the maximum number allowed by the AEAD.