### PR TITLE
allow 0-RTT resumption if the server's stream limit was increased

### DIFF
--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -466,7 +466,7 @@ func (h *cryptoSetup) GetSessionTicket() ([]byte, error) {
 func (h *cryptoSetup) accept0RTT(sessionTicketData []byte) bool {
 	var t sessionTicket
 	if err := t.Unmarshal(sessionTicketData); err != nil {
-		h.logger.Debugf("Unmarshaling transport parameters from session ticket failed: %s", err.Error())
+		h.logger.Debugf("Unmarshalling transport parameters from session ticket failed: %s", err.Error())
 		return false
 	}
 	valid := h.ourParams.ValidFor0RTT(t.Parameters)

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -483,7 +483,7 @@ var _ = Describe("Transport Parameters", func() {
 
 		Context("rejects the parameters if they changed", func() {
 			var p TransportParameters
-			params := &TransportParameters{
+			saved := &TransportParameters{
 				InitialMaxStreamDataBidiLocal:  1,
 				InitialMaxStreamDataBidiRemote: 2,
 				InitialMaxStreamDataUni:        3,
@@ -494,43 +494,53 @@ var _ = Describe("Transport Parameters", func() {
 			}
 
 			BeforeEach(func() {
-				p = *params
-				Expect(params.ValidFor0RTT(&p)).To(BeTrue())
+				p = *saved
+				Expect(p.ValidFor0RTT(saved)).To(BeTrue())
 			})
 
 			It("rejects the parameters if the InitialMaxStreamDataBidiLocal changed", func() {
 				p.InitialMaxStreamDataBidiLocal = 0
-				Expect(params.ValidFor0RTT(&p)).To(BeFalse())
+				Expect(p.ValidFor0RTT(saved)).To(BeFalse())
 			})
 
 			It("rejects the parameters if the InitialMaxStreamDataBidiRemote changed", func() {
 				p.InitialMaxStreamDataBidiRemote = 0
-				Expect(params.ValidFor0RTT(&p)).To(BeFalse())
+				Expect(p.ValidFor0RTT(saved)).To(BeFalse())
 			})
 
 			It("rejects the parameters if the InitialMaxStreamDataUni changed", func() {
 				p.InitialMaxStreamDataUni = 0
-				Expect(params.ValidFor0RTT(&p)).To(BeFalse())
+				Expect(p.ValidFor0RTT(saved)).To(BeFalse())
 			})
 
 			It("rejects the parameters if the InitialMaxData changed", func() {
 				p.InitialMaxData = 0
-				Expect(params.ValidFor0RTT(&p)).To(BeFalse())
+				Expect(p.ValidFor0RTT(saved)).To(BeFalse())
 			})
 
 			It("rejects the parameters if the MaxBidiStreamNum changed", func() {
 				p.MaxBidiStreamNum = 0
-				Expect(params.ValidFor0RTT(&p)).To(BeFalse())
+				Expect(p.ValidFor0RTT(saved)).To(BeFalse())
+			})
+
+			It("accepts the parameters if the MaxBidiStreamNum was increased", func() {
+				p.MaxBidiStreamNum = saved.MaxBidiStreamNum + 1
+				Expect(p.ValidFor0RTT(saved)).To(BeTrue())
 			})
 
 			It("rejects the parameters if the MaxUniStreamNum changed", func() {
-				p.MaxUniStreamNum = 0
-				Expect(params.ValidFor0RTT(&p)).To(BeFalse())
+				p.MaxUniStreamNum = saved.MaxUniStreamNum - 1
+				Expect(p.ValidFor0RTT(saved)).To(BeFalse())
+			})
+
+			It("accepts the parameters if the MaxUniStreamNum was increased", func() {
+				p.MaxUniStreamNum = saved.MaxUniStreamNum + 1
+				Expect(p.ValidFor0RTT(saved)).To(BeTrue())
 			})
 
 			It("rejects the parameters if the ActiveConnectionIDLimit changed", func() {
 				p.ActiveConnectionIDLimit = 0
-				Expect(params.ValidFor0RTT(&p)).To(BeFalse())
+				Expect(p.ValidFor0RTT(saved)).To(BeFalse())
 			})
 		})
 	})

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -440,14 +440,14 @@ func (p *TransportParameters) UnmarshalFromSessionTicket(r *bytes.Reader) error 
 }
 
 // ValidFor0RTT checks if the transport parameters match those saved in the session ticket.
-func (p *TransportParameters) ValidFor0RTT(tp *TransportParameters) bool {
-	return p.InitialMaxStreamDataBidiLocal == tp.InitialMaxStreamDataBidiLocal &&
-		p.InitialMaxStreamDataBidiRemote == tp.InitialMaxStreamDataBidiRemote &&
-		p.InitialMaxStreamDataUni == tp.InitialMaxStreamDataUni &&
-		p.InitialMaxData == tp.InitialMaxData &&
-		p.MaxBidiStreamNum == tp.MaxBidiStreamNum &&
-		p.MaxUniStreamNum == tp.MaxUniStreamNum &&
-		p.ActiveConnectionIDLimit == tp.ActiveConnectionIDLimit
+func (p *TransportParameters) ValidFor0RTT(saved *TransportParameters) bool {
+	return p.InitialMaxStreamDataBidiLocal == saved.InitialMaxStreamDataBidiLocal &&
+		p.InitialMaxStreamDataBidiRemote == saved.InitialMaxStreamDataBidiRemote &&
+		p.InitialMaxStreamDataUni == saved.InitialMaxStreamDataUni &&
+		p.InitialMaxData == saved.InitialMaxData &&
+		p.MaxBidiStreamNum >= saved.MaxBidiStreamNum &&
+		p.MaxUniStreamNum >= saved.MaxUniStreamNum &&
+		p.ActiveConnectionIDLimit == saved.ActiveConnectionIDLimit
 }
 
 // String returns a string representation, intended for logging.


### PR DESCRIPTION
Part of the fix for #3061.