### PR TITLE
fix calculation of the handshake idle timeout

### DIFF
--- a/session.go
+++ b/session.go
@@ -740,7 +740,10 @@ func (s *session) nextKeepAliveTime() time.Time {
 func (s *session) maybeResetTimer() {
 	var deadline time.Time
 	if !s.handshakeComplete {
-		deadline = s.sessionCreationTime.Add(utils.MinDuration(s.config.handshakeTimeout(), s.config.HandshakeIdleTimeout))
+		deadline = utils.MinTime(
+			s.sessionCreationTime.Add(s.config.handshakeTimeout()),
+			s.idleTimeoutStartTime().Add(s.config.HandshakeIdleTimeout),
+		)
 	} else {
 		if keepAliveTime := s.nextKeepAliveTime(); !keepAliveTime.IsZero() {
 			deadline = keepAliveTime

--- a/session_test.go
+++ b/session_test.go
@@ -2158,6 +2158,7 @@ var _ = Describe("Session", func() {
 		})
 
 		It("doesn't send a PING if the handshake isn't completed yet", func() {
+			sess.config.HandshakeIdleTimeout = time.Hour
 			sess.handshakeComplete = false
 			// Needs to be shorter than our idle timeout.
 			// Otherwise we'll try to send a CONNECTION_CLOSE.


### PR DESCRIPTION
This could lead to busy-looping (until the handshake timeout kicks in).