### PR TITLE
reduce memory footprint of undecryptable packet handling

### DIFF
--- a/session.go
+++ b/session.go
@@ -493,7 +493,6 @@ func (s *session) preSetup() {
 	s.receivedPackets = make(chan *receivedPacket, protocol.MaxSessionUnprocessedPackets)
 	s.closeChan = make(chan closeError, 1)
 	s.sendingScheduled = make(chan struct{}, 1)
-	s.undecryptablePackets = make([]*receivedPacket, 0, protocol.MaxUndecryptablePackets)
 	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
 	s.handshakeCtx, s.handshakeCtxCancel = context.WithCancel(context.Background())
 

--- a/session.go
+++ b/session.go
@@ -1674,6 +1674,9 @@ func (s *session) scheduleSending() {
 }
 
 func (s *session) tryQueueingUndecryptablePacket(p *receivedPacket, hdr *wire.Header) {
+	if s.handshakeComplete {
+		panic("shouldn't queue undecryptable packets after handshake completion")
+	}
 	if len(s.undecryptablePackets)+1 > protocol.MaxUndecryptablePackets {
 		if s.tracer != nil {
 			s.tracer.DroppedPacket(logging.PacketTypeFromHeader(hdr), p.Size(), logging.PacketDropDOSPrevention)

--- a/session.go
+++ b/session.go
@@ -675,6 +675,9 @@ func (s *session) handleHandshakeComplete() {
 	s.handshakeComplete = true
 	s.handshakeCompleteChan = nil // prevent this case from ever being selected again
 	s.handshakeCtxCancel()
+	// Once the handshake completes, we have derived 1-RTT keys.
+	// There's no point in queueing undecryptable packets for later decryption any more.
+	s.undecryptablePackets = nil
 
 	s.connIDManager.SetHandshakeComplete()
 	s.connIDGenerator.SetHandshakeComplete()


### PR DESCRIPTION
1. Don't preallocate a slice for undecryptable packets. We only ever expect to receive undecryptable packets in the case of reordering or packet loss during the handshake.
2. Drop the slice used for undecryptable packets when the handshake completes. We won't queue any undecryptable packets after the handshake (as it's not possible that any undecryptable packet will become decryptable later), so we can hand the slice back to the GC.
3. Assert that we actually don't try to queue undecryptable packets.