### PR TITLE
fix YAML syntax error in setup-go step

### DIFF
--- a/.github/workflows/cross-compile.sh
+++ b/.github/workflows/cross-compile.sh
@@ -10,11 +10,13 @@ for dist in $(go tool dist list); do
 	if [[ "$goos" == "android" ]]; then continue; fi 		# cross-compiling for android is a pain...
 	if [[ "$goos" == "darwin" && $goarch == "arm64" ]]; then continue; fi # ... darwin/arm64 neither
 	if [[ $GOVERSION == "1.14" && $goos == "darwin" && $goarch == "arm" ]]; then continue; fi # Go 1.14 lacks syscall.IPV6_RECVTCLASS
-
-	cgo=0
-	if [[ "$goos" == "ios" ]]; then cgo=1; fi # iOS builds require CGO, see https://github.com/golang/go/issues/43343
+  # iOS builds require Cgo, see https://github.com/golang/go/issues/43343
+  # Cgo would then need a C cross compilation setup. Not worth the hassle.
+	if [[ "$goos" == "ios" ]]; then continue; fi
+	# see https://github.com/golang/go/issues/43442
+	if [[ "$GOVERSION" == "1.16" && "$goos" == "openbsd" && "$goarch" == "mips64" ]]; then continue; fi
 
 	echo "$dist"
-	GOOS=$goos GOARCH=$goarch CGO_ENABLED=$cgo go build -o main example/main.go
+	GOOS=$goos GOARCH=$goarch go build -o main example/main.go
 	rm main
 done

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          stable: !contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")
+          stable: '!contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")'
           go-version: ${{ matrix.go }}
       - name: Install build utils
         run: sudo apt-get install -y gcc-multilib

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          stable: !contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")
+          stable: '!contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")'
           go-version: ${{ matrix.go }}
       - run: go version
       - name: Install Ginkgo

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          stable: !contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")
+          stable: '!contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")'
           go-version: ${{ matrix.go }}
       - run: go version
       - name: Install test tools


### PR DESCRIPTION
Apparently adding a `!` makes the YAML invalid. Even more surprisingly, the workflow wasn't marked as failed.