### PR TITLE
introduce an ECNCapablePacketConn interface to determine ECN support

### DIFF
--- a/client.go
+++ b/client.go
@@ -109,6 +109,8 @@ func dialAddrContext(
 }
 
 // Dial establishes a new QUIC connection to a server using a net.PacketConn.
+// If the PacketConn satisfies the ECNCapablePacketConn interface (as a net.UDPConn does), ECN support will be enabled.
+// In this case, ReadMsgUDP will be used instead of ReadFrom to read packets.
 // The same PacketConn can be used for multiple calls to Dial and Listen,
 // QUIC connection IDs are used for demultiplexing the different connections.
 // The host parameter is used for SNI.

--- a/conn_windows.go
+++ b/conn_windows.go
@@ -4,6 +4,6 @@ package quic
 
 import "net"
 
-func newConn(c *net.UDPConn) (connection, error) {
+func newConn(c net.PacketConn) (connection, error) {
 	return &basicConn{PacketConn: c}, nil
 }

--- a/server.go
+++ b/server.go
@@ -148,6 +148,8 @@ func listenAddr(addr string, tlsConf *tls.Config, config *Config, acceptEarly bo
 }
 
 // Listen listens for QUIC connections on a given net.PacketConn.
+// If the PacketConn satisfies the ECNCapablePacketConn interface (as a net.UDPConn does), ECN support will be enabled.
+// In this case, ReadMsgUDP will be used instead of ReadFrom to read packets.
 // A single net.PacketConn only be used for a single call to Listen.
 // The PacketConn can be used for simultaneous calls to Dial.
 // QUIC connection IDs are used for demultiplexing the different connections.


### PR DESCRIPTION
This PR implements solution 2 discussed in https://github.com/lucas-clemente/quic-go/pull/2741#issuecomment-687570072.

TLDR: Currently we only enable ECN support if the user passes a naked `*net.UDPConn` into `Dial` and `Listen`, respectively. With this PR, we'll also enable ECN if the `net.PacketConn` is a wrapped `net.UDPConn`, as long as it exposes the required methods `SyscallConn` and `ReadMsgUDP`.

Note that this might contain an element of surprise for the user: To read packets from the connection, we won't use `ReadFrom` any longer, but `ReadMsgUDP`, so any wrapping of the `ReadFrom` will be bypassed. I added comments at multiple places to make users aware of this.