### PR TITLE
fix linting error on OSX

### DIFF
--- a/conn_helper_darwin.go
+++ b/conn_helper_darwin.go
@@ -5,6 +5,7 @@ package quic
 import "syscall"
 
 const (
+	//nolint:stylecheck
 	ip_recvtos   = 27
 	msgTypeIPTOS = ip_recvtos
 )


### PR DESCRIPTION
Naming is consistent with the syscall package: https://golang.org/pkg/syscall/#pkg-constants