### PR TITLE
only include quic-trace when the quictrace build flag is set

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -256,8 +256,9 @@ type Config struct {
 	StatelessResetKey []byte
 	// KeepAlive defines whether this peer will periodically send a packet to keep the connection alive.
 	KeepAlive bool
-	// QUIC Event Tracer.
-	// Warning: Experimental. This API should not be considered stable and will change soon.
+	// QUIC Event Tracer (see https://github.com/google/quic-trace).
+	// Warning: Support for quic-trace will soon be dropped in favor of qlog.
+	// It is disabled by default. Use the "quictrace" build tag to enable (e.g. go build -tags quictrace).
 	QuicTracer quictrace.Tracer
 	Tracer     logging.Tracer
 }

--- a/quictrace/null_tracer.go
+++ b/quictrace/null_tracer.go
@@ -1,0 +1,17 @@
+// +build !quictrace
+
+package quictrace
+
+import "github.com/lucas-clemente/quic-go/internal/protocol"
+
+// NewTracer returns a new Tracer that doesn't do anything.
+func NewTracer() Tracer {
+	return &nullTracer{}
+}
+
+type nullTracer struct{}
+
+var _ Tracer = &nullTracer{}
+
+func (t *nullTracer) Trace(protocol.ConnectionID, Event) {}
+func (t *nullTracer) GetAllTraces() map[string][]byte    { return make(map[string][]byte) }

--- a/quictrace/tracer.go
+++ b/quictrace/tracer.go
@@ -1,3 +1,5 @@
+// +build quictrace
+
 package quictrace
 
 import (


### PR DESCRIPTION
Fixes #2797.

I'm not ready to drop quic-trace yet, but it turns out to be really easy to hide behind a build tag.

With quic-trace:
```
 ❯ go build -tags quictrace -o server example/main.go &&  go build -tags quictrace -o client ./example/client/main.go && du -sh client server
 14M	client
 15M	server
```

Without quic-trace:
```
❯ go build -o server example/main.go &&  go build -o client ./example/client/main.go && du -sh client server
8.8M	client
 13M	server
```

Not sure why the difference is so much bigger for the client. @egonelbre any ideas?