### PR TITLE
make sure we never derive a RTT of exactly 0

### DIFF
--- a/internal/utils/rtt_stats.go
+++ b/internal/utils/rtt_stats.go
@@ -93,6 +93,16 @@ func (r *RTTStats) UpdateRTT(sendDelta, ackDelay time.Duration, now time.Time) {
 		r.meanDeviation = time.Duration(oneMinusBeta*float32(r.meanDeviation/time.Microsecond)+rttBeta*float32(AbsDuration(r.smoothedRTT-sample)/time.Microsecond)) * time.Microsecond
 		r.smoothedRTT = time.Duration((float32(r.smoothedRTT/time.Microsecond)*oneMinusAlpha)+(float32(sample/time.Microsecond)*rttAlpha)) * time.Microsecond
 	}
+	// Make sure that we arrive at a non-zero RTT, even on systems with a terrible timer resolution (Windows).
+	if r.smoothedRTT == 0 {
+		r.smoothedRTT = time.Nanosecond
+	}
+	if r.latestRTT == 0 {
+		r.latestRTT = time.Nanosecond
+	}
+	if r.meanDeviation == 0 {
+		r.meanDeviation = time.Nanosecond
+	}
 }
 
 // SetMaxAckDelay sets the max_ack_delay

--- a/internal/utils/rtt_stats_test.go
+++ b/internal/utils/rtt_stats_test.go
@@ -74,8 +74,16 @@ var _ = Describe("RTT stats", func() {
 		Expect(rttStats.PTO(true)).To(Equal(rtt + protocol.TimerGranularity))
 	})
 
+	It("doesn't set a zero RTT", func() {
+		const rtt = 5 * time.Nanosecond
+		rttStats.UpdateRTT(rtt, rtt, time.Time{})
+		Expect(rttStats.SmoothedRTT()).To(Equal(rtt))
+		rttStats.UpdateRTT(rtt, rtt, time.Time{})
+		Expect(rttStats.SmoothedRTT()).To(Equal(time.Nanosecond))
+	})
+
 	It("ExpireSmoothedMetrics", func() {
-		initialRtt := (10 * time.Millisecond)
+		const initialRtt = 10 * time.Millisecond
 		rttStats.UpdateRTT(initialRtt, 0, time.Time{})
 		Expect(rttStats.MinRTT()).To(Equal(initialRtt))
 		Expect(rttStats.SmoothedRTT()).To(Equal(initialRtt))
@@ -83,7 +91,7 @@ var _ = Describe("RTT stats", func() {
 		Expect(rttStats.MeanDeviation()).To(Equal(initialRtt / 2))
 
 		// Update once with a 20ms RTT.
-		doubledRtt := initialRtt * (2)
+		const doubledRtt = 2 * initialRtt
 		rttStats.UpdateRTT(doubledRtt, 0, time.Time{})
 		Expect(rttStats.SmoothedRTT()).To(Equal(time.Duration(float32(initialRtt) * 1.125)))
 


### PR DESCRIPTION
Fixes #2974.

The flaky test was caused by a RTT measurement of exactly 0, which then confused the pacing algorithm to never allow a packet to be sent.