### PR TITLE
add a http3.RoundTripOpt to skip the request scheme check

### DIFF
--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -61,11 +61,12 @@ type RoundTripper struct {
 
 // RoundTripOpt are options for the Transport.RoundTripOpt method.
 type RoundTripOpt struct {
-	// OnlyCachedConn controls whether the RoundTripper may
-	// create a new QUIC connection. If set true and
-	// no cached connection is available, RoundTrip
-	// will return ErrNoCachedConn.
+	// OnlyCachedConn controls whether the RoundTripper may create a new QUIC connection.
+	// If set true and no cached connection is available, RoundTrip will return ErrNoCachedConn.
 	OnlyCachedConn bool
+	// SkipSchemeCheck controls whether we check if the scheme is https.
+	// This allows the use of different schemes, e.g. masque://target.example.com:443/.
+	SkipSchemeCheck bool
 }
 
 var _ roundTripCloser = &RoundTripper{}
@@ -99,7 +100,7 @@ func (r *RoundTripper) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.
 				}
 			}
 		}
-	} else {
+	} else if !opt.SkipSchemeCheck {
 		closeRequestBody(req)
 		return nil, fmt.Errorf("http3: unsupported protocol scheme: %s", req.URL.Scheme)
 	}

--- a/http3/roundtrip_test.go
+++ b/http3/roundtrip_test.go
@@ -179,6 +179,15 @@ var _ = Describe("RoundTripper", func() {
 			Expect(req.Body.(*mockBody).closed).To(BeTrue())
 		})
 
+		It("allow non-https schemes if SkipSchemeCheck is set", func() {
+			req, err := http.NewRequest("GET", "masque://www.example.org/", nil)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = rt.RoundTrip(req)
+			Expect(err).To(MatchError("http3: unsupported protocol scheme: masque"))
+			_, err = rt.RoundTripOpt(req, RoundTripOpt{SkipSchemeCheck: true, OnlyCachedConn: true})
+			Expect(err).To(MatchError("http3: no cached connection was available"))
+		})
+
 		It("rejects requests without a URL", func() {
 			req1.URL = nil
 			req1.Body = &mockBody{}


### PR DESCRIPTION
Otherwise, we'll only be able to issue https requests. This is what we usually want, but for MASQUE support, the URL will be of the form masque://example.org.