### PR TITLE
make it possible to trace acknowledged packets

### DIFF
--- a/integrationtests/self/self_suite_test.go
+++ b/integrationtests/self/self_suite_test.go
@@ -354,6 +354,7 @@ func (t *connTracer) DroppedPacket(logging.PacketType, logging.ByteCount, loggin
 func (t *connTracer) UpdatedMetrics(rttStats *logging.RTTStats, cwnd, bytesInFlight logging.ByteCount, packetsInFlight int) {
 }
 
+func (t *connTracer) AcknowledgedPacket(logging.EncryptionLevel, logging.PacketNumber) {}
 func (t *connTracer) LostPacket(logging.EncryptionLevel, logging.PacketNumber, logging.PacketLossReason) {
 }
 func (t *connTracer) UpdatedCongestionState(logging.CongestionState)                     {}

--- a/integrationtests/self/tracer_test.go
+++ b/integrationtests/self/tracer_test.go
@@ -57,6 +57,7 @@ func (t *customConnTracer) DroppedPacket(logging.PacketType, logging.ByteCount, 
 func (t *customConnTracer) UpdatedMetrics(rttStats *logging.RTTStats, cwnd, bytesInFlight logging.ByteCount, packetsInFlight int) {
 }
 
+func (t *customConnTracer) AcknowledgedPacket(logging.EncryptionLevel, logging.PacketNumber) {}
 func (t *customConnTracer) LostPacket(logging.EncryptionLevel, logging.PacketNumber, logging.PacketLossReason) {
 }
 func (t *customConnTracer) UpdatedCongestionState(logging.CongestionState)                     {}

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -399,6 +399,9 @@ func (h *sentPacketHandler) detectAndRemoveAckedPackets(ack *wire.AckFrame, encL
 		if err := pnSpace.history.Remove(p.PacketNumber); err != nil {
 			return nil, err
 		}
+		if h.tracer != nil && !p.skippedPacket {
+			h.tracer.AcknowledgedPacket(encLevel, p.PacketNumber)
+		}
 	}
 
 	return h.ackedPackets, err

--- a/internal/mocks/logging/connection_tracer.go
+++ b/internal/mocks/logging/connection_tracer.go
@@ -39,6 +39,18 @@ func (m *MockConnectionTracer) EXPECT() *MockConnectionTracerMockRecorder {
 	return m.recorder
 }
 
+// AcknowledgedPacket mocks base method.
+func (m *MockConnectionTracer) AcknowledgedPacket(arg0 protocol.EncryptionLevel, arg1 protocol.PacketNumber) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AcknowledgedPacket", arg0, arg1)
+}
+
+// AcknowledgedPacket indicates an expected call of AcknowledgedPacket.
+func (mr *MockConnectionTracerMockRecorder) AcknowledgedPacket(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcknowledgedPacket", reflect.TypeOf((*MockConnectionTracer)(nil).AcknowledgedPacket), arg0, arg1)
+}
+
 // BufferedPacket mocks base method.
 func (m *MockConnectionTracer) BufferedPacket(arg0 protocol.PacketType) {
 	m.ctrl.T.Helper()

--- a/logging/interface.go
+++ b/logging/interface.go
@@ -115,6 +115,7 @@ type ConnectionTracer interface {
 	BufferedPacket(PacketType)
 	DroppedPacket(PacketType, ByteCount, PacketDropReason)
 	UpdatedMetrics(rttStats *RTTStats, cwnd, bytesInFlight ByteCount, packetsInFlight int)
+	AcknowledgedPacket(EncryptionLevel, PacketNumber)
 	LostPacket(EncryptionLevel, PacketNumber, PacketLossReason)
 	UpdatedCongestionState(CongestionState)
 	UpdatedPTOCount(value uint32)

--- a/logging/mock_connection_tracer_test.go
+++ b/logging/mock_connection_tracer_test.go
@@ -38,6 +38,18 @@ func (m *MockConnectionTracer) EXPECT() *MockConnectionTracerMockRecorder {
 	return m.recorder
 }
 
+// AcknowledgedPacket mocks base method.
+func (m *MockConnectionTracer) AcknowledgedPacket(arg0 protocol.EncryptionLevel, arg1 protocol.PacketNumber) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AcknowledgedPacket", arg0, arg1)
+}
+
+// AcknowledgedPacket indicates an expected call of AcknowledgedPacket.
+func (mr *MockConnectionTracerMockRecorder) AcknowledgedPacket(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcknowledgedPacket", reflect.TypeOf((*MockConnectionTracer)(nil).AcknowledgedPacket), arg0, arg1)
+}
+
 // BufferedPacket mocks base method.
 func (m *MockConnectionTracer) BufferedPacket(arg0 protocol.PacketType) {
 	m.ctrl.T.Helper()

--- a/logging/multiplex.go
+++ b/logging/multiplex.go
@@ -139,6 +139,12 @@ func (m *connTracerMultiplexer) UpdatedMetrics(rttStats *RTTStats, cwnd, bytesIn
 	}
 }
 
+func (m *connTracerMultiplexer) AcknowledgedPacket(encLevel EncryptionLevel, pn PacketNumber) {
+	for _, t := range m.tracers {
+		t.AcknowledgedPacket(encLevel, pn)
+	}
+}
+
 func (m *connTracerMultiplexer) LostPacket(encLevel EncryptionLevel, pn PacketNumber, reason PacketLossReason) {
 	for _, t := range m.tracers {
 		t.LostPacket(encLevel, pn, reason)

--- a/logging/multiplex_test.go
+++ b/logging/multiplex_test.go
@@ -190,6 +190,12 @@ var _ = Describe("Tracing", func() {
 			tracer.UpdatedMetrics(rttStats, 1337, 42, 13)
 		})
 
+		It("traces the AcknowledgedPacket event", func() {
+			tr1.EXPECT().AcknowledgedPacket(EncryptionHandshake, PacketNumber(42))
+			tr2.EXPECT().AcknowledgedPacket(EncryptionHandshake, PacketNumber(42))
+			tracer.AcknowledgedPacket(EncryptionHandshake, 42)
+		})
+
 		It("traces the LostPacket event", func() {
 			tr1.EXPECT().LostPacket(EncryptionHandshake, PacketNumber(42), PacketLossReorderingThreshold)
 			tr2.EXPECT().LostPacket(EncryptionHandshake, PacketNumber(42), PacketLossReorderingThreshold)

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -348,6 +348,8 @@ func (t *connectionTracer) UpdatedMetrics(rttStats *utils.RTTStats, cwnd, bytesI
 	t.mutex.Unlock()
 }
 
+func (t *connectionTracer) AcknowledgedPacket(protocol.EncryptionLevel, protocol.PacketNumber) {}
+
 func (t *connectionTracer) LostPacket(encLevel protocol.EncryptionLevel, pn protocol.PacketNumber, lossReason logging.PacketLossReason) {
 	t.mutex.Lock()
 	t.recordEvent(time.Now(), &eventPacketLost{


### PR DESCRIPTION
We need this to get an estimate of the packet loss rate: `lost / (acked + lost)`.