### PR TITLE
upgrade method to convert http client to http3

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -285,3 +285,14 @@ func (c *client) doRequest(
 
 	return res, requestError{}
 }
+
+// ConfigureTransports converts an net/http HTTP/1 Transport to a http3.RoundTripper
+// Uses the original TLS config, if present, relying on the clone created on a
+// new connection.
+func ConfigureTransports(t1 *http.Transport) *RoundTripper {
+	roundtripper := &RoundTripper{
+		TLSClientConfig: t1.TLSClientConfig,
+		QuicConfig:      &quic.Config{},
+	}
+	return roundtripper
+}

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -171,6 +171,23 @@ var _ = Describe("Client", func() {
 		Expect(client.Close()).To(Succeed())
 	})
 
+	Context("Configuring an http1 client", func() {
+		It("uses an empty tls config if none exists", func() {
+			t1 := &http.Transport{}
+			t2 := ConfigureTransports(t1)
+			Expect(t2.TLSClientConfig).To(BeNil())
+		})
+
+		It("uses tls configuration from the original transport", func() {
+			tlsConf := &tls.Config{ServerName: "foo.bar"}
+			t1 := &http.Transport{
+				TLSClientConfig: tlsConf,
+			}
+			t2 := ConfigureTransports(t1)
+			Expect(t2.TLSClientConfig).To(Equal(tlsConf))
+		})
+	})
+
 	Context("Doing requests", func() {
 		var (
 			request *http.Request


### PR DESCRIPTION
[This](https://github.com/tsenart/vegeta/pull/453/files#r339342957) is the mention of copying the TLS config. If we do a clone will this prevent `tls.Config.SetSessionTicketKeys` from being used?

Sorry about the delayed, life got in the way and I let this slip. 

Fixes #2190.