### PR TITLE
fix error message when the UDP receive buffer size can't be increased

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -75,7 +75,7 @@ func setReceiveBuffer(c net.PacketConn, logger utils.Logger) error {
 		return fmt.Errorf("failed to determine receive buffer size: %w", err)
 	}
 	if newSize == size {
-		return fmt.Errorf("failed to determine receive buffer size: %w", err)
+		return fmt.Errorf("failed to increase receive buffer size (wanted: %d kiB, got %d kiB)", protocol.DesiredReceiveBufferSize/1024, newSize/1024)
 	}
 	if newSize < protocol.DesiredReceiveBufferSize {
 		return fmt.Errorf("failed to sufficiently increase receive buffer size (was: %d kiB, wanted: %d kiB, got: %d kiB)", size/1024, protocol.DesiredReceiveBufferSize/1024, newSize/1024)


### PR DESCRIPTION
As reported by @mholt in https://github.com/caddyserver/caddy/pull/3999#issuecomment-778427020.