### PR TITLE
fix response content length

### DIFF
--- a/http3/body.go
+++ b/http3/body.go
@@ -82,6 +82,17 @@ func (r *body) readImpl(b []byte) (int, error) {
 	return n, err
 }
 
+func (r *body) ended() (bool, error) {
+	_, err := r.readImpl(make([]byte, 0))
+	if err == nil {
+		return false, nil
+	} else if err == io.EOF {
+		return true, nil
+	} else {
+		return false, err
+	}
+}
+
 func (r *body) requestDone() {
 	if r.reqDoneClosed || r.reqDone == nil {
 		return

--- a/http3/client.go
+++ b/http3/client.go
@@ -327,6 +327,15 @@ func (c *client) doRequest(
 		res.Uncompressed = true
 	} else {
 		res.Body = respBody
+		if contentLengthStr := res.Header.Get("Content-Length"); contentLengthStr != "" {
+			if contentLength, err := strconv.ParseInt(contentLengthStr, 10, 64); err == nil {
+				res.ContentLength = contentLength
+			}
+		} else {
+			if isEnded, _ := respBody.ended(); !isEnded {
+				res.ContentLength = -1
+			}
+		}
 	}
 
 	return res, requestError{}


### PR DESCRIPTION
Fixes #2398.

Now http.Response.ContentLength is always 0 even the response header includes content-length, this patch is to fix it.