### PR TITLE
add support for QUIC draft-34

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -32,6 +32,7 @@ var (
 const (
 	nextProtoH3Draft29      = "h3-29"
 	nextProtoH3Draft32      = "h3-32"
+	nextProtoH3Draft34      = "h3-34"
 	streamTypeControlStream = 0
 	streamTypePushStream    = 1
 )
@@ -42,6 +43,9 @@ func versionToALPN(v protocol.VersionNumber) string {
 	}
 	if v == protocol.VersionDraft32 {
 		return nextProtoH3Draft32
+	}
+	if v == protocol.VersionDraft34 {
+		return nextProtoH3Draft34
 	}
 	return ""
 }
@@ -145,8 +149,13 @@ func (s *Server) serveImpl(tlsConf *tls.Config, conn net.PacketConn) error {
 		GetConfigForClient: func(ch *tls.ClientHelloInfo) (*tls.Config, error) {
 			// determine the ALPN from the QUIC version used
 			proto := nextProtoH3Draft29
-			if qconn, ok := ch.Conn.(handshake.ConnWithVersion); ok && qconn.GetQUICVersion() == quic.VersionDraft32 {
-				proto = nextProtoH3Draft32
+			if qconn, ok := ch.Conn.(handshake.ConnWithVersion); ok {
+				if qconn.GetQUICVersion() == quic.VersionDraft32 {
+					proto = nextProtoH3Draft32
+				}
+				if qconn.GetQUICVersion() == protocol.VersionDraft34 {
+					proto = nextProtoH3Draft34
+				}
 			}
 			config := tlsConf
 			if tlsConf.GetConfigForClient != nil {

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -93,6 +93,8 @@ type cryptoSetup struct {
 	extraConf *qtls.ExtraConfig
 	conn      *qtls.Conn
 
+	version protocol.VersionNumber
+
 	messageChan               chan []byte
 	isReadingHandshakeMessage chan struct{}
 	readFirstHandshakeMessage bool
@@ -176,6 +178,7 @@ func NewCryptoSetupClient(
 		tracer,
 		logger,
 		protocol.PerspectiveClient,
+		version,
 	)
 	cs.conn = qtls.Client(newConn(localAddr, remoteAddr, version), cs.tlsConf, cs.extraConf)
 	return cs, clientHelloWritten
@@ -209,6 +212,7 @@ func NewCryptoSetupServer(
 		tracer,
 		logger,
 		protocol.PerspectiveServer,
+		version,
 	)
 	cs.conn = qtls.Server(newConn(localAddr, remoteAddr, version), cs.tlsConf, cs.extraConf)
 	return cs
@@ -226,8 +230,9 @@ func newCryptoSetup(
 	tracer logging.ConnectionTracer,
 	logger utils.Logger,
 	perspective protocol.Perspective,
+	version protocol.VersionNumber,
 ) (*cryptoSetup, <-chan *wire.TransportParameters /* ClientHello written. Receive nil for non-0-RTT */) {
-	initialSealer, initialOpener := NewInitialAEAD(connID, perspective)
+	initialSealer, initialOpener := NewInitialAEAD(connID, perspective, version)
 	if tracer != nil {
 		tracer.UpdatedKeyFromTLS(protocol.EncryptionInitial, protocol.PerspectiveClient)
 		tracer.UpdatedKeyFromTLS(protocol.EncryptionInitial, protocol.PerspectiveServer)
@@ -255,6 +260,7 @@ func newCryptoSetup(
 		messageChan:               make(chan []byte, 100),
 		isReadingHandshakeMessage: make(chan struct{}),
 		closeChan:                 make(chan struct{}),
+		version:                   version,
 	}
 	var maxEarlyData uint32
 	if enable0RTT {
@@ -276,7 +282,7 @@ func newCryptoSetup(
 }
 
 func (h *cryptoSetup) ChangeConnectionID(id protocol.ConnectionID) {
-	initialSealer, initialOpener := NewInitialAEAD(id, h.perspective)
+	initialSealer, initialOpener := NewInitialAEAD(id, h.perspective, h.version)
 	h.initialSealer = initialSealer
 	h.initialOpener = initialOpener
 	if h.tracer != nil {

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -237,7 +237,7 @@ func newCryptoSetup(
 		tracer.UpdatedKeyFromTLS(protocol.EncryptionInitial, protocol.PerspectiveClient)
 		tracer.UpdatedKeyFromTLS(protocol.EncryptionInitial, protocol.PerspectiveServer)
 	}
-	extHandler := newExtensionHandler(tp.Marshal(perspective), perspective)
+	extHandler := newExtensionHandler(tp.Marshal(perspective), perspective, version)
 	cs := &cryptoSetup{
 		tlsConf:                   tlsConf,
 		initialStream:             initialStream,

--- a/internal/handshake/initial_aead.go
+++ b/internal/handshake/initial_aead.go
@@ -8,7 +8,17 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/qtls"
 )
 
-var quicVersion1Salt = []byte{0xaf, 0xbf, 0xec, 0x28, 0x99, 0x93, 0xd2, 0x4c, 0x9e, 0x97, 0x86, 0xf1, 0x9c, 0x61, 0x11, 0xe0, 0x43, 0x90, 0xa8, 0x99}
+var (
+	quicSaltOld     = []byte{0xaf, 0xbf, 0xec, 0x28, 0x99, 0x93, 0xd2, 0x4c, 0x9e, 0x97, 0x86, 0xf1, 0x9c, 0x61, 0x11, 0xe0, 0x43, 0x90, 0xa8, 0x99}
+	quicSaltDraft34 = []byte{0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3, 0x4d, 0x17, 0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad, 0xcc, 0xbb, 0x7f, 0x0a}
+)
+
+func getSalt(v protocol.VersionNumber) []byte {
+	if v == protocol.VersionDraft34 {
+		return quicSaltDraft34
+	}
+	return quicSaltOld
+}
 
 var initialSuite = &qtls.CipherSuiteTLS13{
 	ID:     tls.TLS_AES_128_GCM_SHA256,
@@ -18,8 +28,8 @@ var initialSuite = &qtls.CipherSuiteTLS13{
 }
 
 // NewInitialAEAD creates a new AEAD for Initial encryption / decryption.
-func NewInitialAEAD(connID protocol.ConnectionID, pers protocol.Perspective) (LongHeaderSealer, LongHeaderOpener) {
-	clientSecret, serverSecret := computeSecrets(connID)
+func NewInitialAEAD(connID protocol.ConnectionID, pers protocol.Perspective, v protocol.VersionNumber) (LongHeaderSealer, LongHeaderOpener) {
+	clientSecret, serverSecret := computeSecrets(connID, v)
 	var mySecret, otherSecret []byte
 	if pers == protocol.PerspectiveClient {
 		mySecret = clientSecret
@@ -38,8 +48,8 @@ func NewInitialAEAD(connID protocol.ConnectionID, pers protocol.Perspective) (Lo
 		newLongHeaderOpener(decrypter, newAESHeaderProtector(initialSuite, otherSecret, true))
 }
 
-func computeSecrets(connID protocol.ConnectionID) (clientSecret, serverSecret []byte) {
-	initialSecret := qtls.HkdfExtract(crypto.SHA256, connID, quicVersion1Salt)
+func computeSecrets(connID protocol.ConnectionID, v protocol.VersionNumber) (clientSecret, serverSecret []byte) {
+	initialSecret := qtls.HkdfExtract(crypto.SHA256, connID, getSalt(v))
 	clientSecret = hkdfExpandLabel(crypto.SHA256, initialSecret, []byte{}, "client in", crypto.SHA256.Size())
 	serverSecret = hkdfExpandLabel(crypto.SHA256, initialSecret, []byte{}, "server in", crypto.SHA256.Size())
 	return

--- a/internal/handshake/initial_aead_test.go
+++ b/internal/handshake/initial_aead_test.go
@@ -1,6 +1,7 @@
 package handshake
 
 import (
+	"fmt"
 	"math/rand"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
@@ -17,7 +18,8 @@ var _ = Describe("Initial AEAD using AES-GCM", func() {
 	})
 
 	// values taken from the Appendix of the draft
-	Context("using the test vector from the QUIC draft", func() {
+	Context("using the test vector from the QUIC draft, for old draft version", func() {
+		const version = protocol.VersionDraft29
 		var connID protocol.ConnectionID
 
 		BeforeEach(func() {
@@ -25,7 +27,7 @@ var _ = Describe("Initial AEAD using AES-GCM", func() {
 		})
 
 		It("computes the client key and IV", func() {
-			clientSecret, _ := computeSecrets(connID)
+			clientSecret, _ := computeSecrets(connID, version)
 			Expect(clientSecret).To(Equal(splitHexString("0088119288f1d866733ceeed15ff9d50 902cf82952eee27e9d4d4918ea371d87")))
 			key, iv := computeInitialKeyAndIV(clientSecret)
 			Expect(key).To(Equal(splitHexString("175257a31eb09dea9366d8bb79ad80ba")))
@@ -33,7 +35,7 @@ var _ = Describe("Initial AEAD using AES-GCM", func() {
 		})
 
 		It("computes the server key and IV", func() {
-			_, serverSecret := computeSecrets(connID)
+			_, serverSecret := computeSecrets(connID, version)
 			Expect(serverSecret).To(Equal(splitHexString("006f881359244dd9ad1acf85f595bad6 7c13f9f5586f5e64e1acae1d9ea8f616")))
 			key, iv := computeInitialKeyAndIV(serverSecret)
 			Expect(key).To(Equal(splitHexString("149d0b1662ab871fbe63c49b5e655a5d")))
@@ -41,7 +43,7 @@ var _ = Describe("Initial AEAD using AES-GCM", func() {
 		})
 
 		It("encrypts the client's Initial", func() {
-			sealer, _ := NewInitialAEAD(connID, protocol.PerspectiveClient)
+			sealer, _ := NewInitialAEAD(connID, protocol.PerspectiveClient, version)
 			header := splitHexString("c3ff00001d088394c8f03e5157080000449e00000002")
 			data := splitHexString("060040c4010000c003036660261ff947 cea49cce6cfad687f457cf1b14531ba1 4131a0e8f309a1d0b9c4000006130113 031302010000910000000b0009000006 736572766572ff01000100000a001400 12001d00170018001901000101010201 03010400230000003300260024001d00 204cfdfcd178b784bf328cae793b136f 2aedce005ff183d7bb14952072366470 37002b0003020304000d0020001e0403 05030603020308040805080604010501 060102010402050206020202002d0002 0101001c00024001")
 			data = append(data, make([]byte, 1162-len(data))...) // add PADDING
@@ -56,7 +58,7 @@ var _ = Describe("Initial AEAD using AES-GCM", func() {
 		})
 
 		It("encrypt the server's Initial", func() {
-			sealer, _ := NewInitialAEAD(connID, protocol.PerspectiveServer)
+			sealer, _ := NewInitialAEAD(connID, protocol.PerspectiveServer, version)
 			header := splitHexString("c1ff00001d0008f067a5502a4262b50040740001")
 			data := splitHexString("0d0000000018410a020000560303eefc e7f7b37ba1d1632e96677825ddf73988 cfc79825df566dc5430b9a045a120013 0100002e00330024001d00209d3c940d 89690b84d08a60993c144eca684d1081 287c834d5311bcf32bb9da1a002b0002 0304")
 			sealed := sealer.Seal(nil, data, 1, header)
@@ -69,59 +71,119 @@ var _ = Describe("Initial AEAD using AES-GCM", func() {
 		})
 	})
 
-	It("seals and opens", func() {
-		connectionID := protocol.ConnectionID{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
-		clientSealer, clientOpener := NewInitialAEAD(connectionID, protocol.PerspectiveClient)
-		serverSealer, serverOpener := NewInitialAEAD(connectionID, protocol.PerspectiveServer)
+	// values taken from the Appendix of the draft
+	Context("using the test vector from the QUIC draft, for QUIC draft-34", func() {
+		const version = protocol.VersionDraft34
+		var connID protocol.ConnectionID
 
-		clientMessage := clientSealer.Seal(nil, []byte("foobar"), 42, []byte("aad"))
-		m, err := serverOpener.Open(nil, clientMessage, 42, []byte("aad"))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(m).To(Equal([]byte("foobar")))
-		serverMessage := serverSealer.Seal(nil, []byte("raboof"), 99, []byte("daa"))
-		m, err = clientOpener.Open(nil, serverMessage, 99, []byte("daa"))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(m).To(Equal([]byte("raboof")))
+		BeforeEach(func() {
+			connID = protocol.ConnectionID(splitHexString("0x8394c8f03e515708"))
+		})
+
+		It("computes the client key and IV", func() {
+			clientSecret, _ := computeSecrets(connID, version)
+			Expect(clientSecret).To(Equal(splitHexString("c00cf151ca5be075ed0ebfb5c80323c4 2d6b7db67881289af4008f1f6c357aea")))
+			key, iv := computeInitialKeyAndIV(clientSecret)
+			Expect(key).To(Equal(splitHexString("1f369613dd76d5467730efcbe3b1a22d")))
+			Expect(iv).To(Equal(splitHexString("fa044b2f42a3fd3b46fb255c")))
+		})
+
+		It("computes the server key and IV", func() {
+			_, serverSecret := computeSecrets(connID, version)
+			Expect(serverSecret).To(Equal(splitHexString("3c199828fd139efd216c155ad844cc81 fb82fa8d7446fa7d78be803acdda951b")))
+			key, iv := computeInitialKeyAndIV(serverSecret)
+			Expect(key).To(Equal(splitHexString("cf3a5331653c364c88f0f379b6067e37")))
+			Expect(iv).To(Equal(splitHexString("0ac1493ca1905853b0bba03e")))
+		})
+
+		It("encrypts the client's Initial", func() {
+			sealer, _ := NewInitialAEAD(connID, protocol.PerspectiveClient, version)
+			header := splitHexString("c300000001088394c8f03e5157080000449e00000002")
+			data := splitHexString("060040f1010000ed0303ebf8fa56f129 39b9584a3896472ec40bb863cfd3e868 04fe3a47f06a2b69484c000004130113 02010000c000000010000e00000b6578 616d706c652e636f6dff01000100000a 00080006001d00170018001000070005 04616c706e0005000501000000000033 00260024001d00209370b2c9caa47fba baf4559fedba753de171fa71f50f1ce1 5d43e994ec74d748002b000302030400 0d0010000e0403050306030203080408 050806002d00020101001c0002400100 3900320408ffffffffffffffff050480 00ffff07048000ffff08011001048000 75300901100f088394c8f03e51570806 048000ffff")
+			data = append(data, make([]byte, 1162-len(data))...) // add PADDING
+			sealed := sealer.Seal(nil, data, 2, header)
+			sample := sealed[0:16]
+			Expect(sample).To(Equal(splitHexString("d1b1c98dd7689fb8ec11d242b123dc9b")))
+			sealer.EncryptHeader(sample, &header[0], header[len(header)-4:])
+			Expect(header[0]).To(Equal(byte(0xc0)))
+			Expect(header[len(header)-4:]).To(Equal(splitHexString("7b9aec34")))
+			packet := append(header, sealed...)
+			Expect(packet).To(Equal(splitHexString("c000000001088394c8f03e5157080000 449e7b9aec34d1b1c98dd7689fb8ec11 d242b123dc9bd8bab936b47d92ec356c 0bab7df5976d27cd449f63300099f399 1c260ec4c60d17b31f8429157bb35a12 82a643a8d2262cad67500cadb8e7378c 8eb7539ec4d4905fed1bee1fc8aafba1 7c750e2c7ace01e6005f80fcb7df6212 30c83711b39343fa028cea7f7fb5ff89 eac2308249a02252155e2347b63d58c5 457afd84d05dfffdb20392844ae81215 4682e9cf012f9021a6f0be17ddd0c208 4dce25ff9b06cde535d0f920a2db1bf3 62c23e596d11a4f5a6cf3948838a3aec 4e15daf8500a6ef69ec4e3feb6b1d98e 610ac8b7ec3faf6ad760b7bad1db4ba3 485e8a94dc250ae3fdb41ed15fb6a8e5 eba0fc3dd60bc8e30c5c4287e53805db 059ae0648db2f64264ed5e39be2e20d8 2df566da8dd5998ccabdae053060ae6c 7b4378e846d29f37ed7b4ea9ec5d82e7 961b7f25a9323851f681d582363aa5f8 9937f5a67258bf63ad6f1a0b1d96dbd4 faddfcefc5266ba6611722395c906556 be52afe3f565636ad1b17d508b73d874 3eeb524be22b3dcbc2c7468d54119c74 68449a13d8e3b95811a198f3491de3e7 fe942b330407abf82a4ed7c1b311663a c69890f4157015853d91e923037c227a 33cdd5ec281ca3f79c44546b9d90ca00 f064c99e3dd97911d39fe9c5d0b23a22 9a234cb36186c4819e8b9c5927726632 291d6a418211cc2962e20fe47feb3edf 330f2c603a9d48c0fcb5699dbfe58964 25c5bac4aee82e57a85aaf4e2513e4f0 5796b07ba2ee47d80506f8d2c25e50fd 14de71e6c418559302f939b0e1abd576 f279c4b2e0feb85c1f28ff18f58891ff ef132eef2fa09346aee33c28eb130ff2 8f5b766953334113211996d20011a198 e3fc433f9f2541010ae17c1bf202580f 6047472fb36857fe843b19f5984009dd c324044e847a4f4a0ab34f719595de37 252d6235365e9b84392b061085349d73 203a4a13e96f5432ec0fd4a1ee65accd d5e3904df54c1da510b0ff20dcc0c77f cb2c0e0eb605cb0504db87632cf3d8b4 dae6e705769d1de354270123cb11450e fc60ac47683d7b8d0f811365565fd98c 4c8eb936bcab8d069fc33bd801b03ade a2e1fbc5aa463d08ca19896d2bf59a07 1b851e6c239052172f296bfb5e724047 90a2181014f3b94a4e97d117b4381303 68cc39dbb2d198065ae3986547926cd2 162f40a29f0c3c8745c0f50fba3852e5 66d44575c29d39a03f0cda721984b6f4 40591f355e12d439ff150aab7613499d bd49adabc8676eef023b15b65bfc5ca0 6948109f23f350db82123535eb8a7433 bdabcb909271a6ecbcb58b936a88cd4e 8f2e6ff5800175f113253d8fa9ca8885 c2f552e657dc603f252e1a8e308f76f0 be79e2fb8f5d5fbbe2e30ecadd220723 c8c0aea8078cdfcb3868263ff8f09400 54da48781893a7e49ad5aff4af300cd8 04a6b6279ab3ff3afb64491c85194aab 760d58a606654f9f4400e8b38591356f bf6425aca26dc85244259ff2b19c41b9 f96f3ca9ec1dde434da7d2d392b905dd f3d1f9af93d1af5950bd493f5aa731b4 056df31bd267b6b90a079831aaf579be 0a39013137aac6d404f518cfd4684064 7e78bfe706ca4cf5e9c5453e9f7cfd2b 8b4c8d169a44e55c88d4a9a7f9474241 e221af44860018ab0856972e194cd934")))
+		})
+
+		It("encrypt the server's Initial", func() {
+			sealer, _ := NewInitialAEAD(connID, protocol.PerspectiveServer, version)
+			header := splitHexString("c1000000010008f067a5502a4262b50040750001")
+			data := splitHexString("02000000000600405a020000560303ee fce7f7b37ba1d1632e96677825ddf739 88cfc79825df566dc5430b9a045a1200 130100002e00330024001d00209d3c94 0d89690b84d08a60993c144eca684d10 81287c834d5311bcf32bb9da1a002b00 020304")
+			sealed := sealer.Seal(nil, data, 1, header)
+			sample := sealed[2 : 2+16]
+			Expect(sample).To(Equal(splitHexString("2cd0991cd25b0aac406a5816b6394100")))
+			sealer.EncryptHeader(sample, &header[0], header[len(header)-2:])
+			Expect(header).To(Equal(splitHexString("cf000000010008f067a5502a4262b5004075c0d9")))
+			packet := append(header, sealed...)
+			Expect(packet).To(Equal(splitHexString("cf000000010008f067a5502a4262b500 4075c0d95a482cd0991cd25b0aac406a 5816b6394100f37a1c69797554780bb3 8cc5a99f5ede4cf73c3ec2493a1839b3 dbcba3f6ea46c5b7684df3548e7ddeb9 c3bf9c73cc3f3bded74b562bfb19fb84 022f8ef4cdd93795d77d06edbb7aaf2f 58891850abbdca3d20398c276456cbc4 2158407dd074ee")))
+		})
 	})
 
-	It("doesn't work if initialized with different connection IDs", func() {
-		c1 := protocol.ConnectionID{0, 0, 0, 0, 0, 0, 0, 1}
-		c2 := protocol.ConnectionID{0, 0, 0, 0, 0, 0, 0, 2}
-		clientSealer, _ := NewInitialAEAD(c1, protocol.PerspectiveClient)
-		_, serverOpener := NewInitialAEAD(c2, protocol.PerspectiveServer)
+	for _, ver := range []protocol.VersionNumber{protocol.VersionDraft32, protocol.VersionDraft34} {
+		v := ver
 
-		clientMessage := clientSealer.Seal(nil, []byte("foobar"), 42, []byte("aad"))
-		_, err := serverOpener.Open(nil, clientMessage, 42, []byte("aad"))
-		Expect(err).To(MatchError(ErrDecryptionFailed))
-	})
+		Context(fmt.Sprintf("using version %s", v), func() {
+			It("seals and opens", func() {
+				connectionID := protocol.ConnectionID{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
+				clientSealer, clientOpener := NewInitialAEAD(connectionID, protocol.PerspectiveClient, v)
+				serverSealer, serverOpener := NewInitialAEAD(connectionID, protocol.PerspectiveServer, v)
 
-	It("encrypts und decrypts the header", func() {
-		connID := protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad}
-		clientSealer, clientOpener := NewInitialAEAD(connID, protocol.PerspectiveClient)
-		serverSealer, serverOpener := NewInitialAEAD(connID, protocol.PerspectiveServer)
+				clientMessage := clientSealer.Seal(nil, []byte("foobar"), 42, []byte("aad"))
+				m, err := serverOpener.Open(nil, clientMessage, 42, []byte("aad"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m).To(Equal([]byte("foobar")))
+				serverMessage := serverSealer.Seal(nil, []byte("raboof"), 99, []byte("daa"))
+				m, err = clientOpener.Open(nil, serverMessage, 99, []byte("daa"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m).To(Equal([]byte("raboof")))
+			})
 
-		// the first byte and the last 4 bytes should be encrypted
-		header := []byte{0x5e, 0, 1, 2, 3, 4, 0xde, 0xad, 0xbe, 0xef}
-		sample := make([]byte, 16)
-		rand.Read(sample)
-		clientSealer.EncryptHeader(sample, &header[0], header[6:10])
-		// only the last 4 bits of the first byte are encrypted. Check that the first 4 bits are unmodified
-		Expect(header[0] & 0xf0).To(Equal(byte(0x5e & 0xf0)))
-		Expect(header[1:6]).To(Equal([]byte{0, 1, 2, 3, 4}))
-		Expect(header[6:10]).ToNot(Equal([]byte{0xde, 0xad, 0xbe, 0xef}))
-		serverOpener.DecryptHeader(sample, &header[0], header[6:10])
-		Expect(header[0]).To(Equal(byte(0x5e)))
-		Expect(header[1:6]).To(Equal([]byte{0, 1, 2, 3, 4}))
-		Expect(header[6:10]).To(Equal([]byte{0xde, 0xad, 0xbe, 0xef}))
+			It("doesn't work if initialized with different connection IDs", func() {
+				c1 := protocol.ConnectionID{0, 0, 0, 0, 0, 0, 0, 1}
+				c2 := protocol.ConnectionID{0, 0, 0, 0, 0, 0, 0, 2}
+				clientSealer, _ := NewInitialAEAD(c1, protocol.PerspectiveClient, v)
+				_, serverOpener := NewInitialAEAD(c2, protocol.PerspectiveServer, v)
 
-		serverSealer.EncryptHeader(sample, &header[0], header[6:10])
-		// only the last 4 bits of the first byte are encrypted. Check that the first 4 bits are unmodified
-		Expect(header[0] & 0xf0).To(Equal(byte(0x5e & 0xf0)))
-		Expect(header[1:6]).To(Equal([]byte{0, 1, 2, 3, 4}))
-		Expect(header[6:10]).ToNot(Equal([]byte{0xde, 0xad, 0xbe, 0xef}))
-		clientOpener.DecryptHeader(sample, &header[0], header[6:10])
-		Expect(header[0]).To(Equal(byte(0x5e)))
-		Expect(header[1:6]).To(Equal([]byte{0, 1, 2, 3, 4}))
-		Expect(header[6:10]).To(Equal([]byte{0xde, 0xad, 0xbe, 0xef}))
-	})
+				clientMessage := clientSealer.Seal(nil, []byte("foobar"), 42, []byte("aad"))
+				_, err := serverOpener.Open(nil, clientMessage, 42, []byte("aad"))
+				Expect(err).To(MatchError(ErrDecryptionFailed))
+			})
+
+			It("encrypts und decrypts the header", func() {
+				connID := protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad}
+				clientSealer, clientOpener := NewInitialAEAD(connID, protocol.PerspectiveClient, v)
+				serverSealer, serverOpener := NewInitialAEAD(connID, protocol.PerspectiveServer, v)
+
+				// the first byte and the last 4 bytes should be encrypted
+				header := []byte{0x5e, 0, 1, 2, 3, 4, 0xde, 0xad, 0xbe, 0xef}
+				sample := make([]byte, 16)
+				rand.Read(sample)
+				clientSealer.EncryptHeader(sample, &header[0], header[6:10])
+				// only the last 4 bits of the first byte are encrypted. Check that the first 4 bits are unmodified
+				Expect(header[0] & 0xf0).To(Equal(byte(0x5e & 0xf0)))
+				Expect(header[1:6]).To(Equal([]byte{0, 1, 2, 3, 4}))
+				Expect(header[6:10]).ToNot(Equal([]byte{0xde, 0xad, 0xbe, 0xef}))
+				serverOpener.DecryptHeader(sample, &header[0], header[6:10])
+				Expect(header[0]).To(Equal(byte(0x5e)))
+				Expect(header[1:6]).To(Equal([]byte{0, 1, 2, 3, 4}))
+				Expect(header[6:10]).To(Equal([]byte{0xde, 0xad, 0xbe, 0xef}))
+
+				serverSealer.EncryptHeader(sample, &header[0], header[6:10])
+				// only the last 4 bits of the first byte are encrypted. Check that the first 4 bits are unmodified
+				Expect(header[0] & 0xf0).To(Equal(byte(0x5e & 0xf0)))
+				Expect(header[1:6]).To(Equal([]byte{0, 1, 2, 3, 4}))
+				Expect(header[6:10]).ToNot(Equal([]byte{0xde, 0xad, 0xbe, 0xef}))
+				clientOpener.DecryptHeader(sample, &header[0], header[6:10])
+				Expect(header[0]).To(Equal(byte(0x5e)))
+				Expect(header[1:6]).To(Equal([]byte{0, 1, 2, 3, 4}))
+				Expect(header[6:10]).To(Equal([]byte{0xde, 0xad, 0xbe, 0xef}))
+			})
+		})
+	}
 })

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -23,6 +23,7 @@ const (
 	VersionUnknown  VersionNumber = math.MaxUint32
 	VersionDraft29  VersionNumber = 0xff00001d
 	VersionDraft32  VersionNumber = 0xff000020
+	VersionDraft34  VersionNumber = 0xff000022 // If everything goes according to plan at the IETF, this will one day be QUIC v1.
 )
 
 // SupportedVersions lists the versions that the server supports
@@ -50,6 +51,8 @@ func (vn VersionNumber) String() string {
 		return "draft-29"
 	case VersionDraft32:
 		return "draft-32"
+	case VersionDraft34:
+		return "draft-34"
 	default:
 		if vn.isGQUIC() {
 			return fmt.Sprintf("gQUIC %d", vn.toGQUICVersion())

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -16,6 +16,7 @@ var _ = Describe("Version", func() {
 		Expect(IsValidVersion(VersionUnknown)).To(BeFalse())
 		Expect(IsValidVersion(VersionDraft29)).To(BeFalse())
 		Expect(IsValidVersion(VersionDraft32)).To(BeFalse())
+		Expect(IsValidVersion(VersionDraft34)).To(BeFalse())
 		Expect(IsValidVersion(1234)).To(BeFalse())
 	})
 
@@ -29,6 +30,7 @@ var _ = Describe("Version", func() {
 		Expect(VersionUnknown.String()).To(Equal("unknown"))
 		Expect(VersionDraft29.String()).To(Equal("draft-29"))
 		Expect(VersionDraft32.String()).To(Equal("draft-32"))
+		Expect(VersionDraft34.String()).To(Equal("draft-34"))
 		// check with unsupported version numbers from the wiki
 		Expect(VersionNumber(0x51303039).String()).To(Equal("gQUIC 9"))
 		Expect(VersionNumber(0x51303133).String()).To(Equal("gQUIC 13"))

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -65,7 +65,7 @@ func ComposeAckFrame(smallest protocol.PacketNumber, largest protocol.PacketNumb
 // ComposeInitialPacket returns an Initial packet encrypted under key
 // (the original destination connection ID) containing specified frames
 func ComposeInitialPacket(srcConnID protocol.ConnectionID, destConnID protocol.ConnectionID, version protocol.VersionNumber, key protocol.ConnectionID, frames []wire.Frame) []byte {
-	sealer, _ := handshake.NewInitialAEAD(key, protocol.PerspectiveServer)
+	sealer, _ := handshake.NewInitialAEAD(key, protocol.PerspectiveServer, version)
 
 	// compose payload
 	var payload []byte

--- a/server.go
+++ b/server.go
@@ -587,7 +587,7 @@ func (s *baseServer) sendRetry(remoteAddr net.Addr, hdr *wire.Header) error {
 func (s *baseServer) maybeSendInvalidToken(p *receivedPacket, hdr *wire.Header) error {
 	// Only send INVALID_TOKEN if we can unprotect the packet.
 	// This makes sure that we won't send it for packets that were corrupted.
-	sealer, opener := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveServer)
+	sealer, opener := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveServer, hdr.Version)
 	data := p.data[:hdr.ParsedLen()+hdr.Length]
 	extHdr, err := unpackHeader(opener, hdr, data, hdr.Version)
 	if err != nil {
@@ -612,7 +612,7 @@ func (s *baseServer) maybeSendInvalidToken(p *receivedPacket, hdr *wire.Header) 
 }
 
 func (s *baseServer) sendConnectionRefused(remoteAddr net.Addr, hdr *wire.Header) error {
-	sealer, _ := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveServer)
+	sealer, _ := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveServer, hdr.Version)
 	return s.sendError(remoteAddr, hdr, sealer, qerr.ConnectionRefused)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Server", func() {
 		n := buf.Len()
 		buf.Write(p)
 		data := buffer.Data[:buf.Len()]
-		sealer, _ := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveClient)
+		sealer, _ := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveClient, hdr.Version)
 		_ = sealer.Seal(data[n:n], data[n:], 0x42, data[:n])
 		data = data[:len(data)+16]
 		sealer.EncryptHeader(data[n:n+16], &data[0], data[n-4:n])
@@ -516,7 +516,7 @@ var _ = Describe("Server", func() {
 					Expect(replyHdr.Type).To(Equal(protocol.PacketTypeInitial))
 					Expect(replyHdr.SrcConnectionID).To(Equal(hdr.DestConnectionID))
 					Expect(replyHdr.DestConnectionID).To(Equal(hdr.SrcConnectionID))
-					_, opener := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveClient)
+					_, opener := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveClient, replyHdr.Version)
 					extHdr, err := unpackHeader(opener, replyHdr, b, hdr.Version)
 					Expect(err).ToNot(HaveOccurred())
 					data, err := opener.Open(nil, b[extHdr.ParsedLen():], extHdr.PacketNumber, b[:extHdr.ParsedLen()])


### PR DESCRIPTION
QUIC draft-34 will (if everything goes according to plan at the IETF) become QUIC v1.

draft-34 uses a different salt for Initial packet encryption, and it changes the TLS extension code point for the QUIC transport parameter extension (yay!).

We're not allowed to deploy this version on the public internet yet. I added a note for `SupportedVersions`, so we don't forget that when cutting the next release.