### PR TITLE
fail the handshake if the quic_transport_parameter extension is missing

### DIFF
--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -341,7 +341,11 @@ readLoop:
 	for {
 		select {
 		case data := <-h.paramsChan:
-			h.handleTransportParameters(data)
+			if data == nil {
+				h.onError(0x6d, "missing quic_transport_parameters extension")
+			} else {
+				h.handleTransportParameters(data)
+			}
 		case <-h.isReadingHandshakeMessage:
 			break readLoop
 		case <-h.handshakeDone:


### PR DESCRIPTION
Fixes #2800.