### PR TITLE
fix setting of http.Handler in the example server

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -230,7 +230,7 @@ func main() {
 			var err error
 			if *tcp {
 				certFile, keyFile := testdata.GetCertificatePaths()
-				err = http3.ListenAndServe(bCap, certFile, keyFile, nil)
+				err = http3.ListenAndServe(bCap, certFile, keyFile, handler)
 			} else {
 				server := http3.Server{
 					Server:     &http.Server{Handler: handler, Addr: bCap},


### PR DESCRIPTION
... when run with the `-tcp` flag.