### PR TITLE
make the initial stream / connection flow control windows configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -71,6 +71,10 @@ func populateConfig(config *Config) *Config {
 	if config.MaxIdleTimeout != 0 {
 		idleTimeout = config.MaxIdleTimeout
 	}
+	initialStreamFlowControlWindow := config.InitialStreamFlowControlWindow
+	if initialStreamFlowControlWindow == 0 {
+		initialStreamFlowControlWindow = protocol.DefaultInitialMaxStreamData
+	}
 	maxReceiveStreamFlowControlWindow := config.MaxReceiveStreamFlowControlWindow
 	if maxReceiveStreamFlowControlWindow == 0 {
 		maxReceiveStreamFlowControlWindow = protocol.DefaultMaxReceiveStreamFlowControlWindow
@@ -98,6 +102,7 @@ func populateConfig(config *Config) *Config {
 		MaxIdleTimeout:                        idleTimeout,
 		AcceptToken:                           config.AcceptToken,
 		KeepAlive:                             config.KeepAlive,
+		InitialStreamFlowControlWindow:        initialStreamFlowControlWindow,
 		MaxReceiveStreamFlowControlWindow:     maxReceiveStreamFlowControlWindow,
 		MaxReceiveConnectionFlowControlWindow: maxReceiveConnectionFlowControlWindow,
 		MaxIncomingStreams:                    maxIncomingStreams,

--- a/config.go
+++ b/config.go
@@ -79,6 +79,10 @@ func populateConfig(config *Config) *Config {
 	if maxReceiveStreamFlowControlWindow == 0 {
 		maxReceiveStreamFlowControlWindow = protocol.DefaultMaxReceiveStreamFlowControlWindow
 	}
+	initialConnectionFlowControlWindow := config.InitialConnectionFlowControlWindow
+	if initialConnectionFlowControlWindow == 0 {
+		initialConnectionFlowControlWindow = protocol.DefaultInitialMaxData
+	}
 	maxReceiveConnectionFlowControlWindow := config.MaxReceiveConnectionFlowControlWindow
 	if maxReceiveConnectionFlowControlWindow == 0 {
 		maxReceiveConnectionFlowControlWindow = protocol.DefaultMaxReceiveConnectionFlowControlWindow
@@ -104,6 +108,7 @@ func populateConfig(config *Config) *Config {
 		KeepAlive:                             config.KeepAlive,
 		InitialStreamFlowControlWindow:        initialStreamFlowControlWindow,
 		MaxReceiveStreamFlowControlWindow:     maxReceiveStreamFlowControlWindow,
+		InitialConnectionFlowControlWindow:    initialConnectionFlowControlWindow,
 		MaxReceiveConnectionFlowControlWindow: maxReceiveConnectionFlowControlWindow,
 		MaxIncomingStreams:                    maxIncomingStreams,
 		MaxIncomingUniStreams:                 maxIncomingUniStreams,

--- a/config_test.go
+++ b/config_test.go
@@ -57,6 +57,8 @@ var _ = Describe("Config", func() {
 				f.Set(reflect.ValueOf(time.Hour))
 			case "TokenStore":
 				f.Set(reflect.ValueOf(NewLRUTokenStore(2, 3)))
+			case "InitialStreamFlowControlWindow":
+				f.Set(reflect.ValueOf(uint64(1234)))
 			case "MaxReceiveStreamFlowControlWindow":
 				f.Set(reflect.ValueOf(uint64(9)))
 			case "MaxReceiveConnectionFlowControlWindow":
@@ -142,6 +144,7 @@ var _ = Describe("Config", func() {
 			c := populateConfig(&Config{})
 			Expect(c.Versions).To(Equal(protocol.SupportedVersions))
 			Expect(c.HandshakeIdleTimeout).To(Equal(protocol.DefaultHandshakeIdleTimeout))
+			Expect(c.InitialStreamFlowControlWindow).To(BeEquivalentTo(protocol.DefaultInitialMaxStreamData))
 			Expect(c.MaxReceiveStreamFlowControlWindow).To(BeEquivalentTo(protocol.DefaultMaxReceiveStreamFlowControlWindow))
 			Expect(c.MaxReceiveConnectionFlowControlWindow).To(BeEquivalentTo(protocol.DefaultMaxReceiveConnectionFlowControlWindow))
 			Expect(c.MaxIncomingStreams).To(BeEquivalentTo(protocol.DefaultMaxIncomingStreams))

--- a/config_test.go
+++ b/config_test.go
@@ -61,6 +61,8 @@ var _ = Describe("Config", func() {
 				f.Set(reflect.ValueOf(uint64(1234)))
 			case "MaxReceiveStreamFlowControlWindow":
 				f.Set(reflect.ValueOf(uint64(9)))
+			case "InitialConnectionFlowControlWindow":
+				f.Set(reflect.ValueOf(uint64(4321)))
 			case "MaxReceiveConnectionFlowControlWindow":
 				f.Set(reflect.ValueOf(uint64(10)))
 			case "MaxIncomingStreams":
@@ -146,6 +148,7 @@ var _ = Describe("Config", func() {
 			Expect(c.HandshakeIdleTimeout).To(Equal(protocol.DefaultHandshakeIdleTimeout))
 			Expect(c.InitialStreamFlowControlWindow).To(BeEquivalentTo(protocol.DefaultInitialMaxStreamData))
 			Expect(c.MaxReceiveStreamFlowControlWindow).To(BeEquivalentTo(protocol.DefaultMaxReceiveStreamFlowControlWindow))
+			Expect(c.InitialConnectionFlowControlWindow).To(BeEquivalentTo(protocol.DefaultInitialMaxData))
 			Expect(c.MaxReceiveConnectionFlowControlWindow).To(BeEquivalentTo(protocol.DefaultMaxReceiveConnectionFlowControlWindow))
 			Expect(c.MaxIncomingStreams).To(BeEquivalentTo(protocol.DefaultMaxIncomingStreams))
 			Expect(c.MaxIncomingUniStreams).To(BeEquivalentTo(protocol.DefaultMaxIncomingUniStreams))

--- a/interface.go
+++ b/interface.go
@@ -253,6 +253,11 @@ type Config struct {
 	// MaxReceiveStreamFlowControlWindow is the maximum stream-level flow control window for receiving data.
 	// If this value is zero, it will default to 6 MB.
 	MaxReceiveStreamFlowControlWindow uint64
+	// InitialConnectionFlowControlWindow is the initial size of the stream-level flow control window for receiving data.
+	// If the application is consuming data quickly enough, the flow control auto-tuning algorithm
+	// will increase the window up to MaxReceiveConnectionFlowControlWindow.
+	// If this value is zero, it will default to 512 KB.
+	InitialConnectionFlowControlWindow uint64
 	// MaxReceiveConnectionFlowControlWindow is the connection-level flow control window for receiving data.
 	// If this value is zero, it will default to 15 MB.
 	MaxReceiveConnectionFlowControlWindow uint64

--- a/interface.go
+++ b/interface.go
@@ -245,6 +245,11 @@ type Config struct {
 	// The key used to store tokens is the ServerName from the tls.Config, if set
 	// otherwise the token is associated with the server's IP address.
 	TokenStore TokenStore
+	// InitialStreamFlowControlWindow is the initial size of the stream-level flow control window for receiving data.
+	// If the application is consuming data quickly enough, the flow control auto-tuning algorithm
+	// will increase the window up to MaxReceiveStreamFlowControlWindow.
+	// If this value is zero, it will default to 512 KB.
+	InitialStreamFlowControlWindow uint64
 	// MaxReceiveStreamFlowControlWindow is the maximum stream-level flow control window for receiving data.
 	// If this value is zero, it will default to 6 MB.
 	MaxReceiveStreamFlowControlWindow uint64

--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -21,11 +21,11 @@ const MaxUndecryptablePackets = 32
 // This is the value that Chromium is using
 const ConnectionFlowControlMultiplier = 1.5
 
-// InitialMaxStreamData is the stream-level flow control window for receiving data
-const InitialMaxStreamData = (1 << 10) * 512 // 512 kb
+// DefaultInitialMaxStreamData is the default initial stream-level flow control window for receiving data
+const DefaultInitialMaxStreamData = (1 << 10) * 512 // 512 kb
 
 // InitialMaxData is the connection-level flow control window for receiving data
-const InitialMaxData = ConnectionFlowControlMultiplier * InitialMaxStreamData
+const InitialMaxData = ConnectionFlowControlMultiplier * DefaultInitialMaxStreamData
 
 // DefaultMaxReceiveStreamFlowControlWindow is the default maximum stream-level flow control window for receiving data
 const DefaultMaxReceiveStreamFlowControlWindow = 6 * (1 << 20) // 6 MB

--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -24,8 +24,8 @@ const ConnectionFlowControlMultiplier = 1.5
 // DefaultInitialMaxStreamData is the default initial stream-level flow control window for receiving data
 const DefaultInitialMaxStreamData = (1 << 10) * 512 // 512 kb
 
-// InitialMaxData is the connection-level flow control window for receiving data
-const InitialMaxData = ConnectionFlowControlMultiplier * DefaultInitialMaxStreamData
+// DefaultInitialMaxData is the connection-level flow control window for receiving data
+const DefaultInitialMaxData = ConnectionFlowControlMultiplier * DefaultInitialMaxStreamData
 
 // DefaultMaxReceiveStreamFlowControlWindow is the default maximum stream-level flow control window for receiving data
 const DefaultMaxReceiveStreamFlowControlWindow = 6 * (1 << 20) // 6 MB

--- a/session.go
+++ b/session.go
@@ -286,7 +286,7 @@ var newSession = func(
 		InitialMaxStreamDataBidiLocal:   protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
 		InitialMaxStreamDataBidiRemote:  protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
 		InitialMaxStreamDataUni:         protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
-		InitialMaxData:                  protocol.InitialMaxData,
+		InitialMaxData:                  protocol.ByteCount(s.config.InitialConnectionFlowControlWindow),
 		MaxIdleTimeout:                  s.config.MaxIdleTimeout,
 		MaxBidiStreamNum:                protocol.StreamNum(s.config.MaxIncomingStreams),
 		MaxUniStreamNum:                 protocol.StreamNum(s.config.MaxIncomingUniStreams),
@@ -410,7 +410,7 @@ var newClientSession = func(
 		InitialMaxStreamDataBidiRemote: protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
 		InitialMaxStreamDataBidiLocal:  protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
 		InitialMaxStreamDataUni:        protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
-		InitialMaxData:                 protocol.InitialMaxData,
+		InitialMaxData:                 protocol.ByteCount(s.config.InitialConnectionFlowControlWindow),
 		MaxIdleTimeout:                 s.config.MaxIdleTimeout,
 		MaxBidiStreamNum:               protocol.StreamNum(s.config.MaxIncomingStreams),
 		MaxUniStreamNum:                protocol.StreamNum(s.config.MaxIncomingUniStreams),
@@ -484,7 +484,7 @@ func (s *session) preSetup() {
 	s.frameParser = wire.NewFrameParser(s.config.EnableDatagrams, s.version)
 	s.rttStats = &utils.RTTStats{}
 	s.connFlowController = flowcontrol.NewConnectionFlowController(
-		protocol.InitialMaxData,
+		protocol.ByteCount(s.config.InitialConnectionFlowControlWindow),
 		protocol.ByteCount(s.config.MaxReceiveConnectionFlowControlWindow),
 		s.onHasConnectionWindowUpdate,
 		s.rttStats,

--- a/session.go
+++ b/session.go
@@ -283,9 +283,9 @@ var newSession = func(
 	initialStream := newCryptoStream()
 	handshakeStream := newCryptoStream()
 	params := &wire.TransportParameters{
-		InitialMaxStreamDataBidiLocal:   protocol.InitialMaxStreamData,
-		InitialMaxStreamDataBidiRemote:  protocol.InitialMaxStreamData,
-		InitialMaxStreamDataUni:         protocol.InitialMaxStreamData,
+		InitialMaxStreamDataBidiLocal:   protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
+		InitialMaxStreamDataBidiRemote:  protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
+		InitialMaxStreamDataUni:         protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
 		InitialMaxData:                  protocol.InitialMaxData,
 		MaxIdleTimeout:                  s.config.MaxIdleTimeout,
 		MaxBidiStreamNum:                protocol.StreamNum(s.config.MaxIncomingStreams),
@@ -407,9 +407,9 @@ var newClientSession = func(
 	initialStream := newCryptoStream()
 	handshakeStream := newCryptoStream()
 	params := &wire.TransportParameters{
-		InitialMaxStreamDataBidiRemote: protocol.InitialMaxStreamData,
-		InitialMaxStreamDataBidiLocal:  protocol.InitialMaxStreamData,
-		InitialMaxStreamDataUni:        protocol.InitialMaxStreamData,
+		InitialMaxStreamDataBidiRemote: protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
+		InitialMaxStreamDataBidiLocal:  protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
+		InitialMaxStreamDataUni:        protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
 		InitialMaxData:                 protocol.InitialMaxData,
 		MaxIdleTimeout:                 s.config.MaxIdleTimeout,
 		MaxBidiStreamNum:               protocol.StreamNum(s.config.MaxIncomingStreams),
@@ -1791,7 +1791,7 @@ func (s *session) newFlowController(id protocol.StreamID) flowcontrol.StreamFlow
 	return flowcontrol.NewStreamFlowController(
 		id,
 		s.connFlowController,
-		protocol.InitialMaxStreamData,
+		protocol.ByteCount(s.config.InitialStreamFlowControlWindow),
 		protocol.ByteCount(s.config.MaxReceiveStreamFlowControlWindow),
 		initialSendWindow,
 		s.onHasStreamWindowUpdate,


### PR DESCRIPTION
This is primarily to make 0-RTT better testable when we relax the resumption condition, see #3061.

As we're shifting more responsibility for setting these values to the application, we could say this fixes #88.

Should we rename the config options? The current ones are a bit of a mouthful. Suggestion:
`Initial{Stream, Connection}FlowControlWindow` => `Initial{Stream, Connection}ReceiveWindow`
`MaxReceive{Stream, Connection}FlowControlWindow` => `Max{Stream, Connection}ReceiveWindow`