### PR TITLE
reenable key updates for HTTP/3

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net"
 	"net/http"
 	"runtime"
@@ -23,13 +22,6 @@ import (
 	"github.com/lucas-clemente/quic-go/quicvarint"
 	"github.com/marten-seemann/qpack"
 )
-
-func init() {
-	// Chrome compatibility mode:
-	// Chrome 87 doesn't support key updates (support was added in Chrome 88).
-	// Don't initiate key updates to avoid breaking large downloads.
-	handshake.KeyUpdateInterval = math.MaxUint64
-}
 
 // allows mocking of quic.Listen and quic.ListenAddr
 var (


### PR DESCRIPTION
Fixes #2926.

Chrome was recently updated to v88, which is able to handle key updates correctly.