### PR TITLE
remove unneeded check in receivedPacketHandler.IsPotentiallyDuplicate

### DIFF
--- a/internal/ackhandler/received_packet_handler.go
+++ b/internal/ackhandler/received_packet_handler.go
@@ -130,9 +130,7 @@ func (h *receivedPacketHandler) IsPotentiallyDuplicate(pn protocol.PacketNumber,
 			return h.handshakePackets.IsPotentiallyDuplicate(pn)
 		}
 	case protocol.Encryption0RTT, protocol.Encryption1RTT:
-		if h.appDataPackets != nil {
-			return h.appDataPackets.IsPotentiallyDuplicate(pn)
-		}
+		return h.appDataPackets.IsPotentiallyDuplicate(pn)
 	}
 	panic("unexpected encryption level")
 }


### PR DESCRIPTION
The application data packet number space is never dropped.