### PR TITLE
add the time_format field to qlog common_fields

### DIFF
--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Tracing", func() {
 			Expect(commonFields).To(HaveKey("reference_time"))
 			referenceTime := time.Unix(0, int64(commonFields["reference_time"].(float64)*1e6))
 			Expect(referenceTime).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+			Expect(commonFields).To(HaveKeyWithValue("time_format", "relative"))
 			Expect(trace).To(HaveKey("vantage_point"))
 			vantagePoint := trace["vantage_point"].(map[string]interface{})
 			Expect(vantagePoint).To(HaveKeyWithValue("type", "server"))

--- a/qlog/trace.go
+++ b/qlog/trace.go
@@ -49,6 +49,7 @@ func (f commonFields) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("group_id", f.ODCID.String())
 	enc.StringKeyOmitEmpty("protocol_type", f.ProtocolType)
 	enc.Float64Key("reference_time", float64(f.ReferenceTime.UnixNano())/1e6)
+	enc.StringKey("time_format", "relative")
 }
 
 func (f commonFields) IsNil() bool { return false }


### PR DESCRIPTION
qvis is complaining about this:
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/1478487/107842030-04d1a880-6dfb-11eb-8f21-dddff89ede99.png">
