### PR TITLE
only start PMTUD after handshake confirmation

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -2555,6 +2555,7 @@ var _ = Describe("Client Session", func() {
 	})
 
 	It("handles HANDSHAKE_DONE frames", func() {
+		sess.peerParams = &wire.TransportParameters{}
 		sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 		sess.sentPacketHandler = sph
 		sph.EXPECT().SetHandshakeConfirmed()


### PR DESCRIPTION
Our PMTUD packets are never coalesced packets. Since we try packing coalesced packets until the handshake is confirmed, it makes sense to start PMTUD then.

This mismatch in expectation can also lead to busy-looping: we might set a timer to send a PMTUD packet, but then we never send one, because the handshake isn't confirmed yet.