### PR TITLE
use a single map in the incoming streams map

### DIFF
--- a/streams_map_incoming_uni.go
+++ b/streams_map_incoming_uni.go
@@ -12,14 +12,18 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
+// When a stream is deleted before it was accepted, we can't delete it from the map immediately.
+// We need to wait until the application accepts it, and delete it then.
+type receiveStreamIEntry struct {
+	stream       receiveStreamI
+	shouldDelete bool
+}
+
 type incomingUniStreamsMap struct {
 	mutex         sync.RWMutex
 	newStreamChan chan struct{}
 
-	streams map[protocol.StreamNum]receiveStreamI
-	// When a stream is deleted before it was accepted, we can't delete it immediately.
-	// We need to wait until the application accepts it, and delete it immediately then.
-	streamsToDelete map[protocol.StreamNum]struct{} // used as a set
+	streams map[protocol.StreamNum]receiveStreamIEntry
 
 	nextStreamToAccept protocol.StreamNum // the next stream that will be returned by AcceptStream()
 	nextStreamToOpen   protocol.StreamNum // the highest stream that the peer opened
@@ -39,8 +43,7 @@ func newIncomingUniStreamsMap(
 ) *incomingUniStreamsMap {
 	return &incomingUniStreamsMap{
 		newStreamChan:      make(chan struct{}, 1),
-		streams:            make(map[protocol.StreamNum]receiveStreamI),
-		streamsToDelete:    make(map[protocol.StreamNum]struct{}),
+		streams:            make(map[protocol.StreamNum]receiveStreamIEntry),
 		maxStream:          protocol.StreamNum(maxStreams),
 		maxNumStreams:      maxStreams,
 		newStream:          newStream,
@@ -60,7 +63,7 @@ func (m *incomingUniStreamsMap) AcceptStream(ctx context.Context) (receiveStream
 	m.mutex.Lock()
 
 	var num protocol.StreamNum
-	var str receiveStreamI
+	var entry receiveStreamIEntry
 	for {
 		num = m.nextStreamToAccept
 		if m.closeErr != nil {
@@ -68,7 +71,7 @@ func (m *incomingUniStreamsMap) AcceptStream(ctx context.Context) (receiveStream
 			return nil, m.closeErr
 		}
 		var ok bool
-		str, ok = m.streams[num]
+		entry, ok = m.streams[num]
 		if ok {
 			break
 		}
@@ -82,15 +85,14 @@ func (m *incomingUniStreamsMap) AcceptStream(ctx context.Context) (receiveStream
 	}
 	m.nextStreamToAccept++
 	// If this stream was completed before being accepted, we can delete it now.
-	if _, ok := m.streamsToDelete[num]; ok {
-		delete(m.streamsToDelete, num)
+	if entry.shouldDelete {
 		if err := m.deleteStream(num); err != nil {
 			m.mutex.Unlock()
 			return nil, err
 		}
 	}
 	m.mutex.Unlock()
-	return str, nil
+	return entry.stream, nil
 }
 
 func (m *incomingUniStreamsMap) GetOrOpenStream(num protocol.StreamNum) (receiveStreamI, error) {
@@ -108,8 +110,8 @@ func (m *incomingUniStreamsMap) GetOrOpenStream(num protocol.StreamNum) (receive
 	if num < m.nextStreamToOpen {
 		var s receiveStreamI
 		// If the stream was already queued for deletion, and is just waiting to be accepted, don't return it.
-		if _, ok := m.streamsToDelete[num]; !ok {
-			s = m.streams[num]
+		if entry, ok := m.streams[num]; ok && !entry.shouldDelete {
+			s = entry.stream
 		}
 		m.mutex.RUnlock()
 		return s, nil
@@ -121,16 +123,16 @@ func (m *incomingUniStreamsMap) GetOrOpenStream(num protocol.StreamNum) (receive
 	// * maxStream can only increase, so if the id was valid before, it definitely is valid now
 	// * highestStream is only modified by this function
 	for newNum := m.nextStreamToOpen; newNum <= num; newNum++ {
-		m.streams[newNum] = m.newStream(newNum)
+		m.streams[newNum] = receiveStreamIEntry{stream: m.newStream(newNum)}
 		select {
 		case m.newStreamChan <- struct{}{}:
 		default:
 		}
 	}
 	m.nextStreamToOpen = num + 1
-	s := m.streams[num]
+	entry := m.streams[num]
 	m.mutex.Unlock()
-	return s, nil
+	return entry.stream, nil
 }
 
 func (m *incomingUniStreamsMap) DeleteStream(num protocol.StreamNum) error {
@@ -151,13 +153,15 @@ func (m *incomingUniStreamsMap) deleteStream(num protocol.StreamNum) error {
 	// Don't delete this stream yet, if it was not yet accepted.
 	// Just save it to streamsToDelete map, to make sure it is deleted as soon as it gets accepted.
 	if num >= m.nextStreamToAccept {
-		if _, ok := m.streamsToDelete[num]; ok {
+		entry, ok := m.streams[num]
+		if ok && entry.shouldDelete {
 			return streamError{
 				message: "Tried to delete incoming stream %d multiple times",
 				nums:    []protocol.StreamNum{num},
 			}
 		}
-		m.streamsToDelete[num] = struct{}{}
+		entry.shouldDelete = true
+		m.streams[num] = entry // can't assign to struct in map, so we need to reassign
 		return nil
 	}
 
@@ -180,8 +184,8 @@ func (m *incomingUniStreamsMap) deleteStream(num protocol.StreamNum) error {
 func (m *incomingUniStreamsMap) CloseWithError(err error) {
 	m.mutex.Lock()
 	m.closeErr = err
-	for _, str := range m.streams {
-		str.closeForShutdown(err)
+	for _, entry := range m.streams {
+		entry.stream.closeForShutdown(err)
 	}
 	m.mutex.Unlock()
 	close(m.newStreamChan)


### PR DESCRIPTION
Turns out that map access are not free if you do them in large numbers:

```
❯ benchstat old.txt new.txt                          
name                              old time/op  new time/op  delta
StreamsMap5000Stream0Closed-16    41.5ns ± 5%  39.8ns ± 2%   -4.11%  (p=0.000 n=15+15)
StreamsMap1000Stream0Closed-16    37.7ns ± 5%  33.8ns ± 2%  -10.45%  (p=0.000 n=13+15)
StreamsMap1000Stream10Closed-16   47.9ns ± 9%  35.1ns ± 7%  -26.88%  (p=0.000 n=16+16)
StreamsMap1000Stream600Closed-16  41.5ns ± 7%  32.9ns ±15%  -20.71%  (p=0.000 n=16+16)
StreamsMap1000Stream900Closed-16  37.3ns ± 6%  32.5ns ± 5%  -12.94%  (p=0.000 n=16+15)
StreamsMap100Stream0Closed-16     29.0ns ± 2%  27.3ns ± 8%   -5.97%  (p=0.000 n=15+16)
StreamsMap100Stream10Closed-16    43.8ns ± 9%  27.9ns ± 8%  -36.24%  (p=0.000 n=16+16)
StreamsMap100Stream60Closed-16    33.3ns ± 9%  28.2ns ± 8%  -15.18%  (p=0.000 n=16+16)
StreamsMap100Stream90Closed-16    27.9ns ± 2%  29.0ns ± 7%     ~     (p=0.090 n=15+16)
StreamsMap30Stream0Closed-16      28.4ns ± 2%  26.9ns ± 2%   -5.30%  (p=0.000 n=16+16)
StreamsMap30Stream5Closed-16      33.9ns ± 9%  29.5ns ±14%  -12.98%  (p=0.000 n=16+16)
```