### PR TITLE
improve string representation of timeout errors

### DIFF
--- a/internal/qerr/quic_error.go
+++ b/internal/qerr/quic_error.go
@@ -65,9 +65,14 @@ func (e *QuicError) Error() string {
 		}
 		return fmt.Sprintf("Application error %#x: %s", uint64(e.ErrorCode), e.ErrorMessage)
 	}
-	str := e.ErrorCode.String()
-	if e.FrameType != 0 {
-		str += fmt.Sprintf(" (frame type: %#x)", e.FrameType)
+	var str string
+	if e.isTimeout {
+		str = "Timeout"
+	} else {
+		str = e.ErrorCode.String()
+		if e.FrameType != 0 {
+			str += fmt.Sprintf(" (frame type: %#x)", e.FrameType)
+		}
 	}
 	msg := e.ErrorMessage
 	if len(msg) == 0 {

--- a/internal/qerr/quic_error_test.go
+++ b/internal/qerr/quic_error_test.go
@@ -33,7 +33,7 @@ var _ = Describe("QUIC Transport Errors", func() {
 	It("has a string representation for timeout errors", func() {
 		err := NewTimeoutError("foobar")
 		Expect(err.Timeout()).To(BeTrue())
-		Expect(err.Error()).To(Equal("NO_ERROR: foobar"))
+		Expect(err.Error()).To(Equal("Timeout: foobar"))
 	})
 
 	Context("crypto errors", func() {


### PR DESCRIPTION
Currently, an idle timeout's string representation is `NO_ERROR: No recent network activity`. With this PR, it will be `Timeout: No recent network activity`.

Note that this will break some applications building on top of quic-go that are performing string matching to detect timeout errors. I don't see this as a problem with this PR though, I regard this as a feature.
While it is true that our errors are not as helpful as they could be (see #2441), detecting timeout errors is not a problem: Our errors implement the [`net.Error`](https://golang.org/pkg/net/#Error) interface, which defines a `Timeout() bool` method.