### PR TITLE
return an error when the max datagram size is reduced

### DIFF
--- a/internal/ackhandler/frame.go
+++ b/internal/ackhandler/frame.go
@@ -5,5 +5,5 @@ import "github.com/lucas-clemente/quic-go/internal/wire"
 type Frame struct {
 	wire.Frame // nil if the frame has already been acknowledged in another packet
 	OnLost     func(wire.Frame)
-	OnAcked    func(wire.Frame)
+	OnAcked    func(wire.Frame) error
 }

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -40,7 +40,7 @@ type SentPacketHandler interface {
 	TimeUntilSend() time.Time
 	// HasPacingBudget says if the pacer allows sending of a (full size) packet at this moment.
 	HasPacingBudget() bool
-	SetMaxDatagramSize(count protocol.ByteCount)
+	SetMaxDatagramSize(count protocol.ByteCount) error
 
 	// only to be called once the handshake is complete
 	QueueProbePacket(protocol.EncryptionLevel) bool /* was a packet queued */

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -393,7 +393,9 @@ func (h *sentPacketHandler) detectAndRemoveAckedPackets(ack *wire.AckFrame, encL
 
 		for _, f := range p.Frames {
 			if f.OnAcked != nil {
-				f.OnAcked(f.Frame)
+				if err := f.OnAcked(f.Frame); err != nil {
+					return nil, err
+				}
 			}
 		}
 		if err := pnSpace.history.Remove(p.PacketNumber); err != nil {
@@ -708,8 +710,8 @@ func (h *sentPacketHandler) HasPacingBudget() bool {
 	return h.congestion.HasPacingBudget()
 }
 
-func (h *sentPacketHandler) SetMaxDatagramSize(s protocol.ByteCount) {
-	h.congestion.SetMaxDatagramSize(s)
+func (h *sentPacketHandler) SetMaxDatagramSize(s protocol.ByteCount) error {
+	return h.congestion.SetMaxDatagramSize(s)
 }
 
 func (h *sentPacketHandler) isAmplificationLimited() bool {

--- a/internal/congestion/cubic_sender.go
+++ b/internal/congestion/cubic_sender.go
@@ -1,6 +1,7 @@
 package congestion
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
@@ -281,9 +282,9 @@ func (c *cubicSender) maybeTraceStateChange(new logging.CongestionState) {
 	c.lastState = new
 }
 
-func (c *cubicSender) SetMaxDatagramSize(s protocol.ByteCount) {
+func (c *cubicSender) SetMaxDatagramSize(s protocol.ByteCount) error {
 	if s < c.maxDatagramSize {
-		panic("congestion BUG: decreased max datagram size")
+		return fmt.Errorf("congestion BUG: decreased max datagram size from %d to %d bytes", c.maxDatagramSize, s)
 	}
 	cwndIsMinCwnd := c.congestionWindow == c.minCongestionWindow()
 	c.maxDatagramSize = s
@@ -291,4 +292,5 @@ func (c *cubicSender) SetMaxDatagramSize(s protocol.ByteCount) {
 		c.congestionWindow = c.minCongestionWindow()
 	}
 	c.pacer.SetMaxDatagramSize(s)
+	return nil
 }

--- a/internal/congestion/cubic_sender_test.go
+++ b/internal/congestion/cubic_sender_test.go
@@ -460,13 +460,13 @@ var _ = Describe("Cubic Sender", func() {
 	})
 
 	It("doesn't allow reductions of the maximum packet size", func() {
-		Expect(func() { sender.SetMaxDatagramSize(initialMaxDatagramSize - 1) }).To(Panic())
+		Expect(sender.SetMaxDatagramSize(initialMaxDatagramSize - 1)).To(MatchError("congestion BUG: decreased max datagram size from 1252 to 1251 bytes"))
 	})
 
 	It("slow starts up to maximum congestion window, if larger packets are sent", func() {
 		sender = newCubicSender(&clock, rttStats, true, initialCongestionWindowPackets*maxDatagramSize, initialMaxCongestionWindow, nil)
 		const packetSize = initialMaxDatagramSize + 100
-		sender.SetMaxDatagramSize(packetSize)
+		Expect(sender.SetMaxDatagramSize(packetSize)).To(Succeed())
 		for i := 1; i < protocol.MaxCongestionWindowPackets; i++ {
 			sender.OnPacketAcked(protocol.PacketNumber(i), packetSize, sender.GetCongestionWindow(), clock.Now())
 		}

--- a/internal/congestion/interface.go
+++ b/internal/congestion/interface.go
@@ -16,7 +16,7 @@ type SendAlgorithm interface {
 	OnPacketAcked(number protocol.PacketNumber, ackedBytes protocol.ByteCount, priorInFlight protocol.ByteCount, eventTime time.Time)
 	OnPacketLost(number protocol.PacketNumber, lostBytes protocol.ByteCount, priorInFlight protocol.ByteCount)
 	OnRetransmissionTimeout(packetsRetransmitted bool)
-	SetMaxDatagramSize(protocol.ByteCount)
+	SetMaxDatagramSize(protocol.ByteCount) error
 }
 
 // A SendAlgorithmWithDebugInfos is a SendAlgorithm that exposes some debug infos

--- a/internal/mocks/congestion.go
+++ b/internal/mocks/congestion.go
@@ -166,9 +166,11 @@ func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) OnRetransmissionTimeout(a
 }
 
 // SetMaxDatagramSize mocks base method.
-func (m *MockSendAlgorithmWithDebugInfos) SetMaxDatagramSize(arg0 protocol.ByteCount) {
+func (m *MockSendAlgorithmWithDebugInfos) SetMaxDatagramSize(arg0 protocol.ByteCount) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMaxDatagramSize", arg0)
+	ret := m.ctrl.Call(m, "SetMaxDatagramSize", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // SetMaxDatagramSize indicates an expected call of SetMaxDatagramSize.

--- a/send_stream.go
+++ b/send_stream.go
@@ -342,13 +342,13 @@ func (s *sendStream) getDataForWriting(f *wire.StreamFrame, maxBytes protocol.By
 	}
 }
 
-func (s *sendStream) frameAcked(f wire.Frame) {
+func (s *sendStream) frameAcked(f wire.Frame) error {
 	f.(*wire.StreamFrame).PutBack()
 
 	s.mutex.Lock()
 	if s.canceledWrite {
 		s.mutex.Unlock()
-		return
+		return nil
 	}
 	s.numOutstandingFrames--
 	if s.numOutstandingFrames < 0 {
@@ -360,6 +360,7 @@ func (s *sendStream) frameAcked(f wire.Frame) {
 	if newlyCompleted {
 		s.sender.onStreamCompleted(s.streamID)
 	}
+	return nil
 }
 
 func (s *sendStream) isNewlyCompleted() bool {

--- a/session.go
+++ b/session.go
@@ -796,9 +796,9 @@ func (s *session) handleHandshakeComplete() {
 			s.rttStats,
 			getMaxPacketSize(s.conn.RemoteAddr()),
 			maxPacketSize,
-			func(size protocol.ByteCount) {
-				s.sentPacketHandler.SetMaxDatagramSize(size)
+			func(size protocol.ByteCount) error {
 				s.packer.SetMaxPacketSize(size)
+				return s.sentPacketHandler.SetMaxDatagramSize(size)
 			},
 		)
 	}


### PR DESCRIPTION
There's no need to panic here. This seems to be more brittle than expected, see #3122.
An error will show up in the logs as well.