### PR TITLE
immediately remove reset tokens when retiring a connection ID

### DIFF
--- a/conn_id_manager.go
+++ b/conn_id_manager.go
@@ -30,7 +30,6 @@ type connIDManager struct {
 
 	addStatelessResetToken    func(protocol.StatelessResetToken)
 	removeStatelessResetToken func(protocol.StatelessResetToken)
-	retireStatelessResetToken func(protocol.StatelessResetToken)
 	queueControlFrame         func(wire.Frame)
 }
 
@@ -38,7 +37,6 @@ func newConnIDManager(
 	initialDestConnID protocol.ConnectionID,
 	addStatelessResetToken func(protocol.StatelessResetToken),
 	removeStatelessResetToken func(protocol.StatelessResetToken),
-	retireStatelessResetToken func(protocol.StatelessResetToken),
 	queueControlFrame func(wire.Frame),
 ) *connIDManager {
 	b := make([]byte, 8)
@@ -48,7 +46,6 @@ func newConnIDManager(
 		activeConnectionID:        initialDestConnID,
 		addStatelessResetToken:    addStatelessResetToken,
 		removeStatelessResetToken: removeStatelessResetToken,
-		retireStatelessResetToken: retireStatelessResetToken,
 		queueControlFrame:         queueControlFrame,
 		rand:                      mrand.New(mrand.NewSource(seed)),
 	}
@@ -150,7 +147,7 @@ func (h *connIDManager) updateConnectionID() {
 	})
 	h.highestRetired = utils.MaxUint64(h.highestRetired, h.activeSequenceNumber)
 	if h.activeStatelessResetToken != nil {
-		h.retireStatelessResetToken(*h.activeStatelessResetToken)
+		h.removeStatelessResetToken(*h.activeStatelessResetToken)
 	}
 
 	front := h.queue.Remove(h.queue.Front())

--- a/mock_packet_handler_manager_test.go
+++ b/mock_packet_handler_manager_test.go
@@ -162,18 +162,6 @@ func (mr *MockPacketHandlerManagerMockRecorder) Retire(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Retire", reflect.TypeOf((*MockPacketHandlerManager)(nil).Retire), arg0)
 }
 
-// RetireResetToken mocks base method
-func (m *MockPacketHandlerManager) RetireResetToken(arg0 protocol.StatelessResetToken) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RetireResetToken", arg0)
-}
-
-// RetireResetToken indicates an expected call of RetireResetToken
-func (mr *MockPacketHandlerManagerMockRecorder) RetireResetToken(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetireResetToken", reflect.TypeOf((*MockPacketHandlerManager)(nil).RetireResetToken), arg0)
-}
-
 // SetServer mocks base method
 func (m *MockPacketHandlerManager) SetServer(arg0 unknownPacketHandler) {
 	m.ctrl.T.Helper()

--- a/mock_session_runner_test.go
+++ b/mock_session_runner_test.go
@@ -121,15 +121,3 @@ func (mr *MockSessionRunnerMockRecorder) Retire(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Retire", reflect.TypeOf((*MockSessionRunner)(nil).Retire), arg0)
 }
-
-// RetireResetToken mocks base method
-func (m *MockSessionRunner) RetireResetToken(arg0 protocol.StatelessResetToken) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RetireResetToken", arg0)
-}
-
-// RetireResetToken indicates an expected call of RetireResetToken
-func (mr *MockSessionRunnerMockRecorder) RetireResetToken(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetireResetToken", reflect.TypeOf((*MockSessionRunner)(nil).RetireResetToken), arg0)
-}

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -222,14 +222,6 @@ func (h *packetHandlerMap) RemoveResetToken(token protocol.StatelessResetToken) 
 	h.mutex.Unlock()
 }
 
-func (h *packetHandlerMap) RetireResetToken(token protocol.StatelessResetToken) {
-	time.AfterFunc(h.deleteRetiredSessionsAfter, func() {
-		h.mutex.Lock()
-		delete(h.resetTokens, token)
-		h.mutex.Unlock()
-	})
-}
-
 func (h *packetHandlerMap) SetServer(s unknownPacketHandler) {
 	h.mutex.Lock()
 	h.server = s

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -322,20 +322,19 @@ var _ = Describe("Packet Handler Map", func() {
 					Eventually(destroyed).Should(BeClosed())
 				})
 
-				It("retires reset tokens", func() {
-					handler.deleteRetiredSessionsAfter = scaleDuration(10 * time.Millisecond)
+				It("removes reset tokens", func() {
 					connID := protocol.ConnectionID{0xde, 0xad, 0xbe, 0xef, 0x42}
 					packetHandler := NewMockPacketHandler(mockCtrl)
 					handler.Add(connID, packetHandler)
 					token := protocol.StatelessResetToken{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 					handler.AddResetToken(token, NewMockPacketHandler(mockCtrl))
-					handler.RetireResetToken(token)
+					handler.RemoveResetToken(token)
+					// don't EXPECT any call to packetHandler.destroy()
 					packetHandler.EXPECT().handlePacket(gomock.Any())
 					p := append([]byte{0x40} /* short header packet */, connID.Bytes()...)
 					p = append(p, make([]byte, 50)...)
 					p = append(p, token[:]...)
 
-					time.Sleep(scaleDuration(30 * time.Millisecond))
 					handler.handlePacket(&receivedPacket{data: p})
 				})
 

--- a/session.go
+++ b/session.go
@@ -88,7 +88,6 @@ type sessionRunner interface {
 	ReplaceWithClosed(protocol.ConnectionID, packetHandler)
 	AddResetToken(protocol.StatelessResetToken, packetHandler)
 	RemoveResetToken(protocol.StatelessResetToken)
-	RetireResetToken(protocol.StatelessResetToken)
 }
 
 type handshakeRunner struct {
@@ -258,7 +257,6 @@ var newSession = func(
 		destConnID,
 		func(token protocol.StatelessResetToken) { runner.AddResetToken(token, s) },
 		runner.RemoveResetToken,
-		runner.RetireResetToken,
 		s.queueControlFrame,
 	)
 	s.connIDGenerator = newConnIDGenerator(
@@ -382,7 +380,6 @@ var newClientSession = func(
 		destConnID,
 		func(token protocol.StatelessResetToken) { runner.AddResetToken(token, s) },
 		runner.RemoveResetToken,
-		runner.RetireResetToken,
 		s.queueControlFrame,
 	)
 	s.connIDGenerator = newConnIDGenerator(


### PR DESCRIPTION
Otherwise, packet reordering could result in a stateless reset and an unwanted termination of the session.

It will probably be wise to cut another patch release after merging this PR.