### PR TITLE
allow sending 1xx responses

### DIFF
--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -57,7 +57,10 @@ func (w *responseWriter) WriteHeader(status int) {
 	if w.headerWritten {
 		return
 	}
-	w.headerWritten = true
+
+	if status < 100 || status >= 200 {
+		w.headerWritten = true
+	}
 	w.status = status
 
 	var headers bytes.Buffer

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -82,6 +82,9 @@ func (w *responseWriter) WriteHeader(status int) {
 	if _, err := w.bufferedStream.Write(headers.Bytes()); err != nil {
 		w.logger.Errorf("could not write header frame payload: %s", err.Error())
 	}
+	if !w.headerWritten {
+		w.Flush()
+	}
 }
 
 func (w *responseWriter) Write(p []byte) (int, error) {

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Response Writer", func() {
 	BeforeEach(func() {
 		strBuf = &bytes.Buffer{}
 		str := mockquic.NewMockStream(mockCtrl)
-		str.EXPECT().Write(gomock.Any()).Do(strBuf.Write).AnyTimes()
+		str.EXPECT().Write(gomock.Any()).DoAndReturn(strBuf.Write).AnyTimes()
 		rw = newResponseWriter(str, utils.DefaultLogger)
 	})
 


### PR DESCRIPTION
Currently, it's not possible to send informational responses such as 103 Early Hints or 102 Processing.

This patch allows calling WriteHeader() multiple times in order to send informational responses before the final one.
It follows the patch for HTTP/1 (golang/go#42597) and HTTP/2 (golang/net#96).

In conformance with RFC 8297, if the status code is 103 the current content of the header map is also sent. Its content is not removed after the call to WriteHeader() because the headers must also be included in the final response.

The Chrome and Fastly teams are starting a large-scale experiment to measure the real-life impact of the 103 status code.
Using Early Hints is proposed as a (partial) alternative to Server Push, which are going to be removed from Chrome: https://groups.google.com/a/chromium.org/g/blink-dev/c/K3rYLvmQUBY/m/21anpFhxAQAJ

Being able to send this status code from servers implemented using Go would help to see if implementing it in browsers is worth it.