### PR TITLE
wait until the handshake is complete before updating the connection ID

### DIFF
--- a/conn_id_manager.go
+++ b/conn_id_manager.go
@@ -15,6 +15,7 @@ import (
 type connIDManager struct {
 	queue utils.NewConnectionIDList
 
+	handshakeComplete         bool
 	activeSequenceNumber      uint64
 	highestRetired            uint64
 	activeConnectionID        protocol.ConnectionID
@@ -190,7 +191,10 @@ func (h *connIDManager) SentPacket() {
 }
 
 func (h *connIDManager) shouldUpdateConnID() bool {
-	// initiate the first change as early as possible
+	if !h.handshakeComplete {
+		return false
+	}
+	// initiate the first change as early as possible (after handshake completion)
 	if h.queue.Len() > 0 && h.activeSequenceNumber == 0 {
 		return true
 	}
@@ -206,4 +210,8 @@ func (h *connIDManager) Get() protocol.ConnectionID {
 		h.updateConnectionID()
 	}
 	return h.activeConnectionID
+}
+
+func (h *connIDManager) SetHandshakeComplete() {
+	h.handshakeComplete = true
 }

--- a/session.go
+++ b/session.go
@@ -691,6 +691,7 @@ func (s *session) handleHandshakeComplete() {
 	s.handshakeCompleteChan = nil // prevent this case from ever being selected again
 	s.handshakeCtxCancel()
 
+	s.connIDManager.SetHandshakeComplete()
 	s.connIDGenerator.SetHandshakeComplete()
 
 	if s.perspective == protocol.PerspectiveServer {

--- a/session_test.go
+++ b/session_test.go
@@ -2251,6 +2251,7 @@ var _ = Describe("Client Session", func() {
 		unpacker := NewMockUnpacker(mockCtrl)
 		sess.unpacker = unpacker
 		sessionRunner.EXPECT().AddResetToken(gomock.Any(), gomock.Any())
+		sess.connIDManager.SetHandshakeComplete()
 		sess.handleNewConnectionIDFrame(&wire.NewConnectionIDFrame{
 			SequenceNumber: 1,
 			ConnectionID:   protocol.ConnectionID{1, 2, 3, 4, 5},
@@ -2494,6 +2495,7 @@ var _ = Describe("Client Session", func() {
 			packer.EXPECT().PackCoalescedPacket(protocol.MaxByteCount).MaxTimes(1)
 			tracer.EXPECT().ReceivedTransportParameters(params)
 			sess.processTransportParameters(params)
+			sess.connIDManager.SetHandshakeComplete()
 			// make sure the connection ID is not retired
 			cf, _ := sess.framer.AppendControlFrames(nil, protocol.MaxByteCount)
 			Expect(cf).To(BeEmpty())


### PR DESCRIPTION
This is not required anywhere, but we don't need to unnecessarily complicate things.