### PR TITLE
update golangci-lint, use errors.Is / As for error comparisons

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,4 +10,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.31
+          version: v1.32

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -576,7 +576,7 @@ func (p *packetPacker) MaybePackProbePacket(encLevel protocol.EncryptionLevel) (
 	var contents *packetContents
 	var err error
 	buffer := getPacketBuffer()
-	//nolint:exhaustive Probe packets are never sent for 0-RTT.
+	//nolint:exhaustive // Probe packets are never sent for 0-RTT.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		contents, err = p.maybeAppendCryptoPacket(buffer, p.maxPacketSize, protocol.EncryptionInitial)


### PR DESCRIPTION
Currently blocked by GitHub Actions: golangci-lint v1.32 seems to be not yet available.