### PR TITLE
avoid using rand.Source

### DIFF
--- a/conn_id_manager.go
+++ b/conn_id_manager.go
@@ -1,10 +1,7 @@
 package quic
 
 import (
-	"crypto/rand"
-	"encoding/binary"
 	"fmt"
-	mrand "math/rand"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/qerr"
@@ -25,7 +22,7 @@ type connIDManager struct {
 	// protocol.PacketsPerConnectionID packets. The actual value is randomized
 	// hide the packet loss rate from on-path observers.
 	packetsSinceLastChange uint64
-	rand                   *mrand.Rand
+	rand                   utils.Rand
 	packetsPerConnectionID uint64
 
 	addStatelessResetToken    func(protocol.StatelessResetToken)
@@ -39,15 +36,11 @@ func newConnIDManager(
 	removeStatelessResetToken func(protocol.StatelessResetToken),
 	queueControlFrame func(wire.Frame),
 ) *connIDManager {
-	b := make([]byte, 8)
-	_, _ = rand.Read(b) // ignore the error here. Nothing bad will happen if the seed is not perfectly random.
-	seed := int64(binary.BigEndian.Uint64(b))
 	return &connIDManager{
 		activeConnectionID:        initialDestConnID,
 		addStatelessResetToken:    addStatelessResetToken,
 		removeStatelessResetToken: removeStatelessResetToken,
 		queueControlFrame:         queueControlFrame,
-		rand:                      mrand.New(mrand.NewSource(seed)),
 	}
 }
 
@@ -155,7 +148,7 @@ func (h *connIDManager) updateConnectionID() {
 	h.activeConnectionID = front.ConnectionID
 	h.activeStatelessResetToken = &front.StatelessResetToken
 	h.packetsSinceLastChange = 0
-	h.packetsPerConnectionID = protocol.PacketsPerConnectionID/2 + uint64(h.rand.Int63n(protocol.PacketsPerConnectionID))
+	h.packetsPerConnectionID = protocol.PacketsPerConnectionID/2 + uint64(h.rand.Int31n(protocol.PacketsPerConnectionID))
 	h.addStatelessResetToken(*h.activeStatelessResetToken)
 }
 

--- a/conn_id_manager.go
+++ b/conn_id_manager.go
@@ -21,9 +21,9 @@ type connIDManager struct {
 	// We change the connection ID after sending on average
 	// protocol.PacketsPerConnectionID packets. The actual value is randomized
 	// hide the packet loss rate from on-path observers.
-	packetsSinceLastChange uint64
 	rand                   utils.Rand
-	packetsPerConnectionID uint64
+	packetsSinceLastChange uint32
+	packetsPerConnectionID uint32
 
 	addStatelessResetToken    func(protocol.StatelessResetToken)
 	removeStatelessResetToken func(protocol.StatelessResetToken)
@@ -148,7 +148,7 @@ func (h *connIDManager) updateConnectionID() {
 	h.activeConnectionID = front.ConnectionID
 	h.activeStatelessResetToken = &front.StatelessResetToken
 	h.packetsSinceLastChange = 0
-	h.packetsPerConnectionID = protocol.PacketsPerConnectionID/2 + uint64(h.rand.Int31n(protocol.PacketsPerConnectionID))
+	h.packetsPerConnectionID = protocol.PacketsPerConnectionID/2 + uint32(h.rand.Int31n(protocol.PacketsPerConnectionID))
 	h.addStatelessResetToken(*h.activeStatelessResetToken)
 }
 

--- a/internal/utils/rand.go
+++ b/internal/utils/rand.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+)
+
+// Rand is a wrapper around crypto/rand that adds some convenience functions known from math/rand.
+type Rand struct {
+	buf [4]byte
+}
+
+func (r *Rand) Int31() int32 {
+	rand.Read(r.buf[:])
+	return int32(binary.BigEndian.Uint32(r.buf[:]) & ^uint32(1<<31))
+}
+
+// copied from the standard library math/rand implementation of Int63n
+func (r *Rand) Int31n(n int32) int32 {
+	if n&(n-1) == 0 { // n is power of two, can mask
+		return r.Int31() & (n - 1)
+	}
+	max := int32((1 << 31) - 1 - (1<<31)%uint32(n))
+	v := r.Int31()
+	for v > max {
+		v = r.Int31()
+	}
+	return v % n
+}

--- a/internal/utils/rand_test.go
+++ b/internal/utils/rand_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Rand", func() {
+	It("generates random numbers", func() {
+		const (
+			num = 1000
+			max = 123456
+		)
+
+		var values [num]int32
+		var r Rand
+		for i := 0; i < num; i++ {
+			v := r.Int31n(max)
+			Expect(v).To(And(
+				BeNumerically(">=", 0),
+				BeNumerically("<", max),
+			))
+			values[i] = v
+		}
+
+		var sum uint64
+		for _, n := range values {
+			sum += uint64(n)
+		}
+		Expect(float64(sum) / num).To(BeNumerically("~", max/2, max/25))
+	})
+})


### PR DESCRIPTION
Blocked by #3045, which is blocked by CircleCI. @circleci, thanks for slowing down my development workflow!

Fixes #3044.

The alternative would be to use one `rand.Source` for all connections, but then we'd have to deal with it not being thread-safe. Reading 4 bytes from `crypto/rand` every 10000 packets shouldn't be too expensive, so we can just use cryptographic random here.