### PR TITLE
increase the maximum size of DATAGRAM frames

### DIFF
--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -135,7 +135,7 @@ const MaxAckFrameSize ByteCount = 1000
 // MaxDatagramFrameSize is the maximum size of a DATAGRAM frame as defined in
 // https://datatracker.ietf.org/doc/draft-pauly-quic-datagram/.
 // The size is chosen such that a DATAGRAM frame fits into a QUIC packet.
-const MaxDatagramFrameSize ByteCount = 1200
+const MaxDatagramFrameSize ByteCount = 1220
 
 // DatagramRcvQueueLen is the length of the receive queue for DATAGRAM frames.
 // See https://datatracker.ietf.org/doc/draft-pauly-quic-datagram/.


### PR DESCRIPTION
We'll need a payload size of 1200 bytes if we want to use MASQUE's CONNECT-UDP to establish a QUIC connection (due to the minimum size requirement for Initial packets).