### PR TITLE
optimize control message parsing

### DIFF
--- a/cmsg.go
+++ b/cmsg.go
@@ -1,0 +1,46 @@
+// +build darwin linux
+
+package quic
+
+import (
+	"syscall"
+	"unsafe"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+)
+
+// ecnFromControlMessage parses b as an array of socket control messages.
+// This is an optimization over using syscall.ParseSocketControlMessage() (which returns a []syscall.SocketControlMessage).
+// thereby avoiding unnecessary allocations.
+func ecnFromControlMessage(b []byte) (protocol.ECN, error) {
+	var ecn protocol.ECN
+	i := 0
+	for i+syscall.CmsgLen(0) <= len(b) {
+		h, dbuf, err := socketControlMessageHeaderAndData(b[i:])
+		if err != nil {
+			return 0, err
+		}
+		if h.Level == syscall.IPPROTO_IP && h.Type == msgTypeIPTOS {
+			ecn = protocol.ECN(dbuf[0] & ecnMask)
+			break
+		}
+		if h.Level == syscall.IPPROTO_IPV6 && h.Type == syscall.IPV6_TCLASS {
+			ecn = protocol.ECN(dbuf[0] & ecnMask)
+			break
+		}
+		i += cmsgAlignOf(int(h.Len))
+	}
+	return ecn, nil
+}
+
+func socketControlMessageHeaderAndData(b []byte) (*syscall.Cmsghdr, []byte, error) {
+	h := (*syscall.Cmsghdr)(unsafe.Pointer(&b[0]))
+	//nolint:unconvert // h.Len uses a different type depending on the architecture
+	if h.Len < syscall.SizeofCmsghdr || uint64(h.Len) > uint64(len(b)) {
+		return nil, nil, syscall.EINVAL
+	}
+	return h, b[cmsgAlignOf(syscall.SizeofCmsghdr):h.Len], nil
+}
+
+//go:linkname cmsgAlignOf syscall.cmsgAlignOf
+func cmsgAlignOf(salen int) int

--- a/conn_ecn.go
+++ b/conn_ecn.go
@@ -88,20 +88,9 @@ func (c *ecnConn) ReadPacket() (*receivedPacket, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctrlMsgs, err := syscall.ParseSocketControlMessage(c.oobBuffer[:oobn])
+	ecn, err := ecnFromControlMessage(c.oobBuffer[:oobn])
 	if err != nil {
 		return nil, err
-	}
-	var ecn protocol.ECN
-	for _, ctrlMsg := range ctrlMsgs {
-		if ctrlMsg.Header.Level == syscall.IPPROTO_IP && ctrlMsg.Header.Type == msgTypeIPTOS {
-			ecn = protocol.ECN(ctrlMsg.Data[0] & ecnMask)
-			break
-		}
-		if ctrlMsg.Header.Level == syscall.IPPROTO_IPV6 && ctrlMsg.Header.Type == syscall.IPV6_TCLASS {
-			ecn = protocol.ECN(ctrlMsg.Data[0] & ecnMask)
-			break
-		}
 	}
 	return &receivedPacket{
 		remoteAddr: addr,


### PR DESCRIPTION
`syscall.ParseSocketControlMessage` allocates, as it returns a `[]syscall.SocketControlMessage`. To avoid allocations, we can parse the information we're looking for while parsing the control messages.

The speedup is significant, at the cost of pulling yet another `unsafe` operation into the project.
```
❯ go test -bench . -benchmem -run Bench 
goos: darwin
goarch: amd64
pkg: github.com/lucas-clemente/quic-go
BenchmarkSyscallParseControlMessage-16          14987308                72.7 ns/op            48 B/op             1 allocs/op
BenchmarkParseControlMessage-16                 163042294                7.21 ns/op            0 B/op             0 allocs/op
PASS
ok      github.com/lucas-clemente/quic-go       3.232s
```
