### PR TITLE
cancel reading on unidirectional streams when the stream type is unknown

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -158,6 +158,7 @@ func (c *client) handleUnidirectionalStreams() {
 				c.session.CloseWithError(quic.ErrorCode(errorIDError), "")
 				return
 			default:
+				str.CancelRead(quic.ErrorCode(errorStreamCreationError))
 				return
 			}
 			f, err := parseNextFrame(str)

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -218,22 +218,17 @@ var _ = Describe("Client", func() {
 		})
 
 		It("ignores streams other than the control stream", func() {
-			controlBuf := &bytes.Buffer{}
-			utils.WriteVarInt(controlBuf, streamTypeControlStream)
-			(&settingsFrame{}).Write(controlBuf)
-			controlStr := mockquic.NewMockStream(mockCtrl)
-			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(controlBuf.Read).AnyTimes()
-
-			otherBuf := &bytes.Buffer{}
-			utils.WriteVarInt(otherBuf, 1337)
-			otherStr := mockquic.NewMockStream(mockCtrl)
-			otherStr.EXPECT().Read(gomock.Any()).DoAndReturn(otherBuf.Read).AnyTimes()
-
-			sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
-				return otherStr, nil
+			buf := &bytes.Buffer{}
+			utils.WriteVarInt(buf, 1337)
+			str := mockquic.NewMockStream(mockCtrl)
+			str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+			done := make(chan struct{})
+			str.EXPECT().CancelRead(quic.ErrorCode(errorStreamCreationError)).Do(func(code quic.ErrorCode) {
+				close(done)
 			})
+
 			sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
-				return controlStr, nil
+				return str, nil
 			})
 			sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
 				<-testDone
@@ -241,7 +236,7 @@ var _ = Describe("Client", func() {
 			})
 			_, err := client.RoundTrip(request)
 			Expect(err).To(MatchError("done"))
-			time.Sleep(scaleDuration(20 * time.Millisecond)) // don't EXPECT any calls to sess.CloseWithError
+			Eventually(done).Should(BeClosed())
 		})
 
 		It("errors when the first frame on the control stream is not a SETTINGS frame", func() {

--- a/http3/server.go
+++ b/http3/server.go
@@ -280,6 +280,7 @@ func (s *Server) handleUnidirectionalStreams(sess quic.EarlySession) {
 				sess.CloseWithError(quic.ErrorCode(errorStreamCreationError), "")
 				return
 			default:
+				str.CancelRead(quic.ErrorCode(errorStreamCreationError))
 				return
 			}
 			f, err := parseNextFrame(str)


### PR DESCRIPTION
Otherwise the stream would remain open indefinitely.