### PR TITLE
refactor merge packet number ranges

### DIFF
--- a/internal/ackhandler/received_packet_history.go
+++ b/internal/ackhandler/received_packet_history.go
@@ -44,23 +44,19 @@ func (h *receivedPacketHistory) addToRanges(p protocol.PacketNumber) bool /* is 
 			return false
 		}
 
-		var rangeExtended bool
 		if el.Value.End == p-1 { // extend a range at the end
-			rangeExtended = true
 			el.Value.End = p
-		} else if el.Value.Start == p+1 { // extend a range at the beginning
-			rangeExtended = true
-			el.Value.Start = p
+			return true
 		}
+		if el.Value.Start == p+1 { // extend a range at the beginning
+			el.Value.Start = p
 
-		// if a range was extended (either at the beginning or at the end, maybe it is possible to merge two ranges into one)
-		if rangeExtended {
 			prev := el.Prev()
 			if prev != nil && prev.Value.End+1 == el.Value.Start { // merge two ranges
 				prev.Value.End = el.Value.End
 				h.ranges.Remove(el)
 			}
-			return true // if the two ranges were not merge, we're done here
+			return true
 		}
 
 		// create a new range at the end


### PR DESCRIPTION
Since we iterate ranges from back to front, it is possible to merge two ranges only if extended at the beginning of a range.

1. It's unnecessary to do a merge-check when extended at the end.
2. `// if the two ranges were not merge, we're done here`, this comment is not matched with the original source code, we're done here because the range was extended(no matter merge or not).