### PR TITLE
use code points from x/sys/unix for PKTINFO syscalls

### DIFF
--- a/conn_helper_darwin.go
+++ b/conn_helper_darwin.go
@@ -7,11 +7,11 @@ import "golang.org/x/sys/unix"
 const msgTypeIPTOS = unix.IP_RECVTOS
 
 const (
-	ipv4RECVPKTINFO = 0x1a
+	ipv4RECVPKTINFO = unix.IP_RECVPKTINFO
 	ipv6RECVPKTINFO = 0x3d
 )
 
 const (
-	msgTypeIPv4PKTINFO = 0x1a
+	msgTypeIPv4PKTINFO = unix.IP_PKTINFO
 	msgTypeIPv6PKTINFO = 0x2e
 )

--- a/conn_helper_linux.go
+++ b/conn_helper_linux.go
@@ -7,11 +7,11 @@ import "golang.org/x/sys/unix"
 const msgTypeIPTOS = unix.IP_TOS
 
 const (
-	ipv4RECVPKTINFO = 0x8
-	ipv6RECVPKTINFO = 0x31
+	ipv4RECVPKTINFO = unix.IP_PKTINFO
+	ipv6RECVPKTINFO = unix.IPV6_RECVPKTINFO
 )
 
 const (
-	msgTypeIPv4PKTINFO = 0x8
-	msgTypeIPv6PKTINFO = 0x32
+	msgTypeIPv4PKTINFO = unix.IP_PKTINFO
+	msgTypeIPv6PKTINFO = unix.IPV6_PKTINFO
 )


### PR DESCRIPTION
Looks like there's no `IPV6_{RECV}PKTINFO` on `darwin` though.