### PR TITLE
make it possible to associate a ConnectionTracer with a Session

### DIFF
--- a/client.go
+++ b/client.go
@@ -203,13 +203,17 @@ func dialContext(
 	}
 	c.packetHandlers = packetHandlers
 
+	c.tracingID = nextSessionTracingID()
 	if c.config.Tracer != nil {
-		c.tracer = c.config.Tracer.TracerForConnection(protocol.PerspectiveClient, c.destConnID)
+		c.tracer = c.config.Tracer.TracerForConnection(
+			context.WithValue(ctx, SessionTracingKey, c.tracingID),
+			protocol.PerspectiveClient,
+			c.destConnID,
+		)
 	}
 	if c.tracer != nil {
 		c.tracer.StartedConnection(c.conn.LocalAddr(), c.conn.RemoteAddr(), c.srcConnID, c.destConnID)
 	}
-	c.tracingID = nextSessionTracingID()
 	if err := c.dial(ctx); err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -37,8 +37,9 @@ type client struct {
 
 	session quicSession
 
-	tracer logging.ConnectionTracer
-	logger utils.Logger
+	tracer    logging.ConnectionTracer
+	tracingID uint64
+	logger    utils.Logger
 }
 
 var (
@@ -208,6 +209,7 @@ func dialContext(
 	if c.tracer != nil {
 		c.tracer.StartedConnection(c.conn.LocalAddr(), c.conn.RemoteAddr(), c.srcConnID, c.destConnID)
 	}
+	c.tracingID = nextSessionTracingID()
 	if err := c.dial(ctx); err != nil {
 		return nil, err
 	}
@@ -285,6 +287,7 @@ func (c *client) dial(ctx context.Context) error {
 		c.use0RTT,
 		c.hasNegotiatedVersion,
 		c.tracer,
+		c.tracingID,
 		c.logger,
 		c.version,
 	)

--- a/client_test.go
+++ b/client_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Client", func() {
 		originalClientSessConstructor = newClientSession
 		tracer = mocklogging.NewMockConnectionTracer(mockCtrl)
 		tr := mocklogging.NewMockTracer(mockCtrl)
-		tr.EXPECT().TracerForConnection(protocol.PerspectiveClient, gomock.Any()).Return(tracer).MaxTimes(1)
+		tr.EXPECT().TracerForConnection(gomock.Any(), protocol.PerspectiveClient, gomock.Any()).Return(tracer).MaxTimes(1)
 		config = &Config{Tracer: tr, Versions: []protocol.VersionNumber{protocol.VersionTLS}}
 		Eventually(areSessionsRunning).Should(BeFalse())
 		// sess = NewMockQuicSession(mockCtrl)

--- a/client_test.go
+++ b/client_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Client", func() {
 			enable0RTT bool,
 			hasNegotiatedVersion bool,
 			tracer logging.ConnectionTracer,
+			tracingID uint64,
 			logger utils.Logger,
 			v protocol.VersionNumber,
 		) quicSession
@@ -129,6 +130,7 @@ var _ = Describe("Client", func() {
 				_ bool,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -161,6 +163,7 @@ var _ = Describe("Client", func() {
 				_ bool,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -193,6 +196,7 @@ var _ = Describe("Client", func() {
 				_ bool,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -231,6 +235,7 @@ var _ = Describe("Client", func() {
 				enable0RTT bool,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -273,6 +278,7 @@ var _ = Describe("Client", func() {
 				enable0RTT bool,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -320,6 +326,7 @@ var _ = Describe("Client", func() {
 				_ bool,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -362,6 +369,7 @@ var _ = Describe("Client", func() {
 				_ bool,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -413,6 +421,7 @@ var _ = Describe("Client", func() {
 				_ bool,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -532,6 +541,7 @@ var _ = Describe("Client", func() {
 				_ bool,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				versionP protocol.VersionNumber,
 			) quicSession {
@@ -571,6 +581,7 @@ var _ = Describe("Client", func() {
 				_ bool,
 				hasNegotiatedVersion bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				versionP protocol.VersionNumber,
 			) quicSession {

--- a/integrationtests/self/self_suite_test.go
+++ b/integrationtests/self/self_suite_test.go
@@ -3,6 +3,7 @@ package self_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -327,7 +328,7 @@ func newTracer(c func() logging.ConnectionTracer) logging.Tracer {
 	return &tracer{createNewConnTracer: c}
 }
 
-func (t *tracer) TracerForConnection(p logging.Perspective, odcid logging.ConnectionID) logging.ConnectionTracer {
+func (t *tracer) TracerForConnection(context.Context, logging.Perspective, logging.ConnectionID) logging.ConnectionTracer {
 	return t.createNewConnTracer()
 }
 func (t *tracer) SentPacket(net.Addr, *logging.Header, logging.ByteCount, []logging.Frame) {}

--- a/integrationtests/self/tracer_test.go
+++ b/integrationtests/self/tracer_test.go
@@ -25,7 +25,7 @@ type customTracer struct{}
 
 var _ logging.Tracer = &customTracer{}
 
-func (t *customTracer) TracerForConnection(p logging.Perspective, odcid logging.ConnectionID) logging.ConnectionTracer {
+func (t *customTracer) TracerForConnection(context.Context, logging.Perspective, logging.ConnectionID) logging.ConnectionTracer {
 	return &customConnTracer{}
 }
 func (t *customTracer) SentPacket(net.Addr, *logging.Header, logging.ByteCount, []logging.Frame) {}

--- a/interface.go
+++ b/interface.go
@@ -75,6 +75,13 @@ type ErrorCode = protocol.ApplicationErrorCode
 // when the server rejects a 0-RTT connection attempt.
 var Err0RTTRejected = errors.New("0-RTT rejected")
 
+// SessionTracingKey can be used to associate a ConnectionTracer with a Session.
+// It is set on the Session.Context() context,
+// as well as on the context passed to logging.Tracer.NewConnectionTracer.
+var SessionTracingKey = sessionTracingCtxKey{}
+
+type sessionTracingCtxKey struct{}
+
 // Stream is the interface implemented by QUIC streams
 type Stream interface {
 	ReceiveStream

--- a/internal/mocks/logging/tracer.go
+++ b/internal/mocks/logging/tracer.go
@@ -5,6 +5,7 @@
 package mocklogging
 
 import (
+	context "context"
 	net "net"
 	reflect "reflect"
 
@@ -62,15 +63,15 @@ func (mr *MockTracerMockRecorder) SentPacket(arg0, arg1, arg2, arg3 interface{})
 }
 
 // TracerForConnection mocks base method.
-func (m *MockTracer) TracerForConnection(arg0 protocol.Perspective, arg1 protocol.ConnectionID) logging.ConnectionTracer {
+func (m *MockTracer) TracerForConnection(arg0 context.Context, arg1 protocol.Perspective, arg2 protocol.ConnectionID) logging.ConnectionTracer {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TracerForConnection", arg0, arg1)
+	ret := m.ctrl.Call(m, "TracerForConnection", arg0, arg1, arg2)
 	ret0, _ := ret[0].(logging.ConnectionTracer)
 	return ret0
 }
 
 // TracerForConnection indicates an expected call of TracerForConnection.
-func (mr *MockTracerMockRecorder) TracerForConnection(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockTracerMockRecorder) TracerForConnection(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TracerForConnection", reflect.TypeOf((*MockTracer)(nil).TracerForConnection), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TracerForConnection", reflect.TypeOf((*MockTracer)(nil).TracerForConnection), arg0, arg1, arg2)
 }

--- a/logging/interface.go
+++ b/logging/interface.go
@@ -3,6 +3,7 @@
 package logging
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -95,7 +96,7 @@ type Tracer interface {
 	// The ODCID is the original destination connection ID:
 	// The destination connection ID that the client used on the first Initial packet it sent on this connection.
 	// If nil is returned, tracing will be disabled for this connection.
-	TracerForConnection(p Perspective, odcid ConnectionID) ConnectionTracer
+	TracerForConnection(ctx context.Context, p Perspective, odcid ConnectionID) ConnectionTracer
 
 	SentPacket(net.Addr, *Header, ByteCount, []Frame)
 	DroppedPacket(net.Addr, PacketType, ByteCount, PacketDropReason)

--- a/logging/mock_tracer_test.go
+++ b/logging/mock_tracer_test.go
@@ -5,6 +5,7 @@
 package logging
 
 import (
+	context "context"
 	net "net"
 	reflect "reflect"
 
@@ -61,15 +62,15 @@ func (mr *MockTracerMockRecorder) SentPacket(arg0, arg1, arg2, arg3 interface{})
 }
 
 // TracerForConnection mocks base method.
-func (m *MockTracer) TracerForConnection(arg0 protocol.Perspective, arg1 protocol.ConnectionID) ConnectionTracer {
+func (m *MockTracer) TracerForConnection(arg0 context.Context, arg1 protocol.Perspective, arg2 protocol.ConnectionID) ConnectionTracer {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TracerForConnection", arg0, arg1)
+	ret := m.ctrl.Call(m, "TracerForConnection", arg0, arg1, arg2)
 	ret0, _ := ret[0].(ConnectionTracer)
 	return ret0
 }
 
 // TracerForConnection indicates an expected call of TracerForConnection.
-func (mr *MockTracerMockRecorder) TracerForConnection(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockTracerMockRecorder) TracerForConnection(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TracerForConnection", reflect.TypeOf((*MockTracer)(nil).TracerForConnection), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TracerForConnection", reflect.TypeOf((*MockTracer)(nil).TracerForConnection), arg0, arg1, arg2)
 }

--- a/logging/multiplex.go
+++ b/logging/multiplex.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"net"
 	"time"
 )
@@ -22,10 +23,10 @@ func NewMultiplexedTracer(tracers ...Tracer) Tracer {
 	return &tracerMultiplexer{tracers}
 }
 
-func (m *tracerMultiplexer) TracerForConnection(p Perspective, odcid ConnectionID) ConnectionTracer {
+func (m *tracerMultiplexer) TracerForConnection(ctx context.Context, p Perspective, odcid ConnectionID) ConnectionTracer {
 	var connTracers []ConnectionTracer
 	for _, t := range m.tracers {
-		if ct := t.TracerForConnection(p, odcid); ct != nil {
+		if ct := t.TracerForConnection(ctx, p, odcid); ct != nil {
 			connTracers = append(connTracers, ct)
 		}
 	}

--- a/logging/multiplex_test.go
+++ b/logging/multiplex_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -35,35 +36,39 @@ var _ = Describe("Tracing", func() {
 			})
 
 			It("multiplexes the TracerForConnection call", func() {
-				tr1.EXPECT().TracerForConnection(PerspectiveClient, ConnectionID{1, 2, 3})
-				tr2.EXPECT().TracerForConnection(PerspectiveClient, ConnectionID{1, 2, 3})
-				tracer.TracerForConnection(PerspectiveClient, ConnectionID{1, 2, 3})
+				ctx := context.Background()
+				tr1.EXPECT().TracerForConnection(ctx, PerspectiveClient, ConnectionID{1, 2, 3})
+				tr2.EXPECT().TracerForConnection(ctx, PerspectiveClient, ConnectionID{1, 2, 3})
+				tracer.TracerForConnection(ctx, PerspectiveClient, ConnectionID{1, 2, 3})
 			})
 
 			It("uses multiple connection tracers", func() {
+				ctx := context.Background()
 				ctr1 := NewMockConnectionTracer(mockCtrl)
 				ctr2 := NewMockConnectionTracer(mockCtrl)
-				tr1.EXPECT().TracerForConnection(PerspectiveServer, ConnectionID{1, 2, 3}).Return(ctr1)
-				tr2.EXPECT().TracerForConnection(PerspectiveServer, ConnectionID{1, 2, 3}).Return(ctr2)
-				tr := tracer.TracerForConnection(PerspectiveServer, ConnectionID{1, 2, 3})
+				tr1.EXPECT().TracerForConnection(ctx, PerspectiveServer, ConnectionID{1, 2, 3}).Return(ctr1)
+				tr2.EXPECT().TracerForConnection(ctx, PerspectiveServer, ConnectionID{1, 2, 3}).Return(ctr2)
+				tr := tracer.TracerForConnection(ctx, PerspectiveServer, ConnectionID{1, 2, 3})
 				ctr1.EXPECT().LossTimerCanceled()
 				ctr2.EXPECT().LossTimerCanceled()
 				tr.LossTimerCanceled()
 			})
 
 			It("handles tracers that return a nil ConnectionTracer", func() {
+				ctx := context.Background()
 				ctr1 := NewMockConnectionTracer(mockCtrl)
-				tr1.EXPECT().TracerForConnection(PerspectiveServer, ConnectionID{1, 2, 3}).Return(ctr1)
-				tr2.EXPECT().TracerForConnection(PerspectiveServer, ConnectionID{1, 2, 3})
-				tr := tracer.TracerForConnection(PerspectiveServer, ConnectionID{1, 2, 3})
+				tr1.EXPECT().TracerForConnection(ctx, PerspectiveServer, ConnectionID{1, 2, 3}).Return(ctr1)
+				tr2.EXPECT().TracerForConnection(ctx, PerspectiveServer, ConnectionID{1, 2, 3})
+				tr := tracer.TracerForConnection(ctx, PerspectiveServer, ConnectionID{1, 2, 3})
 				ctr1.EXPECT().LossTimerCanceled()
 				tr.LossTimerCanceled()
 			})
 
 			It("returns nil when all tracers return a nil ConnectionTracer", func() {
-				tr1.EXPECT().TracerForConnection(PerspectiveClient, ConnectionID{1, 2, 3})
-				tr2.EXPECT().TracerForConnection(PerspectiveClient, ConnectionID{1, 2, 3})
-				Expect(tracer.TracerForConnection(PerspectiveClient, ConnectionID{1, 2, 3})).To(BeNil())
+				ctx := context.Background()
+				tr1.EXPECT().TracerForConnection(ctx, PerspectiveClient, ConnectionID{1, 2, 3})
+				tr2.EXPECT().TracerForConnection(ctx, PerspectiveClient, ConnectionID{1, 2, 3})
+				Expect(tracer.TracerForConnection(ctx, PerspectiveClient, ConnectionID{1, 2, 3})).To(BeNil())
 			})
 
 			It("traces the PacketSent event", func() {

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -2,6 +2,7 @@ package qlog
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -59,7 +60,7 @@ func NewTracer(getLogWriter func(p logging.Perspective, connectionID []byte) io.
 	return &tracer{getLogWriter: getLogWriter}
 }
 
-func (t *tracer) TracerForConnection(p logging.Perspective, odcid protocol.ConnectionID) logging.ConnectionTracer {
+func (t *tracer) TracerForConnection(_ context.Context, p logging.Perspective, odcid protocol.ConnectionID) logging.ConnectionTracer {
 	if w := t.getLogWriter(p, odcid.Bytes()); w != nil {
 		return NewConnectionTracer(w, p, odcid)
 	}

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -2,6 +2,7 @@ package qlog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -52,7 +53,7 @@ var _ = Describe("Tracing", func() {
 	Context("tracer", func() {
 		It("returns nil when there's no io.WriteCloser", func() {
 			t := NewTracer(func(logging.Perspective, []byte) io.WriteCloser { return nil })
-			Expect(t.TracerForConnection(logging.PerspectiveClient, logging.ConnectionID{1, 2, 3, 4})).To(BeNil())
+			Expect(t.TracerForConnection(context.Background(), logging.PerspectiveClient, logging.ConnectionID{1, 2, 3, 4})).To(BeNil())
 		})
 	})
 
@@ -83,7 +84,7 @@ var _ = Describe("Tracing", func() {
 		BeforeEach(func() {
 			buf = &bytes.Buffer{}
 			t := NewTracer(func(logging.Perspective, []byte) io.WriteCloser { return nopWriteCloser(buf) })
-			tracer = t.TracerForConnection(logging.PerspectiveServer, logging.ConnectionID{0xde, 0xad, 0xbe, 0xef})
+			tracer = t.TracerForConnection(context.Background(), logging.PerspectiveServer, logging.ConnectionID{0xde, 0xad, 0xbe, 0xef})
 		})
 
 		It("exports a trace that has the right metadata", func() {

--- a/server.go
+++ b/server.go
@@ -87,6 +87,7 @@ type baseServer struct {
 		*handshake.TokenGenerator,
 		bool, /* enable 0-RTT */
 		logging.ConnectionTracer,
+		uint64,
 		utils.Logger,
 		protocol.VersionNumber,
 	) quicSession
@@ -474,6 +475,7 @@ func (s *baseServer) handleInitialImpl(p *receivedPacket, hdr *wire.Header) erro
 			s.tokenGenerator,
 			s.acceptEarlySessions,
 			tracer,
+			nextSessionTracingID(),
 			s.logger,
 			hdr.Version,
 		)

--- a/server_test.go
+++ b/server_test.go
@@ -338,6 +338,7 @@ var _ = Describe("Server", func() {
 					_ *handshake.TokenGenerator,
 					enable0RTT bool,
 					_ logging.ConnectionTracer,
+					_ uint64,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -595,6 +596,7 @@ var _ = Describe("Server", func() {
 					_ *handshake.TokenGenerator,
 					enable0RTT bool,
 					_ logging.ConnectionTracer,
+					_ uint64,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -654,6 +656,7 @@ var _ = Describe("Server", func() {
 					_ *handshake.TokenGenerator,
 					_ bool,
 					_ logging.ConnectionTracer,
+					_ uint64,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -707,6 +710,7 @@ var _ = Describe("Server", func() {
 					_ *handshake.TokenGenerator,
 					_ bool,
 					_ logging.ConnectionTracer,
+					_ uint64,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -737,6 +741,7 @@ var _ = Describe("Server", func() {
 					_ *handshake.TokenGenerator,
 					_ bool,
 					_ logging.ConnectionTracer,
+					_ uint64,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -808,6 +813,7 @@ var _ = Describe("Server", func() {
 					_ *handshake.TokenGenerator,
 					_ bool,
 					_ logging.ConnectionTracer,
+					_ uint64,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -919,6 +925,7 @@ var _ = Describe("Server", func() {
 					_ *handshake.TokenGenerator,
 					_ bool,
 					_ logging.ConnectionTracer,
+					_ uint64,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicSession {
@@ -992,6 +999,7 @@ var _ = Describe("Server", func() {
 				_ *handshake.TokenGenerator,
 				enable0RTT bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -1034,6 +1042,7 @@ var _ = Describe("Server", func() {
 				_ *handshake.TokenGenerator,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {
@@ -1097,6 +1106,7 @@ var _ = Describe("Server", func() {
 				_ *handshake.TokenGenerator,
 				_ bool,
 				_ logging.ConnectionTracer,
+				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicSession {

--- a/server_test.go
+++ b/server_test.go
@@ -322,7 +322,7 @@ var _ = Describe("Server", func() {
 					fn()
 					return true
 				})
-				tracer.EXPECT().TracerForConnection(protocol.PerspectiveServer, protocol.ConnectionID{0xde, 0xad, 0xc0, 0xde})
+				tracer.EXPECT().TracerForConnection(gomock.Any(), protocol.PerspectiveServer, protocol.ConnectionID{0xde, 0xad, 0xc0, 0xde})
 				sess := NewMockQuicSession(mockCtrl)
 				serv.newSession = func(
 					_ sendConn,
@@ -579,7 +579,7 @@ var _ = Describe("Server", func() {
 					fn()
 					return true
 				})
-				tracer.EXPECT().TracerForConnection(protocol.PerspectiveServer, protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+				tracer.EXPECT().TracerForConnection(gomock.Any(), protocol.PerspectiveServer, protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 
 				sess := NewMockQuicSession(mockCtrl)
 				serv.newSession = func(
@@ -637,7 +637,7 @@ var _ = Describe("Server", func() {
 					fn()
 					return true
 				}).AnyTimes()
-				tracer.EXPECT().TracerForConnection(protocol.PerspectiveServer, gomock.Any()).AnyTimes()
+				tracer.EXPECT().TracerForConnection(gomock.Any(), protocol.PerspectiveServer, gomock.Any()).AnyTimes()
 
 				serv.config.AcceptToken = func(net.Addr, *Token) bool { return true }
 				acceptSession := make(chan struct{})
@@ -760,7 +760,7 @@ var _ = Describe("Server", func() {
 					fn()
 					return true
 				}).Times(protocol.MaxAcceptQueueSize)
-				tracer.EXPECT().TracerForConnection(protocol.PerspectiveServer, gomock.Any()).Times(protocol.MaxAcceptQueueSize)
+				tracer.EXPECT().TracerForConnection(gomock.Any(), protocol.PerspectiveServer, gomock.Any()).Times(protocol.MaxAcceptQueueSize)
 
 				var wg sync.WaitGroup
 				wg.Add(protocol.MaxAcceptQueueSize)
@@ -832,7 +832,7 @@ var _ = Describe("Server", func() {
 					fn()
 					return true
 				})
-				tracer.EXPECT().TracerForConnection(protocol.PerspectiveServer, gomock.Any())
+				tracer.EXPECT().TracerForConnection(gomock.Any(), protocol.PerspectiveServer, gomock.Any())
 
 				serv.handlePacket(p)
 				// make sure there are no Write calls on the packet conn
@@ -940,7 +940,7 @@ var _ = Describe("Server", func() {
 					fn()
 					return true
 				})
-				tracer.EXPECT().TracerForConnection(protocol.PerspectiveServer, gomock.Any())
+				tracer.EXPECT().TracerForConnection(gomock.Any(), protocol.PerspectiveServer, gomock.Any())
 				serv.handleInitialImpl(
 					&receivedPacket{buffer: getPacketBuffer()},
 					&wire.Header{DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8}},

--- a/session_test.go
+++ b/session_test.go
@@ -107,6 +107,7 @@ var _ = Describe("Session", func() {
 			tokenGenerator,
 			false,
 			tracer,
+			1234,
 			utils.DefaultLogger,
 			protocol.VersionTLS,
 		).(*session)
@@ -2478,6 +2479,7 @@ var _ = Describe("Client Session", func() {
 			false,
 			false,
 			tracer,
+			1234,
 			utils.DefaultLogger,
 			protocol.VersionTLS,
 		).(*session)


### PR DESCRIPTION
Fixes #3145.

This PR implements a combination of the options discussed on the issue:
* `logging.Tracer.NewConnectionTracer` now takes a `context.Context`, which has values associated with it.
* Both this context as well as the context returned from `Session.Context` have a context with a `SessionTracingKey` value (which is a uint64).
* For outgoing connections, the context passed to `NewConnectionTracer` is derived from the context passed to `Dial`. This allows us (for example) to associate the peer ID we were dialing even if the handshake fails (and no `Session` is returned).

@mvdan, how does this look to you?