### PR TITLE
don't retransmit PING frames added to ACK-only packets

### DIFF
--- a/packet_packer.go
+++ b/packet_packer.go
@@ -565,7 +565,8 @@ func (p *packetPacker) maybeGetAppDataPacketWithEncLevel(maxPayloadSize protocol
 		// the packet only contains an ACK
 		if p.numNonAckElicitingAcks >= protocol.MaxNonAckElicitingAcks {
 			ping := &wire.PingFrame{}
-			payload.frames = append(payload.frames, ackhandler.Frame{Frame: ping})
+			// don't retransmit the PING frame when it is lost
+			payload.frames = append(payload.frames, ackhandler.Frame{Frame: ping, OnLost: func(wire.Frame) {}})
 			payload.length += ping.Length(p.version)
 			p.numNonAckElicitingAcks = 0
 		} else {


### PR DESCRIPTION
Every 20 non-ack-eliciting packets, we add a PING frame to make that packet ack-eliciting. That way, we regularly receive acknowledgements, even if we're not actually sending any data. This allows us to clean up our sent packet history.

There's no need to retransmit this PING frame though. We'll just send a new one if one of them is lost, as soon as we've sent another 20 non-ack-eliciting packets.