### PR TITLE
correctly handle key updates within the 3 PTO period

### DIFF
--- a/internal/handshake/updatable_aead.go
+++ b/internal/handshake/updatable_aead.go
@@ -100,6 +100,14 @@ func newUpdatableAEAD(rttStats *utils.RTTStats, tracer logging.ConnectionTracer,
 }
 
 func (a *updatableAEAD) rollKeys() {
+	if a.prevRcvAEAD != nil {
+		a.logger.Debugf("Dropping key phase %d ahead of scheduled time. Drop time was: %s", a.keyPhase-1, a.prevRcvAEADExpiry)
+		if a.tracer != nil {
+			a.tracer.DroppedKey(a.keyPhase - 1)
+		}
+		a.prevRcvAEADExpiry = time.Time{}
+	}
+
 	a.keyPhase++
 	a.firstRcvdWithCurrentKey = protocol.InvalidPacketNumber
 	a.firstSentWithCurrentKey = protocol.InvalidPacketNumber


### PR DESCRIPTION
Depends on #2781.

We need to:
* stop the timer to drop the previous generation
* correctly log that the N-1 keys are dropped immediately when keys are updated to N+1