### PR TITLE
introduce a quic.UDPConn interface

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -17,18 +17,17 @@ type connection interface {
 	io.Closer
 }
 
-// If the PacketConn passed to Dial or Listen satisfies this interface, quic-go will read the ECN bits from the IP header.
-// In this case, ReadMsgUDP() will be used instead of ReadFrom() to read packets.
-type ECNCapablePacketConn interface {
+type ecnCapablePacketConn interface {
 	net.PacketConn
 	SyscallConn() (syscall.RawConn, error)
 	ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error)
 }
 
-var _ ECNCapablePacketConn = &net.UDPConn{}
+var _ ecnCapablePacketConn = (UDPConn)(nil)
+var _ ecnCapablePacketConn = &net.UDPConn{}
 
 func wrapConn(pc net.PacketConn) (connection, error) {
-	c, ok := pc.(ECNCapablePacketConn)
+	c, ok := pc.(ecnCapablePacketConn)
 	if !ok {
 		utils.DefaultLogger.Infof("PacketConn is not a net.UDPConn. Disabling optimizations possible on UDP connections.")
 		return &basicConn{PacketConn: pc}, nil

--- a/conn_ecn.go
+++ b/conn_ecn.go
@@ -14,13 +14,13 @@ import (
 const ecnMask uint8 = 0x3
 
 type ecnConn struct {
-	ECNCapablePacketConn
+	ecnCapablePacketConn
 	oobBuffer []byte
 }
 
 var _ connection = &ecnConn{}
 
-func newConn(c ECNCapablePacketConn) (*ecnConn, error) {
+func newConn(c ecnCapablePacketConn) (*ecnConn, error) {
 	rawConn, err := c.SyscallConn()
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func newConn(c ECNCapablePacketConn) (*ecnConn, error) {
 		return nil, errors.New("activating ECN failed for both IPv4 and IPv6")
 	}
 	return &ecnConn{
-		ECNCapablePacketConn: c,
+		ecnCapablePacketConn: c,
 		oobBuffer:            make([]byte, 128),
 	}, nil
 }
@@ -61,7 +61,7 @@ func (c *ecnConn) ReadPacket() (*receivedPacket, error) {
 	// If it does, we only read a truncated packet, which will then end up undecryptable
 	buffer.Data = buffer.Data[:protocol.MaxReceivePacketSize]
 	c.oobBuffer = c.oobBuffer[:cap(c.oobBuffer)]
-	n, oobn, _, addr, err := c.ECNCapablePacketConn.ReadMsgUDP(buffer.Data, c.oobBuffer)
+	n, oobn, _, addr, err := c.ecnCapablePacketConn.ReadMsgUDP(buffer.Data, c.oobBuffer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This interface can be used by applications that want to make sure that the packet conn they pass to `Dial` and `Listen` actually makes use of all UDP-specific optimizations.

Related: https://github.com/libp2p/go-libp2p-quic-transport/issues/178.