### PR TITLE
add support for the ChaCha20 test on the server side

### DIFF
--- a/interop/server/main.go
+++ b/interop/server/main.go
@@ -60,6 +60,9 @@ func main() {
 	switch testcase {
 	case "versionnegotiation", "handshake", "transfer", "resumption", "zerortt", "multiconnect":
 		err = runHTTP09Server(quicConf)
+	case "chacha20":
+		tlsConf.CipherSuites = []uint16{tls.TLS_CHACHA20_POLY1305_SHA256}
+		err = runHTTP09Server(quicConf)
 	case "retry":
 		// By default, quic-go performs a Retry on every incoming connection.
 		quicConf.AcceptToken = nil


### PR DESCRIPTION
See https://github.com/marten-seemann/quic-interop-runner/pull/221.