### PR TITLE
add a generic Debug() function to the connection tracer

### DIFF
--- a/integrationtests/self/key_update_test.go
+++ b/integrationtests/self/key_update_test.go
@@ -89,6 +89,7 @@ func (t *connTracer) DroppedKey(logging.KeyPhase)                               
 func (t *connTracer) SetLossTimer(logging.TimerType, logging.EncryptionLevel, time.Time) {}
 func (t *connTracer) LossTimerExpired(logging.TimerType, logging.EncryptionLevel)        {}
 func (t *connTracer) LossTimerCanceled()                                                 {}
+func (t *connTracer) Debug(string, string)                                               {}
 func (t *connTracer) Close()                                                             {}
 
 var _ = Describe("Key Update tests", func() {

--- a/internal/mocks/logging/connection_tracer.go
+++ b/internal/mocks/logging/connection_tracer.go
@@ -75,6 +75,18 @@ func (mr *MockConnectionTracerMockRecorder) ClosedConnection(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosedConnection", reflect.TypeOf((*MockConnectionTracer)(nil).ClosedConnection), arg0)
 }
 
+// Debug mocks base method
+func (m *MockConnectionTracer) Debug(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Debug", arg0, arg1)
+}
+
+// Debug indicates an expected call of Debug
+func (mr *MockConnectionTracerMockRecorder) Debug(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debug", reflect.TypeOf((*MockConnectionTracer)(nil).Debug), arg0, arg1)
+}
+
 // DroppedEncryptionLevel mocks base method
 func (m *MockConnectionTracer) DroppedEncryptionLevel(arg0 protocol.EncryptionLevel) {
 	m.ctrl.T.Helper()

--- a/logging/interface.go
+++ b/logging/interface.go
@@ -126,4 +126,5 @@ type ConnectionTracer interface {
 	LossTimerCanceled()
 	// Close is called when the connection is closed.
 	Close()
+	Debug(name, msg string)
 }

--- a/logging/mock_connection_tracer_test.go
+++ b/logging/mock_connection_tracer_test.go
@@ -74,6 +74,18 @@ func (mr *MockConnectionTracerMockRecorder) ClosedConnection(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosedConnection", reflect.TypeOf((*MockConnectionTracer)(nil).ClosedConnection), arg0)
 }
 
+// Debug mocks base method
+func (m *MockConnectionTracer) Debug(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Debug", arg0, arg1)
+}
+
+// Debug indicates an expected call of Debug
+func (mr *MockConnectionTracerMockRecorder) Debug(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debug", reflect.TypeOf((*MockConnectionTracer)(nil).Debug), arg0, arg1)
+}
+
 // DroppedEncryptionLevel mocks base method
 func (m *MockConnectionTracer) DroppedEncryptionLevel(arg0 protocol.EncryptionLevel) {
 	m.ctrl.T.Helper()

--- a/logging/multiplex.go
+++ b/logging/multiplex.go
@@ -186,6 +186,12 @@ func (m *connTracerMultiplexer) LossTimerCanceled() {
 	}
 }
 
+func (m *connTracerMultiplexer) Debug(name, msg string) {
+	for _, t := range m.tracers {
+		t.Debug(name, msg)
+	}
+}
+
 func (m *connTracerMultiplexer) Close() {
 	for _, t := range m.tracers {
 		t.Close()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -218,4 +218,5 @@ func (t *connTracer) DroppedKey(logging.KeyPhase)                               
 func (t *connTracer) SetLossTimer(logging.TimerType, logging.EncryptionLevel, time.Time) {}
 func (t *connTracer) LossTimerExpired(logging.TimerType, logging.EncryptionLevel)        {}
 func (t *connTracer) LossTimerCanceled()                                                 {}
+func (t *connTracer) Debug(string, string)                                               {}
 func (t *connTracer) Close()                                                             {}

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -462,3 +462,16 @@ func (e eventCongestionStateUpdated) IsNil() bool        { return false }
 func (e eventCongestionStateUpdated) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("new", e.state.String())
 }
+
+type eventGeneric struct {
+	name string
+	msg  string
+}
+
+func (e eventGeneric) Category() category { return categoryTransport }
+func (e eventGeneric) Name() string       { return e.name }
+func (e eventGeneric) IsNil() bool        { return false }
+
+func (e eventGeneric) MarshalJSONObject(enc *gojay.Encoder) {
+	enc.StringKey("details", e.msg)
+}

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -417,3 +417,12 @@ func (t *connectionTracer) LossTimerCanceled() {
 	t.recordEvent(time.Now(), &eventLossTimerCanceled{})
 	t.mutex.Unlock()
 }
+
+func (t *connectionTracer) Debug(name, msg string) {
+	t.mutex.Lock()
+	t.recordEvent(time.Now(), &eventGeneric{
+		name: name,
+		msg:  msg,
+	})
+	t.mutex.Unlock()
+}

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -698,6 +698,17 @@ var _ = Describe("Tracing", func() {
 				Expect(ev).To(HaveLen(1))
 				Expect(ev).To(HaveKeyWithValue("event_type", "cancelled"))
 			})
+
+			It("records a generic event", func() {
+				tracer.Debug("foo", "bar")
+				entry := exportAndParseSingle()
+				Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+				Expect(entry.Category).To(Equal("transport"))
+				Expect(entry.Name).To(Equal("foo"))
+				ev := entry.Event
+				Expect(ev).To(HaveLen(1))
+				Expect(ev).To(HaveKeyWithValue("details", "bar"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
This might not be the cleanest API, but we really need a way to get custom events into qlog / qvis, to facilitate debugging.