### PR TITLE
implement HTTP/3 control stream handling

### DIFF
--- a/http3/http3_suite_test.go
+++ b/http3/http3_suite_test.go
@@ -1,7 +1,10 @@
 package http3
 
 import (
+	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 
@@ -23,3 +26,13 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() {
 	mockCtrl.Finish()
 })
+
+//nolint:unparam
+func scaleDuration(t time.Duration) time.Duration {
+	scaleFactor := 1
+	if f, err := strconv.Atoi(os.Getenv("TIMESCALE_FACTOR")); err == nil { // parsing "" errors, so this works fine if the env is not set
+		scaleFactor = f
+	}
+	Expect(scaleFactor).ToNot(BeZero())
+	return time.Duration(scaleFactor) * t
+}

--- a/http3/roundtrip_test.go
+++ b/http3/roundtrip_test.go
@@ -101,6 +101,10 @@ var _ = Describe("RoundTripper", func() {
 			session.EXPECT().OpenUniStream().AnyTimes().Return(nil, testErr)
 			session.EXPECT().HandshakeComplete().Return(handshakeCtx)
 			session.EXPECT().OpenStreamSync(context.Background()).Return(nil, testErr)
+			session.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
+				<-closed
+				return nil, errors.New("test done")
+			}).MaxTimes(1)
 			session.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(quic.ErrorCode, string) { close(closed) })
 			_, err = rt.RoundTrip(req)
 			Expect(err).To(MatchError(testErr))
@@ -139,6 +143,10 @@ var _ = Describe("RoundTripper", func() {
 			session.EXPECT().OpenUniStream().AnyTimes().Return(nil, testErr)
 			session.EXPECT().HandshakeComplete().Return(handshakeCtx).Times(2)
 			session.EXPECT().OpenStreamSync(context.Background()).Return(nil, testErr).Times(2)
+			session.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
+				<-closed
+				return nil, errors.New("test done")
+			}).MaxTimes(1)
 			session.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(quic.ErrorCode, string) { close(closed) })
 			req, err := http.NewRequest("GET", "https://quic.clemente.io/file1.html", nil)
 			Expect(err).ToNot(HaveOccurred())

--- a/http3/server.go
+++ b/http3/server.go
@@ -37,8 +37,9 @@ var (
 )
 
 const (
-	nextProtoH3Draft29 = "h3-29"
-	nextProtoH3Draft32 = "h3-32"
+	nextProtoH3Draft29      = "h3-29"
+	nextProtoH3Draft32      = "h3-32"
+	streamTypeControlStream = 0
 )
 
 func versionToALPN(v protocol.VersionNumber) string {
@@ -219,9 +220,12 @@ func (s *Server) handleConn(sess quic.EarlySession) {
 		s.logger.Debugf("Opening the control stream failed.")
 		return
 	}
-	buf := bytes.NewBuffer([]byte{0})
+	buf := &bytes.Buffer{}
+	utils.WriteVarInt(buf, streamTypeControlStream) // stream type
 	(&settingsFrame{}).Write(buf)
 	str.Write(buf.Bytes())
+
+	go s.handleUnidirectionalStreams(sess)
 
 	// Process all requests immediately.
 	// It's the client's responsibility to decide which requests are eligible for 0-RTT.
@@ -251,6 +255,35 @@ func (s *Server) handleConn(sess quic.EarlySession) {
 			}
 			str.Close()
 		}()
+	}
+}
+
+func (s *Server) handleUnidirectionalStreams(sess quic.EarlySession) {
+	for {
+		str, err := sess.AcceptUniStream(context.Background())
+		if err != nil {
+			s.logger.Debugf("accepting unidirectional stream failed: %s", err)
+			return
+		}
+
+		go func(str quic.ReceiveStream) {
+			streamType, err := utils.ReadVarInt(&byteReaderImpl{str})
+			if err != nil {
+				s.logger.Debugf("reading stream type on stream %d failed: %s", str.StreamID(), err)
+				return
+			}
+			if streamType != streamTypeControlStream {
+				return
+			}
+			f, err := parseNextFrame(str)
+			if err != nil {
+				sess.CloseWithError(quic.ErrorCode(errorFrameError), "")
+				return
+			}
+			if _, ok := f.(*settingsFrame); !ok {
+				sess.CloseWithError(quic.ErrorCode(errorMissingSettings), "")
+			}
+		}(str)
 	}
 }
 


### PR DESCRIPTION
We'll need this if we ever want to read the SETTINGS frame. This frame is used to negotiate HTTP/3 extensions.