### PR TITLE
fix flaky key update integration test

### DIFF
--- a/integrationtests/self/key_update_test.go
+++ b/integrationtests/self/key_update_test.go
@@ -135,6 +135,6 @@ var _ = Describe("Key Update tests", func() {
 		keyPhasesSent, keyPhasesReceived := countKeyPhases()
 		fmt.Fprintf(GinkgoWriter, "Used %d key phases on outgoing and %d key phases on incoming packets.\n", keyPhasesSent, keyPhasesReceived)
 		Expect(keyPhasesReceived).To(BeNumerically(">", 10))
-		Expect(keyPhasesReceived).To(BeNumerically("~", keyPhasesSent, 1))
+		Expect(keyPhasesReceived).To(BeNumerically("~", keyPhasesSent, 2))
 	})
 })


### PR DESCRIPTION
We can receive a packet with key phase 0 and immediately update to key phase 1, without ever having sent a packet with key phase 0.
Equivalently, it might happen that we receive a packet with key phase N containing the CONNECTION_CLOSE, and never reply with a packet in key phase N.