### PR TITLE
use golang.org/x/sys/unix instead of syscall

### DIFF
--- a/conn_ecn_test.go
+++ b/conn_ecn_test.go
@@ -4,8 +4,9 @@ package quic
 
 import (
 	"net"
-	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
@@ -60,7 +61,7 @@ var _ = Describe("Basic Conn Test", func() {
 				"udp4",
 				conn.LocalAddr().(*net.UDPAddr),
 				func(fd uintptr) {
-					Expect(syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TOS, 2)).To(Succeed())
+					Expect(unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_TOS, 2)).To(Succeed())
 				},
 			)
 
@@ -80,7 +81,7 @@ var _ = Describe("Basic Conn Test", func() {
 				"udp6",
 				conn.LocalAddr().(*net.UDPAddr),
 				func(fd uintptr) {
-					Expect(syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_TCLASS, 3)).To(Succeed())
+					Expect(unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_TCLASS, 3)).To(Succeed())
 				},
 			)
 
@@ -102,7 +103,7 @@ var _ = Describe("Basic Conn Test", func() {
 				"udp4",
 				&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
 				func(fd uintptr) {
-					Expect(syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TOS, 3)).To(Succeed())
+					Expect(unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_TOS, 3)).To(Succeed())
 				},
 			)
 
@@ -116,7 +117,7 @@ var _ = Describe("Basic Conn Test", func() {
 				"udp6",
 				&net.UDPAddr{IP: net.IPv6loopback, Port: port},
 				func(fd uintptr) {
-					Expect(syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_TCLASS, 1)).To(Succeed())
+					Expect(unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_TCLASS, 1)).To(Succeed())
 				},
 			)
 

--- a/conn_helper_darwin.go
+++ b/conn_helper_darwin.go
@@ -2,14 +2,6 @@
 
 package quic
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
-const (
-	//nolint:stylecheck
-	ip_recvtos   = 27
-	msgTypeIPTOS = ip_recvtos
-)
-
-func setRECVTOS(fd uintptr) error {
-	return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, ip_recvtos, 1)
-}
+const msgTypeIPTOS = unix.IP_RECVTOS

--- a/conn_helper_linux.go
+++ b/conn_helper_linux.go
@@ -2,10 +2,6 @@
 
 package quic
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
-const msgTypeIPTOS = syscall.IP_TOS
-
-func setRECVTOS(fd uintptr) error {
-	return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_RECVTOS, 1)
-}
+const msgTypeIPTOS = unix.IP_TOS

--- a/conn_windows.go
+++ b/conn_windows.go
@@ -29,7 +29,7 @@ func inspectReadBuffer(c net.PacketConn) (int, error) {
 	var size int
 	var serr error
 	if err := rawConn.Control(func(fd uintptr) {
-		size, serr = windows.GetsockoptInt(windows.Handle(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+		size, serr = windows.GetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_RCVBUF)
 	}); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
As suggested by @mvdan in https://github.com/lucas-clemente/quic-go/pull/2896#pullrequestreview-544133159. An excellent suggestion, as it allows us to get rid of two OS-specific files.