### PR TITLE
Split http3.ListenAndServe function in two parts to allow use of certificates which are not file based

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -393,8 +393,8 @@ func ListenAndServeQUIC(addr, certFile, keyFile string, handler http.Handler) er
 	return server.ListenAndServeTLS(certFile, keyFile)
 }
 
-// creates tls config from certificate and key files
-// calls ListenAndServeCfg
+// ListenAndServe creates tls config from certificate and key files
+// calls http3.ListenAndServeCfg
 func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error {
 	// Load certs
 	var err error
@@ -411,7 +411,7 @@ func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error 
 	return ListenAndServeCfg(addr, config, handler)
 }
 
-// ListenAndServe listens on the given network address for both, TLS and QUIC
+// ListenAndServeCfg listens on the given network address for both, TLS and QUIC
 // connetions in parallel. It returns if one of the two returns an error.
 // http.DefaultServeMux is used when handler is nil.
 // The correct Alt-Svc headers for QUIC are set.

--- a/http3/server.go
+++ b/http3/server.go
@@ -393,10 +393,8 @@ func ListenAndServeQUIC(addr, certFile, keyFile string, handler http.Handler) er
 	return server.ListenAndServeTLS(certFile, keyFile)
 }
 
-// ListenAndServe listens on the given network address for both, TLS and QUIC
-// connetions in parallel. It returns if one of the two returns an error.
-// http.DefaultServeMux is used when handler is nil.
-// The correct Alt-Svc headers for QUIC are set.
+// creates tls config from certificate and key files
+// calls ListenAndServeCfg
 func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error {
 	// Load certs
 	var err error
@@ -410,7 +408,14 @@ func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error 
 	config := &tls.Config{
 		Certificates: certs,
 	}
+	return ListenAndServeCfg(addr, config, handler)
+}
 
+// ListenAndServe listens on the given network address for both, TLS and QUIC
+// connetions in parallel. It returns if one of the two returns an error.
+// http.DefaultServeMux is used when handler is nil.
+// The correct Alt-Svc headers for QUIC are set.
+func ListenAndServeCfg(addr string, config *tls.Config, handler http.Handler) error {
 	// Open the listeners
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {

--- a/http3/server.go
+++ b/http3/server.go
@@ -412,7 +412,7 @@ func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error 
 }
 
 // ListenAndServeCfg listens on the given network address for both, TLS and QUIC
-// connetions in parallel. It returns if one of the two returns an error.
+// connections in parallel. It returns if one of the two returns an error.
 // http.DefaultServeMux is used when handler is nil.
 // The correct Alt-Svc headers for QUIC are set.
 func ListenAndServeCfg(addr string, config *tls.Config, handler http.Handler) error {


### PR DESCRIPTION
The http3.ListenAndServe function works only with certificate and key files. There's no easy way to use certificates which are already loaded. Therefor, the function should be splitted in two functions, whereas the only task of http3.ListenAndServe is to create a tls.Config structure from cert and key files and call a second function http3.ListenAndServeCfg which does the work.