### PR TITLE
make it possible to send and receive datagrams for a HTTP/3 client

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -61,7 +61,10 @@ type client struct {
 	logger utils.Logger
 }
 
-var _ http.RoundTripper = &client{}
+var (
+	_ http.RoundTripper = &client{}
+	_ DatagramHandler   = &client{}
+)
 
 func newClient(
 	hostname string,
@@ -331,4 +334,12 @@ func (c *client) doRequest(
 	}
 
 	return res, requestError{}
+}
+
+func (c *client) SendMessage(b []byte) error {
+	return c.session.SendMessage(b)
+}
+
+func (c *client) ReceiveMessage() ([]byte, error) {
+	return c.session.ReceiveMessage()
 }

--- a/http3/client.go
+++ b/http3/client.go
@@ -41,7 +41,7 @@ type roundTripperOpts struct {
 	MaxHeaderBytes     int64
 }
 
-// client is a HTTP3 client doing requests
+// client is a http.RoundTripper that performs HTTP/3 requests to a single server.
 type client struct {
 	tlsConf *tls.Config
 	config  *quic.Config
@@ -60,6 +60,8 @@ type client struct {
 
 	logger utils.Logger
 }
+
+var _ http.RoundTripper = &client{}
 
 func newClient(
 	hostname string,

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -441,7 +441,7 @@ var _ = Describe("Client", func() {
 
 		It("returns a response", func() {
 			rspBuf := &bytes.Buffer{}
-			rw := newResponseWriter(rspBuf, utils.DefaultLogger)
+			rw := newResponseWriter(rspBuf, nil, utils.DefaultLogger)
 			rw.WriteHeader(418)
 			rw.Flush()
 
@@ -590,7 +590,7 @@ var _ = Describe("Client", func() {
 
 			It("cancels a request after the response arrived", func() {
 				rspBuf := &bytes.Buffer{}
-				rw := newResponseWriter(rspBuf, utils.DefaultLogger)
+				rw := newResponseWriter(rspBuf, nil, utils.DefaultLogger)
 				rw.WriteHeader(418)
 				rw.Flush()
 
@@ -655,7 +655,7 @@ var _ = Describe("Client", func() {
 				sess.EXPECT().OpenStreamSync(context.Background()).Return(str, nil)
 				sess.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				buf := &bytes.Buffer{}
-				rw := newResponseWriter(buf, utils.DefaultLogger)
+				rw := newResponseWriter(buf, nil, utils.DefaultLogger)
 				rw.Header().Set("Content-Encoding", "gzip")
 				gz := gzip.NewWriter(rw)
 				gz.Write([]byte("gzipped response"))
@@ -679,7 +679,7 @@ var _ = Describe("Client", func() {
 				sess.EXPECT().OpenStreamSync(context.Background()).Return(str, nil)
 				sess.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				buf := &bytes.Buffer{}
-				rw := newResponseWriter(buf, utils.DefaultLogger)
+				rw := newResponseWriter(buf, nil, utils.DefaultLogger)
 				rw.Write([]byte("not gzipped"))
 				rw.Flush()
 				str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -109,12 +109,19 @@ func (r *RoundTripper) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.
 		return nil, fmt.Errorf("http3: invalid method %q", req.Method)
 	}
 
-	hostname := authorityAddr("https", hostnameFromRequest(req))
-	cl, err := r.getClient(hostname, opt.OnlyCachedConn)
+	cl, err := r.GetRoundTripperForRequest(req, opt)
 	if err != nil {
 		return nil, err
 	}
 	return cl.RoundTrip(req)
+}
+
+// GetClientForRequests return the http.RoundTripper responsible for performing a request.
+// Most users won't need to use this function, they should use RoundTrip on this struct instead.
+// This function is useful for users that need access to functions on the underlying QUIC connection.
+func (r *RoundTripper) GetRoundTripperForRequest(req *http.Request, opt RoundTripOpt) (http.RoundTripper, error) {
+	hostname := authorityAddr("https", hostnameFromRequest(req))
+	return r.getClient(hostname, opt.OnlyCachedConn)
 }
 
 // RoundTrip does a round trip.

--- a/http3/server.go
+++ b/http3/server.go
@@ -367,7 +367,7 @@ func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpac
 	ctx = context.WithValue(ctx, ServerContextKey, s)
 	ctx = context.WithValue(ctx, http.LocalAddrContextKey, sess.LocalAddr())
 	req = req.WithContext(ctx)
-	responseWriter := newResponseWriter(str, s.logger)
+	responseWriter := newResponseWriter(str, sess, s.logger)
 	defer responseWriter.Flush()
 	handler := s.Handler
 	if handler == nil {


### PR DESCRIPTION
Depends on #2963.

Most users will just need to call `http3.RoundTripper.RoundTrip()`. For users that need access to the underlying QUIC connection, they can get a particular client (which owns one QUIC session) using the newly added `GetRoundTripperForRequest`. This will be heavily used by MASQUE.