### PR TITLE
various improvements to the packet number generator

### DIFF
--- a/internal/ackhandler/packet_number_generator.go
+++ b/internal/ackhandler/packet_number_generator.go
@@ -2,7 +2,8 @@ package ackhandler
 
 import (
 	"crypto/rand"
-	"math"
+	"encoding/binary"
+	mrand "math/rand"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 )
@@ -11,6 +12,7 @@ import (
 // it randomly skips a packet number every averagePeriod packets (on average).
 // It is guaranteed to never skip two consecutive packet numbers.
 type packetNumberGenerator struct {
+	rand          *mrand.Rand
 	averagePeriod protocol.PacketNumber
 
 	next       protocol.PacketNumber
@@ -18,7 +20,10 @@ type packetNumberGenerator struct {
 }
 
 func newPacketNumberGenerator(initial, averagePeriod protocol.PacketNumber) *packetNumberGenerator {
+	b := make([]byte, 8)
+	rand.Read(b) // it's not the end of the world if we don't get perfect random here
 	g := &packetNumberGenerator{
+		rand:          mrand.New(mrand.NewSource(int64(binary.LittleEndian.Uint64(b)))),
 		next:          initial,
 		averagePeriod: averagePeriod,
 	}
@@ -44,18 +49,6 @@ func (p *packetNumberGenerator) Pop() protocol.PacketNumber {
 }
 
 func (p *packetNumberGenerator) generateNewSkip() {
-	num := p.getRandomNumber()
-	skip := protocol.PacketNumber(num) * (p.averagePeriod - 1) / (math.MaxUint16 / 2)
 	// make sure that there are never two consecutive packet numbers that are skipped
-	p.nextToSkip = p.next + 2 + skip
-}
-
-// getRandomNumber() generates a cryptographically secure random number between 0 and MaxUint16 (= 65535)
-// The expectation value is 65535/2
-func (p *packetNumberGenerator) getRandomNumber() uint16 {
-	b := make([]byte, 2)
-	rand.Read(b) // ignore the error here
-
-	num := uint16(b[0])<<8 + uint16(b[1])
-	return num
+	p.nextToSkip = p.next + 2 + protocol.PacketNumber(p.rand.Int31n(int32(2*p.averagePeriod)))
 }

--- a/internal/ackhandler/packet_number_generator_test.go
+++ b/internal/ackhandler/packet_number_generator_test.go
@@ -6,16 +6,29 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Packet Number Generator", func() {
-	var png *packetNumberGenerator
+var _ = Describe("Sequential Packet Number Generator", func() {
+	It("generates sequential packet numbers", func() {
+		const initialPN protocol.PacketNumber = 123
+		png := newSequentialPacketNumberGenerator(initialPN)
+
+		for i := initialPN; i < initialPN+1000; i++ {
+			Expect(png.Peek()).To(Equal(i))
+			Expect(png.Peek()).To(Equal(i))
+			Expect(png.Pop()).To(Equal(i))
+		}
+	})
+})
+
+var _ = Describe("Skipping Packet Number Generator", func() {
+	var png *skippingPacketNumberGenerator
 	const initialPN protocol.PacketNumber = 8
 
 	BeforeEach(func() {
-		png = newPacketNumberGenerator(initialPN, 100)
+		png = newSkippingPacketNumberGenerator(initialPN, 100).(*skippingPacketNumberGenerator)
 	})
 
 	It("can be initialized to return any first packet number", func() {
-		png = newPacketNumberGenerator(12345, 100)
+		png = newSkippingPacketNumberGenerator(12345, 100).(*skippingPacketNumberGenerator)
 		Expect(png.Pop()).To(Equal(protocol.PacketNumber(12345)))
 	})
 

--- a/internal/ackhandler/packet_number_generator_test.go
+++ b/internal/ackhandler/packet_number_generator_test.go
@@ -1,8 +1,6 @@
 package ackhandler
 
 import (
-	"math"
-
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,9 +8,10 @@ import (
 
 var _ = Describe("Packet Number Generator", func() {
 	var png *packetNumberGenerator
+	const initialPN protocol.PacketNumber = 8
 
 	BeforeEach(func() {
-		png = newPacketNumberGenerator(1, 100)
+		png = newPacketNumberGenerator(initialPN, 100)
 	})
 
 	It("can be initialized to return any first packet number", func() {
@@ -20,19 +19,18 @@ var _ = Describe("Packet Number Generator", func() {
 		Expect(png.Pop()).To(Equal(protocol.PacketNumber(12345)))
 	})
 
-	It("gets 1 as the first packet number", func() {
+	It("gets the first packet number", func() {
 		num := png.Pop()
-		Expect(num).To(Equal(protocol.PacketNumber(1)))
+		Expect(num).To(Equal(initialPN))
 	})
 
 	It("allows peeking", func() {
 		png.nextToSkip = 1000
-		Expect(png.Peek()).To(Equal(protocol.PacketNumber(1)))
-		Expect(png.Peek()).To(Equal(protocol.PacketNumber(1)))
-		num := png.Pop()
-		Expect(num).To(Equal(protocol.PacketNumber(1)))
-		Expect(png.Peek()).To(Equal(protocol.PacketNumber(2)))
-		Expect(png.Peek()).To(Equal(protocol.PacketNumber(2)))
+		Expect(png.Peek()).To(Equal(initialPN))
+		Expect(png.Peek()).To(Equal(initialPN))
+		Expect(png.Pop()).To(Equal(initialPN))
+		Expect(png.Peek()).To(Equal(initialPN + 1))
+		Expect(png.Peek()).To(Equal(initialPN + 1))
 	})
 
 	It("skips a packet number", func() {
@@ -50,51 +48,34 @@ var _ = Describe("Packet Number Generator", func() {
 	})
 
 	It("skips a specific packet number", func() {
-		png.nextToSkip = 2
-		num := png.Pop()
-		Expect(num).To(Equal(protocol.PacketNumber(1)))
-		Expect(png.Peek()).To(Equal(protocol.PacketNumber(3)))
-		num = png.Pop()
-		Expect(num).To(Equal(protocol.PacketNumber(3)))
+		png.nextToSkip = initialPN + 1
+		Expect(png.Pop()).To(Equal(initialPN))
+		Expect(png.Peek()).To(Equal(initialPN + 2))
+		Expect(png.Pop()).To(Equal(initialPN + 2))
 	})
 
 	It("generates a new packet number to skip", func() {
-		png.next = 100
-		png.averagePeriod = 100
+		const averagePeriod = 25
+		png.averagePeriod = averagePeriod
 
-		rep := 5000
-		var sum protocol.PacketNumber
-
-		for i := 0; i < rep; i++ {
-			png.generateNewSkip()
-			Expect(png.nextToSkip).ToNot(Equal(protocol.PacketNumber(101)))
-			sum += png.nextToSkip
+		periods := make([]protocol.PacketNumber, 0, 500)
+		last := initialPN
+		var lastSkip protocol.PacketNumber
+		for len(periods) < cap(periods) {
+			next := png.Pop()
+			if next > last+1 {
+				skipped := next - 1
+				Expect(skipped).To(BeNumerically(">", lastSkip+1))
+				periods = append(periods, skipped-lastSkip-1)
+				lastSkip = skipped
+			}
+			last = next
 		}
 
-		average := sum / protocol.PacketNumber(rep)
-		Expect(average).To(BeNumerically("==", protocol.PacketNumber(200), 4))
-	})
-
-	It("uses random numbers", func() {
-		var smallest uint16 = math.MaxUint16
-		var largest uint16
-		var sum uint64
-
-		rep := 10000
-
-		for i := 0; i < rep; i++ {
-			num := png.getRandomNumber()
-			sum += uint64(num)
-			if num > largest {
-				largest = num
-			}
-			if num < smallest {
-				smallest = num
-			}
+		var average float64
+		for _, p := range periods {
+			average += float64(p) / float64(len(periods))
 		}
-
-		Expect(smallest).To(BeNumerically("<", 300))
-		Expect(largest).To(BeNumerically(">", math.MaxUint16-300))
-		Expect(sum / uint64(rep)).To(BeNumerically("==", uint64(math.MaxUint16/2), 1000))
+		Expect(average).To(BeNumerically("~", averagePeriod+1 /* we never skip two packet numbers at the same time */, 5))
 	})
 })

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -25,7 +25,7 @@ const (
 
 type packetNumberSpace struct {
 	history *sentPacketHistory
-	pns     *packetNumberGenerator
+	pns     packetNumberGenerator
 
 	lossTime                   time.Time
 	lastAckElicitingPacketTime time.Time
@@ -34,10 +34,16 @@ type packetNumberSpace struct {
 	largestSent  protocol.PacketNumber
 }
 
-func newPacketNumberSpace(initialPN protocol.PacketNumber, rttStats *utils.RTTStats) *packetNumberSpace {
+func newPacketNumberSpace(initialPN protocol.PacketNumber, skipPNs bool, rttStats *utils.RTTStats) *packetNumberSpace {
+	var pns packetNumberGenerator
+	if skipPNs {
+		pns = newSkippingPacketNumberGenerator(initialPN, protocol.SkipPacketAveragePeriodLength)
+	} else {
+		pns = newSequentialPacketNumberGenerator(initialPN)
+	}
 	return &packetNumberSpace{
 		history:      newSentPacketHistory(rttStats),
-		pns:          newPacketNumberGenerator(initialPN, protocol.SkipPacketAveragePeriodLength),
+		pns:          pns,
 		largestSent:  protocol.InvalidPacketNumber,
 		largestAcked: protocol.InvalidPacketNumber,
 	}
@@ -94,7 +100,7 @@ var (
 )
 
 func newSentPacketHandler(
-	initialPacketNumber protocol.PacketNumber,
+	initialPN protocol.PacketNumber,
 	rttStats *utils.RTTStats,
 	pers protocol.Perspective,
 	tracer logging.ConnectionTracer,
@@ -110,9 +116,9 @@ func newSentPacketHandler(
 	return &sentPacketHandler{
 		peerCompletedAddressValidation: pers == protocol.PerspectiveServer,
 		peerAddressValidated:           pers == protocol.PerspectiveClient,
-		initialPackets:                 newPacketNumberSpace(initialPacketNumber, rttStats),
-		handshakePackets:               newPacketNumberSpace(0, rttStats),
-		appDataPackets:                 newPacketNumberSpace(0, rttStats),
+		initialPackets:                 newPacketNumberSpace(initialPN, false, rttStats),
+		handshakePackets:               newPacketNumberSpace(0, false, rttStats),
+		appDataPackets:                 newPacketNumberSpace(0, true, rttStats),
 		rttStats:                       rttStats,
 		congestion:                     congestion,
 		perspective:                    pers,
@@ -765,8 +771,8 @@ func (h *sentPacketHandler) ResetForRetry() error {
 			h.tracer.UpdatedMetrics(h.rttStats, h.congestion.GetCongestionWindow(), h.bytesInFlight, h.packetsInFlight())
 		}
 	}
-	h.initialPackets = newPacketNumberSpace(h.initialPackets.pns.Pop(), h.rttStats)
-	h.appDataPackets = newPacketNumberSpace(h.appDataPackets.pns.Pop(), h.rttStats)
+	h.initialPackets = newPacketNumberSpace(h.initialPackets.pns.Pop(), false, h.rttStats)
+	h.appDataPackets = newPacketNumberSpace(h.appDataPackets.pns.Pop(), true, h.rttStats)
 	oldAlarm := h.alarm
 	h.alarm = time.Time{}
 	if h.tracer != nil {

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -37,7 +37,7 @@ type packetNumberSpace struct {
 func newPacketNumberSpace(initialPN protocol.PacketNumber, skipPNs bool, rttStats *utils.RTTStats) *packetNumberSpace {
 	var pns packetNumberGenerator
 	if skipPNs {
-		pns = newSkippingPacketNumberGenerator(initialPN, protocol.SkipPacketAveragePeriodLength)
+		pns = newSkippingPacketNumberGenerator(initialPN, protocol.SkipPacketInitialPeriod, protocol.SkipPacketMaxPeriod)
 	} else {
 		pns = newSequentialPacketNumberGenerator(initialPN)
 	}

--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -48,8 +48,12 @@ const MaxServerUnprocessedPackets = 1024
 // MaxSessionUnprocessedPackets is the max number of packets stored in each session that are not yet processed.
 const MaxSessionUnprocessedPackets = 256
 
-// SkipPacketAveragePeriodLength is the average period length in which one packet number is skipped to prevent an Optimistic ACK attack
-const SkipPacketAveragePeriodLength PacketNumber = 500
+// SkipPacketInitialPeriod is the initial period length used for packet number skipping to prevent an Optimistic ACK attack.
+// Every time a packet number is skipped, the period is doubled, up to SkipPacketMaxPeriod.
+const SkipPacketInitialPeriod PacketNumber = 256
+
+// SkipPacketMaxPeriod is the maximum period length used for packet number skipping.
+const SkipPacketMaxPeriod PacketNumber = 128 * 1024
 
 // MaxAcceptQueueSize is the maximum number of sessions that the server queues for accepting.
 // If the queue is full, new connection attempts will be rejected.


### PR DESCRIPTION
Fixes #398.

We skip packet numbers to defend against the [Optimistic ACK attack](https://quicwg.org/base-drafts/draft-ietf-quic-transport.html#name-optimistic-ack-attack).

1. Reduce calls to `crypto/rand.Read`. Instead, use a `math/rand.Rand`, initialized with cryptographic random.
2. Only skip packet numbers in the application data packet number space. Initial and Handshake packets are only used for very few packets during the connection, so there was only a small chance we'd skip a PN there anyway.
3. Implement an exponential backoff for skipping packet numbers, starting at an expected frequency of once per 256 packets, going up to once per 128*1024 packets.

A good way to think about this is by looking at the packet numbers skipped per max congestion windows (10000 packets). The current algorithm skips (on average) one PN in 500, which leads to 20 skipped packet numbers per cwnd (and therefore, per RTT). As a consequence, the ACK frames will have roughly 20 ACK ranges (assuming no packet loss). Clearly, this is a waste.