### PR TITLE
trace and qlog version selection / negotiation

### DIFF
--- a/integrationtests/self/self_suite_test.go
+++ b/integrationtests/self/self_suite_test.go
@@ -340,6 +340,9 @@ var _ logging.ConnectionTracer = &connTracer{}
 
 func (t *connTracer) StartedConnection(local, remote net.Addr, srcConnID, destConnID logging.ConnectionID) {
 }
+
+func (t *connTracer) NegotiatedVersion(chosen logging.VersionNumber, clientVersions, serverVersions []logging.VersionNumber) {
+}
 func (t *connTracer) ClosedConnection(logging.CloseReason)                     {}
 func (t *connTracer) SentTransportParameters(*logging.TransportParameters)     {}
 func (t *connTracer) ReceivedTransportParameters(*logging.TransportParameters) {}

--- a/integrationtests/self/tracer_test.go
+++ b/integrationtests/self/tracer_test.go
@@ -38,6 +38,9 @@ var _ logging.ConnectionTracer = &customConnTracer{}
 
 func (t *customConnTracer) StartedConnection(local, remote net.Addr, srcConnID, destConnID logging.ConnectionID) {
 }
+
+func (t *customConnTracer) NegotiatedVersion(chosen logging.VersionNumber, clientVersions, serverVersions []logging.VersionNumber) {
+}
 func (t *customConnTracer) ClosedConnection(logging.CloseReason)                     {}
 func (t *customConnTracer) SentTransportParameters(*logging.TransportParameters)     {}
 func (t *customConnTracer) ReceivedTransportParameters(*logging.TransportParameters) {}

--- a/internal/mocks/logging/connection_tracer.go
+++ b/internal/mocks/logging/connection_tracer.go
@@ -171,6 +171,18 @@ func (mr *MockConnectionTracerMockRecorder) LostPacket(arg0, arg1, arg2 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LostPacket", reflect.TypeOf((*MockConnectionTracer)(nil).LostPacket), arg0, arg1, arg2)
 }
 
+// NegotiatedVersion mocks base method.
+func (m *MockConnectionTracer) NegotiatedVersion(arg0 protocol.VersionNumber, arg1, arg2 []protocol.VersionNumber) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NegotiatedVersion", arg0, arg1, arg2)
+}
+
+// NegotiatedVersion indicates an expected call of NegotiatedVersion.
+func (mr *MockConnectionTracerMockRecorder) NegotiatedVersion(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NegotiatedVersion", reflect.TypeOf((*MockConnectionTracer)(nil).NegotiatedVersion), arg0, arg1, arg2)
+}
+
 // ReceivedPacket mocks base method.
 func (m *MockConnectionTracer) ReceivedPacket(arg0 *wire.ExtendedHeader, arg1 protocol.ByteCount, arg2 []logging.Frame) {
 	m.ctrl.T.Helper()

--- a/logging/interface.go
+++ b/logging/interface.go
@@ -104,6 +104,7 @@ type Tracer interface {
 // A ConnectionTracer records events.
 type ConnectionTracer interface {
 	StartedConnection(local, remote net.Addr, srcConnID, destConnID ConnectionID)
+	NegotiatedVersion(chosen VersionNumber, clientVersions, serverVersions []VersionNumber)
 	ClosedConnection(CloseReason)
 	SentTransportParameters(*TransportParameters)
 	ReceivedTransportParameters(*TransportParameters)

--- a/logging/mock_connection_tracer_test.go
+++ b/logging/mock_connection_tracer_test.go
@@ -170,6 +170,18 @@ func (mr *MockConnectionTracerMockRecorder) LostPacket(arg0, arg1, arg2 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LostPacket", reflect.TypeOf((*MockConnectionTracer)(nil).LostPacket), arg0, arg1, arg2)
 }
 
+// NegotiatedVersion mocks base method.
+func (m *MockConnectionTracer) NegotiatedVersion(arg0 protocol.VersionNumber, arg1, arg2 []protocol.VersionNumber) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NegotiatedVersion", arg0, arg1, arg2)
+}
+
+// NegotiatedVersion indicates an expected call of NegotiatedVersion.
+func (mr *MockConnectionTracerMockRecorder) NegotiatedVersion(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NegotiatedVersion", reflect.TypeOf((*MockConnectionTracer)(nil).NegotiatedVersion), arg0, arg1, arg2)
+}
+
 // ReceivedPacket mocks base method.
 func (m *MockConnectionTracer) ReceivedPacket(arg0 *wire.ExtendedHeader, arg1 protocol.ByteCount, arg2 []Frame) {
 	m.ctrl.T.Helper()

--- a/logging/multiplex.go
+++ b/logging/multiplex.go
@@ -67,6 +67,12 @@ func (m *connTracerMultiplexer) StartedConnection(local, remote net.Addr, srcCon
 	}
 }
 
+func (m *connTracerMultiplexer) NegotiatedVersion(chosen VersionNumber, clientVersions, serverVersions []VersionNumber) {
+	for _, t := range m.tracers {
+		t.NegotiatedVersion(chosen, clientVersions, serverVersions)
+	}
+}
+
 func (m *connTracerMultiplexer) ClosedConnection(reason CloseReason) {
 	for _, t := range m.tracers {
 		t.ClosedConnection(reason)

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -83,6 +83,25 @@ func (e eventConnectionStarted) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("dst_cid", connectionID(e.DestConnectionID).String())
 }
 
+type eventVersionNegotiated struct {
+	clientVersions, serverVersions []versionNumber
+	chosenVersion                  versionNumber
+}
+
+func (e eventVersionNegotiated) Category() category { return categoryTransport }
+func (e eventVersionNegotiated) Name() string       { return "version_information" }
+func (e eventVersionNegotiated) IsNil() bool        { return false }
+
+func (e eventVersionNegotiated) MarshalJSONObject(enc *gojay.Encoder) {
+	if len(e.clientVersions) > 0 {
+		enc.ArrayKey("client_versions", versions(e.clientVersions))
+	}
+	if len(e.serverVersions) > 0 {
+		enc.ArrayKey("server_versions", versions(e.serverVersions))
+	}
+	enc.StringKey("chosen_version", e.chosenVersion.String())
+}
+
 type eventConnectionClosed struct {
 	Reason logging.CloseReason
 }

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -182,6 +182,29 @@ func (t *connectionTracer) StartedConnection(local, remote net.Addr, srcConnID, 
 	t.mutex.Unlock()
 }
 
+func (t *connectionTracer) NegotiatedVersion(chosen logging.VersionNumber, client, server []logging.VersionNumber) {
+	var clientVersions, serverVersions []versionNumber
+	if len(client) > 0 {
+		clientVersions = make([]versionNumber, len(client))
+		for i, v := range client {
+			clientVersions[i] = versionNumber(v)
+		}
+	}
+	if len(server) > 0 {
+		serverVersions = make([]versionNumber, len(server))
+		for i, v := range server {
+			serverVersions[i] = versionNumber(v)
+		}
+	}
+	t.mutex.Lock()
+	t.recordEvent(time.Now(), &eventVersionNegotiated{
+		clientVersions: clientVersions,
+		serverVersions: serverVersions,
+		chosenVersion:  versionNumber(chosen),
+	})
+	t.mutex.Unlock()
+}
+
 func (t *connectionTracer) ClosedConnection(r logging.CloseReason) {
 	t.mutex.Lock()
 	t.recordEvent(time.Now(), &eventConnectionClosed{Reason: r})

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -169,6 +169,30 @@ var _ = Describe("Tracing", func() {
 				Expect(ev).To(HaveKeyWithValue("dst_cid", "05060708"))
 			})
 
+			It("records the version, if no version negotiation happened", func() {
+				tracer.NegotiatedVersion(0x1337, nil, nil)
+				entry := exportAndParseSingle()
+				Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+				Expect(entry.Name).To(Equal("transport:version_information"))
+				ev := entry.Event
+				Expect(ev).To(HaveLen(1))
+				Expect(ev).To(HaveKeyWithValue("chosen_version", "1337"))
+			})
+
+			It("records the version, if version negotiation happened", func() {
+				tracer.NegotiatedVersion(0x1337, []logging.VersionNumber{1, 2, 3}, []logging.VersionNumber{4, 5, 6})
+				entry := exportAndParseSingle()
+				Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+				Expect(entry.Name).To(Equal("transport:version_information"))
+				ev := entry.Event
+				Expect(ev).To(HaveLen(3))
+				Expect(ev).To(HaveKeyWithValue("chosen_version", "1337"))
+				Expect(ev).To(HaveKey("client_versions"))
+				Expect(ev["client_versions"].([]interface{})).To(Equal([]interface{}{"1", "2", "3"}))
+				Expect(ev).To(HaveKey("server_versions"))
+				Expect(ev["server_versions"].([]interface{})).To(Equal([]interface{}{"4", "5", "6"}))
+			})
+
 			It("records idle timeouts", func() {
 				tracer.ClosedConnection(logging.NewTimeoutCloseReason(logging.TimeoutReasonIdle))
 				entry := exportAndParseSingle()

--- a/session.go
+++ b/session.go
@@ -1093,6 +1093,9 @@ func (s *session) handleVersionNegotiationPacket(p *receivedPacket) {
 		s.logger.Infof("No compatible QUIC version found.")
 		return
 	}
+	if s.tracer != nil {
+		s.tracer.NegotiatedVersion(newVersion, s.config.Versions, supportedVersions)
+	}
 
 	s.logger.Infof("Switching to QUIC version %s.", newVersion)
 	nextPN, _ := s.sentPacketHandler.PeekPacketNumber(protocol.EncryptionInitial)
@@ -1114,6 +1117,16 @@ func (s *session) handleUnpackedPacket(
 
 	if !s.receivedFirstPacket {
 		s.receivedFirstPacket = true
+		if !s.versionNegotiated && s.tracer != nil {
+			var clientVersions, serverVersions []protocol.VersionNumber
+			switch s.perspective {
+			case protocol.PerspectiveClient:
+				clientVersions = s.config.Versions
+			case protocol.PerspectiveServer:
+				serverVersions = s.config.Versions
+			}
+			s.tracer.NegotiatedVersion(s.version, clientVersions, serverVersions)
+		}
 		// The server can change the source connection ID with the first Handshake packet.
 		if s.perspective == protocol.PerspectiveClient && packet.hdr.IsLongHeader && !packet.hdr.SrcConnectionID.Equal(s.handshakeDestConnID) {
 			cid := packet.hdr.SrcConnectionID

--- a/session_test.go
+++ b/session_test.go
@@ -90,6 +90,7 @@ var _ = Describe("Session", func() {
 		tokenGenerator, err := handshake.NewTokenGenerator(rand.Reader)
 		Expect(err).ToNot(HaveOccurred())
 		tracer = mocklogging.NewMockConnectionTracer(mockCtrl)
+		tracer.EXPECT().NegotiatedVersion(gomock.Any(), gomock.Any(), gomock.Any()).MaxTimes(1)
 		tracer.EXPECT().SentTransportParameters(gomock.Any())
 		tracer.EXPECT().UpdatedKeyFromTLS(gomock.Any(), gomock.Any()).AnyTimes()
 		tracer.EXPECT().UpdatedCongestionState(gomock.Any())
@@ -2464,6 +2465,7 @@ var _ = Describe("Client Session", func() {
 		}
 		sessionRunner = NewMockSessionRunner(mockCtrl)
 		tracer = mocklogging.NewMockConnectionTracer(mockCtrl)
+		tracer.EXPECT().NegotiatedVersion(gomock.Any(), gomock.Any(), gomock.Any()).MaxTimes(1)
 		tracer.EXPECT().SentTransportParameters(gomock.Any())
 		tracer.EXPECT().UpdatedKeyFromTLS(gomock.Any(), gomock.Any()).AnyTimes()
 		tracer.EXPECT().UpdatedCongestionState(gomock.Any())


### PR DESCRIPTION
#3109 removed the version information from the `connection_started` event. This PR now implements support for the [`version_information`](https://quiclog.github.io/internet-drafts/draft-marx-qlog-event-definitions-quic-h3.html#name-version_information) event.