### PR TITLE
fix interpretation of time.Time{} as a pacing deadline

### DIFF
--- a/internal/congestion/pacer.go
+++ b/internal/congestion/pacer.go
@@ -57,6 +57,7 @@ func (p *pacer) maxBurstSize() protocol.ByteCount {
 }
 
 // TimeUntilSend returns when the next packet should be sent.
+// It returns the zero value of time.Time if a packet can be sent immediately.
 func (p *pacer) TimeUntilSend() time.Time {
 	if p.budgetAtLastSent >= maxDatagramSize {
 		return time.Time{}

--- a/session.go
+++ b/session.go
@@ -211,9 +211,10 @@ type session struct {
 }
 
 var (
-	_ Session      = &session{}
-	_ EarlySession = &session{}
-	_ streamSender = &session{}
+	_                       Session      = &session{}
+	_                       EarlySession = &session{}
+	_                       streamSender = &session{}
+	deadlineSendImmediately              = time.Time{}.Add(42 * time.Millisecond) // any value > time.Time{} and before time.Now() is fine
 )
 
 var newSession = func(
@@ -1484,7 +1485,11 @@ func (s *session) sendPackets() error {
 			}
 		case ackhandler.SendAny:
 			if s.handshakeComplete && !s.sentPacketHandler.HasPacingBudget() {
-				s.pacingDeadline = s.sentPacketHandler.TimeUntilSend()
+				deadline := s.sentPacketHandler.TimeUntilSend()
+				if deadline.IsZero() {
+					deadline = deadlineSendImmediately
+				}
+				s.pacingDeadline = deadline
 				return nil
 			}
 			sent, err := s.sendPacket()


### PR DESCRIPTION
Fixes #2974. Closes #2977 (that PR just fixes the symptoms, not the underlying problem).

The pacer returns the zero value of `time.Time` when a packet can be sent immediately. The session uses the zero value to unset the pacing deadline.