### PR TITLE
only run gofumpt on .go files in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,8 +13,8 @@ for f in $(git diff --cached --name-only); do
 	fi
 done
 
-# Check that all files are properly gofumpt-ed.
-output=$(gofumpt -d $(git diff --cached --name-only))
+# Check that all Go files are properly gofumpt-ed.
+output=$(gofumpt -d $(git diff --cached --name-only -- '*.go'))
 if [ -n "$output" ]; then
 	echo "Found files that are not properly gofumpt-ed."
 	echo "$output"


### PR DESCRIPTION
Editing `README.md` otherwise produces a warning like this:
```
README.md:1:1: illegal character U+0023 '#'
```