### PR TITLE
avoid type confusion between protocol.PacketType and logging.PacketType

### DIFF
--- a/internal/mocks/logging/connection_tracer.go
+++ b/internal/mocks/logging/connection_tracer.go
@@ -40,7 +40,7 @@ func (m *MockConnectionTracer) EXPECT() *MockConnectionTracerMockRecorder {
 }
 
 // BufferedPacket mocks base method.
-func (m *MockConnectionTracer) BufferedPacket(arg0 protocol.PacketType) {
+func (m *MockConnectionTracer) BufferedPacket(arg0 logging.PacketType) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "BufferedPacket", arg0)
 }
@@ -112,7 +112,7 @@ func (mr *MockConnectionTracerMockRecorder) DroppedKey(arg0 interface{}) *gomock
 }
 
 // DroppedPacket mocks base method.
-func (m *MockConnectionTracer) DroppedPacket(arg0 protocol.PacketType, arg1 protocol.ByteCount, arg2 logging.PacketDropReason) {
+func (m *MockConnectionTracer) DroppedPacket(arg0 logging.PacketType, arg1 protocol.ByteCount, arg2 logging.PacketDropReason) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DroppedPacket", arg0, arg1, arg2)
 }

--- a/internal/mocks/logging/tracer.go
+++ b/internal/mocks/logging/tracer.go
@@ -38,7 +38,7 @@ func (m *MockTracer) EXPECT() *MockTracerMockRecorder {
 }
 
 // DroppedPacket mocks base method.
-func (m *MockTracer) DroppedPacket(arg0 net.Addr, arg1 protocol.PacketType, arg2 protocol.ByteCount, arg3 logging.PacketDropReason) {
+func (m *MockTracer) DroppedPacket(arg0 net.Addr, arg1 logging.PacketType, arg2 protocol.ByteCount, arg3 logging.PacketDropReason) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DroppedPacket", arg0, arg1, arg2, arg3)
 }

--- a/logging/mock_connection_tracer_test.go
+++ b/logging/mock_connection_tracer_test.go
@@ -39,7 +39,7 @@ func (m *MockConnectionTracer) EXPECT() *MockConnectionTracerMockRecorder {
 }
 
 // BufferedPacket mocks base method.
-func (m *MockConnectionTracer) BufferedPacket(arg0 protocol.PacketType) {
+func (m *MockConnectionTracer) BufferedPacket(arg0 PacketType) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "BufferedPacket", arg0)
 }
@@ -111,7 +111,7 @@ func (mr *MockConnectionTracerMockRecorder) DroppedKey(arg0 interface{}) *gomock
 }
 
 // DroppedPacket mocks base method.
-func (m *MockConnectionTracer) DroppedPacket(arg0 protocol.PacketType, arg1 protocol.ByteCount, arg2 PacketDropReason) {
+func (m *MockConnectionTracer) DroppedPacket(arg0 PacketType, arg1 protocol.ByteCount, arg2 PacketDropReason) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DroppedPacket", arg0, arg1, arg2)
 }

--- a/logging/mock_tracer_test.go
+++ b/logging/mock_tracer_test.go
@@ -37,7 +37,7 @@ func (m *MockTracer) EXPECT() *MockTracerMockRecorder {
 }
 
 // DroppedPacket mocks base method.
-func (m *MockTracer) DroppedPacket(arg0 net.Addr, arg1 protocol.PacketType, arg2 protocol.ByteCount, arg3 PacketDropReason) {
+func (m *MockTracer) DroppedPacket(arg0 net.Addr, arg1 PacketType, arg2 protocol.ByteCount, arg3 PacketDropReason) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DroppedPacket", arg0, arg1, arg2, arg3)
 }

--- a/logging/types.go
+++ b/logging/types.go
@@ -1,9 +1,7 @@
 package logging
 
-import "github.com/lucas-clemente/quic-go/internal/protocol"
-
 // PacketType is the packet type of a QUIC packet
-type PacketType = protocol.PacketType
+type PacketType uint8
 
 const (
 	// PacketTypeInitial is the packet type of an Initial packet


### PR DESCRIPTION
The enums have completely different meanings. `protocol.PacketType` only defines long header types, whereas `logging.PacketType` defines all different types of QUIC packets (including short header packets).

This led to a bug in metrics implementation in libp2p: There, we were doing something along those lines:
```go
func (m *tracer) getEncLevel(hdr *logging.ExtendedHeader) string {
	if hdr.Type == logging.PacketType0RTT {
		return "0-RTT"
	}
        // ....
}
```

This leads to wrong results, as `hdr.Type` is a `protocol.PacketType` and not a `logging.PacketType`. It just compiled because we defined `logging.PacketType` as an alias for `protocol.PacketType`. With this PR, the code snippet above will fail to compile.