### PR TITLE
publicize QUIC varint reading and writing

### DIFF
--- a/framer.go
+++ b/framer.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/ackhandler"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/internal/wire"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 type framer interface {
@@ -114,7 +114,7 @@ func (f *framerI) AppendStreamFrames(frames []ackhandler.Frame, maxLen protocol.
 		// For the last STREAM frame, we'll remove the DataLen field later.
 		// Therefore, we can pretend to have more bytes available when popping
 		// the STREAM frame (which will always have the DataLen set).
-		remainingLen += utils.VarIntLen(uint64(remainingLen))
+		remainingLen += quicvarint.VarIntLen(uint64(remainingLen))
 		frame, hasMoreData := str.popStreamFrame(remainingLen)
 		if hasMoreData { // put the stream back in the queue (at the end)
 			f.streamQueue = append(f.streamQueue, id)

--- a/framer.go
+++ b/framer.go
@@ -114,7 +114,7 @@ func (f *framerI) AppendStreamFrames(frames []ackhandler.Frame, maxLen protocol.
 		// For the last STREAM frame, we'll remove the DataLen field later.
 		// Therefore, we can pretend to have more bytes available when popping
 		// the STREAM frame (which will always have the DataLen set).
-		remainingLen += quicvarint.VarIntLen(uint64(remainingLen))
+		remainingLen += quicvarint.Len(uint64(remainingLen))
 		frame, hasMoreData := str.popStreamFrame(remainingLen)
 		if hasMoreData { // put the stream back in the queue (at the end)
 			f.streamQueue = append(f.streamQueue, id)

--- a/http3/client.go
+++ b/http3/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qtls"
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 	"github.com/marten-seemann/qpack"
 )
 
@@ -131,7 +132,7 @@ func (c *client) setupSession() error {
 		return err
 	}
 	buf := &bytes.Buffer{}
-	utils.WriteVarInt(buf, streamTypeControlStream)
+	quicvarint.WriteVarInt(buf, streamTypeControlStream)
 	// send the SETTINGS frame
 	(&settingsFrame{Datagram: c.opts.EnableDatagram}).Write(buf)
 	_, err = str.Write(buf.Bytes())
@@ -147,7 +148,7 @@ func (c *client) handleUnidirectionalStreams() {
 		}
 
 		go func() {
-			streamType, err := utils.ReadVarInt(&byteReaderImpl{str})
+			streamType, err := quicvarint.ReadVarInt(&byteReaderImpl{str})
 			if err != nil {
 				c.logger.Debugf("reading stream type on stream %d failed: %s", str.StreamID(), err)
 				return

--- a/http3/client.go
+++ b/http3/client.go
@@ -132,7 +132,7 @@ func (c *client) setupSession() error {
 		return err
 	}
 	buf := &bytes.Buffer{}
-	quicvarint.WriteVarInt(buf, streamTypeControlStream)
+	quicvarint.Write(buf, streamTypeControlStream)
 	// send the SETTINGS frame
 	(&settingsFrame{Datagram: c.opts.EnableDatagram}).Write(buf)
 	_, err = str.Write(buf.Bytes())
@@ -148,7 +148,7 @@ func (c *client) handleUnidirectionalStreams() {
 		}
 
 		go func() {
-			streamType, err := quicvarint.ReadVarInt(&byteReaderImpl{str})
+			streamType, err := quicvarint.Read(&byteReaderImpl{str})
 			if err != nil {
 				c.logger.Debugf("reading stream type on stream %d failed: %s", str.StreamID(), err)
 				return

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Client", func() {
 
 		It("parses the SETTINGS frame", func() {
 			buf := &bytes.Buffer{}
-			quicvarint.WriteVarInt(buf, streamTypeControlStream)
+			quicvarint.Write(buf, streamTypeControlStream)
 			(&settingsFrame{}).Write(buf)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -236,7 +236,7 @@ var _ = Describe("Client", func() {
 
 		It("ignores streams other than the control stream", func() {
 			buf := &bytes.Buffer{}
-			quicvarint.WriteVarInt(buf, 1337)
+			quicvarint.Write(buf, 1337)
 			str := mockquic.NewMockStream(mockCtrl)
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 			done := make(chan struct{})
@@ -258,7 +258,7 @@ var _ = Describe("Client", func() {
 
 		It("errors when the first frame on the control stream is not a SETTINGS frame", func() {
 			buf := &bytes.Buffer{}
-			quicvarint.WriteVarInt(buf, streamTypeControlStream)
+			quicvarint.Write(buf, streamTypeControlStream)
 			(&dataFrame{}).Write(buf)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -282,7 +282,7 @@ var _ = Describe("Client", func() {
 
 		It("errors when parsing the frame on the control stream fails", func() {
 			buf := &bytes.Buffer{}
-			quicvarint.WriteVarInt(buf, streamTypeControlStream)
+			quicvarint.Write(buf, streamTypeControlStream)
 			b := &bytes.Buffer{}
 			(&settingsFrame{}).Write(b)
 			buf.Write(b.Bytes()[:b.Len()-1])
@@ -308,7 +308,7 @@ var _ = Describe("Client", func() {
 
 		It("errors when parsing the server opens a push stream", func() {
 			buf := &bytes.Buffer{}
-			quicvarint.WriteVarInt(buf, streamTypePushStream)
+			quicvarint.Write(buf, streamTypePushStream)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 			sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
@@ -332,7 +332,7 @@ var _ = Describe("Client", func() {
 		It("errors when the server advertises datagram support (and we enabled support for it)", func() {
 			client.opts.EnableDatagram = true
 			buf := &bytes.Buffer{}
-			quicvarint.WriteVarInt(buf, streamTypeControlStream)
+			quicvarint.Write(buf, streamTypeControlStream)
 			(&settingsFrame{Datagram: true}).Write(buf)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -391,7 +391,7 @@ var _ = Describe("Client", func() {
 			controlStr.EXPECT().Write(gomock.Any()).Do(func(b []byte) {
 				defer GinkgoRecover()
 				r := bytes.NewReader(b)
-				streamType, err := quicvarint.ReadVarInt(r)
+				streamType, err := quicvarint.Read(r)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(streamType).To(BeEquivalentTo(streamTypeControlStream))
 				close(settingsFrameWritten)

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -12,8 +12,9 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 	mockquic "github.com/lucas-clemente/quic-go/internal/mocks/quic"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
@@ -217,7 +218,7 @@ var _ = Describe("Client", func() {
 
 		It("parses the SETTINGS frame", func() {
 			buf := &bytes.Buffer{}
-			utils.WriteVarInt(buf, streamTypeControlStream)
+			quicvarint.WriteVarInt(buf, streamTypeControlStream)
 			(&settingsFrame{}).Write(buf)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -235,7 +236,7 @@ var _ = Describe("Client", func() {
 
 		It("ignores streams other than the control stream", func() {
 			buf := &bytes.Buffer{}
-			utils.WriteVarInt(buf, 1337)
+			quicvarint.WriteVarInt(buf, 1337)
 			str := mockquic.NewMockStream(mockCtrl)
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 			done := make(chan struct{})
@@ -257,7 +258,7 @@ var _ = Describe("Client", func() {
 
 		It("errors when the first frame on the control stream is not a SETTINGS frame", func() {
 			buf := &bytes.Buffer{}
-			utils.WriteVarInt(buf, streamTypeControlStream)
+			quicvarint.WriteVarInt(buf, streamTypeControlStream)
 			(&dataFrame{}).Write(buf)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -281,7 +282,7 @@ var _ = Describe("Client", func() {
 
 		It("errors when parsing the frame on the control stream fails", func() {
 			buf := &bytes.Buffer{}
-			utils.WriteVarInt(buf, streamTypeControlStream)
+			quicvarint.WriteVarInt(buf, streamTypeControlStream)
 			b := &bytes.Buffer{}
 			(&settingsFrame{}).Write(b)
 			buf.Write(b.Bytes()[:b.Len()-1])
@@ -307,7 +308,7 @@ var _ = Describe("Client", func() {
 
 		It("errors when parsing the server opens a push stream", func() {
 			buf := &bytes.Buffer{}
-			utils.WriteVarInt(buf, streamTypePushStream)
+			quicvarint.WriteVarInt(buf, streamTypePushStream)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 			sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
@@ -331,7 +332,7 @@ var _ = Describe("Client", func() {
 		It("errors when the server advertises datagram support (and we enabled support for it)", func() {
 			client.opts.EnableDatagram = true
 			buf := &bytes.Buffer{}
-			utils.WriteVarInt(buf, streamTypeControlStream)
+			quicvarint.WriteVarInt(buf, streamTypeControlStream)
 			(&settingsFrame{Datagram: true}).Write(buf)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -390,7 +391,7 @@ var _ = Describe("Client", func() {
 			controlStr.EXPECT().Write(gomock.Any()).Do(func(b []byte) {
 				defer GinkgoRecover()
 				r := bytes.NewReader(b)
-				streamType, err := utils.ReadVarInt(r)
+				streamType, err := quicvarint.ReadVarInt(r)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(streamType).To(BeEquivalentTo(streamTypeControlStream))
 				close(settingsFrameWritten)

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("Frames", func() {
 	appendVarInt := func(b []byte, val uint64) []byte {
 		buf := &bytes.Buffer{}
-		quicvarint.WriteVarInt(buf, val)
+		quicvarint.Write(buf, val)
 		return append(b, buf.Bytes()...)
 	}
 

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,7 +14,7 @@ import (
 var _ = Describe("Frames", func() {
 	appendVarInt := func(b []byte, val uint64) []byte {
 		buf := &bytes.Buffer{}
-		utils.WriteVarInt(buf, val)
+		quicvarint.WriteVarInt(buf, val)
 		return append(b, buf.Bytes()...)
 	}
 

--- a/http3/server.go
+++ b/http3/server.go
@@ -237,7 +237,7 @@ func (s *Server) handleConn(sess quic.EarlySession) {
 		return
 	}
 	buf := &bytes.Buffer{}
-	quicvarint.WriteVarInt(buf, streamTypeControlStream) // stream type
+	quicvarint.Write(buf, streamTypeControlStream) // stream type
 	(&settingsFrame{Datagram: s.EnableDatagrams}).Write(buf)
 	str.Write(buf.Bytes())
 
@@ -283,7 +283,7 @@ func (s *Server) handleUnidirectionalStreams(sess quic.EarlySession) {
 		}
 
 		go func(str quic.ReceiveStream) {
-			streamType, err := quicvarint.ReadVarInt(&byteReaderImpl{str})
+			streamType, err := quicvarint.Read(&byteReaderImpl{str})
 			if err != nil {
 				s.logger.Debugf("reading stream type on stream %d failed: %s", str.StreamID(), err)
 				return

--- a/http3/server.go
+++ b/http3/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 	"github.com/marten-seemann/qpack"
 )
 
@@ -236,7 +237,7 @@ func (s *Server) handleConn(sess quic.EarlySession) {
 		return
 	}
 	buf := &bytes.Buffer{}
-	utils.WriteVarInt(buf, streamTypeControlStream) // stream type
+	quicvarint.WriteVarInt(buf, streamTypeControlStream) // stream type
 	(&settingsFrame{Datagram: s.EnableDatagrams}).Write(buf)
 	str.Write(buf.Bytes())
 
@@ -282,7 +283,7 @@ func (s *Server) handleUnidirectionalStreams(sess quic.EarlySession) {
 		}
 
 		go func(str quic.ReceiveStream) {
-			streamType, err := utils.ReadVarInt(&byteReaderImpl{str})
+			streamType, err := quicvarint.ReadVarInt(&byteReaderImpl{str})
 			if err != nil {
 				s.logger.Debugf("reading stream type on stream %d failed: %s", str.StreamID(), err)
 				return

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Server", func() {
 
 			It("parses the SETTINGS frame", func() {
 				buf := &bytes.Buffer{}
-				quicvarint.WriteVarInt(buf, streamTypeControlStream)
+				quicvarint.Write(buf, streamTypeControlStream)
 				(&settingsFrame{}).Write(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -212,7 +212,7 @@ var _ = Describe("Server", func() {
 
 			It("ignores streams other than the control stream", func() {
 				buf := &bytes.Buffer{}
-				quicvarint.WriteVarInt(buf, 1337)
+				quicvarint.Write(buf, 1337)
 				str := mockquic.NewMockStream(mockCtrl)
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				done := make(chan struct{})
@@ -233,7 +233,7 @@ var _ = Describe("Server", func() {
 
 			It("errors when the first frame on the control stream is not a SETTINGS frame", func() {
 				buf := &bytes.Buffer{}
-				quicvarint.WriteVarInt(buf, streamTypeControlStream)
+				quicvarint.Write(buf, streamTypeControlStream)
 				(&dataFrame{}).Write(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -256,7 +256,7 @@ var _ = Describe("Server", func() {
 
 			It("errors when parsing the frame on the control stream fails", func() {
 				buf := &bytes.Buffer{}
-				quicvarint.WriteVarInt(buf, streamTypeControlStream)
+				quicvarint.Write(buf, streamTypeControlStream)
 				b := &bytes.Buffer{}
 				(&settingsFrame{}).Write(b)
 				buf.Write(b.Bytes()[:b.Len()-1])
@@ -281,7 +281,7 @@ var _ = Describe("Server", func() {
 
 			It("errors when the client opens a push stream", func() {
 				buf := &bytes.Buffer{}
-				quicvarint.WriteVarInt(buf, streamTypePushStream)
+				quicvarint.Write(buf, streamTypePushStream)
 				(&dataFrame{}).Write(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -305,7 +305,7 @@ var _ = Describe("Server", func() {
 			It("errors when the client advertises datagram support (and we enabled support for it)", func() {
 				s.EnableDatagrams = true
 				buf := &bytes.Buffer{}
-				quicvarint.WriteVarInt(buf, streamTypeControlStream)
+				quicvarint.Write(buf, streamTypeControlStream)
 				(&settingsFrame{Datagram: true}).Write(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 	"github.com/lucas-clemente/quic-go/logging"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // TLS unexpected_message alert
@@ -405,8 +406,8 @@ func (h *cryptoSetup) handleTransportParameters(data []byte) {
 // must be called after receiving the transport parameters
 func (h *cryptoSetup) marshalDataForSessionState() []byte {
 	buf := &bytes.Buffer{}
-	utils.WriteVarInt(buf, clientSessionStateRevision)
-	utils.WriteVarInt(buf, uint64(h.rttStats.SmoothedRTT().Microseconds()))
+	quicvarint.WriteVarInt(buf, clientSessionStateRevision)
+	quicvarint.WriteVarInt(buf, uint64(h.rttStats.SmoothedRTT().Microseconds()))
 	h.peerParams.MarshalForSessionTicket(buf)
 	return buf.Bytes()
 }
@@ -422,14 +423,14 @@ func (h *cryptoSetup) handleDataFromSessionState(data []byte) {
 
 func (h *cryptoSetup) handleDataFromSessionStateImpl(data []byte) (*wire.TransportParameters, error) {
 	r := bytes.NewReader(data)
-	ver, err := utils.ReadVarInt(r)
+	ver, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
 	if ver != clientSessionStateRevision {
 		return nil, fmt.Errorf("mismatching version. Got %d, expected %d", ver, clientSessionStateRevision)
 	}
-	rtt, err := utils.ReadVarInt(r)
+	rtt, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -406,8 +406,8 @@ func (h *cryptoSetup) handleTransportParameters(data []byte) {
 // must be called after receiving the transport parameters
 func (h *cryptoSetup) marshalDataForSessionState() []byte {
 	buf := &bytes.Buffer{}
-	quicvarint.WriteVarInt(buf, clientSessionStateRevision)
-	quicvarint.WriteVarInt(buf, uint64(h.rttStats.SmoothedRTT().Microseconds()))
+	quicvarint.Write(buf, clientSessionStateRevision)
+	quicvarint.Write(buf, uint64(h.rttStats.SmoothedRTT().Microseconds()))
 	h.peerParams.MarshalForSessionTicket(buf)
 	return buf.Bytes()
 }
@@ -423,14 +423,14 @@ func (h *cryptoSetup) handleDataFromSessionState(data []byte) {
 
 func (h *cryptoSetup) handleDataFromSessionStateImpl(data []byte) (*wire.TransportParameters, error) {
 	r := bytes.NewReader(data)
-	ver, err := quicvarint.ReadVarInt(r)
+	ver, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
 	if ver != clientSessionStateRevision {
 		return nil, fmt.Errorf("mismatching version. Got %d, expected %d", ver, clientSessionStateRevision)
 	}
-	rtt, err := quicvarint.ReadVarInt(r)
+	rtt, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handshake/session_ticket.go
+++ b/internal/handshake/session_ticket.go
@@ -19,22 +19,22 @@ type sessionTicket struct {
 
 func (t *sessionTicket) Marshal() []byte {
 	b := &bytes.Buffer{}
-	quicvarint.WriteVarInt(b, sessionTicketRevision)
-	quicvarint.WriteVarInt(b, uint64(t.RTT.Microseconds()))
+	quicvarint.Write(b, sessionTicketRevision)
+	quicvarint.Write(b, uint64(t.RTT.Microseconds()))
 	t.Parameters.MarshalForSessionTicket(b)
 	return b.Bytes()
 }
 
 func (t *sessionTicket) Unmarshal(b []byte) error {
 	r := bytes.NewReader(b)
-	rev, err := quicvarint.ReadVarInt(r)
+	rev, err := quicvarint.Read(r)
 	if err != nil {
 		return errors.New("failed to read session ticket revision")
 	}
 	if rev != sessionTicketRevision {
 		return fmt.Errorf("unknown session ticket revision: %d", rev)
 	}
-	rtt, err := quicvarint.ReadVarInt(r)
+	rtt, err := quicvarint.Read(r)
 	if err != nil {
 		return errors.New("failed to read RTT")
 	}

--- a/internal/handshake/session_ticket.go
+++ b/internal/handshake/session_ticket.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/internal/wire"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 const sessionTicketRevision = 2
@@ -19,22 +19,22 @@ type sessionTicket struct {
 
 func (t *sessionTicket) Marshal() []byte {
 	b := &bytes.Buffer{}
-	utils.WriteVarInt(b, sessionTicketRevision)
-	utils.WriteVarInt(b, uint64(t.RTT.Microseconds()))
+	quicvarint.WriteVarInt(b, sessionTicketRevision)
+	quicvarint.WriteVarInt(b, uint64(t.RTT.Microseconds()))
 	t.Parameters.MarshalForSessionTicket(b)
 	return b.Bytes()
 }
 
 func (t *sessionTicket) Unmarshal(b []byte) error {
 	r := bytes.NewReader(b)
-	rev, err := utils.ReadVarInt(r)
+	rev, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return errors.New("failed to read session ticket revision")
 	}
 	if rev != sessionTicketRevision {
 		return fmt.Errorf("unknown session ticket revision: %d", rev)
 	}
-	rtt, err := utils.ReadVarInt(r)
+	rtt, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return errors.New("failed to read RTT")
 	}

--- a/internal/handshake/session_ticket_test.go
+++ b/internal/handshake/session_ticket_test.go
@@ -33,19 +33,19 @@ var _ = Describe("Session Ticket", func() {
 
 	It("refuses to unmarshal if the revision doesn't match", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, 1337)
+		quicvarint.Write(b, 1337)
 		Expect((&sessionTicket{}).Unmarshal(b.Bytes())).To(MatchError("unknown session ticket revision: 1337"))
 	})
 
 	It("refuses to unmarshal if the RTT cannot be read", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, sessionTicketRevision)
+		quicvarint.Write(b, sessionTicketRevision)
 		Expect((&sessionTicket{}).Unmarshal(b.Bytes())).To(MatchError("failed to read RTT"))
 	})
 
 	It("refuses to unmarshal if unmarshaling the transport parameters fails", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, sessionTicketRevision)
+		quicvarint.Write(b, sessionTicketRevision)
 		b.Write([]byte("foobar"))
 		err := (&sessionTicket{}).Unmarshal(b.Bytes())
 		Expect(err).To(HaveOccurred())

--- a/internal/handshake/session_ticket_test.go
+++ b/internal/handshake/session_ticket_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"time"
 
-	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/internal/wire"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,19 +33,19 @@ var _ = Describe("Session Ticket", func() {
 
 	It("refuses to unmarshal if the revision doesn't match", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, 1337)
+		quicvarint.WriteVarInt(b, 1337)
 		Expect((&sessionTicket{}).Unmarshal(b.Bytes())).To(MatchError("unknown session ticket revision: 1337"))
 	})
 
 	It("refuses to unmarshal if the RTT cannot be read", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, sessionTicketRevision)
+		quicvarint.WriteVarInt(b, sessionTicketRevision)
 		Expect((&sessionTicket{}).Unmarshal(b.Bytes())).To(MatchError("failed to read RTT"))
 	})
 
 	It("refuses to unmarshal if unmarshaling the transport parameters fails", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, sessionTicketRevision)
+		quicvarint.WriteVarInt(b, sessionTicketRevision)
 		b.Write([]byte("foobar"))
 		err := (&sessionTicket{}).Unmarshal(b.Bytes())
 		Expect(err).To(HaveOccurred())

--- a/internal/wire/ack_frame.go
+++ b/internal/wire/ack_frame.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 var errInvalidAckRanges = errors.New("AckFrame: ACK frame contains invalid ACK ranges")
@@ -30,12 +31,12 @@ func parseAckFrame(r *bytes.Reader, ackDelayExponent uint8, _ protocol.VersionNu
 
 	frame := &AckFrame{}
 
-	la, err := utils.ReadVarInt(r)
+	la, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
 	largestAcked := protocol.PacketNumber(la)
-	delay, err := utils.ReadVarInt(r)
+	delay, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -47,13 +48,13 @@ func parseAckFrame(r *bytes.Reader, ackDelayExponent uint8, _ protocol.VersionNu
 	}
 	frame.DelayTime = delayTime
 
-	numBlocks, err := utils.ReadVarInt(r)
+	numBlocks, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
 
 	// read the first ACK range
-	ab, err := utils.ReadVarInt(r)
+	ab, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +67,7 @@ func parseAckFrame(r *bytes.Reader, ackDelayExponent uint8, _ protocol.VersionNu
 	// read all the other ACK ranges
 	frame.AckRanges = append(frame.AckRanges, AckRange{Smallest: smallest, Largest: largestAcked})
 	for i := uint64(0); i < numBlocks; i++ {
-		g, err := utils.ReadVarInt(r)
+		g, err := quicvarint.ReadVarInt(r)
 		if err != nil {
 			return nil, err
 		}
@@ -76,7 +77,7 @@ func parseAckFrame(r *bytes.Reader, ackDelayExponent uint8, _ protocol.VersionNu
 		}
 		largest := smallest - gap - 2
 
-		ab, err := utils.ReadVarInt(r)
+		ab, err := quicvarint.ReadVarInt(r)
 		if err != nil {
 			return nil, err
 		}
@@ -96,7 +97,7 @@ func parseAckFrame(r *bytes.Reader, ackDelayExponent uint8, _ protocol.VersionNu
 	// parse (and skip) the ECN section
 	if ecn {
 		for i := 0; i < 3; i++ {
-			if _, err := utils.ReadVarInt(r); err != nil {
+			if _, err := quicvarint.ReadVarInt(r); err != nil {
 				return nil, err
 			}
 		}
@@ -113,27 +114,27 @@ func (f *AckFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	} else {
 		b.WriteByte(0x2)
 	}
-	utils.WriteVarInt(b, uint64(f.LargestAcked()))
-	utils.WriteVarInt(b, encodeAckDelay(f.DelayTime))
+	quicvarint.WriteVarInt(b, uint64(f.LargestAcked()))
+	quicvarint.WriteVarInt(b, encodeAckDelay(f.DelayTime))
 
 	numRanges := f.numEncodableAckRanges()
-	utils.WriteVarInt(b, uint64(numRanges-1))
+	quicvarint.WriteVarInt(b, uint64(numRanges-1))
 
 	// write the first range
 	_, firstRange := f.encodeAckRange(0)
-	utils.WriteVarInt(b, firstRange)
+	quicvarint.WriteVarInt(b, firstRange)
 
 	// write all the other range
 	for i := 1; i < numRanges; i++ {
 		gap, len := f.encodeAckRange(i)
-		utils.WriteVarInt(b, gap)
-		utils.WriteVarInt(b, len)
+		quicvarint.WriteVarInt(b, gap)
+		quicvarint.WriteVarInt(b, len)
 	}
 
 	if hasECN {
-		utils.WriteVarInt(b, f.ECT0)
-		utils.WriteVarInt(b, f.ECT1)
-		utils.WriteVarInt(b, f.ECNCE)
+		quicvarint.WriteVarInt(b, f.ECT0)
+		quicvarint.WriteVarInt(b, f.ECT1)
+		quicvarint.WriteVarInt(b, f.ECNCE)
 	}
 	return nil
 }
@@ -143,21 +144,21 @@ func (f *AckFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
 	largestAcked := f.AckRanges[0].Largest
 	numRanges := f.numEncodableAckRanges()
 
-	length := 1 + utils.VarIntLen(uint64(largestAcked)) + utils.VarIntLen(encodeAckDelay(f.DelayTime))
+	length := 1 + quicvarint.VarIntLen(uint64(largestAcked)) + quicvarint.VarIntLen(encodeAckDelay(f.DelayTime))
 
-	length += utils.VarIntLen(uint64(numRanges - 1))
+	length += quicvarint.VarIntLen(uint64(numRanges - 1))
 	lowestInFirstRange := f.AckRanges[0].Smallest
-	length += utils.VarIntLen(uint64(largestAcked - lowestInFirstRange))
+	length += quicvarint.VarIntLen(uint64(largestAcked - lowestInFirstRange))
 
 	for i := 1; i < numRanges; i++ {
 		gap, len := f.encodeAckRange(i)
-		length += utils.VarIntLen(gap)
-		length += utils.VarIntLen(len)
+		length += quicvarint.VarIntLen(gap)
+		length += quicvarint.VarIntLen(len)
 	}
 	if f.ECT0 > 0 || f.ECT1 > 0 || f.ECNCE > 0 {
-		length += utils.VarIntLen(f.ECT0)
-		length += utils.VarIntLen(f.ECT1)
-		length += utils.VarIntLen(f.ECNCE)
+		length += quicvarint.VarIntLen(f.ECT0)
+		length += quicvarint.VarIntLen(f.ECT1)
+		length += quicvarint.VarIntLen(f.ECNCE)
 	}
 	return length
 }
@@ -165,11 +166,11 @@ func (f *AckFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
 // gets the number of ACK ranges that can be encoded
 // such that the resulting frame is smaller than the maximum ACK frame size
 func (f *AckFrame) numEncodableAckRanges() int {
-	length := 1 + utils.VarIntLen(uint64(f.LargestAcked())) + utils.VarIntLen(encodeAckDelay(f.DelayTime))
+	length := 1 + quicvarint.VarIntLen(uint64(f.LargestAcked())) + quicvarint.VarIntLen(encodeAckDelay(f.DelayTime))
 	length += 2 // assume that the number of ranges will consume 2 bytes
 	for i := 1; i < len(f.AckRanges); i++ {
 		gap, len := f.encodeAckRange(i)
-		rangeLen := utils.VarIntLen(gap) + utils.VarIntLen(len)
+		rangeLen := quicvarint.VarIntLen(gap) + quicvarint.VarIntLen(len)
 		if length+rangeLen > protocol.MaxAckFrameSize {
 			// Writing range i would exceed the MaxAckFrameSize.
 			// So encode one range less than that.

--- a/internal/wire/connection_close_frame.go
+++ b/internal/wire/connection_close_frame.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qerr"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A ConnectionCloseFrame is a CONNECTION_CLOSE frame
@@ -24,21 +24,21 @@ func parseConnectionCloseFrame(r *bytes.Reader, _ protocol.VersionNumber) (*Conn
 	}
 
 	f := &ConnectionCloseFrame{IsApplicationError: typeByte == 0x1d}
-	ec, err := utils.ReadVarInt(r)
+	ec, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
 	f.ErrorCode = qerr.ErrorCode(ec)
 	// read the Frame Type, if this is not an application error
 	if !f.IsApplicationError {
-		ft, err := utils.ReadVarInt(r)
+		ft, err := quicvarint.ReadVarInt(r)
 		if err != nil {
 			return nil, err
 		}
 		f.FrameType = ft
 	}
 	var reasonPhraseLen uint64
-	reasonPhraseLen, err = utils.ReadVarInt(r)
+	reasonPhraseLen, err = quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -60,9 +60,9 @@ func parseConnectionCloseFrame(r *bytes.Reader, _ protocol.VersionNumber) (*Conn
 
 // Length of a written frame
 func (f *ConnectionCloseFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	length := 1 + utils.VarIntLen(uint64(f.ErrorCode)) + utils.VarIntLen(uint64(len(f.ReasonPhrase))) + protocol.ByteCount(len(f.ReasonPhrase))
+	length := 1 + quicvarint.VarIntLen(uint64(f.ErrorCode)) + quicvarint.VarIntLen(uint64(len(f.ReasonPhrase))) + protocol.ByteCount(len(f.ReasonPhrase))
 	if !f.IsApplicationError {
-		length += utils.VarIntLen(f.FrameType) // for the frame type
+		length += quicvarint.VarIntLen(f.FrameType) // for the frame type
 	}
 	return length
 }
@@ -74,11 +74,11 @@ func (f *ConnectionCloseFrame) Write(b *bytes.Buffer, version protocol.VersionNu
 		b.WriteByte(0x1c)
 	}
 
-	utils.WriteVarInt(b, uint64(f.ErrorCode))
+	quicvarint.WriteVarInt(b, uint64(f.ErrorCode))
 	if !f.IsApplicationError {
-		utils.WriteVarInt(b, f.FrameType)
+		quicvarint.WriteVarInt(b, f.FrameType)
 	}
-	utils.WriteVarInt(b, uint64(len(f.ReasonPhrase)))
+	quicvarint.WriteVarInt(b, uint64(len(f.ReasonPhrase)))
 	b.WriteString(f.ReasonPhrase)
 	return nil
 }

--- a/internal/wire/crypto_frame.go
+++ b/internal/wire/crypto_frame.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A CryptoFrame is a CRYPTO frame
@@ -20,12 +20,12 @@ func parseCryptoFrame(r *bytes.Reader, _ protocol.VersionNumber) (*CryptoFrame, 
 	}
 
 	frame := &CryptoFrame{}
-	offset, err := utils.ReadVarInt(r)
+	offset, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
 	frame.Offset = protocol.ByteCount(offset)
-	dataLen, err := utils.ReadVarInt(r)
+	dataLen, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -44,27 +44,27 @@ func parseCryptoFrame(r *bytes.Reader, _ protocol.VersionNumber) (*CryptoFrame, 
 
 func (f *CryptoFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x6)
-	utils.WriteVarInt(b, uint64(f.Offset))
-	utils.WriteVarInt(b, uint64(len(f.Data)))
+	quicvarint.WriteVarInt(b, uint64(f.Offset))
+	quicvarint.WriteVarInt(b, uint64(len(f.Data)))
 	b.Write(f.Data)
 	return nil
 }
 
 // Length of a written frame
 func (f *CryptoFrame) Length(_ protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(f.Offset)) + utils.VarIntLen(uint64(len(f.Data))) + protocol.ByteCount(len(f.Data))
+	return 1 + quicvarint.VarIntLen(uint64(f.Offset)) + quicvarint.VarIntLen(uint64(len(f.Data))) + protocol.ByteCount(len(f.Data))
 }
 
 // MaxDataLen returns the maximum data length
 func (f *CryptoFrame) MaxDataLen(maxSize protocol.ByteCount) protocol.ByteCount {
 	// pretend that the data size will be 1 bytes
 	// if it turns out that varint encoding the length will consume 2 bytes, we need to adjust the data length afterwards
-	headerLen := 1 + utils.VarIntLen(uint64(f.Offset)) + 1
+	headerLen := 1 + quicvarint.VarIntLen(uint64(f.Offset)) + 1
 	if headerLen > maxSize {
 		return 0
 	}
 	maxDataLen := maxSize - headerLen
-	if utils.VarIntLen(uint64(maxDataLen)) != 1 {
+	if quicvarint.VarIntLen(uint64(maxDataLen)) != 1 {
 		maxDataLen--
 	}
 	return maxDataLen

--- a/internal/wire/crypto_frame_test.go
+++ b/internal/wire/crypto_frame_test.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -99,7 +100,7 @@ var _ = Describe("CRYPTO frame", func() {
 				Offset: 0x1337,
 				Data:   []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + utils.VarIntLen(0x1337) + utils.VarIntLen(6) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(6) + 6))
 		})
 	})
 

--- a/internal/wire/crypto_frame_test.go
+++ b/internal/wire/crypto_frame_test.go
@@ -100,7 +100,7 @@ var _ = Describe("CRYPTO frame", func() {
 				Offset: 0x1337,
 				Data:   []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(6) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.Len(0x1337) + quicvarint.Len(6) + 6))
 		})
 	})
 

--- a/internal/wire/data_blocked_frame.go
+++ b/internal/wire/data_blocked_frame.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A DataBlockedFrame is a DATA_BLOCKED frame
@@ -16,7 +16,7 @@ func parseDataBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*DataBloc
 	if _, err := r.ReadByte(); err != nil {
 		return nil, err
 	}
-	offset, err := utils.ReadVarInt(r)
+	offset, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -28,11 +28,11 @@ func parseDataBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*DataBloc
 func (f *DataBlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
 	typeByte := uint8(0x14)
 	b.WriteByte(typeByte)
-	utils.WriteVarInt(b, uint64(f.MaximumData))
+	quicvarint.WriteVarInt(b, uint64(f.MaximumData))
 	return nil
 }
 
 // Length of a written frame
 func (f *DataBlockedFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(f.MaximumData))
+	return 1 + quicvarint.VarIntLen(uint64(f.MaximumData))
 }

--- a/internal/wire/data_blocked_frame.go
+++ b/internal/wire/data_blocked_frame.go
@@ -16,7 +16,7 @@ func parseDataBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*DataBloc
 	if _, err := r.ReadByte(); err != nil {
 		return nil, err
 	}
-	offset, err := quicvarint.ReadVarInt(r)
+	offset, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -28,11 +28,11 @@ func parseDataBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*DataBloc
 func (f *DataBlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
 	typeByte := uint8(0x14)
 	b.WriteByte(typeByte)
-	quicvarint.WriteVarInt(b, uint64(f.MaximumData))
+	quicvarint.Write(b, uint64(f.MaximumData))
 	return nil
 }
 
 // Length of a written frame
 func (f *DataBlockedFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(uint64(f.MaximumData))
+	return 1 + quicvarint.Len(uint64(f.MaximumData))
 }

--- a/internal/wire/data_blocked_frame_test.go
+++ b/internal/wire/data_blocked_frame_test.go
@@ -48,7 +48,7 @@ var _ = Describe("DATA_BLOCKED frame", func() {
 
 		It("has the correct min length", func() {
 			frame := DataBlockedFrame{MaximumData: 0x12345}
-			Expect(frame.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x12345)))
+			Expect(frame.Length(versionIETFFrames)).To(Equal(1 + quicvarint.Len(0x12345)))
 		})
 	})
 })

--- a/internal/wire/data_blocked_frame_test.go
+++ b/internal/wire/data_blocked_frame_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -48,7 +48,7 @@ var _ = Describe("DATA_BLOCKED frame", func() {
 
 		It("has the correct min length", func() {
 			frame := DataBlockedFrame{MaximumData: 0x12345}
-			Expect(frame.Length(versionIETFFrames)).To(Equal(1 + utils.VarIntLen(0x12345)))
+			Expect(frame.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x12345)))
 		})
 	})
 })

--- a/internal/wire/datagram_frame.go
+++ b/internal/wire/datagram_frame.go
@@ -26,7 +26,7 @@ func parseDatagramFrame(r *bytes.Reader, _ protocol.VersionNumber) (*DatagramFra
 	var length uint64
 	if f.DataLenPresent {
 		var err error
-		len, err := quicvarint.ReadVarInt(r)
+		len, err := quicvarint.Read(r)
 		if err != nil {
 			return nil, err
 		}
@@ -51,7 +51,7 @@ func (f *DatagramFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	}
 	b.WriteByte(typeByte)
 	if f.DataLenPresent {
-		quicvarint.WriteVarInt(b, uint64(len(f.Data)))
+		quicvarint.Write(b, uint64(len(f.Data)))
 	}
 	b.Write(f.Data)
 	return nil
@@ -69,7 +69,7 @@ func (f *DatagramFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.
 		return 0
 	}
 	maxDataLen := maxSize - headerLen
-	if f.DataLenPresent && quicvarint.VarIntLen(uint64(maxDataLen)) != 1 {
+	if f.DataLenPresent && quicvarint.Len(uint64(maxDataLen)) != 1 {
 		maxDataLen--
 	}
 	return maxDataLen
@@ -79,7 +79,7 @@ func (f *DatagramFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.
 func (f *DatagramFrame) Length(_ protocol.VersionNumber) protocol.ByteCount {
 	length := 1 + protocol.ByteCount(len(f.Data))
 	if f.DataLenPresent {
-		length += quicvarint.VarIntLen(uint64(len(f.Data)))
+		length += quicvarint.Len(uint64(len(f.Data)))
 	}
 	return length
 }

--- a/internal/wire/datagram_frame.go
+++ b/internal/wire/datagram_frame.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A DatagramFrame is a DATAGRAM frame
@@ -26,7 +26,7 @@ func parseDatagramFrame(r *bytes.Reader, _ protocol.VersionNumber) (*DatagramFra
 	var length uint64
 	if f.DataLenPresent {
 		var err error
-		len, err := utils.ReadVarInt(r)
+		len, err := quicvarint.ReadVarInt(r)
 		if err != nil {
 			return nil, err
 		}
@@ -51,7 +51,7 @@ func (f *DatagramFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	}
 	b.WriteByte(typeByte)
 	if f.DataLenPresent {
-		utils.WriteVarInt(b, uint64(len(f.Data)))
+		quicvarint.WriteVarInt(b, uint64(len(f.Data)))
 	}
 	b.Write(f.Data)
 	return nil
@@ -69,7 +69,7 @@ func (f *DatagramFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.
 		return 0
 	}
 	maxDataLen := maxSize - headerLen
-	if f.DataLenPresent && utils.VarIntLen(uint64(maxDataLen)) != 1 {
+	if f.DataLenPresent && quicvarint.VarIntLen(uint64(maxDataLen)) != 1 {
 		maxDataLen--
 	}
 	return maxDataLen
@@ -79,7 +79,7 @@ func (f *DatagramFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.
 func (f *DatagramFrame) Length(_ protocol.VersionNumber) protocol.ByteCount {
 	length := 1 + protocol.ByteCount(len(f.Data))
 	if f.DataLenPresent {
-		length += utils.VarIntLen(uint64(len(f.Data)))
+		length += quicvarint.VarIntLen(uint64(len(f.Data)))
 	}
 	return length
 }

--- a/internal/wire/datagram_frame_test.go
+++ b/internal/wire/datagram_frame_test.go
@@ -5,7 +5,8 @@ import (
 	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -87,7 +88,7 @@ var _ = Describe("STREAM frame", func() {
 				DataLenPresent: true,
 				Data:           []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + utils.VarIntLen(6) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(6) + 6))
 		})
 
 		It("has the right length for a frame without length", func() {

--- a/internal/wire/datagram_frame_test.go
+++ b/internal/wire/datagram_frame_test.go
@@ -88,7 +88,7 @@ var _ = Describe("STREAM frame", func() {
 				DataLenPresent: true,
 				Data:           []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(6) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.Len(6) + 6))
 		})
 
 		It("has the right length for a frame without length", func() {

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -159,10 +159,10 @@ func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, _ protocol.VersionNumb
 		b.Write(h.Token)
 		return nil
 	case protocol.PacketTypeInitial:
-		quicvarint.WriteVarInt(b, uint64(len(h.Token)))
+		quicvarint.Write(b, uint64(len(h.Token)))
 		b.Write(h.Token)
 	}
-	quicvarint.WriteVarIntWithLen(b, uint64(h.Length), 2)
+	quicvarint.WriteWithLen(b, uint64(h.Length), 2)
 	return h.writePacketNumber(b)
 }
 
@@ -203,7 +203,7 @@ func (h *ExtendedHeader) GetLength(v protocol.VersionNumber) protocol.ByteCount 
 	if h.IsLongHeader {
 		length := 1 /* type byte */ + 4 /* version */ + 1 /* dest conn ID len */ + protocol.ByteCount(h.DestConnectionID.Len()) + 1 /* src conn ID len */ + protocol.ByteCount(h.SrcConnectionID.Len()) + protocol.ByteCount(h.PacketNumberLen) + 2 /* length */
 		if h.Type == protocol.PacketTypeInitial {
-			length += quicvarint.VarIntLen(uint64(len(h.Token))) + protocol.ByteCount(len(h.Token))
+			length += quicvarint.Len(uint64(len(h.Token))) + protocol.ByteCount(len(h.Token))
 		}
 		return length
 	}

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // ErrInvalidReservedBits is returned when the reserved bits are incorrect.
@@ -158,10 +159,10 @@ func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, _ protocol.VersionNumb
 		b.Write(h.Token)
 		return nil
 	case protocol.PacketTypeInitial:
-		utils.WriteVarInt(b, uint64(len(h.Token)))
+		quicvarint.WriteVarInt(b, uint64(len(h.Token)))
 		b.Write(h.Token)
 	}
-	utils.WriteVarIntWithLen(b, uint64(h.Length), 2)
+	quicvarint.WriteVarIntWithLen(b, uint64(h.Length), 2)
 	return h.writePacketNumber(b)
 }
 
@@ -202,7 +203,7 @@ func (h *ExtendedHeader) GetLength(v protocol.VersionNumber) protocol.ByteCount 
 	if h.IsLongHeader {
 		length := 1 /* type byte */ + 4 /* version */ + 1 /* dest conn ID len */ + protocol.ByteCount(h.DestConnectionID.Len()) + 1 /* src conn ID len */ + protocol.ByteCount(h.SrcConnectionID.Len()) + protocol.ByteCount(h.PacketNumberLen) + 2 /* length */
 		if h.Type == protocol.PacketTypeInitial {
-			length += utils.VarIntLen(uint64(len(h.Token))) + protocol.ByteCount(len(h.Token))
+			length += quicvarint.VarIntLen(uint64(len(h.Token))) + protocol.ByteCount(len(h.Token))
 		}
 		return length
 	}

--- a/internal/wire/extended_header_test.go
+++ b/internal/wire/extended_header_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Header", func() {
 					PacketNumberLen: protocol.PacketNumberLen4,
 				}).Write(buf, versionIETFHeader)).To(Succeed())
 				b := &bytes.Buffer{}
-				quicvarint.WriteVarIntWithLen(b, 37, 2)
+				quicvarint.WriteWithLen(b, 37, 2)
 				Expect(buf.Bytes()[buf.Len()-6 : buf.Len()-4]).To(Equal(b.Bytes()))
 			})
 

--- a/internal/wire/extended_header_test.go
+++ b/internal/wire/extended_header_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -109,7 +111,7 @@ var _ = Describe("Header", func() {
 					PacketNumberLen: protocol.PacketNumberLen4,
 				}).Write(buf, versionIETFHeader)).To(Succeed())
 				b := &bytes.Buffer{}
-				utils.WriteVarIntWithLen(b, 37, 2)
+				quicvarint.WriteVarIntWithLen(b, 37, 2)
 				Expect(buf.Bytes()[buf.Len()-6 : buf.Len()-4]).To(Equal(b.Bytes()))
 			})
 

--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // ParseConnectionID parses the destination connection ID of a packet.
@@ -187,7 +188,7 @@ func (h *Header) parseLongHeader(b *bytes.Reader) error {
 	}
 
 	if h.Type == protocol.PacketTypeInitial {
-		tokenLen, err := utils.ReadVarInt(b)
+		tokenLen, err := quicvarint.ReadVarInt(b)
 		if err != nil {
 			return err
 		}
@@ -200,7 +201,7 @@ func (h *Header) parseLongHeader(b *bytes.Reader) error {
 		}
 	}
 
-	pl, err := utils.ReadVarInt(b)
+	pl, err := quicvarint.ReadVarInt(b)
 	if err != nil {
 		return err
 	}

--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -188,7 +188,7 @@ func (h *Header) parseLongHeader(b *bytes.Reader) error {
 	}
 
 	if h.Type == protocol.PacketTypeInitial {
-		tokenLen, err := quicvarint.ReadVarInt(b)
+		tokenLen, err := quicvarint.Read(b)
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ func (h *Header) parseLongHeader(b *bytes.Reader) error {
 		}
 	}
 
-	pl, err := quicvarint.ReadVarInt(b)
+	pl, err := quicvarint.Read(b)
 	if err != nil {
 		return err
 	}

--- a/internal/wire/max_data_frame.go
+++ b/internal/wire/max_data_frame.go
@@ -19,7 +19,7 @@ func parseMaxDataFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxDataFrame
 	}
 
 	frame := &MaxDataFrame{}
-	byteOffset, err := quicvarint.ReadVarInt(r)
+	byteOffset, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +30,11 @@ func parseMaxDataFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxDataFrame
 // Write writes a MAX_STREAM_DATA frame
 func (f *MaxDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
 	b.WriteByte(0x10)
-	quicvarint.WriteVarInt(b, uint64(f.MaximumData))
+	quicvarint.Write(b, uint64(f.MaximumData))
 	return nil
 }
 
 // Length of a written frame
 func (f *MaxDataFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(uint64(f.MaximumData))
+	return 1 + quicvarint.Len(uint64(f.MaximumData))
 }

--- a/internal/wire/max_data_frame.go
+++ b/internal/wire/max_data_frame.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A MaxDataFrame carries flow control information for the connection
@@ -19,7 +19,7 @@ func parseMaxDataFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxDataFrame
 	}
 
 	frame := &MaxDataFrame{}
-	byteOffset, err := utils.ReadVarInt(r)
+	byteOffset, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -30,11 +30,11 @@ func parseMaxDataFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxDataFrame
 // Write writes a MAX_STREAM_DATA frame
 func (f *MaxDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
 	b.WriteByte(0x10)
-	utils.WriteVarInt(b, uint64(f.MaximumData))
+	quicvarint.WriteVarInt(b, uint64(f.MaximumData))
 	return nil
 }
 
 // Length of a written frame
 func (f *MaxDataFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(f.MaximumData))
+	return 1 + quicvarint.VarIntLen(uint64(f.MaximumData))
 }

--- a/internal/wire/max_data_frame_test.go
+++ b/internal/wire/max_data_frame_test.go
@@ -39,7 +39,7 @@ var _ = Describe("MAX_DATA frame", func() {
 			f := &MaxDataFrame{
 				MaximumData: 0xdeadbeef,
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0xdeadbeef)))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.Len(0xdeadbeef)))
 		})
 
 		It("writes a MAX_DATA frame", func() {

--- a/internal/wire/max_data_frame_test.go
+++ b/internal/wire/max_data_frame_test.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -38,7 +39,7 @@ var _ = Describe("MAX_DATA frame", func() {
 			f := &MaxDataFrame{
 				MaximumData: 0xdeadbeef,
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + utils.VarIntLen(0xdeadbeef)))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0xdeadbeef)))
 		})
 
 		It("writes a MAX_DATA frame", func() {

--- a/internal/wire/max_stream_data_frame.go
+++ b/internal/wire/max_stream_data_frame.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A MaxStreamDataFrame is a MAX_STREAM_DATA frame
@@ -18,11 +18,11 @@ func parseMaxStreamDataFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxStr
 		return nil, err
 	}
 
-	sid, err := utils.ReadVarInt(r)
+	sid, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
-	offset, err := utils.ReadVarInt(r)
+	offset, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +35,12 @@ func parseMaxStreamDataFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxStr
 
 func (f *MaxStreamDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
 	b.WriteByte(0x11)
-	utils.WriteVarInt(b, uint64(f.StreamID))
-	utils.WriteVarInt(b, uint64(f.MaximumStreamData))
+	quicvarint.WriteVarInt(b, uint64(f.StreamID))
+	quicvarint.WriteVarInt(b, uint64(f.MaximumStreamData))
 	return nil
 }
 
 // Length of a written frame
 func (f *MaxStreamDataFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(f.StreamID)) + utils.VarIntLen(uint64(f.MaximumStreamData))
+	return 1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.MaximumStreamData))
 }

--- a/internal/wire/max_stream_data_frame.go
+++ b/internal/wire/max_stream_data_frame.go
@@ -18,11 +18,11 @@ func parseMaxStreamDataFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxStr
 		return nil, err
 	}
 
-	sid, err := quicvarint.ReadVarInt(r)
+	sid, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
-	offset, err := quicvarint.ReadVarInt(r)
+	offset, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +35,12 @@ func parseMaxStreamDataFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxStr
 
 func (f *MaxStreamDataFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
 	b.WriteByte(0x11)
-	quicvarint.WriteVarInt(b, uint64(f.StreamID))
-	quicvarint.WriteVarInt(b, uint64(f.MaximumStreamData))
+	quicvarint.Write(b, uint64(f.StreamID))
+	quicvarint.Write(b, uint64(f.MaximumStreamData))
 	return nil
 }
 
 // Length of a written frame
 func (f *MaxStreamDataFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.MaximumStreamData))
+	return 1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.MaximumStreamData))
 }

--- a/internal/wire/max_stream_data_frame_test.go
+++ b/internal/wire/max_stream_data_frame_test.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -42,7 +43,7 @@ var _ = Describe("MAX_STREAM_DATA frame", func() {
 				StreamID:          0x1337,
 				MaximumStreamData: 0xdeadbeef,
 			}
-			Expect(f.Length(protocol.VersionWhatever)).To(Equal(1 + utils.VarIntLen(uint64(f.StreamID)) + utils.VarIntLen(uint64(f.MaximumStreamData))))
+			Expect(f.Length(protocol.VersionWhatever)).To(Equal(1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.MaximumStreamData))))
 		})
 
 		It("writes a sample frame", func() {

--- a/internal/wire/max_stream_data_frame_test.go
+++ b/internal/wire/max_stream_data_frame_test.go
@@ -43,7 +43,7 @@ var _ = Describe("MAX_STREAM_DATA frame", func() {
 				StreamID:          0x1337,
 				MaximumStreamData: 0xdeadbeef,
 			}
-			Expect(f.Length(protocol.VersionWhatever)).To(Equal(1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.MaximumStreamData))))
+			Expect(f.Length(protocol.VersionWhatever)).To(Equal(1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.MaximumStreamData))))
 		})
 
 		It("writes a sample frame", func() {

--- a/internal/wire/max_streams_frame.go
+++ b/internal/wire/max_streams_frame.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A MaxStreamsFrame is a MAX_STREAMS frame
@@ -27,7 +27,7 @@ func parseMaxStreamsFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxStream
 	case 0x13:
 		f.Type = protocol.StreamTypeUni
 	}
-	streamID, err := utils.ReadVarInt(r)
+	streamID, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -45,11 +45,11 @@ func (f *MaxStreamsFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error
 	case protocol.StreamTypeUni:
 		b.WriteByte(0x13)
 	}
-	utils.WriteVarInt(b, uint64(f.MaxStreamNum))
+	quicvarint.WriteVarInt(b, uint64(f.MaxStreamNum))
 	return nil
 }
 
 // Length of a written frame
 func (f *MaxStreamsFrame) Length(protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(f.MaxStreamNum))
+	return 1 + quicvarint.VarIntLen(uint64(f.MaxStreamNum))
 }

--- a/internal/wire/max_streams_frame.go
+++ b/internal/wire/max_streams_frame.go
@@ -27,7 +27,7 @@ func parseMaxStreamsFrame(r *bytes.Reader, _ protocol.VersionNumber) (*MaxStream
 	case 0x13:
 		f.Type = protocol.StreamTypeUni
 	}
-	streamID, err := quicvarint.ReadVarInt(r)
+	streamID, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -45,11 +45,11 @@ func (f *MaxStreamsFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error
 	case protocol.StreamTypeUni:
 		b.WriteByte(0x13)
 	}
-	quicvarint.WriteVarInt(b, uint64(f.MaxStreamNum))
+	quicvarint.Write(b, uint64(f.MaxStreamNum))
 	return nil
 }
 
 // Length of a written frame
 func (f *MaxStreamsFrame) Length(protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(uint64(f.MaxStreamNum))
+	return 1 + quicvarint.Len(uint64(f.MaxStreamNum))
 }

--- a/internal/wire/max_streams_frame_test.go
+++ b/internal/wire/max_streams_frame_test.go
@@ -101,7 +101,7 @@ var _ = Describe("MAX_STREAMS frame", func() {
 
 		It("has the correct min length", func() {
 			frame := MaxStreamsFrame{MaxStreamNum: 0x1337}
-			Expect(frame.Length(protocol.VersionWhatever)).To(Equal(1 + quicvarint.VarIntLen(0x1337)))
+			Expect(frame.Length(protocol.VersionWhatever)).To(Equal(1 + quicvarint.Len(0x1337)))
 		})
 	})
 })

--- a/internal/wire/max_streams_frame_test.go
+++ b/internal/wire/max_streams_frame_test.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -100,7 +101,7 @@ var _ = Describe("MAX_STREAMS frame", func() {
 
 		It("has the correct min length", func() {
 			frame := MaxStreamsFrame{MaxStreamNum: 0x1337}
-			Expect(frame.Length(protocol.VersionWhatever)).To(Equal(1 + utils.VarIntLen(0x1337)))
+			Expect(frame.Length(protocol.VersionWhatever)).To(Equal(1 + quicvarint.VarIntLen(0x1337)))
 		})
 	})
 })

--- a/internal/wire/new_connection_id_frame.go
+++ b/internal/wire/new_connection_id_frame.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/lucas-clemente/quic-go/internal/utils"
-
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A NewConnectionIDFrame is a NEW_CONNECTION_ID frame
@@ -23,11 +22,11 @@ func parseNewConnectionIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*NewC
 		return nil, err
 	}
 
-	seq, err := utils.ReadVarInt(r)
+	seq, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
-	ret, err := utils.ReadVarInt(r)
+	ret, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -63,8 +62,8 @@ func parseNewConnectionIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*NewC
 
 func (f *NewConnectionIDFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x18)
-	utils.WriteVarInt(b, f.SequenceNumber)
-	utils.WriteVarInt(b, f.RetirePriorTo)
+	quicvarint.WriteVarInt(b, f.SequenceNumber)
+	quicvarint.WriteVarInt(b, f.RetirePriorTo)
 	connIDLen := f.ConnectionID.Len()
 	if connIDLen > protocol.MaxConnIDLen {
 		return fmt.Errorf("invalid connection ID length: %d", connIDLen)
@@ -77,5 +76,5 @@ func (f *NewConnectionIDFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) 
 
 // Length of a written frame
 func (f *NewConnectionIDFrame) Length(protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(f.SequenceNumber) + utils.VarIntLen(f.RetirePriorTo) + 1 /* connection ID length */ + protocol.ByteCount(f.ConnectionID.Len()) + 16
+	return 1 + quicvarint.VarIntLen(f.SequenceNumber) + quicvarint.VarIntLen(f.RetirePriorTo) + 1 /* connection ID length */ + protocol.ByteCount(f.ConnectionID.Len()) + 16
 }

--- a/internal/wire/new_connection_id_frame.go
+++ b/internal/wire/new_connection_id_frame.go
@@ -22,11 +22,11 @@ func parseNewConnectionIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*NewC
 		return nil, err
 	}
 
-	seq, err := quicvarint.ReadVarInt(r)
+	seq, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
-	ret, err := quicvarint.ReadVarInt(r)
+	ret, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +62,8 @@ func parseNewConnectionIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*NewC
 
 func (f *NewConnectionIDFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x18)
-	quicvarint.WriteVarInt(b, f.SequenceNumber)
-	quicvarint.WriteVarInt(b, f.RetirePriorTo)
+	quicvarint.Write(b, f.SequenceNumber)
+	quicvarint.Write(b, f.RetirePriorTo)
 	connIDLen := f.ConnectionID.Len()
 	if connIDLen > protocol.MaxConnIDLen {
 		return fmt.Errorf("invalid connection ID length: %d", connIDLen)
@@ -76,5 +76,5 @@ func (f *NewConnectionIDFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) 
 
 // Length of a written frame
 func (f *NewConnectionIDFrame) Length(protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(f.SequenceNumber) + quicvarint.VarIntLen(f.RetirePriorTo) + 1 /* connection ID length */ + protocol.ByteCount(f.ConnectionID.Len()) + 16
+	return 1 + quicvarint.Len(f.SequenceNumber) + quicvarint.Len(f.RetirePriorTo) + 1 /* connection ID length */ + protocol.ByteCount(f.ConnectionID.Len()) + 16
 }

--- a/internal/wire/new_token_frame.go
+++ b/internal/wire/new_token_frame.go
@@ -18,7 +18,7 @@ func parseNewTokenFrame(r *bytes.Reader, _ protocol.VersionNumber) (*NewTokenFra
 	if _, err := r.ReadByte(); err != nil {
 		return nil, err
 	}
-	tokenLen, err := quicvarint.ReadVarInt(r)
+	tokenLen, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -37,12 +37,12 @@ func parseNewTokenFrame(r *bytes.Reader, _ protocol.VersionNumber) (*NewTokenFra
 
 func (f *NewTokenFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x7)
-	quicvarint.WriteVarInt(b, uint64(len(f.Token)))
+	quicvarint.Write(b, uint64(len(f.Token)))
 	b.Write(f.Token)
 	return nil
 }
 
 // Length of a written frame
 func (f *NewTokenFrame) Length(protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(uint64(len(f.Token))) + protocol.ByteCount(len(f.Token))
+	return 1 + quicvarint.Len(uint64(len(f.Token))) + protocol.ByteCount(len(f.Token))
 }

--- a/internal/wire/new_token_frame.go
+++ b/internal/wire/new_token_frame.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A NewTokenFrame is a NEW_TOKEN frame
@@ -18,7 +18,7 @@ func parseNewTokenFrame(r *bytes.Reader, _ protocol.VersionNumber) (*NewTokenFra
 	if _, err := r.ReadByte(); err != nil {
 		return nil, err
 	}
-	tokenLen, err := utils.ReadVarInt(r)
+	tokenLen, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -37,12 +37,12 @@ func parseNewTokenFrame(r *bytes.Reader, _ protocol.VersionNumber) (*NewTokenFra
 
 func (f *NewTokenFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x7)
-	utils.WriteVarInt(b, uint64(len(f.Token)))
+	quicvarint.WriteVarInt(b, uint64(len(f.Token)))
 	b.Write(f.Token)
 	return nil
 }
 
 // Length of a written frame
 func (f *NewTokenFrame) Length(protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(len(f.Token))) + protocol.ByteCount(len(f.Token))
+	return 1 + quicvarint.VarIntLen(uint64(len(f.Token))) + protocol.ByteCount(len(f.Token))
 }

--- a/internal/wire/new_token_frame_test.go
+++ b/internal/wire/new_token_frame_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -60,7 +60,7 @@ var _ = Describe("NEW_TOKEN frame", func() {
 
 		It("has the correct min length", func() {
 			frame := &NewTokenFrame{Token: []byte("foobar")}
-			Expect(frame.Length(protocol.VersionWhatever)).To(Equal(1 + utils.VarIntLen(6) + 6))
+			Expect(frame.Length(protocol.VersionWhatever)).To(Equal(1 + quicvarint.VarIntLen(6) + 6))
 		})
 	})
 })

--- a/internal/wire/new_token_frame_test.go
+++ b/internal/wire/new_token_frame_test.go
@@ -60,7 +60,7 @@ var _ = Describe("NEW_TOKEN frame", func() {
 
 		It("has the correct min length", func() {
 			frame := &NewTokenFrame{Token: []byte("foobar")}
-			Expect(frame.Length(protocol.VersionWhatever)).To(Equal(1 + quicvarint.VarIntLen(6) + 6))
+			Expect(frame.Length(protocol.VersionWhatever)).To(Equal(1 + quicvarint.Len(6) + 6))
 		})
 	})
 })

--- a/internal/wire/reset_stream_frame.go
+++ b/internal/wire/reset_stream_frame.go
@@ -21,16 +21,16 @@ func parseResetStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*ResetStr
 
 	var streamID protocol.StreamID
 	var byteOffset protocol.ByteCount
-	sid, err := quicvarint.ReadVarInt(r)
+	sid, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
 	streamID = protocol.StreamID(sid)
-	errorCode, err := quicvarint.ReadVarInt(r)
+	errorCode, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
-	bo, err := quicvarint.ReadVarInt(r)
+	bo, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -45,13 +45,13 @@ func parseResetStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*ResetStr
 
 func (f *ResetStreamFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x4)
-	quicvarint.WriteVarInt(b, uint64(f.StreamID))
-	quicvarint.WriteVarInt(b, uint64(f.ErrorCode))
-	quicvarint.WriteVarInt(b, uint64(f.FinalSize))
+	quicvarint.Write(b, uint64(f.StreamID))
+	quicvarint.Write(b, uint64(f.ErrorCode))
+	quicvarint.Write(b, uint64(f.FinalSize))
 	return nil
 }
 
 // Length of a written frame
 func (f *ResetStreamFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.ErrorCode)) + quicvarint.VarIntLen(uint64(f.FinalSize))
+	return 1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.ErrorCode)) + quicvarint.Len(uint64(f.FinalSize))
 }

--- a/internal/wire/reset_stream_frame.go
+++ b/internal/wire/reset_stream_frame.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A ResetStreamFrame is a RESET_STREAM frame in QUIC
@@ -21,16 +21,16 @@ func parseResetStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*ResetStr
 
 	var streamID protocol.StreamID
 	var byteOffset protocol.ByteCount
-	sid, err := utils.ReadVarInt(r)
+	sid, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
 	streamID = protocol.StreamID(sid)
-	errorCode, err := utils.ReadVarInt(r)
+	errorCode, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
-	bo, err := utils.ReadVarInt(r)
+	bo, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -45,13 +45,13 @@ func parseResetStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*ResetStr
 
 func (f *ResetStreamFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x4)
-	utils.WriteVarInt(b, uint64(f.StreamID))
-	utils.WriteVarInt(b, uint64(f.ErrorCode))
-	utils.WriteVarInt(b, uint64(f.FinalSize))
+	quicvarint.WriteVarInt(b, uint64(f.StreamID))
+	quicvarint.WriteVarInt(b, uint64(f.ErrorCode))
+	quicvarint.WriteVarInt(b, uint64(f.FinalSize))
 	return nil
 }
 
 // Length of a written frame
 func (f *ResetStreamFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(f.StreamID)) + utils.VarIntLen(uint64(f.ErrorCode)) + utils.VarIntLen(uint64(f.FinalSize))
+	return 1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.ErrorCode)) + quicvarint.VarIntLen(uint64(f.FinalSize))
 }

--- a/internal/wire/reset_stream_frame_test.go
+++ b/internal/wire/reset_stream_frame_test.go
@@ -62,7 +62,7 @@ var _ = Describe("RESET_STREAM frame", func() {
 				FinalSize: 0x1234567,
 				ErrorCode: 0xde,
 			}
-			expectedLen := 1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(0x1234567) + 2
+			expectedLen := 1 + quicvarint.Len(0x1337) + quicvarint.Len(0x1234567) + 2
 			Expect(rst.Length(versionIETFFrames)).To(Equal(expectedLen))
 		})
 	})

--- a/internal/wire/reset_stream_frame_test.go
+++ b/internal/wire/reset_stream_frame_test.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -61,7 +62,7 @@ var _ = Describe("RESET_STREAM frame", func() {
 				FinalSize: 0x1234567,
 				ErrorCode: 0xde,
 			}
-			expectedLen := 1 + utils.VarIntLen(0x1337) + utils.VarIntLen(0x1234567) + 2
+			expectedLen := 1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(0x1234567) + 2
 			Expect(rst.Length(versionIETFFrames)).To(Equal(expectedLen))
 		})
 	})

--- a/internal/wire/retire_connection_id_frame.go
+++ b/internal/wire/retire_connection_id_frame.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A RetireConnectionIDFrame is a RETIRE_CONNECTION_ID frame
@@ -17,7 +17,7 @@ func parseRetireConnectionIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*R
 		return nil, err
 	}
 
-	seq, err := utils.ReadVarInt(r)
+	seq, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -26,11 +26,11 @@ func parseRetireConnectionIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*R
 
 func (f *RetireConnectionIDFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x19)
-	utils.WriteVarInt(b, f.SequenceNumber)
+	quicvarint.WriteVarInt(b, f.SequenceNumber)
 	return nil
 }
 
 // Length of a written frame
 func (f *RetireConnectionIDFrame) Length(protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(f.SequenceNumber)
+	return 1 + quicvarint.VarIntLen(f.SequenceNumber)
 }

--- a/internal/wire/retire_connection_id_frame.go
+++ b/internal/wire/retire_connection_id_frame.go
@@ -17,7 +17,7 @@ func parseRetireConnectionIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*R
 		return nil, err
 	}
 
-	seq, err := quicvarint.ReadVarInt(r)
+	seq, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -26,11 +26,11 @@ func parseRetireConnectionIDFrame(r *bytes.Reader, _ protocol.VersionNumber) (*R
 
 func (f *RetireConnectionIDFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x19)
-	quicvarint.WriteVarInt(b, f.SequenceNumber)
+	quicvarint.Write(b, f.SequenceNumber)
 	return nil
 }
 
 // Length of a written frame
 func (f *RetireConnectionIDFrame) Length(protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(f.SequenceNumber)
+	return 1 + quicvarint.Len(f.SequenceNumber)
 }

--- a/internal/wire/stop_sending_frame.go
+++ b/internal/wire/stop_sending_frame.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A StopSendingFrame is a STOP_SENDING frame
@@ -19,11 +19,11 @@ func parseStopSendingFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StopSend
 		return nil, err
 	}
 
-	streamID, err := utils.ReadVarInt(r)
+	streamID, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
-	errorCode, err := utils.ReadVarInt(r)
+	errorCode, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -36,12 +36,12 @@ func parseStopSendingFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StopSend
 
 // Length of a written frame
 func (f *StopSendingFrame) Length(_ protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(f.StreamID)) + utils.VarIntLen(uint64(f.ErrorCode))
+	return 1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.ErrorCode))
 }
 
 func (f *StopSendingFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x5)
-	utils.WriteVarInt(b, uint64(f.StreamID))
-	utils.WriteVarInt(b, uint64(f.ErrorCode))
+	quicvarint.WriteVarInt(b, uint64(f.StreamID))
+	quicvarint.WriteVarInt(b, uint64(f.ErrorCode))
 	return nil
 }

--- a/internal/wire/stop_sending_frame.go
+++ b/internal/wire/stop_sending_frame.go
@@ -19,11 +19,11 @@ func parseStopSendingFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StopSend
 		return nil, err
 	}
 
-	streamID, err := quicvarint.ReadVarInt(r)
+	streamID, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
-	errorCode, err := quicvarint.ReadVarInt(r)
+	errorCode, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -36,12 +36,12 @@ func parseStopSendingFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StopSend
 
 // Length of a written frame
 func (f *StopSendingFrame) Length(_ protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.ErrorCode))
+	return 1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.ErrorCode))
 }
 
 func (f *StopSendingFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) error {
 	b.WriteByte(0x5)
-	quicvarint.WriteVarInt(b, uint64(f.StreamID))
-	quicvarint.WriteVarInt(b, uint64(f.ErrorCode))
+	quicvarint.Write(b, uint64(f.StreamID))
+	quicvarint.Write(b, uint64(f.ErrorCode))
 	return nil
 }

--- a/internal/wire/stop_sending_frame_test.go
+++ b/internal/wire/stop_sending_frame_test.go
@@ -56,7 +56,7 @@ var _ = Describe("STOP_SENDING frame", func() {
 				StreamID:  0xdeadbeef,
 				ErrorCode: 0x1234567,
 			}
-			Expect(frame.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0xdeadbeef) + quicvarint.VarIntLen(0x1234567)))
+			Expect(frame.Length(versionIETFFrames)).To(Equal(1 + quicvarint.Len(0xdeadbeef) + quicvarint.Len(0x1234567)))
 		})
 	})
 })

--- a/internal/wire/stop_sending_frame_test.go
+++ b/internal/wire/stop_sending_frame_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -56,7 +56,7 @@ var _ = Describe("STOP_SENDING frame", func() {
 				StreamID:  0xdeadbeef,
 				ErrorCode: 0x1234567,
 			}
-			Expect(frame.Length(versionIETFFrames)).To(Equal(1 + utils.VarIntLen(0xdeadbeef) + utils.VarIntLen(0x1234567)))
+			Expect(frame.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0xdeadbeef) + quicvarint.VarIntLen(0x1234567)))
 		})
 	})
 })

--- a/internal/wire/stream_data_blocked_frame.go
+++ b/internal/wire/stream_data_blocked_frame.go
@@ -18,11 +18,11 @@ func parseStreamDataBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*St
 		return nil, err
 	}
 
-	sid, err := quicvarint.ReadVarInt(r)
+	sid, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
-	offset, err := quicvarint.ReadVarInt(r)
+	offset, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +35,12 @@ func parseStreamDataBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*St
 
 func (f *StreamDataBlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
 	b.WriteByte(0x15)
-	quicvarint.WriteVarInt(b, uint64(f.StreamID))
-	quicvarint.WriteVarInt(b, uint64(f.MaximumStreamData))
+	quicvarint.Write(b, uint64(f.StreamID))
+	quicvarint.Write(b, uint64(f.MaximumStreamData))
 	return nil
 }
 
 // Length of a written frame
 func (f *StreamDataBlockedFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.MaximumStreamData))
+	return 1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.MaximumStreamData))
 }

--- a/internal/wire/stream_data_blocked_frame.go
+++ b/internal/wire/stream_data_blocked_frame.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A StreamDataBlockedFrame is a STREAM_DATA_BLOCKED frame
@@ -18,11 +18,11 @@ func parseStreamDataBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*St
 		return nil, err
 	}
 
-	sid, err := utils.ReadVarInt(r)
+	sid, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
-	offset, err := utils.ReadVarInt(r)
+	offset, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +35,12 @@ func parseStreamDataBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*St
 
 func (f *StreamDataBlockedFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) error {
 	b.WriteByte(0x15)
-	utils.WriteVarInt(b, uint64(f.StreamID))
-	utils.WriteVarInt(b, uint64(f.MaximumStreamData))
+	quicvarint.WriteVarInt(b, uint64(f.StreamID))
+	quicvarint.WriteVarInt(b, uint64(f.MaximumStreamData))
 	return nil
 }
 
 // Length of a written frame
 func (f *StreamDataBlockedFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(f.StreamID)) + utils.VarIntLen(uint64(f.MaximumStreamData))
+	return 1 + quicvarint.VarIntLen(uint64(f.StreamID)) + quicvarint.VarIntLen(uint64(f.MaximumStreamData))
 }

--- a/internal/wire/stream_data_blocked_frame_test.go
+++ b/internal/wire/stream_data_blocked_frame_test.go
@@ -43,7 +43,7 @@ var _ = Describe("STREAM_DATA_BLOCKED frame", func() {
 				StreamID:          0x1337,
 				MaximumStreamData: 0xdeadbeef,
 			}
-			Expect(f.Length(0)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(0xdeadbeef)))
+			Expect(f.Length(0)).To(Equal(1 + quicvarint.Len(0x1337) + quicvarint.Len(0xdeadbeef)))
 		})
 
 		It("writes a sample frame", func() {

--- a/internal/wire/stream_data_blocked_frame_test.go
+++ b/internal/wire/stream_data_blocked_frame_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -43,7 +43,7 @@ var _ = Describe("STREAM_DATA_BLOCKED frame", func() {
 				StreamID:          0x1337,
 				MaximumStreamData: 0xdeadbeef,
 			}
-			Expect(f.Length(0)).To(Equal(1 + utils.VarIntLen(0x1337) + utils.VarIntLen(0xdeadbeef)))
+			Expect(f.Length(0)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(0xdeadbeef)))
 		})
 
 		It("writes a sample frame", func() {

--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -31,13 +31,13 @@ func parseStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StreamFrame, 
 	fin := typeByte&0x1 > 0
 	hasDataLen := typeByte&0x2 > 0
 
-	streamID, err := quicvarint.ReadVarInt(r)
+	streamID, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
 	var offset uint64
 	if hasOffset {
-		offset, err = quicvarint.ReadVarInt(r)
+		offset, err = quicvarint.Read(r)
 		if err != nil {
 			return nil, err
 		}
@@ -46,7 +46,7 @@ func parseStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StreamFrame, 
 	var dataLen uint64
 	if hasDataLen {
 		var err error
-		dataLen, err = quicvarint.ReadVarInt(r)
+		dataLen, err = quicvarint.Read(r)
 		if err != nil {
 			return nil, err
 		}
@@ -102,12 +102,12 @@ func (f *StreamFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) err
 		typeByte ^= 0x4
 	}
 	b.WriteByte(typeByte)
-	quicvarint.WriteVarInt(b, uint64(f.StreamID))
+	quicvarint.Write(b, uint64(f.StreamID))
 	if hasOffset {
-		quicvarint.WriteVarInt(b, uint64(f.Offset))
+		quicvarint.Write(b, uint64(f.Offset))
 	}
 	if f.DataLenPresent {
-		quicvarint.WriteVarInt(b, uint64(f.DataLen()))
+		quicvarint.Write(b, uint64(f.DataLen()))
 	}
 	b.Write(f.Data)
 	return nil
@@ -115,12 +115,12 @@ func (f *StreamFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) err
 
 // Length returns the total length of the STREAM frame
 func (f *StreamFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	length := 1 + quicvarint.VarIntLen(uint64(f.StreamID))
+	length := 1 + quicvarint.Len(uint64(f.StreamID))
 	if f.Offset != 0 {
-		length += quicvarint.VarIntLen(uint64(f.Offset))
+		length += quicvarint.Len(uint64(f.Offset))
 	}
 	if f.DataLenPresent {
-		length += quicvarint.VarIntLen(uint64(f.DataLen()))
+		length += quicvarint.Len(uint64(f.DataLen()))
 	}
 	return length + f.DataLen()
 }
@@ -133,9 +133,9 @@ func (f *StreamFrame) DataLen() protocol.ByteCount {
 // MaxDataLen returns the maximum data length
 // If 0 is returned, writing will fail (a STREAM frame must contain at least 1 byte of data).
 func (f *StreamFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.VersionNumber) protocol.ByteCount {
-	headerLen := 1 + quicvarint.VarIntLen(uint64(f.StreamID))
+	headerLen := 1 + quicvarint.Len(uint64(f.StreamID))
 	if f.Offset != 0 {
-		headerLen += quicvarint.VarIntLen(uint64(f.Offset))
+		headerLen += quicvarint.Len(uint64(f.Offset))
 	}
 	if f.DataLenPresent {
 		// pretend that the data size will be 1 bytes
@@ -146,7 +146,7 @@ func (f *StreamFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.Ve
 		return 0
 	}
 	maxDataLen := maxSize - headerLen
-	if f.DataLenPresent && quicvarint.VarIntLen(uint64(maxDataLen)) != 1 {
+	if f.DataLenPresent && quicvarint.Len(uint64(maxDataLen)) != 1 {
 		maxDataLen--
 	}
 	return maxDataLen

--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qerr"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A StreamFrame of QUIC
@@ -31,13 +31,13 @@ func parseStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StreamFrame, 
 	fin := typeByte&0x1 > 0
 	hasDataLen := typeByte&0x2 > 0
 
-	streamID, err := utils.ReadVarInt(r)
+	streamID, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
 	var offset uint64
 	if hasOffset {
-		offset, err = utils.ReadVarInt(r)
+		offset, err = quicvarint.ReadVarInt(r)
 		if err != nil {
 			return nil, err
 		}
@@ -46,7 +46,7 @@ func parseStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StreamFrame, 
 	var dataLen uint64
 	if hasDataLen {
 		var err error
-		dataLen, err = utils.ReadVarInt(r)
+		dataLen, err = quicvarint.ReadVarInt(r)
 		if err != nil {
 			return nil, err
 		}
@@ -102,12 +102,12 @@ func (f *StreamFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) err
 		typeByte ^= 0x4
 	}
 	b.WriteByte(typeByte)
-	utils.WriteVarInt(b, uint64(f.StreamID))
+	quicvarint.WriteVarInt(b, uint64(f.StreamID))
 	if hasOffset {
-		utils.WriteVarInt(b, uint64(f.Offset))
+		quicvarint.WriteVarInt(b, uint64(f.Offset))
 	}
 	if f.DataLenPresent {
-		utils.WriteVarInt(b, uint64(f.DataLen()))
+		quicvarint.WriteVarInt(b, uint64(f.DataLen()))
 	}
 	b.Write(f.Data)
 	return nil
@@ -115,12 +115,12 @@ func (f *StreamFrame) Write(b *bytes.Buffer, version protocol.VersionNumber) err
 
 // Length returns the total length of the STREAM frame
 func (f *StreamFrame) Length(version protocol.VersionNumber) protocol.ByteCount {
-	length := 1 + utils.VarIntLen(uint64(f.StreamID))
+	length := 1 + quicvarint.VarIntLen(uint64(f.StreamID))
 	if f.Offset != 0 {
-		length += utils.VarIntLen(uint64(f.Offset))
+		length += quicvarint.VarIntLen(uint64(f.Offset))
 	}
 	if f.DataLenPresent {
-		length += utils.VarIntLen(uint64(f.DataLen()))
+		length += quicvarint.VarIntLen(uint64(f.DataLen()))
 	}
 	return length + f.DataLen()
 }
@@ -133,9 +133,9 @@ func (f *StreamFrame) DataLen() protocol.ByteCount {
 // MaxDataLen returns the maximum data length
 // If 0 is returned, writing will fail (a STREAM frame must contain at least 1 byte of data).
 func (f *StreamFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.VersionNumber) protocol.ByteCount {
-	headerLen := 1 + utils.VarIntLen(uint64(f.StreamID))
+	headerLen := 1 + quicvarint.VarIntLen(uint64(f.StreamID))
 	if f.Offset != 0 {
-		headerLen += utils.VarIntLen(uint64(f.Offset))
+		headerLen += quicvarint.VarIntLen(uint64(f.Offset))
 	}
 	if f.DataLenPresent {
 		// pretend that the data size will be 1 bytes
@@ -146,7 +146,7 @@ func (f *StreamFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.Ve
 		return 0
 	}
 	maxDataLen := maxSize - headerLen
-	if f.DataLenPresent && utils.VarIntLen(uint64(maxDataLen)) != 1 {
+	if f.DataLenPresent && quicvarint.VarIntLen(uint64(maxDataLen)) != 1 {
 		maxDataLen--
 	}
 	return maxDataLen

--- a/internal/wire/stream_frame_test.go
+++ b/internal/wire/stream_frame_test.go
@@ -236,7 +236,7 @@ var _ = Describe("STREAM frame", func() {
 				StreamID: 0x1337,
 				Data:     []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.Len(0x1337) + 6))
 		})
 
 		It("has the right length for a frame with offset", func() {
@@ -245,7 +245,7 @@ var _ = Describe("STREAM frame", func() {
 				Offset:   0x42,
 				Data:     []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(0x42) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.Len(0x1337) + quicvarint.Len(0x42) + 6))
 		})
 
 		It("has the right length for a frame with data length", func() {
@@ -255,7 +255,7 @@ var _ = Describe("STREAM frame", func() {
 				DataLenPresent: true,
 				Data:           []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(0x1234567) + quicvarint.VarIntLen(6) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.Len(0x1337) + quicvarint.Len(0x1234567) + quicvarint.Len(6) + 6))
 		})
 	})
 

--- a/internal/wire/stream_frame_test.go
+++ b/internal/wire/stream_frame_test.go
@@ -5,7 +5,8 @@ import (
 	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -235,7 +236,7 @@ var _ = Describe("STREAM frame", func() {
 				StreamID: 0x1337,
 				Data:     []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + utils.VarIntLen(0x1337) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + 6))
 		})
 
 		It("has the right length for a frame with offset", func() {
@@ -244,7 +245,7 @@ var _ = Describe("STREAM frame", func() {
 				Offset:   0x42,
 				Data:     []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + utils.VarIntLen(0x1337) + utils.VarIntLen(0x42) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(0x42) + 6))
 		})
 
 		It("has the right length for a frame with data length", func() {
@@ -254,7 +255,7 @@ var _ = Describe("STREAM frame", func() {
 				DataLenPresent: true,
 				Data:           []byte("foobar"),
 			}
-			Expect(f.Length(versionIETFFrames)).To(Equal(1 + utils.VarIntLen(0x1337) + utils.VarIntLen(0x1234567) + utils.VarIntLen(6) + 6))
+			Expect(f.Length(versionIETFFrames)).To(Equal(1 + quicvarint.VarIntLen(0x1337) + quicvarint.VarIntLen(0x1234567) + quicvarint.VarIntLen(6) + 6))
 		})
 	})
 

--- a/internal/wire/streams_blocked_frame.go
+++ b/internal/wire/streams_blocked_frame.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A StreamsBlockedFrame is a STREAMS_BLOCKED frame
@@ -27,7 +27,7 @@ func parseStreamsBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*Strea
 	case 0x17:
 		f.Type = protocol.StreamTypeUni
 	}
-	streamLimit, err := utils.ReadVarInt(r)
+	streamLimit, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return nil, err
 	}
@@ -45,11 +45,11 @@ func (f *StreamsBlockedFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) e
 	case protocol.StreamTypeUni:
 		b.WriteByte(0x17)
 	}
-	utils.WriteVarInt(b, uint64(f.StreamLimit))
+	quicvarint.WriteVarInt(b, uint64(f.StreamLimit))
 	return nil
 }
 
 // Length of a written frame
 func (f *StreamsBlockedFrame) Length(_ protocol.VersionNumber) protocol.ByteCount {
-	return 1 + utils.VarIntLen(uint64(f.StreamLimit))
+	return 1 + quicvarint.VarIntLen(uint64(f.StreamLimit))
 }

--- a/internal/wire/streams_blocked_frame.go
+++ b/internal/wire/streams_blocked_frame.go
@@ -27,7 +27,7 @@ func parseStreamsBlockedFrame(r *bytes.Reader, _ protocol.VersionNumber) (*Strea
 	case 0x17:
 		f.Type = protocol.StreamTypeUni
 	}
-	streamLimit, err := quicvarint.ReadVarInt(r)
+	streamLimit, err := quicvarint.Read(r)
 	if err != nil {
 		return nil, err
 	}
@@ -45,11 +45,11 @@ func (f *StreamsBlockedFrame) Write(b *bytes.Buffer, _ protocol.VersionNumber) e
 	case protocol.StreamTypeUni:
 		b.WriteByte(0x17)
 	}
-	quicvarint.WriteVarInt(b, uint64(f.StreamLimit))
+	quicvarint.Write(b, uint64(f.StreamLimit))
 	return nil
 }
 
 // Length of a written frame
 func (f *StreamsBlockedFrame) Length(_ protocol.VersionNumber) protocol.ByteCount {
-	return 1 + quicvarint.VarIntLen(uint64(f.StreamLimit))
+	return 1 + quicvarint.Len(uint64(f.StreamLimit))
 }

--- a/internal/wire/streams_blocked_frame_test.go
+++ b/internal/wire/streams_blocked_frame_test.go
@@ -102,7 +102,7 @@ var _ = Describe("STREAMS_BLOCKED frame", func() {
 
 		It("has the correct min length", func() {
 			frame := StreamsBlockedFrame{StreamLimit: 0x123456}
-			Expect(frame.Length(0)).To(Equal(protocol.ByteCount(1) + quicvarint.VarIntLen(0x123456)))
+			Expect(frame.Length(0)).To(Equal(protocol.ByteCount(1) + quicvarint.Len(0x123456)))
 		})
 	})
 })

--- a/internal/wire/streams_blocked_frame_test.go
+++ b/internal/wire/streams_blocked_frame_test.go
@@ -6,7 +6,8 @@ import (
 	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -101,7 +102,7 @@ var _ = Describe("STREAMS_BLOCKED frame", func() {
 
 		It("has the correct min length", func() {
 			frame := StreamsBlockedFrame{StreamLimit: 0x123456}
-			Expect(frame.Length(0)).To(Equal(protocol.ByteCount(1) + utils.VarIntLen(0x123456)))
+			Expect(frame.Length(0)).To(Equal(protocol.ByteCount(1) + quicvarint.VarIntLen(0x123456)))
 		})
 	})
 })

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -34,8 +34,8 @@ var _ = Describe("Transport Parameters", func() {
 	})
 
 	addInitialSourceConnectionID := func(b *bytes.Buffer) {
-		quicvarint.WriteVarInt(b, uint64(initialSourceConnectionIDParameterID))
-		quicvarint.WriteVarInt(b, 6)
+		quicvarint.Write(b, uint64(initialSourceConnectionIDParameterID))
+		quicvarint.Write(b, 6)
 		b.Write([]byte("foobar"))
 	}
 
@@ -144,32 +144,32 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors when the stateless_reset_token has the wrong length", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, uint64(statelessResetTokenParameterID))
-		quicvarint.WriteVarInt(b, 15)
+		quicvarint.Write(b, uint64(statelessResetTokenParameterID))
+		quicvarint.Write(b, 15)
 		b.Write(make([]byte, 15))
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: wrong length for stateless_reset_token: 15 (expected 16)"))
 	})
 
 	It("errors when the max_packet_size is too small", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, uint64(maxUDPPayloadSizeParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(1199)))
-		quicvarint.WriteVarInt(b, 1199)
+		quicvarint.Write(b, uint64(maxUDPPayloadSizeParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(1199)))
+		quicvarint.Write(b, 1199)
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: invalid value for max_packet_size: 1199 (minimum 1200)"))
 	})
 
 	It("errors when disable_active_migration has content", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, uint64(disableActiveMigrationParameterID))
-		quicvarint.WriteVarInt(b, 6)
+		quicvarint.Write(b, uint64(disableActiveMigrationParameterID))
+		quicvarint.Write(b, 6)
 		b.Write([]byte("foobar"))
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: wrong length for disable_active_migration: 6 (expected empty)"))
 	})
 
 	It("errors when the server doesn't set the original_destination_connection_id", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, uint64(statelessResetTokenParameterID))
-		quicvarint.WriteVarInt(b, 16)
+		quicvarint.Write(b, uint64(statelessResetTokenParameterID))
+		quicvarint.Write(b, 16)
 		b.Write(make([]byte, 16))
 		addInitialSourceConnectionID(b)
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: missing original_destination_connection_id"))
@@ -205,7 +205,7 @@ var _ = Describe("Transport Parameters", func() {
 			}).Marshal(protocol.PerspectiveServer)
 			dataLen += len(data)
 		}
-		entryLen := quicvarint.VarIntLen(uint64(ackDelayExponentParameterID)) /* parameter id */ + quicvarint.VarIntLen(uint64(quicvarint.VarIntLen(uint64(maxAckDelay.Milliseconds())))) /*length */ + quicvarint.VarIntLen(uint64(maxAckDelay.Milliseconds())) /* value */
+		entryLen := quicvarint.Len(uint64(ackDelayExponentParameterID)) /* parameter id */ + quicvarint.Len(uint64(quicvarint.Len(uint64(maxAckDelay.Milliseconds())))) /*length */ + quicvarint.Len(uint64(maxAckDelay.Milliseconds())) /* value */
 		Expect(float32(dataLen) / num).To(BeNumerically("~", float32(defaultLen)/num+float32(entryLen), 1))
 	})
 
@@ -234,7 +234,7 @@ var _ = Describe("Transport Parameters", func() {
 			}).Marshal(protocol.PerspectiveServer)
 			dataLen += len(data)
 		}
-		entryLen := quicvarint.VarIntLen(uint64(ackDelayExponentParameterID)) /* parameter id */ + quicvarint.VarIntLen(uint64(quicvarint.VarIntLen(protocol.DefaultAckDelayExponent+1))) /* length */ + quicvarint.VarIntLen(protocol.DefaultAckDelayExponent+1) /* value */
+		entryLen := quicvarint.Len(uint64(ackDelayExponentParameterID)) /* parameter id */ + quicvarint.Len(uint64(quicvarint.Len(protocol.DefaultAckDelayExponent+1))) /* length */ + quicvarint.Len(protocol.DefaultAckDelayExponent+1) /* value */
 		Expect(float32(dataLen) / num).To(BeNumerically("~", float32(defaultLen)/num+float32(entryLen), 1))
 	})
 
@@ -250,11 +250,11 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors when the varint value has the wrong length", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
-		quicvarint.WriteVarInt(b, 2)
+		quicvarint.Write(b, uint64(initialMaxStreamDataBidiLocalParameterID))
+		quicvarint.Write(b, 2)
 		val := uint64(0xdeadbeef)
-		Expect(quicvarint.VarIntLen(val)).ToNot(BeEquivalentTo(2))
-		quicvarint.WriteVarInt(b, val)
+		Expect(quicvarint.Len(val)).ToNot(BeEquivalentTo(2))
+		quicvarint.Write(b, val)
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)
 		Expect(err).To(HaveOccurred())
@@ -263,9 +263,9 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors if initial_max_streams_bidi is too large", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, uint64(initialMaxStreamsBidiParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(uint64(protocol.MaxStreamCount+1))))
-		quicvarint.WriteVarInt(b, uint64(protocol.MaxStreamCount+1))
+		quicvarint.Write(b, uint64(initialMaxStreamsBidiParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(uint64(protocol.MaxStreamCount+1))))
+		quicvarint.Write(b, uint64(protocol.MaxStreamCount+1))
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)
 		Expect(err).To(HaveOccurred())
@@ -274,9 +274,9 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors if initial_max_streams_uni is too large", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, uint64(initialMaxStreamsUniParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(uint64(protocol.MaxStreamCount+1))))
-		quicvarint.WriteVarInt(b, uint64(protocol.MaxStreamCount+1))
+		quicvarint.Write(b, uint64(initialMaxStreamsUniParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(uint64(protocol.MaxStreamCount+1))))
+		quicvarint.Write(b, uint64(protocol.MaxStreamCount+1))
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)
 		Expect(err).To(HaveOccurred())
@@ -286,9 +286,9 @@ var _ = Describe("Transport Parameters", func() {
 	It("handles huge max_ack_delay values", func() {
 		b := &bytes.Buffer{}
 		val := uint64(math.MaxUint64) / 5
-		quicvarint.WriteVarInt(b, uint64(maxAckDelayParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(val)))
-		quicvarint.WriteVarInt(b, val)
+		quicvarint.Write(b, uint64(maxAckDelayParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(val)))
+		quicvarint.Write(b, val)
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveClient)
 		Expect(err).To(HaveOccurred())
@@ -298,17 +298,17 @@ var _ = Describe("Transport Parameters", func() {
 	It("skips unknown parameters", func() {
 		b := &bytes.Buffer{}
 		// write a known parameter
-		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x1337)))
-		quicvarint.WriteVarInt(b, 0x1337)
+		quicvarint.Write(b, uint64(initialMaxStreamDataBidiLocalParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(0x1337)))
+		quicvarint.Write(b, 0x1337)
 		// write an unknown parameter
-		quicvarint.WriteVarInt(b, 0x42)
-		quicvarint.WriteVarInt(b, 6)
+		quicvarint.Write(b, 0x42)
+		quicvarint.Write(b, 6)
 		b.Write([]byte("foobar"))
 		// write a known parameter
-		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiRemoteParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x42)))
-		quicvarint.WriteVarInt(b, 0x42)
+		quicvarint.Write(b, uint64(initialMaxStreamDataBidiRemoteParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(0x42)))
+		quicvarint.Write(b, 0x42)
 		addInitialSourceConnectionID(b)
 		p := &TransportParameters{}
 		Expect(p.Unmarshal(b.Bytes(), protocol.PerspectiveClient)).To(Succeed())
@@ -319,17 +319,17 @@ var _ = Describe("Transport Parameters", func() {
 	It("rejects duplicate parameters", func() {
 		b := &bytes.Buffer{}
 		// write first parameter
-		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x1337)))
-		quicvarint.WriteVarInt(b, 0x1337)
+		quicvarint.Write(b, uint64(initialMaxStreamDataBidiLocalParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(0x1337)))
+		quicvarint.Write(b, 0x1337)
 		// write a second parameter
-		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiRemoteParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x42)))
-		quicvarint.WriteVarInt(b, 0x42)
+		quicvarint.Write(b, uint64(initialMaxStreamDataBidiRemoteParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(0x42)))
+		quicvarint.Write(b, 0x42)
 		// write first parameter again
-		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x1337)))
-		quicvarint.WriteVarInt(b, 0x1337)
+		quicvarint.Write(b, uint64(initialMaxStreamDataBidiLocalParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(0x1337)))
+		quicvarint.Write(b, 0x1337)
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveClient)
 		Expect(err).To(HaveOccurred())
@@ -338,8 +338,8 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors if there's not enough data to read", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, 0x42)
-		quicvarint.WriteVarInt(b, 7)
+		quicvarint.Write(b, 0x42)
+		quicvarint.Write(b, 7)
 		b.Write([]byte("foobar"))
 		p := &TransportParameters{}
 		Expect(p.Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: remaining length (6) smaller than parameter length (7)"))
@@ -347,16 +347,16 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors if the client sent a stateless_reset_token", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, uint64(statelessResetTokenParameterID))
-		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(16)))
+		quicvarint.Write(b, uint64(statelessResetTokenParameterID))
+		quicvarint.Write(b, uint64(quicvarint.Len(16)))
 		b.Write(make([]byte, 16))
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveClient)).To(MatchError("TRANSPORT_PARAMETER_ERROR: client sent a stateless_reset_token"))
 	})
 
 	It("errors if the client sent the original_destination_connection_id", func() {
 		b := &bytes.Buffer{}
-		quicvarint.WriteVarInt(b, uint64(originalDestinationConnectionIDParameterID))
-		quicvarint.WriteVarInt(b, 6)
+		quicvarint.Write(b, uint64(originalDestinationConnectionIDParameterID))
+		quicvarint.Write(b, 6)
 		b.Write([]byte("foobar"))
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveClient)).To(MatchError("TRANSPORT_PARAMETER_ERROR: client sent an original_destination_connection_id"))
 	})
@@ -392,8 +392,8 @@ var _ = Describe("Transport Parameters", func() {
 
 		It("errors if the client sent a preferred_address", func() {
 			b := &bytes.Buffer{}
-			quicvarint.WriteVarInt(b, uint64(preferredAddressParameterID))
-			quicvarint.WriteVarInt(b, 6)
+			quicvarint.Write(b, uint64(preferredAddressParameterID))
+			quicvarint.Write(b, 6)
 			b.Write([]byte("foobar"))
 			p := &TransportParameters{}
 			Expect(p.Unmarshal(b.Bytes(), protocol.PerspectiveClient)).To(MatchError("TRANSPORT_PARAMETER_ERROR: client sent a preferred_address"))
@@ -432,7 +432,7 @@ var _ = Describe("Transport Parameters", func() {
 			}
 			for i := 1; i < len(raw); i++ {
 				buf := &bytes.Buffer{}
-				quicvarint.WriteVarInt(buf, uint64(preferredAddressParameterID))
+				quicvarint.Write(buf, uint64(preferredAddressParameterID))
 				buf.Write(raw[:i])
 				p := &TransportParameters{}
 				Expect(p.Unmarshal(buf.Bytes(), protocol.PerspectiveServer)).ToNot(Succeed())
@@ -476,8 +476,8 @@ var _ = Describe("Transport Parameters", func() {
 			p.MarshalForSessionTicket(buf)
 			data := buf.Bytes()
 			b := &bytes.Buffer{}
-			quicvarint.WriteVarInt(b, transportParameterMarshalingVersion+1)
-			b.Write(data[quicvarint.VarIntLen(transportParameterMarshalingVersion):])
+			quicvarint.Write(b, transportParameterMarshalingVersion+1)
+			b.Write(data[quicvarint.Len(transportParameterMarshalingVersion):])
 			Expect(p.UnmarshalFromSessionTicket(bytes.NewReader(b.Bytes()))).To(MatchError(fmt.Sprintf("unknown transport parameter marshaling version: %d", transportParameterMarshalingVersion+1)))
 		})
 

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -9,7 +9,8 @@ import (
 	"time"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -33,8 +34,8 @@ var _ = Describe("Transport Parameters", func() {
 	})
 
 	addInitialSourceConnectionID := func(b *bytes.Buffer) {
-		utils.WriteVarInt(b, uint64(initialSourceConnectionIDParameterID))
-		utils.WriteVarInt(b, 6)
+		quicvarint.WriteVarInt(b, uint64(initialSourceConnectionIDParameterID))
+		quicvarint.WriteVarInt(b, 6)
 		b.Write([]byte("foobar"))
 	}
 
@@ -143,32 +144,32 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors when the stateless_reset_token has the wrong length", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(statelessResetTokenParameterID))
-		utils.WriteVarInt(b, 15)
+		quicvarint.WriteVarInt(b, uint64(statelessResetTokenParameterID))
+		quicvarint.WriteVarInt(b, 15)
 		b.Write(make([]byte, 15))
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: wrong length for stateless_reset_token: 15 (expected 16)"))
 	})
 
 	It("errors when the max_packet_size is too small", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(maxUDPPayloadSizeParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(1199)))
-		utils.WriteVarInt(b, 1199)
+		quicvarint.WriteVarInt(b, uint64(maxUDPPayloadSizeParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(1199)))
+		quicvarint.WriteVarInt(b, 1199)
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: invalid value for max_packet_size: 1199 (minimum 1200)"))
 	})
 
 	It("errors when disable_active_migration has content", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(disableActiveMigrationParameterID))
-		utils.WriteVarInt(b, 6)
+		quicvarint.WriteVarInt(b, uint64(disableActiveMigrationParameterID))
+		quicvarint.WriteVarInt(b, 6)
 		b.Write([]byte("foobar"))
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: wrong length for disable_active_migration: 6 (expected empty)"))
 	})
 
 	It("errors when the server doesn't set the original_destination_connection_id", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(statelessResetTokenParameterID))
-		utils.WriteVarInt(b, 16)
+		quicvarint.WriteVarInt(b, uint64(statelessResetTokenParameterID))
+		quicvarint.WriteVarInt(b, 16)
 		b.Write(make([]byte, 16))
 		addInitialSourceConnectionID(b)
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: missing original_destination_connection_id"))
@@ -204,7 +205,7 @@ var _ = Describe("Transport Parameters", func() {
 			}).Marshal(protocol.PerspectiveServer)
 			dataLen += len(data)
 		}
-		entryLen := utils.VarIntLen(uint64(ackDelayExponentParameterID)) /* parameter id */ + utils.VarIntLen(uint64(utils.VarIntLen(uint64(maxAckDelay.Milliseconds())))) /*length */ + utils.VarIntLen(uint64(maxAckDelay.Milliseconds())) /* value */
+		entryLen := quicvarint.VarIntLen(uint64(ackDelayExponentParameterID)) /* parameter id */ + quicvarint.VarIntLen(uint64(quicvarint.VarIntLen(uint64(maxAckDelay.Milliseconds())))) /*length */ + quicvarint.VarIntLen(uint64(maxAckDelay.Milliseconds())) /* value */
 		Expect(float32(dataLen) / num).To(BeNumerically("~", float32(defaultLen)/num+float32(entryLen), 1))
 	})
 
@@ -233,7 +234,7 @@ var _ = Describe("Transport Parameters", func() {
 			}).Marshal(protocol.PerspectiveServer)
 			dataLen += len(data)
 		}
-		entryLen := utils.VarIntLen(uint64(ackDelayExponentParameterID)) /* parameter id */ + utils.VarIntLen(uint64(utils.VarIntLen(protocol.DefaultAckDelayExponent+1))) /* length */ + utils.VarIntLen(protocol.DefaultAckDelayExponent+1) /* value */
+		entryLen := quicvarint.VarIntLen(uint64(ackDelayExponentParameterID)) /* parameter id */ + quicvarint.VarIntLen(uint64(quicvarint.VarIntLen(protocol.DefaultAckDelayExponent+1))) /* length */ + quicvarint.VarIntLen(protocol.DefaultAckDelayExponent+1) /* value */
 		Expect(float32(dataLen) / num).To(BeNumerically("~", float32(defaultLen)/num+float32(entryLen), 1))
 	})
 
@@ -249,11 +250,11 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors when the varint value has the wrong length", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
-		utils.WriteVarInt(b, 2)
+		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
+		quicvarint.WriteVarInt(b, 2)
 		val := uint64(0xdeadbeef)
-		Expect(utils.VarIntLen(val)).ToNot(BeEquivalentTo(2))
-		utils.WriteVarInt(b, val)
+		Expect(quicvarint.VarIntLen(val)).ToNot(BeEquivalentTo(2))
+		quicvarint.WriteVarInt(b, val)
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)
 		Expect(err).To(HaveOccurred())
@@ -262,9 +263,9 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors if initial_max_streams_bidi is too large", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(initialMaxStreamsBidiParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(uint64(protocol.MaxStreamCount+1))))
-		utils.WriteVarInt(b, uint64(protocol.MaxStreamCount+1))
+		quicvarint.WriteVarInt(b, uint64(initialMaxStreamsBidiParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(uint64(protocol.MaxStreamCount+1))))
+		quicvarint.WriteVarInt(b, uint64(protocol.MaxStreamCount+1))
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)
 		Expect(err).To(HaveOccurred())
@@ -273,9 +274,9 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors if initial_max_streams_uni is too large", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(initialMaxStreamsUniParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(uint64(protocol.MaxStreamCount+1))))
-		utils.WriteVarInt(b, uint64(protocol.MaxStreamCount+1))
+		quicvarint.WriteVarInt(b, uint64(initialMaxStreamsUniParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(uint64(protocol.MaxStreamCount+1))))
+		quicvarint.WriteVarInt(b, uint64(protocol.MaxStreamCount+1))
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveServer)
 		Expect(err).To(HaveOccurred())
@@ -285,9 +286,9 @@ var _ = Describe("Transport Parameters", func() {
 	It("handles huge max_ack_delay values", func() {
 		b := &bytes.Buffer{}
 		val := uint64(math.MaxUint64) / 5
-		utils.WriteVarInt(b, uint64(maxAckDelayParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(val)))
-		utils.WriteVarInt(b, val)
+		quicvarint.WriteVarInt(b, uint64(maxAckDelayParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(val)))
+		quicvarint.WriteVarInt(b, val)
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveClient)
 		Expect(err).To(HaveOccurred())
@@ -297,17 +298,17 @@ var _ = Describe("Transport Parameters", func() {
 	It("skips unknown parameters", func() {
 		b := &bytes.Buffer{}
 		// write a known parameter
-		utils.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(0x1337)))
-		utils.WriteVarInt(b, 0x1337)
+		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x1337)))
+		quicvarint.WriteVarInt(b, 0x1337)
 		// write an unknown parameter
-		utils.WriteVarInt(b, 0x42)
-		utils.WriteVarInt(b, 6)
+		quicvarint.WriteVarInt(b, 0x42)
+		quicvarint.WriteVarInt(b, 6)
 		b.Write([]byte("foobar"))
 		// write a known parameter
-		utils.WriteVarInt(b, uint64(initialMaxStreamDataBidiRemoteParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(0x42)))
-		utils.WriteVarInt(b, 0x42)
+		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiRemoteParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x42)))
+		quicvarint.WriteVarInt(b, 0x42)
 		addInitialSourceConnectionID(b)
 		p := &TransportParameters{}
 		Expect(p.Unmarshal(b.Bytes(), protocol.PerspectiveClient)).To(Succeed())
@@ -318,17 +319,17 @@ var _ = Describe("Transport Parameters", func() {
 	It("rejects duplicate parameters", func() {
 		b := &bytes.Buffer{}
 		// write first parameter
-		utils.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(0x1337)))
-		utils.WriteVarInt(b, 0x1337)
+		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x1337)))
+		quicvarint.WriteVarInt(b, 0x1337)
 		// write a second parameter
-		utils.WriteVarInt(b, uint64(initialMaxStreamDataBidiRemoteParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(0x42)))
-		utils.WriteVarInt(b, 0x42)
+		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiRemoteParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x42)))
+		quicvarint.WriteVarInt(b, 0x42)
 		// write first parameter again
-		utils.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(0x1337)))
-		utils.WriteVarInt(b, 0x1337)
+		quicvarint.WriteVarInt(b, uint64(initialMaxStreamDataBidiLocalParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(0x1337)))
+		quicvarint.WriteVarInt(b, 0x1337)
 		addInitialSourceConnectionID(b)
 		err := (&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveClient)
 		Expect(err).To(HaveOccurred())
@@ -337,8 +338,8 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors if there's not enough data to read", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, 0x42)
-		utils.WriteVarInt(b, 7)
+		quicvarint.WriteVarInt(b, 0x42)
+		quicvarint.WriteVarInt(b, 7)
 		b.Write([]byte("foobar"))
 		p := &TransportParameters{}
 		Expect(p.Unmarshal(b.Bytes(), protocol.PerspectiveServer)).To(MatchError("TRANSPORT_PARAMETER_ERROR: remaining length (6) smaller than parameter length (7)"))
@@ -346,16 +347,16 @@ var _ = Describe("Transport Parameters", func() {
 
 	It("errors if the client sent a stateless_reset_token", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(statelessResetTokenParameterID))
-		utils.WriteVarInt(b, uint64(utils.VarIntLen(16)))
+		quicvarint.WriteVarInt(b, uint64(statelessResetTokenParameterID))
+		quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(16)))
 		b.Write(make([]byte, 16))
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveClient)).To(MatchError("TRANSPORT_PARAMETER_ERROR: client sent a stateless_reset_token"))
 	})
 
 	It("errors if the client sent the original_destination_connection_id", func() {
 		b := &bytes.Buffer{}
-		utils.WriteVarInt(b, uint64(originalDestinationConnectionIDParameterID))
-		utils.WriteVarInt(b, 6)
+		quicvarint.WriteVarInt(b, uint64(originalDestinationConnectionIDParameterID))
+		quicvarint.WriteVarInt(b, 6)
 		b.Write([]byte("foobar"))
 		Expect((&TransportParameters{}).Unmarshal(b.Bytes(), protocol.PerspectiveClient)).To(MatchError("TRANSPORT_PARAMETER_ERROR: client sent an original_destination_connection_id"))
 	})
@@ -391,8 +392,8 @@ var _ = Describe("Transport Parameters", func() {
 
 		It("errors if the client sent a preferred_address", func() {
 			b := &bytes.Buffer{}
-			utils.WriteVarInt(b, uint64(preferredAddressParameterID))
-			utils.WriteVarInt(b, 6)
+			quicvarint.WriteVarInt(b, uint64(preferredAddressParameterID))
+			quicvarint.WriteVarInt(b, 6)
 			b.Write([]byte("foobar"))
 			p := &TransportParameters{}
 			Expect(p.Unmarshal(b.Bytes(), protocol.PerspectiveClient)).To(MatchError("TRANSPORT_PARAMETER_ERROR: client sent a preferred_address"))
@@ -431,7 +432,7 @@ var _ = Describe("Transport Parameters", func() {
 			}
 			for i := 1; i < len(raw); i++ {
 				buf := &bytes.Buffer{}
-				utils.WriteVarInt(buf, uint64(preferredAddressParameterID))
+				quicvarint.WriteVarInt(buf, uint64(preferredAddressParameterID))
 				buf.Write(raw[:i])
 				p := &TransportParameters{}
 				Expect(p.Unmarshal(buf.Bytes(), protocol.PerspectiveServer)).ToNot(Succeed())
@@ -475,8 +476,8 @@ var _ = Describe("Transport Parameters", func() {
 			p.MarshalForSessionTicket(buf)
 			data := buf.Bytes()
 			b := &bytes.Buffer{}
-			utils.WriteVarInt(b, transportParameterMarshalingVersion+1)
-			b.Write(data[utils.VarIntLen(transportParameterMarshalingVersion):])
+			quicvarint.WriteVarInt(b, transportParameterMarshalingVersion+1)
+			b.Write(data[quicvarint.VarIntLen(transportParameterMarshalingVersion):])
 			Expect(p.UnmarshalFromSessionTicket(bytes.NewReader(b.Bytes()))).To(MatchError(fmt.Sprintf("unknown transport parameter marshaling version: %d", transportParameterMarshalingVersion+1)))
 		})
 

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -10,10 +10,10 @@ import (
 	"sort"
 	"time"
 
-	"github.com/lucas-clemente/quic-go/internal/qerr"
-
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 const transportParameterMarshalingVersion = 1
@@ -109,12 +109,12 @@ func (p *TransportParameters) unmarshal(r *bytes.Reader, sentBy protocol.Perspec
 	p.MaxDatagramFrameSize = protocol.InvalidByteCount
 
 	for r.Len() > 0 {
-		paramIDInt, err := utils.ReadVarInt(r)
+		paramIDInt, err := quicvarint.ReadVarInt(r)
 		if err != nil {
 			return err
 		}
 		paramID := transportParameterID(paramIDInt)
-		paramLen, err := utils.ReadVarInt(r)
+		paramLen, err := quicvarint.ReadVarInt(r)
 		if err != nil {
 			return err
 		}
@@ -260,7 +260,7 @@ func (p *TransportParameters) readNumericTransportParameter(
 	expectedLen int,
 ) error {
 	remainingLen := r.Len()
-	val, err := utils.ReadVarInt(r)
+	val, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return fmt.Errorf("error while reading transport parameter %d: %s", paramID, err)
 	}
@@ -323,11 +323,11 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 	b := &bytes.Buffer{}
 
 	// add a greased value
-	utils.WriteVarInt(b, uint64(27+31*rand.Intn(100)))
+	quicvarint.WriteVarInt(b, uint64(27+31*rand.Intn(100)))
 	length := rand.Intn(16)
 	randomData := make([]byte, length)
 	rand.Read(randomData)
-	utils.WriteVarInt(b, uint64(length))
+	quicvarint.WriteVarInt(b, uint64(length))
 	b.Write(randomData)
 
 	// initial_max_stream_data_bidi_local
@@ -358,24 +358,24 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 	}
 	// disable_active_migration
 	if p.DisableActiveMigration {
-		utils.WriteVarInt(b, uint64(disableActiveMigrationParameterID))
-		utils.WriteVarInt(b, 0)
+		quicvarint.WriteVarInt(b, uint64(disableActiveMigrationParameterID))
+		quicvarint.WriteVarInt(b, 0)
 	}
 	if pers == protocol.PerspectiveServer {
 		// stateless_reset_token
 		if p.StatelessResetToken != nil {
-			utils.WriteVarInt(b, uint64(statelessResetTokenParameterID))
-			utils.WriteVarInt(b, 16)
+			quicvarint.WriteVarInt(b, uint64(statelessResetTokenParameterID))
+			quicvarint.WriteVarInt(b, 16)
 			b.Write(p.StatelessResetToken[:])
 		}
 		// original_destination_connection_id
-		utils.WriteVarInt(b, uint64(originalDestinationConnectionIDParameterID))
-		utils.WriteVarInt(b, uint64(p.OriginalDestinationConnectionID.Len()))
+		quicvarint.WriteVarInt(b, uint64(originalDestinationConnectionIDParameterID))
+		quicvarint.WriteVarInt(b, uint64(p.OriginalDestinationConnectionID.Len()))
 		b.Write(p.OriginalDestinationConnectionID.Bytes())
 		// preferred_address
 		if p.PreferredAddress != nil {
-			utils.WriteVarInt(b, uint64(preferredAddressParameterID))
-			utils.WriteVarInt(b, 4+2+16+2+1+uint64(p.PreferredAddress.ConnectionID.Len())+16)
+			quicvarint.WriteVarInt(b, uint64(preferredAddressParameterID))
+			quicvarint.WriteVarInt(b, 4+2+16+2+1+uint64(p.PreferredAddress.ConnectionID.Len())+16)
 			ipv4 := p.PreferredAddress.IPv4
 			b.Write(ipv4[len(ipv4)-4:])
 			utils.BigEndian.WriteUint16(b, p.PreferredAddress.IPv4Port)
@@ -389,13 +389,13 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 	// active_connection_id_limit
 	p.marshalVarintParam(b, activeConnectionIDLimitParameterID, p.ActiveConnectionIDLimit)
 	// initial_source_connection_id
-	utils.WriteVarInt(b, uint64(initialSourceConnectionIDParameterID))
-	utils.WriteVarInt(b, uint64(p.InitialSourceConnectionID.Len()))
+	quicvarint.WriteVarInt(b, uint64(initialSourceConnectionIDParameterID))
+	quicvarint.WriteVarInt(b, uint64(p.InitialSourceConnectionID.Len()))
 	b.Write(p.InitialSourceConnectionID.Bytes())
 	// retry_source_connection_id
 	if pers == protocol.PerspectiveServer && p.RetrySourceConnectionID != nil {
-		utils.WriteVarInt(b, uint64(retrySourceConnectionIDParameterID))
-		utils.WriteVarInt(b, uint64(p.RetrySourceConnectionID.Len()))
+		quicvarint.WriteVarInt(b, uint64(retrySourceConnectionIDParameterID))
+		quicvarint.WriteVarInt(b, uint64(p.RetrySourceConnectionID.Len()))
 		b.Write(p.RetrySourceConnectionID.Bytes())
 	}
 	if p.MaxDatagramFrameSize != protocol.InvalidByteCount {
@@ -405,9 +405,9 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 }
 
 func (p *TransportParameters) marshalVarintParam(b *bytes.Buffer, id transportParameterID, val uint64) {
-	utils.WriteVarInt(b, uint64(id))
-	utils.WriteVarInt(b, uint64(utils.VarIntLen(val)))
-	utils.WriteVarInt(b, val)
+	quicvarint.WriteVarInt(b, uint64(id))
+	quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(val)))
+	quicvarint.WriteVarInt(b, val)
 }
 
 // MarshalForSessionTicket marshals the transport parameters we save in the session ticket.
@@ -419,7 +419,7 @@ func (p *TransportParameters) marshalVarintParam(b *bytes.Buffer, id transportPa
 // Since the session ticket is encrypted, the serialization format is defined by the server.
 // For convenience, we use the same format that we also use for sending the transport parameters.
 func (p *TransportParameters) MarshalForSessionTicket(b *bytes.Buffer) {
-	utils.WriteVarInt(b, transportParameterMarshalingVersion)
+	quicvarint.WriteVarInt(b, transportParameterMarshalingVersion)
 
 	// initial_max_stream_data_bidi_local
 	p.marshalVarintParam(b, initialMaxStreamDataBidiLocalParameterID, uint64(p.InitialMaxStreamDataBidiLocal))
@@ -439,7 +439,7 @@ func (p *TransportParameters) MarshalForSessionTicket(b *bytes.Buffer) {
 
 // UnmarshalFromSessionTicket unmarshals transport parameters from a session ticket.
 func (p *TransportParameters) UnmarshalFromSessionTicket(r *bytes.Reader) error {
-	version, err := utils.ReadVarInt(r)
+	version, err := quicvarint.ReadVarInt(r)
 	if err != nil {
 		return err
 	}

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -109,12 +109,12 @@ func (p *TransportParameters) unmarshal(r *bytes.Reader, sentBy protocol.Perspec
 	p.MaxDatagramFrameSize = protocol.InvalidByteCount
 
 	for r.Len() > 0 {
-		paramIDInt, err := quicvarint.ReadVarInt(r)
+		paramIDInt, err := quicvarint.Read(r)
 		if err != nil {
 			return err
 		}
 		paramID := transportParameterID(paramIDInt)
-		paramLen, err := quicvarint.ReadVarInt(r)
+		paramLen, err := quicvarint.Read(r)
 		if err != nil {
 			return err
 		}
@@ -260,7 +260,7 @@ func (p *TransportParameters) readNumericTransportParameter(
 	expectedLen int,
 ) error {
 	remainingLen := r.Len()
-	val, err := quicvarint.ReadVarInt(r)
+	val, err := quicvarint.Read(r)
 	if err != nil {
 		return fmt.Errorf("error while reading transport parameter %d: %s", paramID, err)
 	}
@@ -323,11 +323,11 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 	b := &bytes.Buffer{}
 
 	// add a greased value
-	quicvarint.WriteVarInt(b, uint64(27+31*rand.Intn(100)))
+	quicvarint.Write(b, uint64(27+31*rand.Intn(100)))
 	length := rand.Intn(16)
 	randomData := make([]byte, length)
 	rand.Read(randomData)
-	quicvarint.WriteVarInt(b, uint64(length))
+	quicvarint.Write(b, uint64(length))
 	b.Write(randomData)
 
 	// initial_max_stream_data_bidi_local
@@ -358,24 +358,24 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 	}
 	// disable_active_migration
 	if p.DisableActiveMigration {
-		quicvarint.WriteVarInt(b, uint64(disableActiveMigrationParameterID))
-		quicvarint.WriteVarInt(b, 0)
+		quicvarint.Write(b, uint64(disableActiveMigrationParameterID))
+		quicvarint.Write(b, 0)
 	}
 	if pers == protocol.PerspectiveServer {
 		// stateless_reset_token
 		if p.StatelessResetToken != nil {
-			quicvarint.WriteVarInt(b, uint64(statelessResetTokenParameterID))
-			quicvarint.WriteVarInt(b, 16)
+			quicvarint.Write(b, uint64(statelessResetTokenParameterID))
+			quicvarint.Write(b, 16)
 			b.Write(p.StatelessResetToken[:])
 		}
 		// original_destination_connection_id
-		quicvarint.WriteVarInt(b, uint64(originalDestinationConnectionIDParameterID))
-		quicvarint.WriteVarInt(b, uint64(p.OriginalDestinationConnectionID.Len()))
+		quicvarint.Write(b, uint64(originalDestinationConnectionIDParameterID))
+		quicvarint.Write(b, uint64(p.OriginalDestinationConnectionID.Len()))
 		b.Write(p.OriginalDestinationConnectionID.Bytes())
 		// preferred_address
 		if p.PreferredAddress != nil {
-			quicvarint.WriteVarInt(b, uint64(preferredAddressParameterID))
-			quicvarint.WriteVarInt(b, 4+2+16+2+1+uint64(p.PreferredAddress.ConnectionID.Len())+16)
+			quicvarint.Write(b, uint64(preferredAddressParameterID))
+			quicvarint.Write(b, 4+2+16+2+1+uint64(p.PreferredAddress.ConnectionID.Len())+16)
 			ipv4 := p.PreferredAddress.IPv4
 			b.Write(ipv4[len(ipv4)-4:])
 			utils.BigEndian.WriteUint16(b, p.PreferredAddress.IPv4Port)
@@ -389,13 +389,13 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 	// active_connection_id_limit
 	p.marshalVarintParam(b, activeConnectionIDLimitParameterID, p.ActiveConnectionIDLimit)
 	// initial_source_connection_id
-	quicvarint.WriteVarInt(b, uint64(initialSourceConnectionIDParameterID))
-	quicvarint.WriteVarInt(b, uint64(p.InitialSourceConnectionID.Len()))
+	quicvarint.Write(b, uint64(initialSourceConnectionIDParameterID))
+	quicvarint.Write(b, uint64(p.InitialSourceConnectionID.Len()))
 	b.Write(p.InitialSourceConnectionID.Bytes())
 	// retry_source_connection_id
 	if pers == protocol.PerspectiveServer && p.RetrySourceConnectionID != nil {
-		quicvarint.WriteVarInt(b, uint64(retrySourceConnectionIDParameterID))
-		quicvarint.WriteVarInt(b, uint64(p.RetrySourceConnectionID.Len()))
+		quicvarint.Write(b, uint64(retrySourceConnectionIDParameterID))
+		quicvarint.Write(b, uint64(p.RetrySourceConnectionID.Len()))
 		b.Write(p.RetrySourceConnectionID.Bytes())
 	}
 	if p.MaxDatagramFrameSize != protocol.InvalidByteCount {
@@ -405,9 +405,9 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 }
 
 func (p *TransportParameters) marshalVarintParam(b *bytes.Buffer, id transportParameterID, val uint64) {
-	quicvarint.WriteVarInt(b, uint64(id))
-	quicvarint.WriteVarInt(b, uint64(quicvarint.VarIntLen(val)))
-	quicvarint.WriteVarInt(b, val)
+	quicvarint.Write(b, uint64(id))
+	quicvarint.Write(b, uint64(quicvarint.Len(val)))
+	quicvarint.Write(b, val)
 }
 
 // MarshalForSessionTicket marshals the transport parameters we save in the session ticket.
@@ -419,7 +419,7 @@ func (p *TransportParameters) marshalVarintParam(b *bytes.Buffer, id transportPa
 // Since the session ticket is encrypted, the serialization format is defined by the server.
 // For convenience, we use the same format that we also use for sending the transport parameters.
 func (p *TransportParameters) MarshalForSessionTicket(b *bytes.Buffer) {
-	quicvarint.WriteVarInt(b, transportParameterMarshalingVersion)
+	quicvarint.Write(b, transportParameterMarshalingVersion)
 
 	// initial_max_stream_data_bidi_local
 	p.marshalVarintParam(b, initialMaxStreamDataBidiLocalParameterID, uint64(p.InitialMaxStreamDataBidiLocal))
@@ -439,7 +439,7 @@ func (p *TransportParameters) MarshalForSessionTicket(b *bytes.Buffer) {
 
 // UnmarshalFromSessionTicket unmarshals transport parameters from a session ticket.
 func (p *TransportParameters) UnmarshalFromSessionTicket(r *bytes.Reader) error {
-	version, err := quicvarint.ReadVarInt(r)
+	version, err := quicvarint.Read(r)
 	if err != nil {
 		return err
 	}

--- a/internal/wire/wire_suite_test.go
+++ b/internal/wire/wire_suite_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/utils"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -22,6 +23,6 @@ const (
 
 func encodeVarInt(i uint64) []byte {
 	b := &bytes.Buffer{}
-	utils.WriteVarInt(b, i)
+	quicvarint.WriteVarInt(b, i)
 	return b.Bytes()
 }

--- a/internal/wire/wire_suite_test.go
+++ b/internal/wire/wire_suite_test.go
@@ -23,6 +23,6 @@ const (
 
 func encodeVarInt(i uint64) []byte {
 	b := &bytes.Buffer{}
-	quicvarint.WriteVarInt(b, i)
+	quicvarint.Write(b, i)
 	return b.Bytes()
 }

--- a/quicvarint/quicvarint_suite_test.go
+++ b/quicvarint/quicvarint_suite_test.go
@@ -1,0 +1,13 @@
+package quicvarint_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestQuicVarint(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "QUIC Varint Suite")
+}

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -1,4 +1,4 @@
-package utils
+package quicvarint
 
 import (
 	"bytes"

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -16,8 +16,8 @@ const (
 	maxVarInt8 = 4611686018427387903
 )
 
-// ReadVarInt reads a number in the QUIC varint format
-func ReadVarInt(b io.ByteReader) (uint64, error) {
+// Read reads a number in the QUIC varint format
+func Read(b io.ByteReader) (uint64, error) {
 	firstByte, err := b.ReadByte()
 	if err != nil {
 		return 0, err
@@ -65,8 +65,8 @@ func ReadVarInt(b io.ByteReader) (uint64, error) {
 	return uint64(b8) + uint64(b7)<<8 + uint64(b6)<<16 + uint64(b5)<<24 + uint64(b4)<<32 + uint64(b3)<<40 + uint64(b2)<<48 + uint64(b1)<<56, nil
 }
 
-// WriteVarInt writes a number in the QUIC varint format
-func WriteVarInt(b *bytes.Buffer, i uint64) {
+// Write writes a number in the QUIC varint format
+func Write(b *bytes.Buffer, i uint64) {
 	if i <= maxVarInt1 {
 		b.WriteByte(uint8(i))
 	} else if i <= maxVarInt2 {
@@ -83,14 +83,14 @@ func WriteVarInt(b *bytes.Buffer, i uint64) {
 	}
 }
 
-// WriteVarIntWithLen writes a number in the QUIC varint format, with the desired length.
-func WriteVarIntWithLen(b *bytes.Buffer, i uint64, length protocol.ByteCount) {
+// WriteWithLen writes a number in the QUIC varint format, with the desired length.
+func WriteWithLen(b *bytes.Buffer, i uint64, length protocol.ByteCount) {
 	if length != 1 && length != 2 && length != 4 && length != 8 {
 		panic("invalid varint length")
 	}
-	l := VarIntLen(i)
+	l := Len(i)
 	if l == length {
-		WriteVarInt(b, i)
+		Write(b, i)
 		return
 	}
 	if l > length {
@@ -111,8 +111,8 @@ func WriteVarIntWithLen(b *bytes.Buffer, i uint64, length protocol.ByteCount) {
 	}
 }
 
-// VarIntLen determines the number of bytes that will be needed to write a number
-func VarIntLen(i uint64) protocol.ByteCount {
+// Len determines the number of bytes that will be needed to write a number
+func Len(i uint64) protocol.ByteCount {
 	if i <= maxVarInt1 {
 		return 1
 	}

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -1,4 +1,4 @@
-package utils
+package quicvarint
 
 import (
 	"bytes"

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Varint encoding / decoding", func() {
 	Context("decoding", func() {
 		It("reads a 1 byte number", func() {
 			b := bytes.NewReader([]byte{0b00011001})
-			val, err := ReadVarInt(b)
+			val, err := Read(b)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(val).To(Equal(uint64(25)))
 			Expect(b.Len()).To(BeZero())
@@ -19,7 +19,7 @@ var _ = Describe("Varint encoding / decoding", func() {
 
 		It("reads a number that is encoded too long", func() {
 			b := bytes.NewReader([]byte{0b01000000, 0x25})
-			val, err := ReadVarInt(b)
+			val, err := Read(b)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(val).To(Equal(uint64(37)))
 			Expect(b.Len()).To(BeZero())
@@ -27,7 +27,7 @@ var _ = Describe("Varint encoding / decoding", func() {
 
 		It("reads a 2 byte number", func() {
 			b := bytes.NewReader([]byte{0b01111011, 0xbd})
-			val, err := ReadVarInt(b)
+			val, err := Read(b)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(val).To(Equal(uint64(15293)))
 			Expect(b.Len()).To(BeZero())
@@ -35,7 +35,7 @@ var _ = Describe("Varint encoding / decoding", func() {
 
 		It("reads a 4 byte number", func() {
 			b := bytes.NewReader([]byte{0b10011101, 0x7f, 0x3e, 0x7d})
-			val, err := ReadVarInt(b)
+			val, err := Read(b)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(val).To(Equal(uint64(494878333)))
 			Expect(b.Len()).To(BeZero())
@@ -43,7 +43,7 @@ var _ = Describe("Varint encoding / decoding", func() {
 
 		It("reads an 8 byte number", func() {
 			b := bytes.NewReader([]byte{0b11000010, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c})
-			val, err := ReadVarInt(b)
+			val, err := Read(b)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(val).To(Equal(uint64(151288809941952652)))
 			Expect(b.Len()).To(BeZero())
@@ -54,158 +54,158 @@ var _ = Describe("Varint encoding / decoding", func() {
 		Context("with minimal length", func() {
 			It("writes a 1 byte number", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, 37)
+				Write(b, 37)
 				Expect(b.Bytes()).To(Equal([]byte{0x25}))
 			})
 
 			It("writes the maximum 1 byte number in 1 byte", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, maxVarInt1)
+				Write(b, maxVarInt1)
 				Expect(b.Bytes()).To(Equal([]byte{0b00111111}))
 			})
 
 			It("writes the minimum 2 byte number in 2 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, maxVarInt1+1)
+				Write(b, maxVarInt1+1)
 				Expect(b.Bytes()).To(Equal([]byte{0x40, maxVarInt1 + 1}))
 			})
 
 			It("writes a 2 byte number", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, 15293)
+				Write(b, 15293)
 				Expect(b.Bytes()).To(Equal([]byte{0b01000000 ^ 0x3b, 0xbd}))
 			})
 
 			It("writes the maximum 2 byte number in 2 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, maxVarInt2)
+				Write(b, maxVarInt2)
 				Expect(b.Bytes()).To(Equal([]byte{0b01111111, 0xff}))
 			})
 
 			It("writes the minimum 4 byte number in 4 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, maxVarInt2+1)
+				Write(b, maxVarInt2+1)
 				Expect(b.Len()).To(Equal(4))
-				num, err := ReadVarInt(b)
+				num, err := Read(b)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(num).To(Equal(uint64(maxVarInt2 + 1)))
 			})
 
 			It("writes a 4 byte number", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, 494878333)
+				Write(b, 494878333)
 				Expect(b.Bytes()).To(Equal([]byte{0b10000000 ^ 0x1d, 0x7f, 0x3e, 0x7d}))
 			})
 
 			It("writes the maximum 4 byte number in 4 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, maxVarInt4)
+				Write(b, maxVarInt4)
 				Expect(b.Bytes()).To(Equal([]byte{0b10111111, 0xff, 0xff, 0xff}))
 			})
 
 			It("writes the minimum 8 byte number in 8 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, maxVarInt4+1)
+				Write(b, maxVarInt4+1)
 				Expect(b.Len()).To(Equal(8))
-				num, err := ReadVarInt(b)
+				num, err := Read(b)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(num).To(Equal(uint64(maxVarInt4 + 1)))
 			})
 
 			It("writes an 8 byte number", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, 151288809941952652)
+				Write(b, 151288809941952652)
 				Expect(b.Bytes()).To(Equal([]byte{0xc2, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c}))
 			})
 
 			It("writes the maximum 8 byte number in 8 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarInt(b, maxVarInt8)
+				Write(b, maxVarInt8)
 				Expect(b.Bytes()).To(Equal([]byte{0xff /* 11111111 */, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}))
 			})
 
 			It("panics when given a too large number (> 62 bit)", func() {
-				Expect(func() { WriteVarInt(&bytes.Buffer{}, maxVarInt8+1) }).Should(Panic())
+				Expect(func() { Write(&bytes.Buffer{}, maxVarInt8+1) }).Should(Panic())
 			})
 		})
 
 		Context("with fixed length", func() {
 			It("panics when given an invalid length", func() {
-				Expect(func() { WriteVarIntWithLen(&bytes.Buffer{}, 25, 3) }).Should(Panic())
+				Expect(func() { WriteWithLen(&bytes.Buffer{}, 25, 3) }).Should(Panic())
 			})
 
 			It("panics when given a too short length", func() {
-				Expect(func() { WriteVarIntWithLen(&bytes.Buffer{}, maxVarInt1+1, 1) }).Should(Panic())
-				Expect(func() { WriteVarIntWithLen(&bytes.Buffer{}, maxVarInt2+1, 2) }).Should(Panic())
-				Expect(func() { WriteVarIntWithLen(&bytes.Buffer{}, maxVarInt4+1, 4) }).Should(Panic())
+				Expect(func() { WriteWithLen(&bytes.Buffer{}, maxVarInt1+1, 1) }).Should(Panic())
+				Expect(func() { WriteWithLen(&bytes.Buffer{}, maxVarInt2+1, 2) }).Should(Panic())
+				Expect(func() { WriteWithLen(&bytes.Buffer{}, maxVarInt4+1, 4) }).Should(Panic())
 			})
 
 			It("writes a 1-byte number in minimal encoding", func() {
 				b := &bytes.Buffer{}
-				WriteVarIntWithLen(b, 37, 1)
+				WriteWithLen(b, 37, 1)
 				Expect(b.Bytes()).To(Equal([]byte{0x25}))
 			})
 
 			It("writes a 1-byte number in 2 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarIntWithLen(b, 37, 2)
+				WriteWithLen(b, 37, 2)
 				Expect(b.Bytes()).To(Equal([]byte{0b01000000, 0x25}))
-				Expect(ReadVarInt(b)).To(BeEquivalentTo(37))
+				Expect(Read(b)).To(BeEquivalentTo(37))
 			})
 
 			It("writes a 1-byte number in 4 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarIntWithLen(b, 37, 4)
+				WriteWithLen(b, 37, 4)
 				Expect(b.Bytes()).To(Equal([]byte{0b10000000, 0, 0, 0x25}))
-				Expect(ReadVarInt(b)).To(BeEquivalentTo(37))
+				Expect(Read(b)).To(BeEquivalentTo(37))
 			})
 
 			It("writes a 1-byte number in 8 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarIntWithLen(b, 37, 8)
+				WriteWithLen(b, 37, 8)
 				Expect(b.Bytes()).To(Equal([]byte{0b11000000, 0, 0, 0, 0, 0, 0, 0x25}))
-				Expect(ReadVarInt(b)).To(BeEquivalentTo(37))
+				Expect(Read(b)).To(BeEquivalentTo(37))
 			})
 
 			It("writes a 2-byte number in 4 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarIntWithLen(b, 15293, 4)
+				WriteWithLen(b, 15293, 4)
 				Expect(b.Bytes()).To(Equal([]byte{0b10000000, 0, 0x3b, 0xbd}))
-				Expect(ReadVarInt(b)).To(BeEquivalentTo(15293))
+				Expect(Read(b)).To(BeEquivalentTo(15293))
 			})
 
 			It("write a 4-byte number in 8 bytes", func() {
 				b := &bytes.Buffer{}
-				WriteVarIntWithLen(b, 494878333, 8)
+				WriteWithLen(b, 494878333, 8)
 				Expect(b.Bytes()).To(Equal([]byte{0b11000000, 0, 0, 0, 0x1d, 0x7f, 0x3e, 0x7d}))
-				Expect(ReadVarInt(b)).To(BeEquivalentTo(494878333))
+				Expect(Read(b)).To(BeEquivalentTo(494878333))
 			})
 		})
 	})
 
 	Context("determining the length needed for encoding", func() {
 		It("for numbers that need 1 byte", func() {
-			Expect(VarIntLen(0)).To(BeEquivalentTo(1))
-			Expect(VarIntLen(maxVarInt1)).To(BeEquivalentTo(1))
+			Expect(Len(0)).To(BeEquivalentTo(1))
+			Expect(Len(maxVarInt1)).To(BeEquivalentTo(1))
 		})
 
 		It("for numbers that need 2 bytes", func() {
-			Expect(VarIntLen(maxVarInt1 + 1)).To(BeEquivalentTo(2))
-			Expect(VarIntLen(maxVarInt2)).To(BeEquivalentTo(2))
+			Expect(Len(maxVarInt1 + 1)).To(BeEquivalentTo(2))
+			Expect(Len(maxVarInt2)).To(BeEquivalentTo(2))
 		})
 
 		It("for numbers that need 4 bytes", func() {
-			Expect(VarIntLen(maxVarInt2 + 1)).To(BeEquivalentTo(4))
-			Expect(VarIntLen(maxVarInt4)).To(BeEquivalentTo(4))
+			Expect(Len(maxVarInt2 + 1)).To(BeEquivalentTo(4))
+			Expect(Len(maxVarInt4)).To(BeEquivalentTo(4))
 		})
 
 		It("for numbers that need 8 bytes", func() {
-			Expect(VarIntLen(maxVarInt4 + 1)).To(BeEquivalentTo(8))
-			Expect(VarIntLen(maxVarInt8)).To(BeEquivalentTo(8))
+			Expect(Len(maxVarInt4 + 1)).To(BeEquivalentTo(8))
+			Expect(Len(maxVarInt8)).To(BeEquivalentTo(8))
 		})
 
 		It("panics when given a too large number (> 62 bit)", func() {
-			Expect(func() { VarIntLen(maxVarInt8 + 1) }).Should(Panic())
+			Expect(func() { Len(maxVarInt8 + 1) }).Should(Panic())
 		})
 	})
 })


### PR DESCRIPTION
Packages outside of quic-go might want to make use of QUIC's varint format. We should expose the respective functions, so they don't have to reimplement this.

Specifically, MASQUE uses varints for the [Stream Chunk](https://www.ietf.org/archive/id/draft-ietf-masque-connect-udp-02.html#name-stream-chunks) encoding.