### PR TITLE
improve timeout measurement in the timeout test

### DIFF
--- a/integrationtests/self/key_update_test.go
+++ b/integrationtests/self/key_update_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Key Update tests", func() {
 		sess, err := quic.DialAddr(
 			fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
 			getTLSClientConfig(),
-			&quic.Config{Tracer: newTracer(func() logging.ConnectionTracer { return &keyUpdateConnTracer{} })},
+			getQuicConfig(&quic.Config{Tracer: newTracer(func() logging.ConnectionTracer { return &keyUpdateConnTracer{} })}),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		str, err := sess.AcceptUniStream(context.Background())

--- a/integrationtests/self/self_suite_test.go
+++ b/integrationtests/self/self_suite_test.go
@@ -272,7 +272,11 @@ func getQuicConfig(conf *quic.Config) *quic.Config {
 	} else {
 		conf = conf.Clone()
 	}
-	conf.Tracer = quicConfigTracer
+	if conf.Tracer == nil {
+		conf.Tracer = quicConfigTracer
+	} else if quicConfigTracer != nil {
+		conf.Tracer = logging.NewMultiplexedTracer(quicConfigTracer, conf.Tracer)
+	}
 	return conf
 }
 


### PR DESCRIPTION
When not sending any packets, the idle timeout starts when receiving the HANDSHAKE_DONE frame (on the client side), not when the handshake completes.