### PR TITLE
preallocate a slice of one frame when packing a packet

### DIFF
--- a/packet_packer.go
+++ b/packet_packer.go
@@ -579,7 +579,7 @@ func (p *packetPacker) maybeGetAppDataPacketWithEncLevel(maxPayloadSize protocol
 }
 
 func (p *packetPacker) composeNextPacket(maxFrameSize protocol.ByteCount, ackAllowed bool) *payload {
-	payload := &payload{}
+	payload := &payload{frames: make([]ackhandler.Frame, 0, 1)}
 
 	var hasDatagram bool
 	if p.datagramQueue != nil {

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -292,7 +292,8 @@ var _ = Describe("Packet packer", func() {
 				pnManager.EXPECT().PopPacketNumber(protocol.Encryption0RTT).Return(protocol.PacketNumber(0x42))
 				cf := ackhandler.Frame{Frame: &wire.MaxDataFrame{MaximumData: 0x1337}}
 				framer.EXPECT().HasData().Return(true)
-				framer.EXPECT().AppendControlFrames(nil, gomock.Any()).DoAndReturn(func(frames []ackhandler.Frame, _ protocol.ByteCount) ([]ackhandler.Frame, protocol.ByteCount) {
+				framer.EXPECT().AppendControlFrames(gomock.Any(), gomock.Any()).DoAndReturn(func(frames []ackhandler.Frame, _ protocol.ByteCount) ([]ackhandler.Frame, protocol.ByteCount) {
+					Expect(frames).To(BeEmpty())
 					return append(frames, cf), cf.Length(packer.version)
 				})
 				// TODO: check sizes


### PR DESCRIPTION
The majority of packets will contain only one STREAM frame.  We should make sure that we don't need to grow the slice in the common case.