### PR TITLE
only allow the HTTP/3 client to dial with a single QUIC version

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go/internal/qtls"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/marten-seemann/qpack"
 )
@@ -240,10 +241,12 @@ func (c *client) doRequest(
 		return nil, newConnError(errorGeneralProtocolError, err)
 	}
 
+	connState := qtls.ToTLSConnectionState(c.session.ConnectionState())
 	res := &http.Response{
 		Proto:      "HTTP/3",
 		ProtoMajor: 3,
 		Header:     http.Header{},
+		TLS:        &connState,
 	}
 	for _, hf := range hfs {
 		switch hf.Name {

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/golang/mock/gomock"
 	quic "github.com/lucas-clemente/quic-go"
 	mockquic "github.com/lucas-clemente/quic-go/internal/mocks/quic"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qtls"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/marten-seemann/qpack"
 
@@ -221,6 +224,7 @@ var _ = Describe("Client", func() {
 			gomock.InOrder(
 				sess.EXPECT().HandshakeComplete().Return(handshakeCtx),
 				sess.EXPECT().OpenStreamSync(context.Background()).Return(str, nil),
+				sess.EXPECT().ConnectionState().Return(qtls.ConnectionState{}),
 			)
 			str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
 			str.EXPECT().Close()
@@ -390,6 +394,7 @@ var _ = Describe("Client", func() {
 				req := request.WithContext(ctx)
 				sess.EXPECT().HandshakeComplete().Return(handshakeCtx)
 				sess.EXPECT().OpenStreamSync(ctx).Return(str, nil)
+				sess.EXPECT().ConnectionState().Return(qtls.ConnectionState{})
 				buf := &bytes.Buffer{}
 				str.EXPECT().Close().MaxTimes(1)
 
@@ -451,6 +456,7 @@ var _ = Describe("Client", func() {
 
 			It("decompresses the response", func() {
 				sess.EXPECT().OpenStreamSync(context.Background()).Return(str, nil)
+				sess.EXPECT().ConnectionState().Return(qtls.ConnectionState{})
 				buf := &bytes.Buffer{}
 				rw := newResponseWriter(buf, utils.DefaultLogger)
 				rw.Header().Set("Content-Encoding", "gzip")
@@ -476,6 +482,7 @@ var _ = Describe("Client", func() {
 
 			It("only decompresses the response if the response contains the right content-encoding header", func() {
 				sess.EXPECT().OpenStreamSync(context.Background()).Return(str, nil)
+				sess.EXPECT().ConnectionState().Return(qtls.ConnectionState{})
 				buf := &bytes.Buffer{}
 				rw := newResponseWriter(buf, utils.DefaultLogger)
 				rw.Write([]byte("not gzipped"))

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -130,7 +130,8 @@ func (r *RoundTripper) getClient(hostname string, onlyCached bool) (http.RoundTr
 		if onlyCached {
 			return nil, ErrNoCachedConn
 		}
-		client = newClient(
+		var err error
+		client, err = newClient(
 			hostname,
 			r.TLSClientConfig,
 			&roundTripperOpts{
@@ -140,6 +141,9 @@ func (r *RoundTripper) getClient(hostname string, onlyCached bool) (http.RoundTr
 			r.QuicConfig,
 			r.Dial,
 		)
+		if err != nil {
+			return nil, err
+		}
 		r.clients[hostname] = client
 	}
 	return client, nil

--- a/http3/server.go
+++ b/http3/server.go
@@ -34,15 +34,13 @@ const (
 )
 
 func versionToALPN(v protocol.VersionNumber) string {
-	//nolint:exhaustive
-	switch v {
-	case protocol.VersionTLS, protocol.VersionDraft29:
+	if v == protocol.VersionTLS || v == protocol.VersionDraft29 {
 		return nextProtoH3Draft29
-	case protocol.VersionDraft32:
-		return nextProtoH3Draft32
-	default:
-		return ""
 	}
+	if v == protocol.VersionDraft32 {
+		return nextProtoH3Draft32
+	}
+	return ""
 }
 
 // contextKey is a value for use with context.WithValue. It's used as

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -35,6 +35,12 @@ func IsValidVersion(v VersionNumber) bool {
 }
 
 func (vn VersionNumber) String() string {
+	// For releases, VersionTLS will be set to a draft version.
+	// A switch statement can't contain duplicate cases.
+	if vn == VersionTLS && VersionTLS != VersionDraft29 && VersionTLS != VersionDraft32 {
+		return "TLS dev version (WIP)"
+	}
+	//nolint:exhaustive
 	switch vn {
 	case VersionWhatever:
 		return "whatever"
@@ -44,8 +50,6 @@ func (vn VersionNumber) String() string {
 		return "draft-29"
 	case VersionDraft32:
 		return "draft-32"
-	case VersionTLS:
-		return "TLS dev version (WIP)"
 	default:
 		if vn.isGQUIC() {
 			return fmt.Sprintf("gQUIC %d", vn.toGQUICVersion())

--- a/internal/qtls/go114.go
+++ b/internal/qtls/go114.go
@@ -143,6 +143,25 @@ func GetConnectionState(conn *Conn) ConnectionState {
 	return conn.ConnectionState()
 }
 
+// ToTLSConnectionState extracts the tls.ConnectionState
+// Warning: Calling ExportKeyingMaterial won't work.
+func ToTLSConnectionState(cs ConnectionState) tls.ConnectionState {
+	return tls.ConnectionState{
+		Version:                     cs.Version,
+		HandshakeComplete:           cs.HandshakeComplete,
+		DidResume:                   cs.DidResume,
+		CipherSuite:                 cs.CipherSuite,
+		NegotiatedProtocol:          cs.NegotiatedProtocol,
+		NegotiatedProtocolIsMutual:  cs.NegotiatedProtocolIsMutual,
+		ServerName:                  cs.ServerName,
+		PeerCertificates:            cs.PeerCertificates,
+		VerifiedChains:              cs.VerifiedChains,
+		SignedCertificateTimestamps: cs.SignedCertificateTimestamps,
+		OCSPResponse:                cs.OCSPResponse,
+		TLSUnique:                   cs.TLSUnique,
+	}
+}
+
 type cipherSuiteTLS13 struct {
 	ID     uint16
 	KeyLen int

--- a/internal/qtls/go115.go
+++ b/internal/qtls/go115.go
@@ -5,6 +5,7 @@ package qtls
 import (
 	"crypto"
 	"crypto/cipher"
+	"crypto/tls"
 	"net"
 	"unsafe"
 
@@ -83,6 +84,11 @@ func Server(conn net.Conn, config *Config, extraConfig *ExtraConfig) *Conn {
 
 func GetConnectionState(conn *Conn) ConnectionState {
 	return conn.ConnectionStateWith0RTT()
+}
+
+// ToTLSConnectionState extracts the tls.ConnectionState
+func ToTLSConnectionState(cs ConnectionState) tls.ConnectionState {
+	return cs.ConnectionState
 }
 
 type cipherSuiteTLS13 struct {


### PR DESCRIPTION
This is an unfortunate outcome, but we don't have any way to set the ALPN value based on the QUIC version in the client. It's better to throw an error than to offer an invalid combination of ALPN and QUIC version.

Depends on #2847.