### PR TITLE
improve the warning about the UDP receive buffer size

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -96,7 +96,7 @@ func newPacketHandlerMap(
 ) (packetHandlerManager, error) {
 	if err := setReceiveBuffer(c, logger); err != nil {
 		receiveBufferWarningOnce.Do(func() {
-			log.Println(err)
+			log.Printf("%s. See https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size for details.", err)
 		})
 	}
 	conn, err := wrapConn(c)

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"crypto/rand"
 	"errors"
+	"io/ioutil"
+	"log"
 	"net"
+	"os"
 	"time"
 
 	mocklogging "github.com/lucas-clemente/quic-go/internal/mocks/logging"
@@ -63,6 +66,7 @@ var _ = Describe("Packet Handler Map", func() {
 	})
 
 	JustBeforeEach(func() {
+		log.SetOutput(ioutil.Discard)
 		conn = NewMockPacketConn(mockCtrl)
 		conn.EXPECT().LocalAddr().Return(&net.UDPAddr{}).AnyTimes()
 		conn.EXPECT().ReadFrom(gomock.Any()).DoAndReturn(func(b []byte) (int, net.Addr, error) {
@@ -76,6 +80,8 @@ var _ = Describe("Packet Handler Map", func() {
 		Expect(err).ToNot(HaveOccurred())
 		handler = phm.(*packetHandlerMap)
 	})
+
+	AfterEach(func() { log.SetOutput(os.Stdout) })
 
 	It("closes", func() {
 		getMultiplexer() // make the sync.Once execute

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"errors"
-	"io/ioutil"
-	"log"
 	"net"
-	"os"
 	"time"
 
 	mocklogging "github.com/lucas-clemente/quic-go/internal/mocks/logging"
@@ -66,7 +63,6 @@ var _ = Describe("Packet Handler Map", func() {
 	})
 
 	JustBeforeEach(func() {
-		log.SetOutput(ioutil.Discard)
 		conn = NewMockPacketConn(mockCtrl)
 		conn.EXPECT().LocalAddr().Return(&net.UDPAddr{}).AnyTimes()
 		conn.EXPECT().ReadFrom(gomock.Any()).DoAndReturn(func(b []byte) (int, net.Addr, error) {
@@ -80,8 +76,6 @@ var _ = Describe("Packet Handler Map", func() {
 		Expect(err).ToNot(HaveOccurred())
 		handler = phm.(*packetHandlerMap)
 	})
-
-	AfterEach(func() { log.SetOutput(os.Stdout) })
 
 	It("closes", func() {
 		getMultiplexer() // make the sync.Once execute

--- a/quic_suite_test.go
+++ b/quic_suite_test.go
@@ -1,6 +1,8 @@
 package quic
 
 import (
+	"io/ioutil"
+	"log"
 	"sync"
 	"testing"
 
@@ -21,6 +23,10 @@ var _ = BeforeEach(func() {
 
 	// reset the sync.Once
 	connMuxerOnce = *new(sync.Once)
+})
+
+var _ = BeforeSuite(func() {
+	log.SetOutput(ioutil.Discard)
 })
 
 var _ = AfterEach(func() {


### PR DESCRIPTION
1. only print it once
2. link to the wiki page: https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size