### PR TITLE
fix flaky streams map test on Windows

### DIFF
--- a/streams_map_outgoing_generic_test.go
+++ b/streams_map_outgoing_generic_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Streams Map (outgoing)", func() {
 			m.mutex.Lock()
 			defer m.mutex.Unlock()
 			return len(m.openQueue)
-		}, 50*time.Millisecond, 50*time.Microsecond).Should(Equal(n))
+		}, 50*time.Millisecond, 100*time.Microsecond).Should(Equal(n))
 	}
 
 	BeforeEach(func() {


### PR DESCRIPTION
Fixes #3008.

Can't really reproduce it locally, but it certainly won't hurt to increase the `Eventually` timeout to its default value.