### PR TITLE
only run Ginkgo focus detection in staged files in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,7 +4,7 @@
 errored=false
 for f in $(git diff --cached --name-only); do
 	if [[ $f != *_test.go ]]; then continue; fi
-	output=$(grep -n -e "FIt(" -e "FContext(" -e "FDescribe(" "$f")
+	output=$(git show :"$f" | grep -n -e "FIt(" -e "FContext(" -e "FDescribe(")
 	if [ $? -eq 0 ]; then
 		echo "$f contains a focussed test:"
 		echo "$output"


### PR DESCRIPTION
If a change is not staged (and therefore won't be committed), we don't care.