### PR TITLE
reject 0-RTT before handling transport parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/francoispqt/gojay v1.2.13
 	github.com/golang/mock v1.5.0
 	github.com/marten-seemann/qpack v0.2.1
-	github.com/marten-seemann/qtls-go1-15 v0.1.3
-	github.com/marten-seemann/qtls-go1-16 v0.1.2
+	github.com/marten-seemann/qtls-go1-15 v0.1.4
+	github.com/marten-seemann/qtls-go1-16 v0.1.3
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,10 @@ github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/marten-seemann/qpack v0.2.1 h1:jvTsT/HpCn2UZJdP+UUB53FfUUgeOyG5K1ns0OJOGVs=
 github.com/marten-seemann/qpack v0.2.1/go.mod h1:F7Gl5L1jIgN1D11ucXefiuJS9UMVP2opoCp2jDKb7wc=
-github.com/marten-seemann/qtls-go1-15 v0.1.3 h1:cH0i027vKKVeYobKzh9G8blXy1Q5LNStwUDPd6zLQ9A=
-github.com/marten-seemann/qtls-go1-15 v0.1.3/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
-github.com/marten-seemann/qtls-go1-16 v0.1.2 h1:NpjDqd65dekK9Webvazkw9IpuZXSto5p7DbjUFLzp+A=
-github.com/marten-seemann/qtls-go1-16 v0.1.2/go.mod h1:gNpI2Ol+lRS3WwSOtIUUtRwZEQMXjYK+dQSBFbethAk=
+github.com/marten-seemann/qtls-go1-15 v0.1.4 h1:RehYMOyRW8hPVEja1KBVsFVNSm35Jj9Mvs5yNoZZ28A=
+github.com/marten-seemann/qtls-go1-15 v0.1.4/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
+github.com/marten-seemann/qtls-go1-16 v0.1.3 h1:XEZ1xGorVy9u+lJq+WXNE+hiqRYLNvJGYmwfwKQN2gU=
+github.com/marten-seemann/qtls-go1-16 v0.1.3/go.mod h1:gNpI2Ol+lRS3WwSOtIUUtRwZEQMXjYK+dQSBFbethAk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
This is more logical order: First 0-RTT is rejected, then we process the transport parameters of the new connection attempt.

Should be merged after #3070.

This will prevent a race condition in the upcoming fix for #2067.

```diff
--- a/handshake_client_tls13.go
+++ b/handshake_client_tls13.go
@@ -403,6 +403,11 @@ func (hs *clientHandshakeStateTLS13) readServerParameters() error {
                c.sendAlert(alertUnexpectedMessage)
                return unexpectedMessageError(encryptedExtensions, msg)
        }
+       // Notify the caller if 0-RTT was rejected.
+       if !encryptedExtensions.earlyData && hs.hello.earlyData && c.extraConfig != nil && c.extraConfig.Rejected0RTT != nil {
+               c.extraConfig.Rejected0RTT()
+       }
+       c.used0RTT = encryptedExtensions.earlyData
        if hs.c.extraConfig != nil && hs.c.extraConfig.ReceivedExtensions != nil {
                hs.c.extraConfig.ReceivedExtensions(typeEncryptedExtensions, encryptedExtensions.additionalExtensions)
        }
@@ -431,11 +436,6 @@ func (hs *clientHandshakeStateTLS13) readServerParameters() error {
                }
                c.clientProtocol = encryptedExtensions.alpnProtocol
        }
-       // Notify the caller if 0-RTT was rejected.
-       if !encryptedExtensions.earlyData && hs.hello.earlyData && c.extraConfig != nil && c.extraConfig.Rejected0RTT != nil {
-               c.extraConfig.Rejected0RTT()
-       }
-       c.used0RTT = encryptedExtensions.earlyData
        return nil
 }
```