### PR TITLE
remove duplicate check of the URL scheme in the HTTP/3 client

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -201,9 +201,6 @@ func (c *client) maxHeaderBytes() uint64 {
 
 // RoundTrip executes a request and returns a response
 func (c *client) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.URL.Scheme != "https" {
-		return nil, errors.New("http3: unsupported scheme")
-	}
 	if authorityAddr("https", hostnameFromRequest(req)) != c.hostname {
 		return nil, fmt.Errorf("http3 client BUG: RoundTrip called for the wrong client (expected %s, got %s)", c.hostname, req.Host)
 	}

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -173,11 +173,15 @@ var _ = Describe("Client", func() {
 			Expect(err).To(MatchError("http3 client BUG: RoundTrip called for the wrong client (expected quic.clemente.io:1337, got quic.clemente.io:1336)"))
 		})
 
-		It("refuses to do plain HTTP requests", func() {
-			req, err := http.NewRequest("https", "http://quic.clemente.io:1337/foobar.html", nil)
+		It("allows requests using a different scheme", func() {
+			testErr := errors.New("handshake error")
+			req, err := http.NewRequest("masque", "masque://quic.clemente.io:1337/foobar.html", nil)
 			Expect(err).ToNot(HaveOccurred())
+			dialAddr = func(hostname string, _ *tls.Config, _ *quic.Config) (quic.EarlySession, error) {
+				return nil, testErr
+			}
 			_, err = client.RoundTrip(req)
-			Expect(err).To(MatchError("http3: unsupported scheme"))
+			Expect(err).To(MatchError(testErr))
 		})
 	})
 


### PR DESCRIPTION
There's already a check like this performed in the `http3.RoundTripper`.