### PR TITLE
update the flow control windows of streams opened in 0-RTT

### DIFF
--- a/mock_send_stream_internal_test.go
+++ b/mock_send_stream_internal_test.go
@@ -133,18 +133,6 @@ func (mr *MockSendStreamIMockRecorder) closeForShutdown(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "closeForShutdown", reflect.TypeOf((*MockSendStreamI)(nil).closeForShutdown), arg0)
 }
 
-// handleMaxStreamDataFrame mocks base method.
-func (m *MockSendStreamI) handleMaxStreamDataFrame(arg0 *wire.MaxStreamDataFrame) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "handleMaxStreamDataFrame", arg0)
-}
-
-// handleMaxStreamDataFrame indicates an expected call of handleMaxStreamDataFrame.
-func (mr *MockSendStreamIMockRecorder) handleMaxStreamDataFrame(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleMaxStreamDataFrame", reflect.TypeOf((*MockSendStreamI)(nil).handleMaxStreamDataFrame), arg0)
-}
-
 // handleStopSendingFrame mocks base method.
 func (m *MockSendStreamI) handleStopSendingFrame(arg0 *wire.StopSendingFrame) {
 	m.ctrl.T.Helper()
@@ -184,4 +172,16 @@ func (m *MockSendStreamI) popStreamFrame(maxBytes protocol.ByteCount) (*ackhandl
 func (mr *MockSendStreamIMockRecorder) popStreamFrame(maxBytes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockSendStreamI)(nil).popStreamFrame), maxBytes)
+}
+
+// updateSendWindow mocks base method.
+func (m *MockSendStreamI) updateSendWindow(arg0 protocol.ByteCount) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "updateSendWindow", arg0)
+}
+
+// updateSendWindow indicates an expected call of updateSendWindow.
+func (mr *MockSendStreamIMockRecorder) updateSendWindow(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateSendWindow", reflect.TypeOf((*MockSendStreamI)(nil).updateSendWindow), arg0)
 }

--- a/mock_stream_internal_test.go
+++ b/mock_stream_internal_test.go
@@ -202,18 +202,6 @@ func (mr *MockStreamIMockRecorder) getWindowUpdate() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getWindowUpdate", reflect.TypeOf((*MockStreamI)(nil).getWindowUpdate))
 }
 
-// handleMaxStreamDataFrame mocks base method.
-func (m *MockStreamI) handleMaxStreamDataFrame(arg0 *wire.MaxStreamDataFrame) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "handleMaxStreamDataFrame", arg0)
-}
-
-// handleMaxStreamDataFrame indicates an expected call of handleMaxStreamDataFrame.
-func (mr *MockStreamIMockRecorder) handleMaxStreamDataFrame(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleMaxStreamDataFrame", reflect.TypeOf((*MockStreamI)(nil).handleMaxStreamDataFrame), arg0)
-}
-
 // handleResetStreamFrame mocks base method.
 func (m *MockStreamI) handleResetStreamFrame(arg0 *wire.ResetStreamFrame) error {
 	m.ctrl.T.Helper()
@@ -281,4 +269,16 @@ func (m *MockStreamI) popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.F
 func (mr *MockStreamIMockRecorder) popStreamFrame(maxBytes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockStreamI)(nil).popStreamFrame), maxBytes)
+}
+
+// updateSendWindow mocks base method.
+func (m *MockStreamI) updateSendWindow(arg0 protocol.ByteCount) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "updateSendWindow", arg0)
+}
+
+// updateSendWindow indicates an expected call of updateSendWindow.
+func (mr *MockStreamIMockRecorder) updateSendWindow(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateSendWindow", reflect.TypeOf((*MockStreamI)(nil).updateSendWindow), arg0)
 }

--- a/send_stream.go
+++ b/send_stream.go
@@ -20,7 +20,7 @@ type sendStreamI interface {
 	hasData() bool
 	popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Frame, bool)
 	closeForShutdown(error)
-	handleMaxStreamDataFrame(*wire.MaxStreamDataFrame)
+	updateSendWindow(protocol.ByteCount)
 }
 
 type sendStream struct {
@@ -437,12 +437,12 @@ func (s *sendStream) cancelWriteImpl(errorCode protocol.ApplicationErrorCode, wr
 	}
 }
 
-func (s *sendStream) handleMaxStreamDataFrame(frame *wire.MaxStreamDataFrame) {
+func (s *sendStream) updateSendWindow(limit protocol.ByteCount) {
 	s.mutex.Lock()
 	hasStreamData := s.dataForWriting != nil || s.nextFrame != nil
 	s.mutex.Unlock()
 
-	s.flowController.UpdateSendWindow(frame.MaximumStreamData)
+	s.flowController.UpdateSendWindow(limit)
 	if hasStreamData {
 		s.sender.onHasStreamData(s.streamID)
 	}

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -652,10 +652,7 @@ var _ = Describe("Send Stream", func() {
 	Context("handling MAX_STREAM_DATA frames", func() {
 		It("informs the flow controller", func() {
 			mockFC.EXPECT().UpdateSendWindow(protocol.ByteCount(0x1337))
-			str.handleMaxStreamDataFrame(&wire.MaxStreamDataFrame{
-				StreamID:          streamID,
-				MaximumStreamData: 0x1337,
-			})
+			str.updateSendWindow(0x1337)
 		})
 
 		It("says when it has data for sending", func() {
@@ -670,10 +667,7 @@ var _ = Describe("Send Stream", func() {
 			}()
 			waitForWrite()
 			mockSender.EXPECT().onHasStreamData(streamID)
-			str.handleMaxStreamDataFrame(&wire.MaxStreamDataFrame{
-				StreamID:          streamID,
-				MaximumStreamData: 42,
-			})
+			str.updateSendWindow(42)
 			// make sure the Write go routine returns
 			str.closeForShutdown(nil)
 			Eventually(done).Should(BeClosed())

--- a/session.go
+++ b/session.go
@@ -1272,7 +1272,7 @@ func (s *session) handleMaxStreamDataFrame(frame *wire.MaxStreamDataFrame) error
 		// stream is closed and already garbage collected
 		return nil
 	}
-	str.handleMaxStreamDataFrame(frame)
+	str.updateSendWindow(frame.MaximumStreamData)
 	return nil
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -220,9 +220,8 @@ var _ = Describe("Session", func() {
 				}
 				str := NewMockSendStreamI(mockCtrl)
 				streamManager.EXPECT().GetOrOpenSendStream(protocol.StreamID(12345)).Return(str, nil)
-				str.EXPECT().handleMaxStreamDataFrame(f)
-				err := sess.handleMaxStreamDataFrame(f)
-				Expect(err).ToNot(HaveOccurred())
+				str.EXPECT().updateSendWindow(protocol.ByteCount(0x1337))
+				Expect(sess.handleMaxStreamDataFrame(f)).To(Succeed())
 			})
 
 			It("updates the flow control window of the connection", func() {

--- a/stream.go
+++ b/stream.go
@@ -61,7 +61,7 @@ type streamI interface {
 	hasData() bool
 	handleStopSendingFrame(*wire.StopSendingFrame)
 	popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Frame, bool)
-	handleMaxStreamDataFrame(*wire.MaxStreamDataFrame)
+	updateSendWindow(protocol.ByteCount)
 }
 
 var (

--- a/streams_map.go
+++ b/streams_map.go
@@ -278,7 +278,9 @@ func (m *streamsMap) HandleMaxStreamsFrame(f *wire.MaxStreamsFrame) {
 }
 
 func (m *streamsMap) UpdateLimits(p *wire.TransportParameters) {
+	m.outgoingBidiStreams.UpdateSendWindow(p.InitialMaxStreamDataBidiRemote)
 	m.outgoingBidiStreams.SetMaxStream(p.MaxBidiStreamNum)
+	m.outgoingUniStreams.UpdateSendWindow(p.InitialMaxStreamDataUni)
 	m.outgoingUniStreams.SetMaxStream(p.MaxUniStreamNum)
 }
 

--- a/streams_map_generic_helper.go
+++ b/streams_map_generic_helper.go
@@ -11,6 +11,7 @@ import (
 // This definition must be in a file that Genny doesn't process.
 type item interface {
 	generic.Type
+	updateSendWindow(protocol.ByteCount)
 	closeForShutdown(error)
 }
 

--- a/streams_map_incoming_generic_test.go
+++ b/streams_map_incoming_generic_test.go
@@ -18,13 +18,18 @@ import (
 type mockGenericStream struct {
 	num protocol.StreamNum
 
-	closed   bool
-	closeErr error
+	closed     bool
+	closeErr   error
+	sendWindow protocol.ByteCount
 }
 
 func (s *mockGenericStream) closeForShutdown(err error) {
 	s.closed = true
 	s.closeErr = err
+}
+
+func (s *mockGenericStream) updateSendWindow(limit protocol.ByteCount) {
+	s.sendWindow = limit
 }
 
 var _ = Describe("Streams Map (incoming)", func() {

--- a/streams_map_outgoing_bidi.go
+++ b/streams_map_outgoing_bidi.go
@@ -180,6 +180,17 @@ func (m *outgoingBidiStreamsMap) SetMaxStream(num protocol.StreamNum) {
 	m.unblockOpenSync()
 }
 
+// UpdateSendWindow is called when the peer's transport parameters are received.
+// Only in the case of a 0-RTT handshake will we have open streams at this point.
+// We might need to update the send window, in case the server increased it.
+func (m *outgoingBidiStreamsMap) UpdateSendWindow(limit protocol.ByteCount) {
+	m.mutex.Lock()
+	for _, str := range m.streams {
+		str.updateSendWindow(limit)
+	}
+	m.mutex.Unlock()
+}
+
 // unblockOpenSync unblocks the next OpenStreamSync go-routine to open a new stream
 func (m *outgoingBidiStreamsMap) unblockOpenSync() {
 	if len(m.openQueue) == 0 {

--- a/streams_map_outgoing_generic.go
+++ b/streams_map_outgoing_generic.go
@@ -178,6 +178,17 @@ func (m *outgoingItemsMap) SetMaxStream(num protocol.StreamNum) {
 	m.unblockOpenSync()
 }
 
+// UpdateSendWindow is called when the peer's transport parameters are received.
+// Only in the case of a 0-RTT handshake will we have open streams at this point.
+// We might need to update the send window, in case the server increased it.
+func (m *outgoingItemsMap) UpdateSendWindow(limit protocol.ByteCount) {
+	m.mutex.Lock()
+	for _, str := range m.streams {
+		str.updateSendWindow(limit)
+	}
+	m.mutex.Unlock()
+}
+
 // unblockOpenSync unblocks the next OpenStreamSync go-routine to open a new stream
 func (m *outgoingItemsMap) unblockOpenSync() {
 	if len(m.openQueue) == 0 {

--- a/streams_map_outgoing_generic_test.go
+++ b/streams_map_outgoing_generic_test.go
@@ -112,6 +112,16 @@ var _ = Describe("Streams Map (outgoing)", func() {
 			Expect(str2.(*mockGenericStream).closed).To(BeTrue())
 			Expect(str2.(*mockGenericStream).closeErr).To(MatchError(testErr))
 		})
+
+		It("updates the send window", func() {
+			str1, err := m.OpenStream()
+			Expect(err).ToNot(HaveOccurred())
+			str2, err := m.OpenStream()
+			Expect(err).ToNot(HaveOccurred())
+			m.UpdateSendWindow(1337)
+			Expect(str1.(*mockGenericStream).sendWindow).To(BeEquivalentTo(1337))
+			Expect(str2.(*mockGenericStream).sendWindow).To(BeEquivalentTo(1337))
+		})
 	})
 
 	Context("with stream ID limits", func() {

--- a/streams_map_outgoing_uni.go
+++ b/streams_map_outgoing_uni.go
@@ -180,6 +180,17 @@ func (m *outgoingUniStreamsMap) SetMaxStream(num protocol.StreamNum) {
 	m.unblockOpenSync()
 }
 
+// UpdateSendWindow is called when the peer's transport parameters are received.
+// Only in the case of a 0-RTT handshake will we have open streams at this point.
+// We might need to update the send window, in case the server increased it.
+func (m *outgoingUniStreamsMap) UpdateSendWindow(limit protocol.ByteCount) {
+	m.mutex.Lock()
+	for _, str := range m.streams {
+		str.updateSendWindow(limit)
+	}
+	m.mutex.Unlock()
+}
+
 // unblockOpenSync unblocks the next OpenStreamSync go-routine to open a new stream
 func (m *outgoingUniStreamsMap) unblockOpenSync() {
 	if len(m.openQueue) == 0 {


### PR DESCRIPTION
The server might have increased the initial flow control window. We need to make sure to inform all streams opened during during the 0-RTT period.

See https://github.com/quicwg/base-drafts/issues/4834.