### PR TITLE
temporarily disable 1.16 on CI, fix cross compile workflow

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -4,7 +4,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.14.x", "1.15.x", "1.16.0-beta1" ]
+        go: [ "1.14.x", "1.15.x" ]
     runs-on: ubuntu-latest
     name: "Cross Compilation (Go ${{matrix.go}})"
     steps:
@@ -14,7 +14,9 @@ jobs:
           stable: '!contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")'
           go-version: ${{ matrix.go }}
       - name: Install build utils
-        run: sudo apt-get install -y gcc-multilib
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
       - name: Install dependencies
         run: go build example/main.go
       - name: Run cross compilation

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.14.x", "1.15.x", "1.16.0-beta1" ]
+        go: [ "1.14.x", "1.15.x" ]
     runs-on: ubuntu-latest
     name: Integration Tests, Go ${{ matrix.go }})
     steps:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
-        go: [ "1.14.x", "1.15.x", "1.16.0-beta1" ]
+        go: [ "1.14.x", "1.15.x" ]
     runs-on: ${{ matrix.os }}-latest
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
     steps:


### PR DESCRIPTION
2 issues here:
1. GitHub Actions apparently update the VMs to a newer Ubuntu version, and we need to run `apt-get update` to install the dependencies.
2. Google seems to have deleted the Go 1.16-beta1 image from their servers. Disable Go 1.16 for now, as we'll need a new qtls release for rc1.