### PR TITLE
send STREAMS_BLOCKED frame when MAX_STREAMS frame allows too few streams 

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -325,7 +325,7 @@ var _ = Describe("Session", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("handles STREAM_ID_BLOCKED frames", func() {
+		It("handles STREAMS_BLOCKED frames", func() {
 			err := sess.handleFrame(&wire.StreamsBlockedFrame{}, protocol.Encryption1RTT, protocol.ConnectionID{})
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/streams_map_outgoing_bidi.go
+++ b/streams_map_outgoing_bidi.go
@@ -119,6 +119,8 @@ func (m *outgoingBidiStreamsMap) openStream() streamI {
 	return s
 }
 
+// maybeSendBlockedFrame queues a STREAMS_BLOCKED frame for the current stream offset,
+// if we haven't sent one for this offset yet
 func (m *outgoingBidiStreamsMap) maybeSendBlockedFrame() {
 	if m.blockedSent {
 		return
@@ -172,8 +174,10 @@ func (m *outgoingBidiStreamsMap) SetMaxStream(num protocol.StreamNum) {
 	}
 	m.maxStream = num
 	m.blockedSent = false
+	if m.maxStream < m.nextStream-1+protocol.StreamNum(len(m.openQueue)) {
+		m.maybeSendBlockedFrame()
+	}
 	m.unblockOpenSync()
-	// TODO(#2826): it might be necessary to send a STREAMS_BLOCKED frame
 }
 
 // unblockOpenSync unblocks the next OpenStreamSync go-routine to open a new stream

--- a/streams_map_outgoing_generic.go
+++ b/streams_map_outgoing_generic.go
@@ -117,6 +117,8 @@ func (m *outgoingItemsMap) openStream() item {
 	return s
 }
 
+// maybeSendBlockedFrame queues a STREAMS_BLOCKED frame for the current stream offset,
+// if we haven't sent one for this offset yet
 func (m *outgoingItemsMap) maybeSendBlockedFrame() {
 	if m.blockedSent {
 		return
@@ -170,8 +172,10 @@ func (m *outgoingItemsMap) SetMaxStream(num protocol.StreamNum) {
 	}
 	m.maxStream = num
 	m.blockedSent = false
+	if m.maxStream < m.nextStream-1+protocol.StreamNum(len(m.openQueue)) {
+		m.maybeSendBlockedFrame()
+	}
 	m.unblockOpenSync()
-	// TODO(#2826): it might be necessary to send a STREAMS_BLOCKED frame
 }
 
 // unblockOpenSync unblocks the next OpenStreamSync go-routine to open a new stream

--- a/streams_map_outgoing_uni.go
+++ b/streams_map_outgoing_uni.go
@@ -119,6 +119,8 @@ func (m *outgoingUniStreamsMap) openStream() sendStreamI {
 	return s
 }
 
+// maybeSendBlockedFrame queues a STREAMS_BLOCKED frame for the current stream offset,
+// if we haven't sent one for this offset yet
 func (m *outgoingUniStreamsMap) maybeSendBlockedFrame() {
 	if m.blockedSent {
 		return
@@ -172,8 +174,10 @@ func (m *outgoingUniStreamsMap) SetMaxStream(num protocol.StreamNum) {
 	}
 	m.maxStream = num
 	m.blockedSent = false
+	if m.maxStream < m.nextStream-1+protocol.StreamNum(len(m.openQueue)) {
+		m.maybeSendBlockedFrame()
+	}
 	m.unblockOpenSync()
-	// TODO(#2826): it might be necessary to send a STREAMS_BLOCKED frame
 }
 
 // unblockOpenSync unblocks the next OpenStreamSync go-routine to open a new stream


### PR DESCRIPTION
Depends on #2827. Fixes #2826.