### PR TITLE
reduce the maximum number of ACK ranges

### DIFF
--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -128,7 +128,7 @@ const MaxAckFrameSize ByteCount = 1000
 // MaxNumAckRanges is the maximum number of ACK ranges that we send in an ACK frame.
 // It also serves as a limit for the packet history.
 // If at any point we keep track of more ranges, old ranges are discarded.
-const MaxNumAckRanges = 500
+const MaxNumAckRanges = 32
 
 // MinPacingDelay is the minimum duration that is used for packet pacing
 // If the packet packing frequency is higher, multiple packets might be sent at once.


### PR DESCRIPTION
This is basically a prerequisite for #2885, as we'll keep ACK frames with `[]wire.AckRange` in the buffer.

Imagine the worst-case scenario here: We're receiving every packet with a gap after the last packet (e.g. packet numbers 2, 4, 6, 8, ...). Every out-of-order packet will elicit an ACK frame, so we'll send out every ACK range in 31 ACK frames (assuming we're not getting an ACK back that clears those ranges). This is assuming that we're not processing packets faster than we send out ACKs (the `select` in the session run loop is not deterministic).