### PR TITLE
remove support for the ECN test case

### DIFF
--- a/interop/client/main.go
+++ b/interop/client/main.go
@@ -85,7 +85,7 @@ func runTestcase(testcase string) error {
 	defer r.Close()
 
 	switch testcase {
-	case "handshake", "transfer", "retry", "ecn":
+	case "handshake", "transfer", "retry":
 	case "chacha20":
 		tlsConf.CipherSuites = []uint16{tls.TLS_CHACHA20_POLY1305_SHA256}
 	case "multiconnect":

--- a/interop/server/main.go
+++ b/interop/server/main.go
@@ -52,7 +52,7 @@ func main() {
 	tlsConf.KeyLogWriter = keyLog
 
 	switch testcase {
-	case "versionnegotiation", "handshake", "transfer", "resumption", "zerortt", "multiconnect", "ecn":
+	case "versionnegotiation", "handshake", "transfer", "resumption", "zerortt", "multiconnect":
 		err = runHTTP09Server(quicConf)
 	case "retry":
 		// By default, quic-go performs a Retry on every incoming connection.


### PR DESCRIPTION
The interop runner test case requires us to proactively set ECN bits, which we currently don't do (see #2789).