### PR TITLE
trace when a packet is dropped because the receivedPackets chan is full

### DIFF
--- a/session.go
+++ b/session.go
@@ -1117,6 +1117,9 @@ func (s *session) handlePacket(p *receivedPacket) {
 	select {
 	case s.receivedPackets <- p:
 	default:
+		if s.tracer != nil {
+			s.tracer.DroppedPacket(logging.PacketTypeNotDetermined, p.Size(), logging.PacketDropDOSPrevention)
+		}
 	}
 }
 


### PR DESCRIPTION
Unfortunately, this is in the blocking path of the go routine that reads packets from the connection.