### PR TITLE
only start PMTUD after handshake confirmation

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -2555,6 +2555,7 @@ var _ = Describe("Client Session", func() {
 	})
 
 	It("handles HANDSHAKE_DONE frames", func() {
+		sess.peerParams = &wire.TransportParameters{}
 		sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 		sess.sentPacketHandler = sph
 		sph.EXPECT().SetHandshakeConfirmed()


### PR DESCRIPTION
Replacement for #3121.

Our PMTUD packets are never coalesced packets. Since we try packing coalesced packets until the handshake is confirmed, it makes sense to start PMTUD then.