### PR TITLE
don't send a version negotiation packet in response to a version negotiation packet

### DIFF
--- a/server.go
+++ b/server.go
@@ -321,6 +321,13 @@ func (s *baseServer) handlePacket(p *receivedPacket) {
 }
 
 func (s *baseServer) handlePacketImpl(p *receivedPacket) bool /* is the buffer still in use? */ {
+	if wire.IsVersionNegotiationPacket(p.data) {
+		s.logger.Debugf("Dropping Version Negotiation packet.")
+		if s.config.Tracer != nil {
+			s.config.Tracer.DroppedPacket(p.remoteAddr, logging.PacketTypeVersionNegotiation, p.Size(), logging.PacketDropUnexpectedPacket)
+		}
+		return false
+	}
 	// If we're creating a new session, the packet will be passed to the session.
 	// The header will then be parsed again.
 	hdr, _, _, err := wire.ParsePacket(p.data, s.config.ConnectionIDLength)

--- a/server.go
+++ b/server.go
@@ -225,7 +225,7 @@ func (s *baseServer) run() {
 		case <-s.errorChan:
 			return
 		case p := <-s.receivedPackets:
-			if shouldReleaseBuffer := s.handlePacketImpl(p); !shouldReleaseBuffer {
+			if bufferStillInUse := s.handlePacketImpl(p); !bufferStillInUse {
 				p.buffer.Release()
 			}
 		}
@@ -320,7 +320,7 @@ func (s *baseServer) handlePacket(p *receivedPacket) {
 	}
 }
 
-func (s *baseServer) handlePacketImpl(p *receivedPacket) bool /* should the buffer be released */ {
+func (s *baseServer) handlePacketImpl(p *receivedPacket) bool /* is the buffer still in use? */ {
 	// If we're creating a new session, the packet will be passed to the session.
 	// The header will then be parsed again.
 	hdr, _, _, err := wire.ParsePacket(p.data, s.config.ConnectionIDLength)


### PR DESCRIPTION
Annoyingly, this is the bug in the QUIC spec I had discovered for the Tokyo interim meeting back in Jan 2017.