### PR TITLE
Fill http.Request.TLS with TLS ConnectionState

### DIFF
--- a/http3/request.go
+++ b/http3/request.go
@@ -1,7 +1,6 @@
 package http3
 
 import (
-	"crypto/tls"
 	"errors"
 	"net/http"
 	"net/url"
@@ -80,7 +79,7 @@ func requestFromHeaders(headers []qpack.HeaderField) (*http.Request, error) {
 		ContentLength: contentLength,
 		Host:          authority,
 		RequestURI:    requestURI,
-		TLS:           &tls.ConnectionState{},
+		TLS:           nil,
 	}, nil
 }
 

--- a/http3/request_test.go
+++ b/http3/request_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Request", func() {
 		Expect(req.Body).To(BeNil())
 		Expect(req.Host).To(Equal("quic.clemente.io"))
 		Expect(req.RequestURI).To(Equal("/foo"))
-		Expect(req.TLS).ToNot(BeNil())
+		Expect(req.TLS).To(BeNil())
 	})
 
 	It("parses path with leading double slashes", func() {

--- a/http3/server.go
+++ b/http3/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qtls"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/marten-seemann/qpack"
 )
@@ -355,6 +356,9 @@ func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpac
 
 	req.RemoteAddr = sess.RemoteAddr().String()
 	req.Body = newRequestBody(str, onFrameError)
+
+	connState := qtls.ToTLSConnectionState(sess.ConnectionState().TLS)
+	req.TLS = &connState
 
 	if s.logger.Debug() {
 		s.logger.Infof("%s %s%s, on stream %d", req.Method, req.Host, req.RequestURI, str.StreamID())

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Server", func() {
 			sess = mockquic.NewMockEarlySession(mockCtrl)
 			addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1337}
 			sess.EXPECT().RemoteAddr().Return(addr).AnyTimes()
+			sess.EXPECT().ConnectionState().AnyTimes()
 			sess.EXPECT().LocalAddr().AnyTimes()
 		})
 
@@ -186,6 +187,7 @@ var _ = Describe("Server", func() {
 				sess.EXPECT().OpenUniStream().Return(controlStr, nil)
 				sess.EXPECT().AcceptStream(gomock.Any()).Return(nil, errors.New("done"))
 				sess.EXPECT().RemoteAddr().Return(&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1337}).AnyTimes()
+				sess.EXPECT().ConnectionState().AnyTimes()
 				sess.EXPECT().LocalAddr().AnyTimes()
 			})
 
@@ -319,7 +321,6 @@ var _ = Describe("Server", func() {
 					<-testDone
 					return nil, errors.New("test done")
 				})
-				sess.EXPECT().ConnectionState().Return(quic.ConnectionState{SupportsDatagrams: false})
 				done := make(chan struct{})
 				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, reason string) {
 					defer GinkgoRecover()
@@ -350,6 +351,7 @@ var _ = Describe("Server", func() {
 				sess.EXPECT().AcceptStream(gomock.Any()).Return(str, nil)
 				sess.EXPECT().AcceptStream(gomock.Any()).Return(nil, errors.New("done"))
 				sess.EXPECT().RemoteAddr().Return(addr).AnyTimes()
+				sess.EXPECT().ConnectionState().AnyTimes()
 				sess.EXPECT().LocalAddr().AnyTimes()
 			})
 


### PR DESCRIPTION
This sets the `http.Request.TLS` to the `quic.ConnectionState` obtained from the QUIC session.

Inspired by https://github.com/mpx/quic-go/commit/b37e51a814a9698ba86c1f405b3f4c14f26d291d

closes #2879