### PR TITLE
use utils.Logger not log

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"hash"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -62,27 +61,27 @@ func setReceiveBuffer(c net.PacketConn, logger utils.Logger) {
 	}
 	size, err := inspectReadBuffer(c)
 	if err != nil {
-		log.Printf("Failed to determine receive buffer size: %s", err)
+		logger.Errorf("Failed to determine receive buffer size: %s", err)
 		return
 	}
 	if size >= protocol.DesiredReceiveBufferSize {
 		logger.Debugf("Conn has receive buffer of %d kiB (wanted: at least %d kiB)", size/1024, protocol.DesiredReceiveBufferSize/1024)
 	}
 	if err := conn.SetReadBuffer(protocol.DesiredReceiveBufferSize); err != nil {
-		log.Printf("Failed to increase receive buffer size: %s\n", err)
+		logger.Errorf("Failed to increase receive buffer size: %s\n", err)
 		return
 	}
 	newSize, err := inspectReadBuffer(c)
 	if err != nil {
-		log.Printf("Failed to determine receive buffer size: %s", err)
+		logger.Errorf("Failed to determine receive buffer size: %s", err)
 		return
 	}
 	if newSize == size {
-		log.Printf("Failed to determine receive buffer size: %s", err)
+		logger.Errorf("Failed to determine receive buffer size: %s", err)
 		return
 	}
 	if newSize < protocol.DesiredReceiveBufferSize {
-		log.Printf("Failed to sufficiently increase receive buffer size. Was: %d kiB, wanted: %d kiB, got: %d kiB.", size/1024, protocol.DesiredReceiveBufferSize/1024, newSize/1024)
+		logger.Errorf("Failed to sufficiently increase receive buffer size. Was: %d kiB, wanted: %d kiB, got: %d kiB.", size/1024, protocol.DesiredReceiveBufferSize/1024, newSize/1024)
 		return
 	}
 	logger.Debugf("Increased receive buffer size to %d kiB", newSize/1024)


### PR DESCRIPTION
I've been doing some quic-unrelated debugging with Syncthing and noticed log output in a format that Syncthing doesn't use (https://github.com/syncthing/syncthing/issues/7146):

```
2020/11/24 10:52:01 Failed to sufficiently increase receive buffer size. Was: 208 kiB, wanted: 2048 kiB, got: 416 kiB.
```

Turns out it is quic logging directly to stdout instead of using it's own logger.

Please let me know if the error itself is problematic, then I can enable quic logging locally and see if it comes up consistently.