### PR TITLE
pad datagrams containing ack-eliciting Initial packets sent by the server

### DIFF
--- a/internal/ackhandler/ack_eliciting.go
+++ b/internal/ackhandler/ack_eliciting.go
@@ -4,8 +4,9 @@ import "github.com/lucas-clemente/quic-go/internal/wire"
 
 // IsFrameAckEliciting returns true if the frame is ack-eliciting.
 func IsFrameAckEliciting(f wire.Frame) bool {
-	_, ok := f.(*wire.AckFrame)
-	return !ok
+	_, isAck := f.(*wire.AckFrame)
+	_, isConnectionClose := f.(*wire.ConnectionCloseFrame)
+	return !isAck && !isConnectionClose
 }
 
 // HasAckElicitingFrames returns true if at least one frame is ack-eliciting.

--- a/internal/ackhandler/ack_eliciting_test.go
+++ b/internal/ackhandler/ack_eliciting_test.go
@@ -11,8 +11,8 @@ import (
 var _ = Describe("ack-eliciting frames", func() {
 	for fl, el := range map[wire.Frame]bool{
 		&wire.AckFrame{}:             false,
+		&wire.ConnectionCloseFrame{}: false,
 		&wire.DataBlockedFrame{}:     true,
-		&wire.ConnectionCloseFrame{}: true,
 		&wire.PingFrame{}:            true,
 		&wire.ResetStreamFrame{}:     true,
 		&wire.StreamFrame{}:          true,


### PR DESCRIPTION
Fixes #2840.