### PR TITLE
qlog the quic-go version

### DIFF
--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -19,8 +19,8 @@ RUN git clone https://github.com/lucas-clemente/quic-go && \
 WORKDIR /quic-go
 
 RUN git rev-parse HEAD > commit.txt
-RUN go build -o server interop/server/main.go && \
- go build -o client interop/client/main.go
+RUN go build -o server -ldflags="-X github.com/lucas-clemente/quic-go/qlog.quicGoVersion=$(git describe --always --long --dirty)" interop/server/main.go
+RUN go build -o client -ldflags="-X github.com/lucas-clemente/quic-go/qlog.quicGoVersion=$(git describe --always --long --dirty)" interop/client/main.go
 
 
 FROM martenseemann/quic-network-simulator-endpoint:latest

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -16,6 +17,24 @@ import (
 
 	"github.com/francoispqt/gojay"
 )
+
+var quicGoVersion = "(devel)"
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok { // no build info available. This happens when quic-go is not used as a library.
+		return
+	}
+	for _, d := range info.Deps {
+		if d.Path == "github.com/lucas-clemente/quic-go" {
+			quicGoVersion = d.Version
+			if d.Replace != nil {
+				quicGoVersion += " (replaced)"
+			}
+			break
+		}
+	}
+}
 
 const eventChanSize = 50
 

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -18,9 +18,15 @@ import (
 	"github.com/francoispqt/gojay"
 )
 
+// Setting of this only works when quic-go is used as a library.
+// When building a binary from this repository, the version can be set using the following go build flag:
+// -ldflags="-X github.com/lucas-clemente/quic-go/qlog.quicGoVersion=foobar"
 var quicGoVersion = "(devel)"
 
 func init() {
+	if quicGoVersion != "(devel)" { // variable set by ldflags
+		return
+	}
 	info, ok := debug.ReadBuildInfo()
 	if !ok { // no build info available. This happens when quic-go is not used as a library.
 		return
@@ -29,7 +35,11 @@ func init() {
 		if d.Path == "github.com/lucas-clemente/quic-go" {
 			quicGoVersion = d.Version
 			if d.Replace != nil {
-				quicGoVersion += " (replaced)"
+				if len(d.Replace.Version) > 0 {
+					quicGoVersion = d.Version
+				} else {
+					quicGoVersion += " (replaced)"
+				}
 			}
 			break
 		}

--- a/qlog/trace.go
+++ b/qlog/trace.go
@@ -17,6 +17,7 @@ func (l topLevel) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("qlog_format", "NDJSON")
 	enc.StringKey("qlog_version", "draft-02")
 	enc.StringKeyOmitEmpty("title", "quic-go qlog")
+	enc.StringKey("code_version", quicGoVersion)
 	enc.ObjectKey("trace", l.trace)
 }
 


### PR DESCRIPTION
Using `runtime/debug.ReadBuildInfo()` only works when quic-go is used as a library, so that's *almost* good enough for us. For the interop runner image, we can manually set the version string using `ldflags`.

Thanks to @mvdan for pointing me towards `BuildInfo`!