### PR TITLE
replace the RWMutex with a Mutex in the flow controller

### DIFF
--- a/internal/flowcontrol/base_flow_controller.go
+++ b/internal/flowcontrol/base_flow_controller.go
@@ -15,7 +15,7 @@ type baseFlowController struct {
 	lastBlockedAt protocol.ByteCount
 
 	// for receiving data
-	mutex                sync.RWMutex
+	mutex                sync.Mutex
 	bytesRead            protocol.ByteCount
 	highestReceived      protocol.ByteCount
 	receiveWindow        protocol.ByteCount


### PR DESCRIPTION
Obviously, the RW feature of the mutex was not used at all.

The mutex is needed because the `Read` go routines on multiple streams will call `AddBytesRead`. However, this is a write access. The only read access we have here is from the session go routine asking for flow control updates. An RW mutex however only makes sense if you have multiple go routines performing read access.