### PR TITLE
implement the HTTP/3 Datagram negotiation

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -136,6 +136,18 @@ var _ = Describe("Client", func() {
 		Expect(dialerCalled).To(BeTrue())
 	})
 
+	It("enables HTTP/3 Datagrams", func() {
+		testErr := errors.New("handshake error")
+		client, err := newClient("localhost:1337", nil, &roundTripperOpts{EnableDatagram: true}, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		dialAddr = func(hostname string, _ *tls.Config, quicConf *quic.Config) (quic.EarlySession, error) {
+			Expect(quicConf.EnableDatagrams).To(BeTrue())
+			return nil, testErr
+		}
+		_, err = client.RoundTrip(req)
+		Expect(err).To(MatchError(testErr))
+	})
+
 	It("errors when dialing fails", func() {
 		testErr := errors.New("handshake error")
 		client, err := newClient("localhost:1337", nil, &roundTripperOpts{}, nil, nil)

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -41,6 +41,11 @@ type RoundTripper struct {
 	// If nil, reasonable default values will be used.
 	QuicConfig *quic.Config
 
+	// Enable support for HTTP/3 datagrams.
+	// If set to true, QuicConfig.EnableDatagram will be set.
+	// See https://www.ietf.org/archive/id/draft-schinazi-masque-h3-datagram-02.html.
+	EnableDatagrams bool
+
 	// Dial specifies an optional dial function for creating QUIC
 	// connections for requests.
 	// If Dial is nil, quic.DialAddr will be used.
@@ -135,6 +140,7 @@ func (r *RoundTripper) getClient(hostname string, onlyCached bool) (http.RoundTr
 			hostname,
 			r.TLSClientConfig,
 			&roundTripperOpts{
+				EnableDatagram:     r.EnableDatagrams,
 				DisableCompression: r.DisableCompression,
 				MaxHeaderBytes:     r.MaxResponseHeaderBytes,
 			},

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -775,4 +775,15 @@ var _ = Describe("Server", func() {
 		fullpem, privkey := testdata.GetCertificatePaths()
 		Expect(ListenAndServeQUIC("", fullpem, privkey, nil)).To(MatchError(testErr))
 	})
+
+	It("supports H3_DATAGRAM", func() {
+		s.EnableDatagrams = true
+		var receivedConf *quic.Config
+		quicListenAddr = func(addr string, _ *tls.Config, config *quic.Config) (quic.EarlyListener, error) {
+			receivedConf = config
+			return nil, errors.New("listen err")
+		}
+		Expect(s.ListenAndServe()).To(HaveOccurred())
+		Expect(receivedConf.EnableDatagrams).To(BeTrue())
+	})
 })

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -304,6 +304,32 @@ var _ = Describe("Server", func() {
 				s.handleConn(sess)
 				Eventually(done).Should(BeClosed())
 			})
+
+			It("errors when the client advertises datagram support (and we enabled support for it)", func() {
+				s.EnableDatagrams = true
+				buf := &bytes.Buffer{}
+				utils.WriteVarInt(buf, streamTypeControlStream)
+				(&settingsFrame{Datagram: true}).Write(buf)
+				controlStr := mockquic.NewMockStream(mockCtrl)
+				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+				sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
+					return controlStr, nil
+				})
+				sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
+					<-testDone
+					return nil, errors.New("test done")
+				})
+				sess.EXPECT().ConnectionState().Return(quic.ConnectionState{SupportsDatagrams: false})
+				done := make(chan struct{})
+				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, reason string) {
+					defer GinkgoRecover()
+					Expect(code).To(BeEquivalentTo(errorSettingsError))
+					Expect(reason).To(Equal("missing QUIC Datagram support"))
+					close(done)
+				})
+				s.handleConn(sess)
+				Eventually(done).Should(BeClosed())
+			})
 		})
 
 		Context("stream- and connection-level errors", func() {


### PR DESCRIPTION
Depends on #2949.

According to https://www.ietf.org/archive/id/draft-schinazi-masque-h3-datagram-02.html.

This PR _only_ adds support for writing and parsing of the datagram option in the HTTP/3 SETTINGS frame, as well as adds the check that datagram support was enabled on the QUIC layer if both client and server negotiated it on the H3 layer.
It is not yet possible to actually send and receive H3 datagrams. That will be added in a subsequent PR.