### PR TITLE
use a sync.Pool for ACK frames

### DIFF
--- a/internal/ackhandler/received_packet_history.go
+++ b/internal/ackhandler/received_packet_history.go
@@ -105,19 +105,20 @@ func (h *receivedPacketHistory) DeleteBelow(p protocol.PacketNumber) {
 	}
 }
 
-// GetAckRanges gets a slice of all AckRanges that can be used in an AckFrame
-func (h *receivedPacketHistory) GetAckRanges() []wire.AckRange {
+// SetAckRanges gets a slice of all AckRanges that can be used in an AckFrame
+func (h *receivedPacketHistory) SetAckRanges(f *wire.AckFrame) {
+	// ranges is guaranteed to never have more than protocol.MaxNumAckRanges elements
+	f.AckRanges = f.AckRanges[:h.ranges.Len()]
 	if h.ranges.Len() == 0 {
-		return nil
+		return
 	}
 
-	ackRanges := make([]wire.AckRange, h.ranges.Len())
 	i := 0
 	for el := h.ranges.Back(); el != nil; el = el.Prev() {
-		ackRanges[i] = wire.AckRange{Smallest: el.Value.Start, Largest: el.Value.End}
+		f.AckRanges[i].Smallest = el.Value.Start
+		f.AckRanges[i].Largest = el.Value.End
 		i++
 	}
-	return ackRanges
 }
 
 func (h *receivedPacketHistory) GetHighestAckRange() wire.AckRange {

--- a/internal/ackhandler/received_packet_history_test.go
+++ b/internal/ackhandler/received_packet_history_test.go
@@ -200,15 +200,19 @@ var _ = Describe("receivedPacketHistory", func() {
 
 	Context("ACK range export", func() {
 		It("returns nil if there are no ranges", func() {
-			Expect(hist.GetAckRanges()).To(BeNil())
+			ack := wire.GetAckFrame()
+			ack.AckRanges = []wire.AckRange{{Smallest: 1, Largest: 2}}
+			hist.SetAckRanges(ack)
+			Expect(ack.AckRanges).To(BeEmpty())
 		})
 
-		It("gets a single ACK range", func() {
+		It("sets a single ACK range", func() {
 			Expect(hist.ReceivedPacket(4)).To(BeTrue())
 			Expect(hist.ReceivedPacket(5)).To(BeTrue())
-			ackRanges := hist.GetAckRanges()
-			Expect(ackRanges).To(HaveLen(1))
-			Expect(ackRanges[0]).To(Equal(wire.AckRange{Smallest: 4, Largest: 5}))
+			ack := wire.GetAckFrame()
+			hist.SetAckRanges(ack)
+			Expect(ack.AckRanges).To(HaveLen(1))
+			Expect(ack.AckRanges[0]).To(Equal(wire.AckRange{Smallest: 4, Largest: 5}))
 		})
 
 		It("gets multiple ACK ranges", func() {
@@ -219,11 +223,12 @@ var _ = Describe("receivedPacketHistory", func() {
 			Expect(hist.ReceivedPacket(11)).To(BeTrue())
 			Expect(hist.ReceivedPacket(10)).To(BeTrue())
 			Expect(hist.ReceivedPacket(2)).To(BeTrue())
-			ackRanges := hist.GetAckRanges()
-			Expect(ackRanges).To(HaveLen(3))
-			Expect(ackRanges[0]).To(Equal(wire.AckRange{Smallest: 10, Largest: 11}))
-			Expect(ackRanges[1]).To(Equal(wire.AckRange{Smallest: 4, Largest: 6}))
-			Expect(ackRanges[2]).To(Equal(wire.AckRange{Smallest: 1, Largest: 2}))
+			ack := wire.GetAckFrame()
+			hist.SetAckRanges(ack)
+			Expect(ack.AckRanges).To(HaveLen(3))
+			Expect(ack.AckRanges[0]).To(Equal(wire.AckRange{Smallest: 10, Largest: 11}))
+			Expect(ack.AckRanges[1]).To(Equal(wire.AckRange{Smallest: 4, Largest: 6}))
+			Expect(ack.AckRanges[2]).To(Equal(wire.AckRange{Smallest: 1, Largest: 2}))
 		})
 	})
 

--- a/internal/wire/ack_frame.go
+++ b/internal/wire/ack_frame.go
@@ -28,7 +28,7 @@ func parseAckFrame(r *bytes.Reader, ackDelayExponent uint8, _ protocol.VersionNu
 	}
 	ecn := typeByte&0x1 > 0
 
-	frame := &AckFrame{}
+	frame := GetAckFrame()
 
 	la, err := utils.ReadVarInt(r)
 	if err != nil {
@@ -64,6 +64,7 @@ func parseAckFrame(r *bytes.Reader, ackDelayExponent uint8, _ protocol.VersionNu
 	smallest := largestAcked - ackBlock
 
 	// read all the other ACK ranges
+	frame.AckRanges = frame.AckRanges[:0]
 	frame.AckRanges = append(frame.AckRanges, AckRange{Smallest: smallest, Largest: largestAcked})
 	for i := uint64(0); i < numBlocks; i++ {
 		g, err := utils.ReadVarInt(r)
@@ -247,4 +248,8 @@ func (f *AckFrame) AcksPacket(p protocol.PacketNumber) bool {
 
 func encodeAckDelay(delay time.Duration) uint64 {
 	return uint64(delay.Nanoseconds() / (1000 * (1 << protocol.AckDelayExponent)))
+}
+
+func (f *AckFrame) PutBack() {
+	putAckFrame(f)
 }

--- a/internal/wire/ack_frame_test.go
+++ b/internal/wire/ack_frame_test.go
@@ -28,6 +28,18 @@ var _ = Describe("ACK Frame (for IETF QUIC)", func() {
 			Expect(b.Len()).To(BeZero())
 		})
 
+		It("uses an ACK frame from the pool", func() {
+			data := []byte{0x2}
+			data = append(data, encodeVarInt(100)...) // largest acked
+			data = append(data, encodeVarInt(0)...)   // delay
+			data = append(data, encodeVarInt(0)...)   // num blocks
+			data = append(data, encodeVarInt(10)...)  // first ack block
+			b := bytes.NewReader(data)
+			frame, err := parseAckFrame(b, protocol.AckDelayExponent, versionIETFFrames)
+			Expect(err).ToNot(HaveOccurred())
+			frame.PutBack() // this will panic if the frame is not from the pool
+		})
+
 		It("parses an ACK frame that only acks a single packet", func() {
 			data := []byte{0x2}
 			data = append(data, encodeVarInt(55)...) // largest acked

--- a/internal/wire/pool_test.go
+++ b/internal/wire/pool_test.go
@@ -1,24 +1,40 @@
 package wire
 
 import (
+	"github.com/lucas-clemente/quic-go/internal/protocol"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Pool", func() {
-	It("gets and puts STREAM frames", func() {
-		f := GetStreamFrame()
-		putStreamFrame(f)
+	Context("for STREAM frames", func() {
+		It("gets and puts STREAM frames", func() {
+			f := GetStreamFrame()
+			putStreamFrame(f)
+		})
+
+		It("panics when putting a STREAM frame with a wrong capacity", func() {
+			f := GetStreamFrame()
+			f.Data = []byte("foobar")
+			Expect(func() { putStreamFrame(f) }).To(Panic())
+		})
+
+		It("accepts STREAM frames not from the buffer, but ignores them", func() {
+			f := &StreamFrame{Data: []byte("foobar")}
+			putStreamFrame(f)
+		})
 	})
 
-	It("panics when putting a STREAM frame with a wrong capacity", func() {
-		f := GetStreamFrame()
-		f.Data = []byte("foobar")
-		Expect(func() { putStreamFrame(f) }).To(Panic())
-	})
+	Context("for ACK frames", func() {
+		It("gets and puts ACK frames", func() {
+			f := GetAckFrame()
+			putAckFrame(f)
+		})
 
-	It("accepts STREAM frames not from the buffer, but ignores them", func() {
-		f := &StreamFrame{Data: []byte("foobar")}
-		putStreamFrame(f)
+		It("panics when putting a STREAM frame with a wrong capacity", func() {
+			f := GetAckFrame()
+			f.AckRanges = make([]AckRange, 0, protocol.MaxNumAckRanges-1)
+			Expect(func() { putAckFrame(f) }).To(Panic())
+		})
 	})
 })

--- a/session.go
+++ b/session.go
@@ -1098,6 +1098,7 @@ func (s *session) handleFrame(f wire.Frame, encLevel protocol.EncryptionLevel, d
 		err = s.handleStreamFrame(frame)
 	case *wire.AckFrame:
 		err = s.handleAckFrame(frame, encLevel)
+		frame.PutBack()
 	case *wire.ConnectionCloseFrame:
 		s.handleConnectionCloseFrame(frame)
 	case *wire.ResetStreamFrame:


### PR DESCRIPTION
ACKs are one of the most common frames, and so far they cost 2 allocations: one for the frame itself, and one for ACK range slice.