### PR TITLE
remove incorrect logging for client side retry packet

### DIFF
--- a/session.go
+++ b/session.go
@@ -963,7 +963,6 @@ func (s *session) handleSinglePacket(p *receivedPacket, hdr *wire.Header) bool /
 }
 
 func (s *session) handleRetryPacket(hdr *wire.Header, data []byte) bool /* was this a valid Retry */ {
-	(&wire.ExtendedHeader{Header: *hdr}).Log(s.logger)
 	if s.perspective == protocol.PerspectiveServer {
 		if s.tracer != nil {
 			s.tracer.DroppedPacket(logging.PacketTypeRetry, protocol.ByteCount(len(data)), logging.PacketDropUnexpectedPacket)


### PR DESCRIPTION
Currently, when receiving a `Retry` packet from server, the client would log the retry packet as if it's part of its sending packet. 
```
2021/03/05 09:51:31 client -> Sending packet 0 (1252 bytes) for connection 9d186471c610d30fef01, Initial
2021/03/05 09:51:31 client 	Long Header{Type: Initial, DestConnectionID: 9d186471c610d30fef01, SrcConnectionID: (empty), Token: (empty), PacketNumber: 0, PacketNumberLen: 2, Length: 1232, Version: TLS dev version (WIP)}
2021/03/05 09:51:31 client 	-> &wire.CryptoFrame{Offset: 0, Data length: 288, Offset + Data length: 288}
2021/03/05 09:51:31 client 	Long Header{Type: Retry, DestConnectionID: (empty), SrcConnectionID: b778d7e8, Token: 0xd530867e323c094c94c5dfcfe17631efcf7764183bea50ebb4f724fe99d0e7f2e8dcf61156484a91b453a7427e9bcebfca8968a2fc30ff58db34e3b7570d98a54859688a7f435f330882c5d09eab7d102c3d0d8dd2c0d376281378cfaf61f6600f06f5a6, Version: TLS dev version (WIP)}
2021/03/05 09:51:31 client <- Received Retry:
2021/03/05 09:51:31 client 	Long Header{Type: Retry, DestConnectionID: (empty), SrcConnectionID: b778d7e8, Token: 0xd530867e323c094c94c5dfcfe17631efcf7764183bea50ebb4f724fe99d0e7f2e8dcf61156484a91b453a7427e9bcebfca8968a2fc30ff58db34e3b7570d98a54859688a7f435f330882c5d09eab7d102c3d0d8dd2c0d376281378cfaf61f6600f06f5a6, Version: TLS dev version (WIP)}
2021/03/05 09:51:31 client Switching destination connection ID to: b778d7e8
2021/03/05 09:51:31 client 	updated RTT: 703.689µs (σ: 351.844µs)
```