### PR TITLE
don't regard PMTU probe packets as outstanding

### DIFF
--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -64,8 +64,9 @@ func (h *sentPacketHistory) Iterate(cb func(*Packet) (cont bool, err error)) err
 // FirstOutStanding returns the first outstanding packet.
 func (h *sentPacketHistory) FirstOutstanding() *Packet {
 	for el := h.packetList.Front(); el != nil; el = el.Next() {
-		if !el.Value.declaredLost && !el.Value.skippedPacket {
-			return &el.Value
+		p := &el.Value
+		if !p.declaredLost && !p.skippedPacket && !p.IsPathMTUProbePacket {
+			return p
 		}
 	}
 	return nil

--- a/internal/ackhandler/sent_packet_history_test.go
+++ b/internal/ackhandler/sent_packet_history_test.go
@@ -87,6 +87,14 @@ var _ = Describe("SentPacketHistory", func() {
 			Expect(front).ToNot(BeNil())
 			Expect(front.PacketNumber).To(Equal(protocol.PacketNumber(2)))
 		})
+
+		It("doesn't regard path MTU packets as outstanding", func() {
+			hist.SentPacket(&Packet{PacketNumber: 2}, true)
+			hist.SentPacket(&Packet{PacketNumber: 4, IsPathMTUProbePacket: true}, true)
+			front := hist.FirstOutstanding()
+			Expect(front).ToNot(BeNil())
+			Expect(front.PacketNumber).To(Equal(protocol.PacketNumber(2)))
+		})
 	})
 
 	It("removes packets", func() {


### PR DESCRIPTION
This also means that PMTU probe packets won't be declared lost when the PTO timer expires.