### PR TITLE
index connections directly in the multiplexer

### DIFF
--- a/mock_multiplexer_test.go
+++ b/mock_multiplexer_test.go
@@ -51,7 +51,7 @@ func (mr *MockMultiplexerMockRecorder) AddConn(arg0, arg1, arg2, arg3 interface{
 }
 
 // RemoveConn mocks base method
-func (m *MockMultiplexer) RemoveConn(arg0 indexableConn) error {
+func (m *MockMultiplexer) RemoveConn(arg0 net.PacketConn) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveConn", arg0)
 	ret0, _ := ret[0].(error)

--- a/multiplexer_test.go
+++ b/multiplexer_test.go
@@ -19,16 +19,14 @@ var _ = Describe("Multiplexer", func() {
 	It("adds a new packet conn ", func() {
 		conn := NewMockPacketConn(mockCtrl)
 		conn.EXPECT().ReadFrom(gomock.Any()).Do(func([]byte) { <-(make(chan struct{})) }).MaxTimes(1)
-		conn.EXPECT().LocalAddr().Return(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234})
 		_, err := getMultiplexer().AddConn(conn, 8, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("recognizes when the same connection is added twice", func() {
 		pconn := NewMockPacketConn(mockCtrl)
-		pconn.EXPECT().LocalAddr().Return(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 4321}).Times(2)
 		pconn.EXPECT().ReadFrom(gomock.Any()).Do(func([]byte) { <-(make(chan struct{})) }).MaxTimes(1)
-		conn := testConn{PacketConn: pconn}
+		conn := &testConn{PacketConn: pconn}
 		tracer := mocklogging.NewMockTracer(mockCtrl)
 		_, err := getMultiplexer().AddConn(conn, 8, []byte("foobar"), tracer)
 		Expect(err).ToNot(HaveOccurred())
@@ -41,7 +39,6 @@ var _ = Describe("Multiplexer", func() {
 	It("errors when adding an existing conn with a different connection ID length", func() {
 		conn := NewMockPacketConn(mockCtrl)
 		conn.EXPECT().ReadFrom(gomock.Any()).Do(func([]byte) { <-(make(chan struct{})) }).MaxTimes(1)
-		conn.EXPECT().LocalAddr().Return(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234}).Times(2)
 		_, err := getMultiplexer().AddConn(conn, 5, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		_, err = getMultiplexer().AddConn(conn, 6, nil, nil)
@@ -51,7 +48,6 @@ var _ = Describe("Multiplexer", func() {
 	It("errors when adding an existing conn with a different stateless rest key", func() {
 		conn := NewMockPacketConn(mockCtrl)
 		conn.EXPECT().ReadFrom(gomock.Any()).Do(func([]byte) { <-(make(chan struct{})) }).MaxTimes(1)
-		conn.EXPECT().LocalAddr().Return(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234}).Times(2)
 		_, err := getMultiplexer().AddConn(conn, 7, []byte("foobar"), nil)
 		Expect(err).ToNot(HaveOccurred())
 		_, err = getMultiplexer().AddConn(conn, 7, []byte("raboof"), nil)
@@ -61,7 +57,6 @@ var _ = Describe("Multiplexer", func() {
 	It("errors when adding an existing conn with different tracers", func() {
 		conn := NewMockPacketConn(mockCtrl)
 		conn.EXPECT().ReadFrom(gomock.Any()).Do(func([]byte) { <-(make(chan struct{})) }).MaxTimes(1)
-		conn.EXPECT().LocalAddr().Return(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234}).Times(2)
 		_, err := getMultiplexer().AddConn(conn, 7, nil, mocklogging.NewMockTracer(mockCtrl))
 		Expect(err).ToNot(HaveOccurred())
 		_, err = getMultiplexer().AddConn(conn, 7, nil, mocklogging.NewMockTracer(mockCtrl))

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Packet Handler Map", func() {
 		sess2.EXPECT().destroy(testErr)
 		handler.Add(protocol.ConnectionID{1, 1, 1, 1}, sess1)
 		handler.Add(protocol.ConnectionID{2, 2, 2, 2}, sess2)
-		mockMultiplexer.EXPECT().RemoveConn(gomock.Any())
+		mockMultiplexer.EXPECT().RemoveConn(conn)
 		handler.close(testErr)
 		close(packetChan)
 		Eventually(handler.listening).Should(BeClosed())


### PR DESCRIPTION
This PR needs some careful review.

Currently, the `multiplexer` takes care of deduplicating `net.PacketConns` that are passed to quic-go via `Dial` and `Listen`. We need to do that because we cannot have more than one `ReadFrom` go-routine per connection. We currently deduplicate by looking at the `LocalAddr()`. This makes it possible for users to use the following pattern:
```go
conn, _ := net.ListenUDP(...)
quic.Listen(conn, ...)
quic.Dial(conn, "host1", ...)
quic.Dial(conn, "host2", ...)
```
As the `multiplexer` detects that it's the same `conn` used here, it will only start a single go routine that calls `ReadFrom` on that connection.
The problem with this approach is that it won't work with SO_REUSEPORT, as connections will have the same `LocalAddr`.

As an alternative approch, it would also be possible to compare the `conn` directly, instead of just asking if they have a matching `LocalAddr()`. This approach would work with wrapped connections:
```go
type wrappedConn { net.PacketConn }
c, _ := net.ListenUDP(...)
conn := &wrappedConn{PacketConn: c}
quic.Listen(conn, ...)
quic.Dial(conn, "host1", ...)
```
However, it will fail when used in the following way:
```go
type wrappedConn { net.PacketConn }
c, _ := net.ListenUDP(...)
quic.Listen(&wrappedConn{PacketConn: c}, ...)
quic.Dial(&wrappedConn{PacketConn: c}, "host1", ...)
```
In fact, that's what Caddy does, and what made us introduce the current logic in #2111.

The question now is, what does a reasonable API for quic-go look like? Should we look at the `LocalAddr()` (or any other function on the interface), or should we *require* users to never wrap the same connection into different objects?

If we decide to merge this PR, we'd have to ask @mholt to change the logic in Caddy, and [not create](https://github.com/caddyserver/caddy/blob/96058538f01bf3fc4f2f7c25dbb2338f058f46c7/listeners.go#L75-L92) a new `wrappedConn` for the same underlying `net.PacketConn`.

The big advantage is that the approach here now allows users to use SO_REUSEPORT (that's why this PR fixes #2597): Connections using SO_REUSEPORT will naturally have the same `LocalAddr()`, so with the current approach of identifying connections, they would be detected as duplicated, although they really aren't.

An alternative to this PR would be to define another interface that connections can implement.
```go
type PacketConnWithIdent interface {
    net.PacketConn
    Identifier() string
}
```
Applications that use SO_REUSEPORT would then have to implement the `Identifier() string` method on the `net.PacketConn` they pass to quic-go.

@lucas-clemente WDYT?
