### PR TITLE
rework error return values

### DIFF
--- a/client.go
+++ b/client.go
@@ -300,7 +300,7 @@ func (c *client) dial(ctx context.Context) error {
 	errorChan := make(chan error, 1)
 	go func() {
 		err := c.session.run() // returns as soon as the session is closed
-		if !errors.Is(err, errCloseForRecreating{}) && c.createdPacketConn {
+		if !errors.Is(err, &errCloseForRecreating{}) && c.createdPacketConn {
 			c.packetHandlers.Destroy()
 		}
 		errorChan <- err

--- a/conn_id_generator_test.go
+++ b/conn_id_generator_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 
 	. "github.com/onsi/ginkgo"
@@ -111,7 +112,10 @@ var _ = Describe("Connection ID Generator", func() {
 	})
 
 	It("errors if the peers tries to retire a connection ID that wasn't yet issued", func() {
-		Expect(g.Retire(1, protocol.ConnectionID{})).To(MatchError("PROTOCOL_VIOLATION: tried to retire connection ID 1. Highest issued: 0"))
+		Expect(g.Retire(1, protocol.ConnectionID{})).To(MatchError(&qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "retired connection ID 1 (highest issued: 0)",
+		}))
 	})
 
 	It("errors if the peers tries to retire a connection ID in a packet with that connection ID", func() {
@@ -119,7 +123,10 @@ var _ = Describe("Connection ID Generator", func() {
 		Expect(queuedFrames).ToNot(BeEmpty())
 		Expect(queuedFrames[0]).To(BeAssignableToTypeOf(&wire.NewConnectionIDFrame{}))
 		f := queuedFrames[0].(*wire.NewConnectionIDFrame)
-		Expect(g.Retire(f.SequenceNumber, f.ConnectionID)).To(MatchError(fmt.Sprintf("PROTOCOL_VIOLATION: tried to retire connection ID %d (%s), which was used as the Destination Connection ID on this packet", f.SequenceNumber, f.ConnectionID)))
+		Expect(g.Retire(f.SequenceNumber, f.ConnectionID)).To(MatchError(&qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: fmt.Sprintf("retired connection ID %d (%s), which was used as the Destination Connection ID on this packet", f.SequenceNumber, f.ConnectionID),
+		}))
 	})
 
 	It("doesn't error if the peers tries to retire a connection ID in a packet with that connection ID in RetireBugBackwardsCompatibilityMode", func() {

--- a/conn_id_manager.go
+++ b/conn_id_manager.go
@@ -53,7 +53,7 @@ func (h *connIDManager) Add(f *wire.NewConnectionIDFrame) error {
 		return err
 	}
 	if h.queue.Len() >= protocol.MaxActiveConnectionIDs {
-		return qerr.ConnectionIDLimitError
+		return &qerr.TransportError{ErrorCode: qerr.ConnectionIDLimitError}
 	}
 	return nil
 }

--- a/conn_id_manager_test.go
+++ b/conn_id_manager_test.go
@@ -2,7 +2,9 @@ package quic
 
 import (
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -231,7 +233,7 @@ var _ = Describe("Connection ID Manager", func() {
 			SequenceNumber:      uint64(9999),
 			ConnectionID:        protocol.ConnectionID{1, 2, 3, 4},
 			StatelessResetToken: protocol.StatelessResetToken{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-		})).To(MatchError("CONNECTION_ID_LIMIT_ERROR"))
+		})).To(MatchError(&qerr.TransportError{ErrorCode: qerr.ConnectionIDLimitError}))
 	})
 
 	It("initiates the first connection ID update as soon as possible", func() {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,30 @@
+package quic
+
+import "github.com/lucas-clemente/quic-go/internal/qerr"
+
+type (
+	TransportError       = qerr.TransportError
+	ApplicationError     = qerr.ApplicationError
+	TransportErrorCode   = qerr.TransportErrorCode
+	ApplicationErrorCode = qerr.ApplicationErrorCode
+)
+
+const (
+	NoError                   = qerr.NoError
+	InternalError             = qerr.InternalError
+	ConnectionRefused         = qerr.ConnectionRefused
+	FlowControlError          = qerr.FlowControlError
+	StreamLimitError          = qerr.StreamLimitError
+	StreamStateError          = qerr.StreamStateError
+	FinalSizeError            = qerr.FinalSizeError
+	FrameEncodingError        = qerr.FrameEncodingError
+	TransportParameterError   = qerr.TransportParameterError
+	ConnectionIDLimitError    = qerr.ConnectionIDLimitError
+	ProtocolViolation         = qerr.ProtocolViolation
+	InvalidToken              = qerr.InvalidToken
+	ApplicationErrorErrorCode = qerr.ApplicationErrorErrorCode
+	CryptoBufferExceeded      = qerr.CryptoBufferExceeded
+	KeyUpdateError            = qerr.KeyUpdateError
+	AEADLimitReached          = qerr.AEADLimitReached
+	NoViablePathError         = qerr.NoViablePathError
+)

--- a/errors.go
+++ b/errors.go
@@ -1,10 +1,16 @@
 package quic
 
-import "github.com/lucas-clemente/quic-go/internal/qerr"
+import (
+	"github.com/lucas-clemente/quic-go/internal/qerr"
+)
 
 type (
-	TransportError       = qerr.TransportError
-	ApplicationError     = qerr.ApplicationError
+	TransportError          = qerr.TransportError
+	ApplicationError        = qerr.ApplicationError
+	VersionNegotiationError = qerr.VersionNegotiationError
+)
+
+type (
 	TransportErrorCode   = qerr.TransportErrorCode
 	ApplicationErrorCode = qerr.ApplicationErrorCode
 )

--- a/errors.go
+++ b/errors.go
@@ -11,6 +11,8 @@ type (
 	ApplicationError        = qerr.ApplicationError
 	VersionNegotiationError = qerr.VersionNegotiationError
 	StatelessResetError     = qerr.StatelessResetError
+	IdleTimeoutError        = qerr.IdleTimeoutError
+	HandshakeTimeoutError   = qerr.HandshakeTimeoutError
 )
 
 type (

--- a/errors.go
+++ b/errors.go
@@ -8,6 +8,7 @@ type (
 	TransportError          = qerr.TransportError
 	ApplicationError        = qerr.ApplicationError
 	VersionNegotiationError = qerr.VersionNegotiationError
+	StatelessResetError     = qerr.StatelessResetError
 )
 
 type (

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,8 @@
 package quic
 
 import (
+	"fmt"
+
 	"github.com/lucas-clemente/quic-go/internal/qerr"
 )
 
@@ -14,6 +16,7 @@ type (
 type (
 	TransportErrorCode   = qerr.TransportErrorCode
 	ApplicationErrorCode = qerr.ApplicationErrorCode
+	StreamErrorCode      = qerr.StreamErrorCode
 )
 
 const (
@@ -35,3 +38,19 @@ const (
 	AEADLimitReached          = qerr.AEADLimitReached
 	NoViablePathError         = qerr.NoViablePathError
 )
+
+// A StreamError is used for Stream.CancelRead and Stream.CancelWrite.
+// It is also returned from Stream.Read and Stream.Write if the peer canceled reading or writing.
+type StreamError struct {
+	StreamID  StreamID
+	ErrorCode StreamErrorCode
+}
+
+func (e *StreamError) Is(target error) bool {
+	_, ok := target.(*StreamError)
+	return ok
+}
+
+func (e *StreamError) Error() string {
+	return fmt.Sprintf("stream %d canceled with error code %d", e.StreamID, e.ErrorCode)
+}

--- a/fuzzing/frames/cmd/corpus.go
+++ b/fuzzing/frames/cmd/corpus.go
@@ -9,7 +9,6 @@ import (
 	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/fuzzing/internal/helper"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
@@ -196,23 +195,23 @@ func getFrames() []wire.Frame {
 		},
 		&wire.ConnectionCloseFrame{ // QUIC error with empty reason
 			IsApplicationError: false,
-			ErrorCode:          qerr.ErrorCode(getRandomNumber()),
+			ErrorCode:          getRandomNumber(),
 			ReasonPhrase:       "",
 		},
 		&wire.ConnectionCloseFrame{ // QUIC error with reason
 			IsApplicationError: false,
 			// TODO: add frame type
-			ErrorCode:    qerr.ErrorCode(getRandomNumber()),
+			ErrorCode:    getRandomNumber(),
 			ReasonPhrase: string(getRandomData(100)),
 		},
 		&wire.ConnectionCloseFrame{ // application error with empty reason
 			IsApplicationError: true,
-			ErrorCode:          qerr.ErrorCode(getRandomNumber()),
+			ErrorCode:          getRandomNumber(),
 			ReasonPhrase:       "",
 		},
 		&wire.ConnectionCloseFrame{ // application error with reason
 			IsApplicationError: true,
-			ErrorCode:          qerr.ErrorCode(getRandomNumber()),
+			ErrorCode:          getRandomNumber(),
 			ReasonPhrase:       string(getRandomData(100)),
 		},
 	}

--- a/fuzzing/frames/cmd/corpus.go
+++ b/fuzzing/frames/cmd/corpus.go
@@ -124,17 +124,17 @@ func getFrames() []wire.Frame {
 		&wire.PingFrame{},
 		&wire.ResetStreamFrame{
 			StreamID:  protocol.StreamID(getRandomNumber()),
-			ErrorCode: quic.ErrorCode(getRandomNumber()),
+			ErrorCode: quic.ApplicationErrorCode(getRandomNumber()),
 			FinalSize: protocol.ByteCount(getRandomNumber()),
 		},
 		&wire.ResetStreamFrame{ // at maximum offset
 			StreamID:  protocol.StreamID(getRandomNumber()),
-			ErrorCode: quic.ErrorCode(getRandomNumber()),
+			ErrorCode: quic.ApplicationErrorCode(getRandomNumber()),
 			FinalSize: protocol.MaxByteCount,
 		},
 		&wire.StopSendingFrame{
 			StreamID:  protocol.StreamID(getRandomNumber()),
-			ErrorCode: quic.ErrorCode(getRandomNumber()),
+			ErrorCode: quic.ApplicationErrorCode(getRandomNumber()),
 		},
 		&wire.CryptoFrame{
 			Data: getRandomData(100),

--- a/fuzzing/frames/cmd/corpus.go
+++ b/fuzzing/frames/cmd/corpus.go
@@ -124,17 +124,17 @@ func getFrames() []wire.Frame {
 		&wire.PingFrame{},
 		&wire.ResetStreamFrame{
 			StreamID:  protocol.StreamID(getRandomNumber()),
-			ErrorCode: quic.ApplicationErrorCode(getRandomNumber()),
+			ErrorCode: quic.StreamErrorCode(getRandomNumber()),
 			FinalSize: protocol.ByteCount(getRandomNumber()),
 		},
 		&wire.ResetStreamFrame{ // at maximum offset
 			StreamID:  protocol.StreamID(getRandomNumber()),
-			ErrorCode: quic.ApplicationErrorCode(getRandomNumber()),
+			ErrorCode: quic.StreamErrorCode(getRandomNumber()),
 			FinalSize: protocol.MaxByteCount,
 		},
 		&wire.StopSendingFrame{
 			StreamID:  protocol.StreamID(getRandomNumber()),
-			ErrorCode: quic.ApplicationErrorCode(getRandomNumber()),
+			ErrorCode: quic.StreamErrorCode(getRandomNumber()),
 		},
 		&wire.CryptoFrame{
 			Data: getRandomData(100),

--- a/http3/body.go
+++ b/http3/body.go
@@ -93,6 +93,6 @@ func (r *body) requestDone() {
 func (r *body) Close() error {
 	r.requestDone()
 	// If the EOF was read, CancelRead() is a no-op.
-	r.str.CancelRead(quic.ApplicationErrorCode(errorRequestCanceled))
+	r.str.CancelRead(quic.StreamErrorCode(errorRequestCanceled))
 	return nil
 }

--- a/http3/body.go
+++ b/http3/body.go
@@ -93,6 +93,6 @@ func (r *body) requestDone() {
 func (r *body) Close() error {
 	r.requestDone()
 	// If the EOF was read, CancelRead() is a no-op.
-	r.str.CancelRead(quic.ErrorCode(errorRequestCanceled))
+	r.str.CancelRead(quic.ApplicationErrorCode(errorRequestCanceled))
 	return nil
 }

--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -173,12 +173,12 @@ var _ = Describe("Body", func() {
 				})
 
 				It("closes responses", func() {
-					str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorRequestCanceled))
+					str.EXPECT().CancelRead(quic.StreamErrorCode(errorRequestCanceled))
 					Expect(rb.Close()).To(Succeed())
 				})
 
 				It("allows multiple calls to Close", func() {
-					str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorRequestCanceled)).MaxTimes(2)
+					str.EXPECT().CancelRead(quic.StreamErrorCode(errorRequestCanceled)).MaxTimes(2)
 					Expect(rb.Close()).To(Succeed())
 					Expect(reqDone).To(BeClosed())
 					Expect(rb.Close()).To(Succeed())

--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -173,12 +173,12 @@ var _ = Describe("Body", func() {
 				})
 
 				It("closes responses", func() {
-					str.EXPECT().CancelRead(quic.ErrorCode(errorRequestCanceled))
+					str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorRequestCanceled))
 					Expect(rb.Close()).To(Succeed())
 				})
 
 				It("allows multiple calls to Close", func() {
-					str.EXPECT().CancelRead(quic.ErrorCode(errorRequestCanceled)).MaxTimes(2)
+					str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorRequestCanceled)).MaxTimes(2)
 					Expect(rb.Close()).To(Succeed())
 					Expect(reqDone).To(BeClosed())
 					Expect(rb.Close()).To(Succeed())

--- a/http3/client.go
+++ b/http3/client.go
@@ -117,7 +117,7 @@ func (c *client) dial() error {
 	go func() {
 		if err := c.setupSession(); err != nil {
 			c.logger.Debugf("Setting up session failed: %s", err)
-			c.session.CloseWithError(quic.ErrorCode(errorInternalError), "")
+			c.session.CloseWithError(quic.ApplicationErrorCode(errorInternalError), "")
 		}
 	}()
 
@@ -162,20 +162,20 @@ func (c *client) handleUnidirectionalStreams() {
 				return
 			case streamTypePushStream:
 				// We never increased the Push ID, so we don't expect any push streams.
-				c.session.CloseWithError(quic.ErrorCode(errorIDError), "")
+				c.session.CloseWithError(quic.ApplicationErrorCode(errorIDError), "")
 				return
 			default:
-				str.CancelRead(quic.ErrorCode(errorStreamCreationError))
+				str.CancelRead(quic.ApplicationErrorCode(errorStreamCreationError))
 				return
 			}
 			f, err := parseNextFrame(str)
 			if err != nil {
-				c.session.CloseWithError(quic.ErrorCode(errorFrameError), "")
+				c.session.CloseWithError(quic.ApplicationErrorCode(errorFrameError), "")
 				return
 			}
 			sf, ok := f.(*settingsFrame)
 			if !ok {
-				c.session.CloseWithError(quic.ErrorCode(errorMissingSettings), "")
+				c.session.CloseWithError(quic.ApplicationErrorCode(errorMissingSettings), "")
 				return
 			}
 			if !sf.Datagram {
@@ -185,7 +185,7 @@ func (c *client) handleUnidirectionalStreams() {
 			// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
 			// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
 			if c.opts.EnableDatagram && !c.session.ConnectionState().SupportsDatagrams {
-				c.session.CloseWithError(quic.ErrorCode(errorSettingsError), "missing QUIC Datagram support")
+				c.session.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), "missing QUIC Datagram support")
 			}
 		}()
 	}
@@ -195,7 +195,7 @@ func (c *client) Close() error {
 	if c.session == nil {
 		return nil
 	}
-	return c.session.CloseWithError(quic.ErrorCode(errorNoError), "")
+	return c.session.CloseWithError(quic.ApplicationErrorCode(errorNoError), "")
 }
 
 func (c *client) maxHeaderBytes() uint64 {
@@ -243,8 +243,8 @@ func (c *client) RoundTrip(req *http.Request) (*http.Response, error) {
 	go func() {
 		select {
 		case <-req.Context().Done():
-			str.CancelWrite(quic.ErrorCode(errorRequestCanceled))
-			str.CancelRead(quic.ErrorCode(errorRequestCanceled))
+			str.CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled))
+			str.CancelRead(quic.ApplicationErrorCode(errorRequestCanceled))
 		case <-reqDone:
 		}
 	}()
@@ -253,14 +253,14 @@ func (c *client) RoundTrip(req *http.Request) (*http.Response, error) {
 	if rerr.err != nil { // if any error occurred
 		close(reqDone)
 		if rerr.streamErr != 0 { // if it was a stream error
-			str.CancelWrite(quic.ErrorCode(rerr.streamErr))
+			str.CancelWrite(quic.ApplicationErrorCode(rerr.streamErr))
 		}
 		if rerr.connErr != 0 { // if it was a connection error
 			var reason string
 			if rerr.err != nil {
 				reason = rerr.err.Error()
 			}
-			c.session.CloseWithError(quic.ErrorCode(rerr.connErr), reason)
+			c.session.CloseWithError(quic.ApplicationErrorCode(rerr.connErr), reason)
 		}
 	}
 	return rsp, rerr.err
@@ -321,7 +321,7 @@ func (c *client) doRequest(
 		}
 	}
 	respBody := newResponseBody(str, reqDone, func() {
-		c.session.CloseWithError(quic.ErrorCode(errorFrameUnexpected), "")
+		c.session.CloseWithError(quic.ApplicationErrorCode(errorFrameUnexpected), "")
 	})
 
 	// Rules for when to set Content-Length are defined in https://tools.ietf.org/html/rfc7230#section-3.3.2.

--- a/http3/client.go
+++ b/http3/client.go
@@ -165,7 +165,7 @@ func (c *client) handleUnidirectionalStreams() {
 				c.session.CloseWithError(quic.ApplicationErrorCode(errorIDError), "")
 				return
 			default:
-				str.CancelRead(quic.ApplicationErrorCode(errorStreamCreationError))
+				str.CancelRead(quic.StreamErrorCode(errorStreamCreationError))
 				return
 			}
 			f, err := parseNextFrame(str)
@@ -243,8 +243,8 @@ func (c *client) RoundTrip(req *http.Request) (*http.Response, error) {
 	go func() {
 		select {
 		case <-req.Context().Done():
-			str.CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled))
-			str.CancelRead(quic.ApplicationErrorCode(errorRequestCanceled))
+			str.CancelWrite(quic.StreamErrorCode(errorRequestCanceled))
+			str.CancelRead(quic.StreamErrorCode(errorRequestCanceled))
 		case <-reqDone:
 		}
 	}()
@@ -253,7 +253,7 @@ func (c *client) RoundTrip(req *http.Request) (*http.Response, error) {
 	if rerr.err != nil { // if any error occurred
 		close(reqDone)
 		if rerr.streamErr != 0 { // if it was a stream error
-			str.CancelWrite(quic.ApplicationErrorCode(rerr.streamErr))
+			str.CancelWrite(quic.StreamErrorCode(rerr.streamErr))
 		}
 		if rerr.connErr != 0 { // if it was a connection error
 			var reason string

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -267,7 +267,7 @@ var _ = Describe("Client", func() {
 			str := mockquic.NewMockStream(mockCtrl)
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 			done := make(chan struct{})
-			str.EXPECT().CancelRead(quic.ErrorCode(errorStreamCreationError)).Do(func(code quic.ErrorCode) {
+			str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorStreamCreationError)).Do(func(code quic.ApplicationErrorCode) {
 				close(done)
 			})
 
@@ -297,7 +297,7 @@ var _ = Describe("Client", func() {
 				return nil, errors.New("test done")
 			})
 			done := make(chan struct{})
-			sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, _ string) {
+			sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ApplicationErrorCode, _ string) {
 				defer GinkgoRecover()
 				Expect(code).To(BeEquivalentTo(errorMissingSettings))
 				close(done)
@@ -323,7 +323,7 @@ var _ = Describe("Client", func() {
 				return nil, errors.New("test done")
 			})
 			done := make(chan struct{})
-			sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, _ string) {
+			sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ApplicationErrorCode, _ string) {
 				defer GinkgoRecover()
 				Expect(code).To(BeEquivalentTo(errorFrameError))
 				close(done)
@@ -346,7 +346,7 @@ var _ = Describe("Client", func() {
 				return nil, errors.New("test done")
 			})
 			done := make(chan struct{})
-			sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, _ string) {
+			sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ApplicationErrorCode, _ string) {
 				defer GinkgoRecover()
 				Expect(code).To(BeEquivalentTo(errorIDError))
 				close(done)
@@ -372,7 +372,7 @@ var _ = Describe("Client", func() {
 			})
 			sess.EXPECT().ConnectionState().Return(quic.ConnectionState{SupportsDatagrams: false})
 			done := make(chan struct{})
-			sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, reason string) {
+			sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ApplicationErrorCode, reason string) {
 				defer GinkgoRecover()
 				Expect(code).To(BeEquivalentTo(errorSettingsError))
 				Expect(reason).To(Equal("missing QUIC Datagram support"))
@@ -546,7 +546,7 @@ var _ = Describe("Client", func() {
 				request.Body.(*mockBody).readErr = errors.New("testErr")
 				done := make(chan struct{})
 				gomock.InOrder(
-					str.EXPECT().CancelWrite(quic.ErrorCode(errorRequestCanceled)).Do(func(quic.ErrorCode) {
+					str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled)).Do(func(quic.ApplicationErrorCode) {
 						close(done)
 					}),
 					str.EXPECT().CancelWrite(gomock.Any()),
@@ -584,7 +584,7 @@ var _ = Describe("Client", func() {
 			It("closes the connection when the first frame is not a HEADERS frame", func() {
 				buf := &bytes.Buffer{}
 				(&dataFrame{Length: 0x42}).Write(buf)
-				sess.EXPECT().CloseWithError(quic.ErrorCode(errorFrameUnexpected), gomock.Any())
+				sess.EXPECT().CloseWithError(quic.ApplicationErrorCode(errorFrameUnexpected), gomock.Any())
 				closed := make(chan struct{})
 				str.EXPECT().Close().Do(func() { close(closed) })
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -596,7 +596,7 @@ var _ = Describe("Client", func() {
 			It("cancels the stream when the HEADERS frame is too large", func() {
 				buf := &bytes.Buffer{}
 				(&headersFrame{Length: 1338}).Write(buf)
-				str.EXPECT().CancelWrite(quic.ErrorCode(errorFrameError))
+				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorFrameError))
 				closed := make(chan struct{})
 				str.EXPECT().Close().Do(func() { close(closed) })
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -635,8 +635,8 @@ var _ = Describe("Client", func() {
 				done := make(chan struct{})
 				canceled := make(chan struct{})
 				gomock.InOrder(
-					str.EXPECT().CancelWrite(quic.ErrorCode(errorRequestCanceled)).Do(func(quic.ErrorCode) { close(canceled) }),
-					str.EXPECT().CancelRead(quic.ErrorCode(errorRequestCanceled)).Do(func(quic.ErrorCode) { close(done) }),
+					str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled)).Do(func(quic.ApplicationErrorCode) { close(canceled) }),
+					str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorRequestCanceled)).Do(func(quic.ApplicationErrorCode) { close(done) }),
 				)
 				str.EXPECT().CancelWrite(gomock.Any()).MaxTimes(1)
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(func([]byte) (int, error) {
@@ -663,8 +663,8 @@ var _ = Describe("Client", func() {
 				done := make(chan struct{})
 				str.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write)
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
-				str.EXPECT().CancelWrite(quic.ErrorCode(errorRequestCanceled))
-				str.EXPECT().CancelRead(quic.ErrorCode(errorRequestCanceled)).Do(func(quic.ErrorCode) { close(done) })
+				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled))
+				str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorRequestCanceled)).Do(func(quic.ApplicationErrorCode) { close(done) })
 				_, err := client.RoundTrip(req)
 				Expect(err).ToNot(HaveOccurred())
 				cancel()

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -267,7 +267,7 @@ var _ = Describe("Client", func() {
 			str := mockquic.NewMockStream(mockCtrl)
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 			done := make(chan struct{})
-			str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorStreamCreationError)).Do(func(code quic.ApplicationErrorCode) {
+			str.EXPECT().CancelRead(quic.StreamErrorCode(errorStreamCreationError)).Do(func(code quic.StreamErrorCode) {
 				close(done)
 			})
 
@@ -546,7 +546,7 @@ var _ = Describe("Client", func() {
 				request.Body.(*mockBody).readErr = errors.New("testErr")
 				done := make(chan struct{})
 				gomock.InOrder(
-					str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled)).Do(func(quic.ApplicationErrorCode) {
+					str.EXPECT().CancelWrite(quic.StreamErrorCode(errorRequestCanceled)).Do(func(quic.StreamErrorCode) {
 						close(done)
 					}),
 					str.EXPECT().CancelWrite(gomock.Any()),
@@ -596,7 +596,7 @@ var _ = Describe("Client", func() {
 			It("cancels the stream when the HEADERS frame is too large", func() {
 				buf := &bytes.Buffer{}
 				(&headersFrame{Length: 1338}).Write(buf)
-				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorFrameError))
+				str.EXPECT().CancelWrite(quic.StreamErrorCode(errorFrameError))
 				closed := make(chan struct{})
 				str.EXPECT().Close().Do(func() { close(closed) })
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -635,8 +635,8 @@ var _ = Describe("Client", func() {
 				done := make(chan struct{})
 				canceled := make(chan struct{})
 				gomock.InOrder(
-					str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled)).Do(func(quic.ApplicationErrorCode) { close(canceled) }),
-					str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorRequestCanceled)).Do(func(quic.ApplicationErrorCode) { close(done) }),
+					str.EXPECT().CancelWrite(quic.StreamErrorCode(errorRequestCanceled)).Do(func(quic.StreamErrorCode) { close(canceled) }),
+					str.EXPECT().CancelRead(quic.StreamErrorCode(errorRequestCanceled)).Do(func(quic.StreamErrorCode) { close(done) }),
 				)
 				str.EXPECT().CancelWrite(gomock.Any()).MaxTimes(1)
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(func([]byte) (int, error) {
@@ -663,8 +663,8 @@ var _ = Describe("Client", func() {
 				done := make(chan struct{})
 				str.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write)
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
-				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled))
-				str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorRequestCanceled)).Do(func(quic.ApplicationErrorCode) { close(done) })
+				str.EXPECT().CancelWrite(quic.StreamErrorCode(errorRequestCanceled))
+				str.EXPECT().CancelRead(quic.StreamErrorCode(errorRequestCanceled)).Do(func(quic.StreamErrorCode) { close(done) })
 				_, err := client.RoundTrip(req)
 				Expect(err).ToNot(HaveOccurred())
 				cancel()

--- a/http3/error_codes.go
+++ b/http3/error_codes.go
@@ -3,10 +3,10 @@ package http3
 import (
 	"fmt"
 
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 )
 
-type errorCode quic.ErrorCode
+type errorCode quic.ApplicationErrorCode
 
 const (
 	errorNoError              errorCode = 0x100

--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -79,7 +79,7 @@ func (w *requestWriter) WriteRequest(str quic.Stream, req *http.Request, gzip bo
 				if rerr == io.EOF {
 					break
 				}
-				str.CancelWrite(quic.ErrorCode(errorRequestCanceled))
+				str.CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled))
 				w.logger.Errorf("Error writing request: %s", rerr)
 				return
 			}

--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -79,7 +79,7 @@ func (w *requestWriter) WriteRequest(str quic.Stream, req *http.Request, gzip bo
 				if rerr == io.EOF {
 					break
 				}
-				str.CancelWrite(quic.ApplicationErrorCode(errorRequestCanceled))
+				str.CancelWrite(quic.StreamErrorCode(errorRequestCanceled))
 				w.logger.Errorf("Error writing request: %s", rerr)
 				return
 			}

--- a/http3/roundtrip_test.go
+++ b/http3/roundtrip_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 	mockquic "github.com/lucas-clemente/quic-go/internal/mocks/quic"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -105,7 +105,7 @@ var _ = Describe("RoundTripper", func() {
 				<-closed
 				return nil, errors.New("test done")
 			}).MaxTimes(1)
-			session.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(quic.ErrorCode, string) { close(closed) })
+			session.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(quic.ApplicationErrorCode, string) { close(closed) })
 			_, err = rt.RoundTrip(req)
 			Expect(err).To(MatchError(testErr))
 			Expect(rt.clients).To(HaveLen(1))
@@ -147,7 +147,7 @@ var _ = Describe("RoundTripper", func() {
 				<-closed
 				return nil, errors.New("test done")
 			}).MaxTimes(1)
-			session.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(quic.ErrorCode, string) { close(closed) })
+			session.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(quic.ApplicationErrorCode, string) { close(closed) })
 			req, err := http.NewRequest("GET", "https://quic.clemente.io/file1.html", nil)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = rt.RoundTrip(req)

--- a/http3/server.go
+++ b/http3/server.go
@@ -263,7 +263,7 @@ func (s *Server) handleConn(sess quic.EarlySession) {
 			if rerr.err != nil || rerr.streamErr != 0 || rerr.connErr != 0 {
 				s.logger.Debugf("Handling request failed: %s", err)
 				if rerr.streamErr != 0 {
-					str.CancelWrite(quic.ApplicationErrorCode(rerr.streamErr))
+					str.CancelWrite(quic.StreamErrorCode(rerr.streamErr))
 				}
 				if rerr.connErr != 0 {
 					var reason string
@@ -304,7 +304,7 @@ func (s *Server) handleUnidirectionalStreams(sess quic.EarlySession) {
 				sess.CloseWithError(quic.ApplicationErrorCode(errorStreamCreationError), "")
 				return
 			default:
-				str.CancelRead(quic.ApplicationErrorCode(errorStreamCreationError))
+				str.CancelRead(quic.StreamErrorCode(errorStreamCreationError))
 				return
 			}
 			f, err := parseNextFrame(str)
@@ -410,7 +410,7 @@ func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpac
 			r.WriteHeader(200)
 		}
 		// If the EOF was read by the handler, CancelRead() is a no-op.
-		str.CancelRead(quic.ApplicationErrorCode(errorNoError))
+		str.CancelRead(quic.StreamErrorCode(errorNoError))
 	}
 	return requestError{}
 }

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -257,7 +257,7 @@ var _ = Describe("Server", func() {
 				str := mockquic.NewMockStream(mockCtrl)
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				done := make(chan struct{})
-				str.EXPECT().CancelRead(quic.ErrorCode(errorStreamCreationError)).Do(func(code quic.ErrorCode) {
+				str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorStreamCreationError)).Do(func(code quic.ApplicationErrorCode) {
 					close(done)
 				})
 
@@ -286,7 +286,7 @@ var _ = Describe("Server", func() {
 					return nil, errors.New("test done")
 				})
 				done := make(chan struct{})
-				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, _ string) {
+				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ApplicationErrorCode, _ string) {
 					defer GinkgoRecover()
 					Expect(code).To(BeEquivalentTo(errorMissingSettings))
 					close(done)
@@ -311,7 +311,7 @@ var _ = Describe("Server", func() {
 					return nil, errors.New("test done")
 				})
 				done := make(chan struct{})
-				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, _ string) {
+				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ApplicationErrorCode, _ string) {
 					defer GinkgoRecover()
 					Expect(code).To(BeEquivalentTo(errorFrameError))
 					close(done)
@@ -334,7 +334,7 @@ var _ = Describe("Server", func() {
 					return nil, errors.New("test done")
 				})
 				done := make(chan struct{})
-				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, _ string) {
+				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ApplicationErrorCode, _ string) {
 					defer GinkgoRecover()
 					Expect(code).To(BeEquivalentTo(errorStreamCreationError))
 					close(done)
@@ -359,7 +359,7 @@ var _ = Describe("Server", func() {
 				})
 				sess.EXPECT().ConnectionState().Return(quic.ConnectionState{SupportsDatagrams: false})
 				done := make(chan struct{})
-				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, reason string) {
+				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ApplicationErrorCode, reason string) {
 					defer GinkgoRecover()
 					Expect(code).To(BeEquivalentTo(errorSettingsError))
 					Expect(reason).To(Equal("missing QUIC Datagram support"))
@@ -408,7 +408,7 @@ var _ = Describe("Server", func() {
 				done := make(chan struct{})
 				str.EXPECT().Context().Return(reqContext)
 				str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
-				str.EXPECT().CancelRead(quic.ErrorCode(errorNoError))
+				str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorNoError))
 				str.EXPECT().Close().Do(func() { close(done) })
 
 				s.handleConn(sess)
@@ -431,7 +431,7 @@ var _ = Describe("Server", func() {
 				setRequest(append(requestData, buf.Bytes()...))
 				done := make(chan struct{})
 				str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
-				str.EXPECT().CancelWrite(quic.ErrorCode(errorFrameError)).Do(func(quic.ErrorCode) { close(done) })
+				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorFrameError)).Do(func(quic.ApplicationErrorCode) { close(done) })
 
 				s.handleConn(sess)
 				Eventually(done).Should(BeClosed())
@@ -446,7 +446,7 @@ var _ = Describe("Server", func() {
 				testErr := errors.New("stream reset")
 				done := make(chan struct{})
 				str.EXPECT().Read(gomock.Any()).Return(0, testErr)
-				str.EXPECT().CancelWrite(quic.ErrorCode(errorRequestIncomplete)).Do(func(quic.ErrorCode) { close(done) })
+				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorRequestIncomplete)).Do(func(quic.ApplicationErrorCode) { close(done) })
 
 				s.handleConn(sess)
 				Consistently(handlerCalled).ShouldNot(BeClosed())
@@ -466,8 +466,8 @@ var _ = Describe("Server", func() {
 				}).AnyTimes()
 
 				done := make(chan struct{})
-				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ErrorCode, _ string) {
-					Expect(code).To(Equal(quic.ErrorCode(errorFrameUnexpected)))
+				sess.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).Do(func(code quic.ApplicationErrorCode, _ string) {
+					Expect(code).To(Equal(quic.ApplicationErrorCode(errorFrameUnexpected)))
 					close(done)
 				})
 				s.handleConn(sess)
@@ -491,7 +491,7 @@ var _ = Describe("Server", func() {
 					return len(p), nil
 				}).AnyTimes()
 				done := make(chan struct{})
-				str.EXPECT().CancelWrite(quic.ErrorCode(errorFrameError)).Do(func(quic.ErrorCode) { close(done) })
+				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorFrameError)).Do(func(quic.ApplicationErrorCode) { close(done) })
 
 				s.handleConn(sess)
 				Eventually(done).Should(BeClosed())
@@ -513,7 +513,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
 				return len(p), nil
 			}).AnyTimes()
-			str.EXPECT().CancelRead(quic.ErrorCode(errorNoError))
+			str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorNoError))
 
 			serr := s.handleRequest(sess, str, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
@@ -536,7 +536,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
 				return len(p), nil
 			}).AnyTimes()
-			str.EXPECT().CancelRead(quic.ErrorCode(errorNoError))
+			str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorNoError))
 
 			serr := s.handleRequest(sess, str, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -257,7 +257,7 @@ var _ = Describe("Server", func() {
 				str := mockquic.NewMockStream(mockCtrl)
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				done := make(chan struct{})
-				str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorStreamCreationError)).Do(func(code quic.ApplicationErrorCode) {
+				str.EXPECT().CancelRead(quic.StreamErrorCode(errorStreamCreationError)).Do(func(code quic.StreamErrorCode) {
 					close(done)
 				})
 
@@ -408,7 +408,7 @@ var _ = Describe("Server", func() {
 				done := make(chan struct{})
 				str.EXPECT().Context().Return(reqContext)
 				str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
-				str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorNoError))
+				str.EXPECT().CancelRead(quic.StreamErrorCode(errorNoError))
 				str.EXPECT().Close().Do(func() { close(done) })
 
 				s.handleConn(sess)
@@ -431,7 +431,7 @@ var _ = Describe("Server", func() {
 				setRequest(append(requestData, buf.Bytes()...))
 				done := make(chan struct{})
 				str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
-				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorFrameError)).Do(func(quic.ApplicationErrorCode) { close(done) })
+				str.EXPECT().CancelWrite(quic.StreamErrorCode(errorFrameError)).Do(func(quic.StreamErrorCode) { close(done) })
 
 				s.handleConn(sess)
 				Eventually(done).Should(BeClosed())
@@ -446,7 +446,7 @@ var _ = Describe("Server", func() {
 				testErr := errors.New("stream reset")
 				done := make(chan struct{})
 				str.EXPECT().Read(gomock.Any()).Return(0, testErr)
-				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorRequestIncomplete)).Do(func(quic.ApplicationErrorCode) { close(done) })
+				str.EXPECT().CancelWrite(quic.StreamErrorCode(errorRequestIncomplete)).Do(func(quic.StreamErrorCode) { close(done) })
 
 				s.handleConn(sess)
 				Consistently(handlerCalled).ShouldNot(BeClosed())
@@ -491,7 +491,7 @@ var _ = Describe("Server", func() {
 					return len(p), nil
 				}).AnyTimes()
 				done := make(chan struct{})
-				str.EXPECT().CancelWrite(quic.ApplicationErrorCode(errorFrameError)).Do(func(quic.ApplicationErrorCode) { close(done) })
+				str.EXPECT().CancelWrite(quic.StreamErrorCode(errorFrameError)).Do(func(quic.StreamErrorCode) { close(done) })
 
 				s.handleConn(sess)
 				Eventually(done).Should(BeClosed())
@@ -513,7 +513,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
 				return len(p), nil
 			}).AnyTimes()
-			str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorNoError))
+			str.EXPECT().CancelRead(quic.StreamErrorCode(errorNoError))
 
 			serr := s.handleRequest(sess, str, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
@@ -536,7 +536,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
 				return len(p), nil
 			}).AnyTimes()
-			str.EXPECT().CancelRead(quic.ApplicationErrorCode(errorNoError))
+			str.EXPECT().CancelRead(quic.StreamErrorCode(errorNoError))
 
 			serr := s.handleRequest(sess, str, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())

--- a/integrationtests/self/cancelation_test.go
+++ b/integrationtests/self/cancelation_test.go
@@ -45,7 +45,10 @@ var _ = Describe("Stream Cancelations", func() {
 						str, err := sess.OpenUniStreamSync(context.Background())
 						Expect(err).ToNot(HaveOccurred())
 						if _, err := str.Write(PRData); err != nil {
-							Expect(err).To(MatchError(fmt.Sprintf("stream %d was reset with error code %d", str.StreamID(), str.StreamID())))
+							Expect(err).To(MatchError(&quic.StreamError{
+								StreamID:  str.StreamID(),
+								ErrorCode: quic.StreamErrorCode(str.StreamID()),
+							}))
 							atomic.AddInt32(&canceledCounter, 1)
 							return
 						}
@@ -87,7 +90,7 @@ var _ = Describe("Stream Cancelations", func() {
 					// cancel around 2/3 of the streams
 					if rand.Int31()%3 != 0 {
 						atomic.AddInt32(&canceledCounter, 1)
-						str.CancelRead(quic.ApplicationErrorCode(str.StreamID()))
+						str.CancelRead(quic.StreamErrorCode(str.StreamID()))
 						return
 					}
 					data, err := ioutil.ReadAll(str)
@@ -133,7 +136,7 @@ var _ = Describe("Stream Cancelations", func() {
 						length := int(rand.Int31n(int32(len(PRData) - 1)))
 						data, err := ioutil.ReadAll(io.LimitReader(str, int64(length)))
 						Expect(err).ToNot(HaveOccurred())
-						str.CancelRead(quic.ApplicationErrorCode(str.StreamID()))
+						str.CancelRead(quic.StreamErrorCode(str.StreamID()))
 						Expect(data).To(Equal(PRData[:length]))
 						atomic.AddInt32(&canceledCounter, 1)
 						return
@@ -179,7 +182,10 @@ var _ = Describe("Stream Cancelations", func() {
 					data, err := ioutil.ReadAll(str)
 					if err != nil {
 						atomic.AddInt32(&counter, 1)
-						Expect(err).To(MatchError(fmt.Sprintf("stream %d was reset with error code %d", str.StreamID(), str.StreamID())))
+						Expect(err).To(MatchError(&quic.StreamError{
+							StreamID:  str.StreamID(),
+							ErrorCode: quic.StreamErrorCode(str.StreamID()),
+						}))
 						return
 					}
 					Expect(data).To(Equal(PRData))
@@ -212,7 +218,7 @@ var _ = Describe("Stream Cancelations", func() {
 						Expect(err).ToNot(HaveOccurred())
 						// cancel about 2/3 of the streams
 						if rand.Int31()%3 != 0 {
-							str.CancelWrite(quic.ApplicationErrorCode(str.StreamID()))
+							str.CancelWrite(quic.StreamErrorCode(str.StreamID()))
 							atomic.AddInt32(&canceledCounter, 1)
 							return
 						}
@@ -246,7 +252,7 @@ var _ = Describe("Stream Cancelations", func() {
 							length := int(rand.Int31n(int32(len(PRData) - 1)))
 							_, err = str.Write(PRData[:length])
 							Expect(err).ToNot(HaveOccurred())
-							str.CancelWrite(quic.ApplicationErrorCode(str.StreamID()))
+							str.CancelWrite(quic.StreamErrorCode(str.StreamID()))
 							atomic.AddInt32(&canceledCounter, 1)
 							return
 						}
@@ -282,11 +288,14 @@ var _ = Describe("Stream Cancelations", func() {
 						Expect(err).ToNot(HaveOccurred())
 						// cancel about half of the streams
 						if rand.Int31()%2 == 0 {
-							str.CancelWrite(quic.ApplicationErrorCode(str.StreamID()))
+							str.CancelWrite(quic.StreamErrorCode(str.StreamID()))
 							return
 						}
 						if _, err = str.Write(PRData); err != nil {
-							Expect(err).To(MatchError(fmt.Sprintf("stream %d was reset with error code %d", str.StreamID(), str.StreamID())))
+							Expect(err).To(MatchError(&quic.StreamError{
+								StreamID:  str.StreamID(),
+								ErrorCode: quic.StreamErrorCode(str.StreamID()),
+							}))
 							return
 						}
 						if err := str.Close(); err != nil {
@@ -317,12 +326,15 @@ var _ = Describe("Stream Cancelations", func() {
 					Expect(err).ToNot(HaveOccurred())
 					// cancel around half of the streams
 					if rand.Int31()%2 == 0 {
-						str.CancelRead(quic.ApplicationErrorCode(str.StreamID()))
+						str.CancelRead(quic.StreamErrorCode(str.StreamID()))
 						return
 					}
 					data, err := ioutil.ReadAll(str)
 					if err != nil {
-						Expect(err).To(MatchError(fmt.Sprintf("stream %d was reset with error code %d", str.StreamID(), str.StreamID())))
+						Expect(err).To(MatchError(&quic.StreamError{
+							StreamID:  str.StreamID(),
+							ErrorCode: quic.StreamErrorCode(str.StreamID()),
+						}))
 						return
 					}
 					atomic.AddInt32(&counter, 1)
@@ -364,11 +376,14 @@ var _ = Describe("Stream Cancelations", func() {
 							length = int(rand.Int31n(int32(len(PRData) - 1)))
 						}
 						if _, err = str.Write(PRData[:length]); err != nil {
-							Expect(err).To(MatchError(fmt.Sprintf("stream %d was reset with error code %d", str.StreamID(), str.StreamID())))
+							Expect(err).To(MatchError(&quic.StreamError{
+								StreamID:  str.StreamID(),
+								ErrorCode: quic.StreamErrorCode(str.StreamID()),
+							}))
 							return
 						}
 						if length < len(PRData) {
-							str.CancelWrite(quic.ApplicationErrorCode(str.StreamID()))
+							str.CancelWrite(quic.StreamErrorCode(str.StreamID()))
 						} else if err := str.Close(); err != nil {
 							Expect(err).To(MatchError(fmt.Sprintf("close called for canceled stream %d", str.StreamID())))
 							return
@@ -405,12 +420,15 @@ var _ = Describe("Stream Cancelations", func() {
 					}
 					data, err := ioutil.ReadAll(r)
 					if err != nil {
-						Expect(err).To(MatchError(fmt.Sprintf("stream %d was reset with error code %d", str.StreamID(), str.StreamID())))
+						Expect(err).To(MatchError(&quic.StreamError{
+							StreamID:  str.StreamID(),
+							ErrorCode: quic.StreamErrorCode(str.StreamID()),
+						}))
 						return
 					}
 					Expect(data).To(Equal(PRData[:length]))
 					if length < len(PRData) {
-						str.CancelRead(quic.ApplicationErrorCode(str.StreamID()))
+						str.CancelRead(quic.StreamErrorCode(str.StreamID()))
 						return
 					}
 

--- a/integrationtests/self/cancelation_test.go
+++ b/integrationtests/self/cancelation_test.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -87,7 +87,7 @@ var _ = Describe("Stream Cancelations", func() {
 					// cancel around 2/3 of the streams
 					if rand.Int31()%3 != 0 {
 						atomic.AddInt32(&canceledCounter, 1)
-						str.CancelRead(quic.ErrorCode(str.StreamID()))
+						str.CancelRead(quic.ApplicationErrorCode(str.StreamID()))
 						return
 					}
 					data, err := ioutil.ReadAll(str)
@@ -133,7 +133,7 @@ var _ = Describe("Stream Cancelations", func() {
 						length := int(rand.Int31n(int32(len(PRData) - 1)))
 						data, err := ioutil.ReadAll(io.LimitReader(str, int64(length)))
 						Expect(err).ToNot(HaveOccurred())
-						str.CancelRead(quic.ErrorCode(str.StreamID()))
+						str.CancelRead(quic.ApplicationErrorCode(str.StreamID()))
 						Expect(data).To(Equal(PRData[:length]))
 						atomic.AddInt32(&canceledCounter, 1)
 						return
@@ -212,7 +212,7 @@ var _ = Describe("Stream Cancelations", func() {
 						Expect(err).ToNot(HaveOccurred())
 						// cancel about 2/3 of the streams
 						if rand.Int31()%3 != 0 {
-							str.CancelWrite(quic.ErrorCode(str.StreamID()))
+							str.CancelWrite(quic.ApplicationErrorCode(str.StreamID()))
 							atomic.AddInt32(&canceledCounter, 1)
 							return
 						}
@@ -246,7 +246,7 @@ var _ = Describe("Stream Cancelations", func() {
 							length := int(rand.Int31n(int32(len(PRData) - 1)))
 							_, err = str.Write(PRData[:length])
 							Expect(err).ToNot(HaveOccurred())
-							str.CancelWrite(quic.ErrorCode(str.StreamID()))
+							str.CancelWrite(quic.ApplicationErrorCode(str.StreamID()))
 							atomic.AddInt32(&canceledCounter, 1)
 							return
 						}
@@ -282,7 +282,7 @@ var _ = Describe("Stream Cancelations", func() {
 						Expect(err).ToNot(HaveOccurred())
 						// cancel about half of the streams
 						if rand.Int31()%2 == 0 {
-							str.CancelWrite(quic.ErrorCode(str.StreamID()))
+							str.CancelWrite(quic.ApplicationErrorCode(str.StreamID()))
 							return
 						}
 						if _, err = str.Write(PRData); err != nil {
@@ -317,7 +317,7 @@ var _ = Describe("Stream Cancelations", func() {
 					Expect(err).ToNot(HaveOccurred())
 					// cancel around half of the streams
 					if rand.Int31()%2 == 0 {
-						str.CancelRead(quic.ErrorCode(str.StreamID()))
+						str.CancelRead(quic.ApplicationErrorCode(str.StreamID()))
 						return
 					}
 					data, err := ioutil.ReadAll(str)
@@ -368,7 +368,7 @@ var _ = Describe("Stream Cancelations", func() {
 							return
 						}
 						if length < len(PRData) {
-							str.CancelWrite(quic.ErrorCode(str.StreamID()))
+							str.CancelWrite(quic.ApplicationErrorCode(str.StreamID()))
 						} else if err := str.Close(); err != nil {
 							Expect(err).To(MatchError(fmt.Sprintf("close called for canceled stream %d", str.StreamID())))
 							return
@@ -410,7 +410,7 @@ var _ = Describe("Stream Cancelations", func() {
 					}
 					Expect(data).To(Equal(PRData[:length]))
 					if length < len(PRData) {
-						str.CancelRead(quic.ErrorCode(str.StreamID()))
+						str.CancelRead(quic.ApplicationErrorCode(str.StreamID()))
 						return
 					}
 

--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"time"
 
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 
@@ -86,7 +86,6 @@ var _ = Describe("Handshake RTT tests", func() {
 			clientConfig,
 		)
 		Expect(err).To(HaveOccurred())
-		// Expect(err.(qerr.ErrorCode)).To(Equal(qerr.InvalidVersion))
 		expectDurationInRTTs(1)
 	})
 

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/integrationtests/tools/israce"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/logging"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -269,7 +269,7 @@ var _ = Describe("Handshake tests", func() {
 						clientConfig,
 					)
 					Expect(err).To(HaveOccurred())
-					var transportErr *qerr.TransportError
+					var transportErr *quic.TransportError
 					Expect(errors.As(err, &transportErr)).To(BeTrue())
 					Expect(transportErr.ErrorCode.IsCryptoError()).To(BeTrue())
 					Expect(transportErr.Error()).To(ContainSubstring("x509: certificate is valid for localhost, not foo.bar"))
@@ -298,7 +298,7 @@ var _ = Describe("Handshake tests", func() {
 						Eventually(errChan).Should(Receive(&err))
 					}
 					Expect(err).To(HaveOccurred())
-					var transportErr *qerr.TransportError
+					var transportErr *quic.TransportError
 					Expect(errors.As(err, &transportErr)).To(BeTrue())
 					Expect(transportErr.ErrorCode.IsCryptoError()).To(BeTrue())
 					Expect(transportErr.Error()).To(ContainSubstring("tls: bad certificate"))
@@ -314,7 +314,7 @@ var _ = Describe("Handshake tests", func() {
 						clientConfig,
 					)
 					Expect(err).To(HaveOccurred())
-					var transportErr *qerr.TransportError
+					var transportErr *quic.TransportError
 					Expect(errors.As(err, &transportErr)).To(BeTrue())
 					Expect(transportErr.ErrorCode.IsCryptoError()).To(BeTrue())
 					Expect(transportErr.Error()).To(ContainSubstring("x509: certificate is valid for localhost, not foo.bar"))
@@ -376,9 +376,9 @@ var _ = Describe("Handshake tests", func() {
 
 			_, err := dial()
 			Expect(err).To(HaveOccurred())
-			var transportErr *qerr.TransportError
+			var transportErr *quic.TransportError
 			Expect(errors.As(err, &transportErr)).To(BeTrue())
-			Expect(transportErr.ErrorCode).To(Equal(qerr.ConnectionRefused))
+			Expect(transportErr.ErrorCode).To(Equal(quic.ConnectionRefused))
 
 			// now accept one session, freeing one spot in the queue
 			_, err = server.Accept(context.Background())
@@ -392,7 +392,7 @@ var _ = Describe("Handshake tests", func() {
 			_, err = dial()
 			Expect(err).To(HaveOccurred())
 			Expect(errors.As(err, &transportErr)).To(BeTrue())
-			Expect(transportErr.ErrorCode).To(Equal(qerr.ConnectionRefused))
+			Expect(transportErr.ErrorCode).To(Equal(quic.ConnectionRefused))
 		})
 
 		It("removes closed connections from the accept queue", func() {
@@ -408,9 +408,9 @@ var _ = Describe("Handshake tests", func() {
 
 			_, err = dial()
 			Expect(err).To(HaveOccurred())
-			var transportErr *qerr.TransportError
+			var transportErr *quic.TransportError
 			Expect(errors.As(err, &transportErr)).To(BeTrue())
-			Expect(transportErr.ErrorCode).To(Equal(qerr.ConnectionRefused))
+			Expect(transportErr.ErrorCode).To(Equal(quic.ConnectionRefused))
 
 			// Now close the one of the session that are waiting to be accepted.
 			// This should free one spot in the queue.
@@ -426,7 +426,7 @@ var _ = Describe("Handshake tests", func() {
 			_, err = dial()
 			Expect(err).To(HaveOccurred())
 			Expect(errors.As(err, &transportErr)).To(BeTrue())
-			Expect(transportErr.ErrorCode).To(Equal(qerr.ConnectionRefused))
+			Expect(transportErr.ErrorCode).To(Equal(quic.ConnectionRefused))
 		})
 	})
 
@@ -469,7 +469,7 @@ var _ = Describe("Handshake tests", func() {
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
-			var transportErr *qerr.TransportError
+			var transportErr *quic.TransportError
 			Expect(errors.As(err, &transportErr)).To(BeTrue())
 			Expect(transportErr.ErrorCode.IsCryptoError()).To(BeTrue())
 			Expect(transportErr.Error()).To(ContainSubstring("no application protocol"))
@@ -550,9 +550,9 @@ var _ = Describe("Handshake tests", func() {
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
-			var transportErr *qerr.TransportError
+			var transportErr *quic.TransportError
 			Expect(errors.As(err, &transportErr)).To(BeTrue())
-			Expect(transportErr.ErrorCode).To(Equal(qerr.InvalidToken))
+			Expect(transportErr.ErrorCode).To(Equal(quic.InvalidToken))
 			// Receiving a Retry might lead the client to measure a very small RTT.
 			// Then, it sometimes would retransmit the ClientHello before receiving the ServerHello.
 			Expect(len(tokenChan)).To(BeNumerically(">=", 2))

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -14,9 +14,10 @@ import (
 	"strconv"
 	"time"
 
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/http3"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/testdata"
 
 	. "github.com/onsi/ginkgo"
@@ -26,7 +27,7 @@ import (
 
 type streamCancelError interface {
 	Canceled() bool
-	ErrorCode() protocol.ApplicationErrorCode
+	ErrorCode() qerr.ApplicationErrorCode
 }
 
 var _ = Describe("HTTP tests", func() {

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/http3"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/testdata"
 
 	. "github.com/onsi/ginkgo"
@@ -27,7 +26,7 @@ import (
 
 type streamCancelError interface {
 	Canceled() bool
-	ErrorCode() qerr.ApplicationErrorCode
+	ErrorCode() quic.ApplicationErrorCode
 }
 
 var _ = Describe("HTTP tests", func() {

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lucas-clemente/quic-go"
 	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/testutils"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 	. "github.com/onsi/ginkgo"
@@ -441,9 +440,9 @@ var _ = Describe("MITM test", func() {
 					}
 					err := runTest(delayCb)
 					Expect(err).To(HaveOccurred())
-					var transportErr *qerr.TransportError
+					var transportErr *quic.TransportError
 					Expect(errors.As(err, &transportErr)).To(BeTrue())
-					Expect(transportErr.ErrorCode).To(Equal(qerr.ProtocolViolation))
+					Expect(transportErr.ErrorCode).To(Equal(quic.ProtocolViolation))
 					Expect(transportErr.ErrorMessage).To(ContainSubstring("received ACK for an unsent packet"))
 				})
 			})

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -371,7 +371,7 @@ var _ = Describe("MITM test", func() {
 					}
 					err := runTest(delayCb)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("no compatible QUIC version found"))
+					Expect(err).To(MatchError(&quic.VersionNegotiationError{}))
 				})
 
 				// times out, because client doesn't accept subsequent real retry packets from server

--- a/integrationtests/self/stateless_reset_test.go
+++ b/integrationtests/self/stateless_reset_test.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"time"
 
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 
@@ -99,7 +99,7 @@ var _ = Describe("Stateless Resets", func() {
 				_, serr = str.Read([]byte{0})
 			}
 			Expect(serr).To(HaveOccurred())
-			Expect(serr.Error()).To(ContainSubstring("INTERNAL_ERROR: received a stateless reset"))
+			Expect(serr.Error()).To(ContainSubstring("received a stateless reset"))
 
 			Expect(ln2.Close()).To(Succeed())
 			Eventually(acceptStopped).Should(BeClosed())

--- a/integrationtests/self/stateless_reset_test.go
+++ b/integrationtests/self/stateless_reset_test.go
@@ -99,8 +99,7 @@ var _ = Describe("Stateless Resets", func() {
 				_, serr = str.Read([]byte{0})
 			}
 			Expect(serr).To(HaveOccurred())
-			Expect(serr.Error()).To(ContainSubstring("received a stateless reset"))
-
+			Expect(serr).To(MatchError(&quic.StatelessResetError{}))
 			Expect(ln2.Close()).To(Succeed())
 			Eventually(acceptStopped).Should(BeClosed())
 		})

--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -3,6 +3,7 @@ package self_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,7 +14,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
+
+	"github.com/lucas-clemente/quic-go"
 	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/logging"

--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -3,7 +3,6 @@ package self_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,12 +13,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/lucas-clemente/quic-go/internal/qerr"
-
 	"github.com/lucas-clemente/quic-go"
 	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/logging"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -54,7 +54,7 @@ func areHandshakesRunning() bool {
 
 var _ = Describe("Timeout tests", func() {
 	checkTimeoutError := func(err error) {
-		ExpectWithOffset(1, err).To(HaveOccurred())
+		ExpectWithOffset(1, err).To(MatchError(&quic.IdleTimeoutError{}))
 		nerr, ok := err.(net.Error)
 		ExpectWithOffset(1, ok).To(BeTrue())
 		ExpectWithOffset(1, nerr.Timeout()).To(BeTrue())

--- a/interface.go
+++ b/interface.go
@@ -79,6 +79,8 @@ var SessionTracingKey = sessionTracingCtxKey{}
 type sessionTracingCtxKey struct{}
 
 // Stream is the interface implemented by QUIC streams
+// In addition to the errors listed on the Session,
+// calls to stream functions can return a StreamError if the stream is canceled.
 type Stream interface {
 	ReceiveStream
 	SendStream
@@ -148,6 +150,13 @@ type SendStream interface {
 }
 
 // A Session is a QUIC connection between two peers.
+// Calls to the session (and to streams) can return the following types of errors:
+// * ApplicationError: for errors triggered by the application running on top of QUIC
+// * TransportError: for errors triggered by the QUIC transport (in many cases a misbehaving peer)
+// * IdleTimeoutError: when the peer goes away unexpectedly (this is a net.Error timeout error)
+// * HandshakeTimeoutError: when the cryptographic handshake takes too long (this is a net.Error timeout error)
+// * StatelessResetError: when we receive a stateless reset (this is a net.Error temporary error)
+// * VersionNegotiationError: returned by the client, when there's no version overlap between the peers
 type Session interface {
 	// AcceptStream returns the next stream opened by the peer, blocking until one is available.
 	// If the session was closed due to a timeout, the error satisfies

--- a/interface.go
+++ b/interface.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/logging"
 )
 
@@ -66,7 +67,7 @@ type TokenStore interface {
 
 // An ErrorCode is an application-defined error code.
 // Valid values range between 0 and MAX_UINT62.
-type ErrorCode = protocol.ApplicationErrorCode
+type ErrorCode = qerr.ApplicationErrorCode
 
 // Err0RTTRejected is the returned from:
 // * Open{Uni}Stream{Sync}

--- a/interface.go
+++ b/interface.go
@@ -104,7 +104,7 @@ type ReceiveStream interface {
 	// It will ask the peer to stop transmitting stream data.
 	// Read will unblock immediately, and future Read calls will fail.
 	// When called multiple times or after reading the io.EOF it is a no-op.
-	CancelRead(ApplicationErrorCode)
+	CancelRead(StreamErrorCode)
 	// SetReadDeadline sets the deadline for future Read calls and
 	// any currently-blocked Read call.
 	// A zero value for t means Read will not time out.
@@ -133,7 +133,7 @@ type SendStream interface {
 	// Data already written, but not yet delivered to the peer is not guaranteed to be delivered reliably.
 	// Write will unblock immediately, and future calls to Write will fail.
 	// When called multiple times or after closing the stream it is a no-op.
-	CancelWrite(ApplicationErrorCode)
+	CancelWrite(StreamErrorCode)
 	// The context is canceled as soon as the write-side of the stream is closed.
 	// This happens when Close() or CancelWrite() is called, or when the peer
 	// cancels the read-side of their stream.
@@ -145,13 +145,6 @@ type SendStream interface {
 	// some of the data was successfully written.
 	// A zero value for t means Write will not time out.
 	SetWriteDeadline(t time.Time) error
-}
-
-// StreamError is returned by Read and Write when the peer cancels the stream.
-type StreamError interface {
-	error
-	Canceled() bool
-	ErrorCode() ApplicationErrorCode
 }
 
 // A Session is a QUIC connection between two peers.

--- a/interface.go
+++ b/interface.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/logging"
 )
 
@@ -65,10 +64,6 @@ type TokenStore interface {
 	Put(key string, token *ClientToken)
 }
 
-// An ErrorCode is an application-defined error code.
-// Valid values range between 0 and MAX_UINT62.
-type ErrorCode = qerr.ApplicationErrorCode
-
 // Err0RTTRejected is the returned from:
 // * Open{Uni}Stream{Sync}
 // * Accept{Uni}Stream
@@ -109,7 +104,7 @@ type ReceiveStream interface {
 	// It will ask the peer to stop transmitting stream data.
 	// Read will unblock immediately, and future Read calls will fail.
 	// When called multiple times or after reading the io.EOF it is a no-op.
-	CancelRead(ErrorCode)
+	CancelRead(ApplicationErrorCode)
 	// SetReadDeadline sets the deadline for future Read calls and
 	// any currently-blocked Read call.
 	// A zero value for t means Read will not time out.
@@ -138,7 +133,7 @@ type SendStream interface {
 	// Data already written, but not yet delivered to the peer is not guaranteed to be delivered reliably.
 	// Write will unblock immediately, and future calls to Write will fail.
 	// When called multiple times or after closing the stream it is a no-op.
-	CancelWrite(ErrorCode)
+	CancelWrite(ApplicationErrorCode)
 	// The context is canceled as soon as the write-side of the stream is closed.
 	// This happens when Close() or CancelWrite() is called, or when the peer
 	// cancels the read-side of their stream.
@@ -156,7 +151,7 @@ type SendStream interface {
 type StreamError interface {
 	error
 	Canceled() bool
-	ErrorCode() ErrorCode
+	ErrorCode() ApplicationErrorCode
 }
 
 // A Session is a QUIC connection between two peers.
@@ -195,9 +190,9 @@ type Session interface {
 	LocalAddr() net.Addr
 	// RemoteAddr returns the address of the peer.
 	RemoteAddr() net.Addr
-	// Close the connection with an error.
+	// CloseWithError closes the connection with an error.
 	// The error string will be sent to the peer.
-	CloseWithError(ErrorCode, string) error
+	CloseWithError(ApplicationErrorCode, string) error
 	// The context is cancelled when the session is closed.
 	// Warning: This API should not be considered stable and might change soon.
 	Context() context.Context

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -282,7 +282,10 @@ func (h *sentPacketHandler) ReceivedAck(ack *wire.AckFrame, encLevel protocol.En
 
 	largestAcked := ack.LargestAcked()
 	if largestAcked > pnSpace.largestSent {
-		return false, qerr.NewError(qerr.ProtocolViolation, "Received ACK for an unsent packet")
+		return false, &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "received ACK for an unsent packet",
+		}
 	}
 
 	pnSpace.largestAcked = utils.MaxPacketNumber(pnSpace.largestAcked, largestAcked)
@@ -385,7 +388,10 @@ func (h *sentPacketHandler) detectAndRemoveAckedPackets(ack *wire.AckFrame, encL
 			}
 		}
 		if p.skippedPacket {
-			return false, fmt.Errorf("received an ACK for skipped packet number: %d (%s)", p.PacketNumber, encLevel)
+			return false, &qerr.TransportError{
+				ErrorCode:    qerr.ProtocolViolation,
+				ErrorMessage: fmt.Sprintf("received an ACK for skipped packet number: %d (%s)", p.PacketNumber, encLevel),
+			}
 		}
 		h.ackedPackets = append(h.ackedPackets, p)
 		return true, nil

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -5,8 +5,10 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+
 	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 
@@ -199,13 +201,19 @@ var _ = Describe("SentPacketHandler", func() {
 				handler.SentPacket(ackElicitingPacket(&Packet{PacketNumber: 102}))
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 100, Largest: 102}}}
 				_, err := handler.ReceivedAck(ack, protocol.Encryption1RTT, time.Now())
-				Expect(err).To(MatchError("received an ACK for skipped packet number: 101 (1-RTT)"))
+				Expect(err).To(MatchError(&qerr.TransportError{
+					ErrorCode:    qerr.ProtocolViolation,
+					ErrorMessage: "received an ACK for skipped packet number: 101 (1-RTT)",
+				}))
 			})
 
 			It("rejects ACKs with a too high LargestAcked packet number", func() {
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 0, Largest: 9999}}}
 				_, err := handler.ReceivedAck(ack, protocol.Encryption1RTT, time.Now())
-				Expect(err).To(MatchError("PROTOCOL_VIOLATION: Received ACK for an unsent packet"))
+				Expect(err).To(MatchError(&qerr.TransportError{
+					ErrorCode:    qerr.ProtocolViolation,
+					ErrorMessage: "received ACK for an unsent packet",
+				}))
 				Expect(handler.bytesInFlight).To(Equal(protocol.ByteCount(10)))
 			})
 
@@ -1131,7 +1139,10 @@ var _ = Describe("SentPacketHandler", func() {
 			}))
 			ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 13, Largest: 13}}}
 			_, err := handler.ReceivedAck(ack, protocol.EncryptionHandshake, time.Now())
-			Expect(err).To(MatchError("PROTOCOL_VIOLATION: Received ACK for an unsent packet"))
+			Expect(err).To(MatchError(&qerr.TransportError{
+				ErrorCode:    qerr.ProtocolViolation,
+				ErrorMessage: "received ACK for an unsent packet",
+			}))
 		})
 
 		It("deletes Initial packets, as a server", func() {

--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -50,7 +50,10 @@ func (c *connectionFlowController) IncrementHighestReceived(increment protocol.B
 
 	c.highestReceived += increment
 	if c.checkFlowControlViolation() {
-		return qerr.NewError(qerr.FlowControlError, fmt.Sprintf("Received %d bytes for the connection, allowed %d bytes", c.highestReceived, c.receiveWindow))
+		return &qerr.TransportError{
+			ErrorCode:    qerr.FlowControlError,
+			ErrorMessage: fmt.Sprintf("received %d bytes for the connection, allowed %d bytes", c.highestReceived, c.receiveWindow),
+		}
 	}
 	return nil
 }

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -403,7 +403,10 @@ func (h *cryptoSetup) checkEncryptionLevel(msgType messageType, encLevel protoco
 func (h *cryptoSetup) handleTransportParameters(data []byte) {
 	var tp wire.TransportParameters
 	if err := tp.Unmarshal(data, h.perspective.Opposite()); err != nil {
-		h.runner.OnError(qerr.NewError(qerr.TransportParameterError, err.Error()))
+		h.runner.OnError(&qerr.TransportError{
+			ErrorCode:    qerr.TransportParameterError,
+			ErrorMessage: err.Error(),
+		})
 	}
 	h.peerParams = &tp
 	h.runner.OnReceivedParams(h.peerParams)

--- a/internal/mocks/quic/early_session.go
+++ b/internal/mocks/quic/early_session.go
@@ -11,7 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	quic "github.com/lucas-clemente/quic-go"
-	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
+	qerr "github.com/lucas-clemente/quic-go/internal/qerr"
 )
 
 // MockEarlySession is a mock of EarlySession interface.
@@ -68,7 +68,7 @@ func (mr *MockEarlySessionMockRecorder) AcceptUniStream(arg0 interface{}) *gomoc
 }
 
 // CloseWithError mocks base method.
-func (m *MockEarlySession) CloseWithError(arg0 protocol.ApplicationErrorCode, arg1 string) error {
+func (m *MockEarlySession) CloseWithError(arg0 qerr.ApplicationErrorCode, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloseWithError", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/internal/mocks/quic/stream.go
+++ b/internal/mocks/quic/stream.go
@@ -38,7 +38,7 @@ func (m *MockStream) EXPECT() *MockStreamMockRecorder {
 }
 
 // CancelRead mocks base method.
-func (m *MockStream) CancelRead(arg0 qerr.ApplicationErrorCode) {
+func (m *MockStream) CancelRead(arg0 qerr.StreamErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelRead", arg0)
 }
@@ -50,7 +50,7 @@ func (mr *MockStreamMockRecorder) CancelRead(arg0 interface{}) *gomock.Call {
 }
 
 // CancelWrite mocks base method.
-func (m *MockStream) CancelWrite(arg0 qerr.ApplicationErrorCode) {
+func (m *MockStream) CancelWrite(arg0 qerr.StreamErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelWrite", arg0)
 }

--- a/internal/mocks/quic/stream.go
+++ b/internal/mocks/quic/stream.go
@@ -11,6 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
+	qerr "github.com/lucas-clemente/quic-go/internal/qerr"
 )
 
 // MockStream is a mock of Stream interface.
@@ -37,7 +38,7 @@ func (m *MockStream) EXPECT() *MockStreamMockRecorder {
 }
 
 // CancelRead mocks base method.
-func (m *MockStream) CancelRead(arg0 protocol.ApplicationErrorCode) {
+func (m *MockStream) CancelRead(arg0 qerr.ApplicationErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelRead", arg0)
 }
@@ -49,7 +50,7 @@ func (mr *MockStreamMockRecorder) CancelRead(arg0 interface{}) *gomock.Call {
 }
 
 // CancelWrite mocks base method.
-func (m *MockStream) CancelWrite(arg0 protocol.ApplicationErrorCode) {
+func (m *MockStream) CancelWrite(arg0 qerr.ApplicationErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelWrite", arg0)
 }

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -52,9 +52,6 @@ const MaxByteCount = ByteCount(1<<62 - 1)
 // InvalidByteCount is an invalid byte count
 const InvalidByteCount ByteCount = -1
 
-// An ApplicationErrorCode is an application-defined error code.
-type ApplicationErrorCode uint64
-
 // A StatelessResetToken is a stateless reset token.
 type StatelessResetToken [16]byte
 

--- a/internal/qerr/error_codes.go
+++ b/internal/qerr/error_codes.go
@@ -6,51 +6,44 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/qtls"
 )
 
-// ErrorCode can be used as a normal error without reason.
-type ErrorCode uint64
+// TransportErrorCode is a QUIC transport error.
+type TransportErrorCode uint64
 
 // The error codes defined by QUIC
 const (
-	NoError                 ErrorCode = 0x0
-	InternalError           ErrorCode = 0x1
-	ConnectionRefused       ErrorCode = 0x2
-	FlowControlError        ErrorCode = 0x3
-	StreamLimitError        ErrorCode = 0x4
-	StreamStateError        ErrorCode = 0x5
-	FinalSizeError          ErrorCode = 0x6
-	FrameEncodingError      ErrorCode = 0x7
-	TransportParameterError ErrorCode = 0x8
-	ConnectionIDLimitError  ErrorCode = 0x9
-	ProtocolViolation       ErrorCode = 0xa
-	InvalidToken            ErrorCode = 0xb
-	ApplicationError        ErrorCode = 0xc
-	CryptoBufferExceeded    ErrorCode = 0xd
-	KeyUpdateError          ErrorCode = 0xe
-	AEADLimitReached        ErrorCode = 0xf
-	NoViablePathError       ErrorCode = 0x10
+	NoError                   TransportErrorCode = 0x0
+	InternalError             TransportErrorCode = 0x1
+	ConnectionRefused         TransportErrorCode = 0x2
+	FlowControlError          TransportErrorCode = 0x3
+	StreamLimitError          TransportErrorCode = 0x4
+	StreamStateError          TransportErrorCode = 0x5
+	FinalSizeError            TransportErrorCode = 0x6
+	FrameEncodingError        TransportErrorCode = 0x7
+	TransportParameterError   TransportErrorCode = 0x8
+	ConnectionIDLimitError    TransportErrorCode = 0x9
+	ProtocolViolation         TransportErrorCode = 0xa
+	InvalidToken              TransportErrorCode = 0xb
+	ApplicationErrorErrorCode TransportErrorCode = 0xc
+	CryptoBufferExceeded      TransportErrorCode = 0xd
+	KeyUpdateError            TransportErrorCode = 0xe
+	AEADLimitReached          TransportErrorCode = 0xf
+	NoViablePathError         TransportErrorCode = 0x10
 )
 
-func (e ErrorCode) isCryptoError() bool {
+func (e TransportErrorCode) IsCryptoError() bool {
 	return e >= 0x100 && e < 0x200
-}
-
-func (e ErrorCode) Error() string {
-	if e.isCryptoError() {
-		return fmt.Sprintf("%s: %s", e.String(), e.Message())
-	}
-	return e.String()
 }
 
 // Message is a description of the error.
 // It only returns a non-empty string for crypto errors.
-func (e ErrorCode) Message() string {
-	if !e.isCryptoError() {
+func (e TransportErrorCode) Message() string {
+	if !e.IsCryptoError() {
 		return ""
 	}
 	return qtls.Alert(e - 0x100).Error()
 }
 
-func (e ErrorCode) String() string {
+func (e TransportErrorCode) String() string {
 	switch e {
 	case NoError:
 		return "NO_ERROR"
@@ -76,7 +69,7 @@ func (e ErrorCode) String() string {
 		return "PROTOCOL_VIOLATION"
 	case InvalidToken:
 		return "INVALID_TOKEN"
-	case ApplicationError:
+	case ApplicationErrorErrorCode:
 		return "APPLICATION_ERROR"
 	case CryptoBufferExceeded:
 		return "CRYPTO_BUFFER_EXCEEDED"
@@ -87,7 +80,7 @@ func (e ErrorCode) String() string {
 	case NoViablePathError:
 		return "NO_VIABLE_PATH"
 	default:
-		if e.isCryptoError() {
+		if e.IsCryptoError() {
 			return fmt.Sprintf("CRYPTO_ERROR (%#x)", uint16(e))
 		}
 		return fmt.Sprintf("unknown error code: %#x", uint16(e))

--- a/internal/qerr/errorcodes_test.go
+++ b/internal/qerr/errorcodes_test.go
@@ -30,11 +30,23 @@ var _ = Describe("error codes", func() {
 			valString := c.(*ast.ValueSpec).Values[0].(*ast.BasicLit).Value
 			val, err := strconv.ParseInt(valString, 0, 64)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ErrorCode(val).String()).ToNot(Equal("unknown error code"))
+			Expect(TransportErrorCode(val).String()).ToNot(Equal("unknown error code"))
 		}
 	})
 
 	It("has a string representation for unknown error codes", func() {
-		Expect(ErrorCode(0x1337).String()).To(Equal("unknown error code: 0x1337"))
+		Expect(TransportErrorCode(0x1337).String()).To(Equal("unknown error code: 0x1337"))
+	})
+
+	It("says if an error is a crypto error", func() {
+		for i := 0; i < 0x100; i++ {
+			Expect(TransportErrorCode(i).IsCryptoError()).To(BeFalse())
+		}
+		for i := 0x100; i < 0x200; i++ {
+			Expect(TransportErrorCode(i).IsCryptoError()).To(BeTrue())
+		}
+		for i := 0x200; i < 0x300; i++ {
+			Expect(TransportErrorCode(i).IsCryptoError()).To(BeFalse())
+		}
 	})
 })

--- a/internal/qerr/quic_error.go
+++ b/internal/qerr/quic_error.go
@@ -2,6 +2,8 @@ package qerr
 
 import (
 	"fmt"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
 )
 
 var (
@@ -90,5 +92,20 @@ func (e *HandshakeTimeoutError) Temporary() bool { return false }
 func (e *HandshakeTimeoutError) Error() string   { return "timeout: handshake did not complete in time" }
 func (e *HandshakeTimeoutError) Is(target error) bool {
 	_, ok := target.(*HandshakeTimeoutError)
+	return ok
+}
+
+// A VersionNegotiationError occurs when the client and the server can't agree on a QUIC version.
+type VersionNegotiationError struct {
+	Ours   []protocol.VersionNumber
+	Theirs []protocol.VersionNumber
+}
+
+func (e *VersionNegotiationError) Error() string {
+	return fmt.Sprintf("no compatible QUIC version found (we support %s, server offered %s)", e.Ours, e.Theirs)
+}
+
+func (e *VersionNegotiationError) Is(target error) bool {
+	_, ok := target.(*VersionNegotiationError)
 	return ok
 }

--- a/internal/qerr/quic_error.go
+++ b/internal/qerr/quic_error.go
@@ -2,6 +2,7 @@ package qerr
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 )
@@ -109,3 +110,22 @@ func (e *VersionNegotiationError) Is(target error) bool {
 	_, ok := target.(*VersionNegotiationError)
 	return ok
 }
+
+// A StatelessResetError occurs when we receive a stateless reset.
+type StatelessResetError struct {
+	Token protocol.StatelessResetToken
+}
+
+var _ net.Error = &StatelessResetError{}
+
+func (e *StatelessResetError) Error() string {
+	return fmt.Sprintf("received a stateless reset with token %x", e.Token)
+}
+
+func (e *StatelessResetError) Is(target error) bool {
+	_, ok := target.(*StatelessResetError)
+	return ok
+}
+
+func (e *StatelessResetError) Timeout() bool   { return false }
+func (e *StatelessResetError) Temporary() bool { return true }

--- a/internal/qerr/quic_error.go
+++ b/internal/qerr/quic_error.go
@@ -52,6 +52,9 @@ func (e *TransportError) Error() string {
 // An ApplicationErrorCode is an application-defined error code.
 type ApplicationErrorCode uint64
 
+// A StreamErrorCode is an error code used to cancel streams.
+type StreamErrorCode uint64
+
 type ApplicationError struct {
 	Remote       bool
 	ErrorCode    ApplicationErrorCode

--- a/internal/qerr/quic_error.go
+++ b/internal/qerr/quic_error.go
@@ -2,82 +2,39 @@ package qerr
 
 import (
 	"fmt"
-	"net"
 )
 
 var (
-	ErrIdleTimeout      = newTimeoutError("No recent network activity")
-	ErrHandshakeTimeout = newTimeoutError("Handshake did not complete in time")
+	ErrHandshakeTimeout = &HandshakeTimeoutError{}
+	ErrIdleTimeout      = &IdleTimeoutError{}
 )
 
-// A QuicError consists of an error code plus a error reason
-type QuicError struct {
-	ErrorCode          ErrorCode
-	FrameType          uint64 // only valid if this not an application error
-	ErrorMessage       string
-	isTimeout          bool
-	isApplicationError bool
+type TransportError struct {
+	Remote       bool
+	FrameType    uint64
+	ErrorCode    TransportErrorCode
+	ErrorMessage string
 }
 
-var _ net.Error = &QuicError{}
+var _ error = &TransportError{}
 
-// NewError creates a new QuicError instance
-func NewError(errorCode ErrorCode, errorMessage string) *QuicError {
-	return &QuicError{
-		ErrorCode:    errorCode,
+// NewCryptoError create a new TransportError instance for a crypto error
+func NewCryptoError(tlsAlert uint8, errorMessage string) *TransportError {
+	return &TransportError{
+		ErrorCode:    0x100 + TransportErrorCode(tlsAlert),
 		ErrorMessage: errorMessage,
 	}
 }
 
-// NewErrorWithFrameType creates a new QuicError instance for a specific frame type
-func NewErrorWithFrameType(errorCode ErrorCode, frameType uint64, errorMessage string) *QuicError {
-	return &QuicError{
-		ErrorCode:    errorCode,
-		FrameType:    frameType,
-		ErrorMessage: errorMessage,
-	}
+func (e *TransportError) Is(target error) bool {
+	_, ok := target.(*TransportError)
+	return ok
 }
 
-// newTimeoutError creates a new QuicError instance for a timeout error
-func newTimeoutError(errorMessage string) *QuicError {
-	return &QuicError{
-		ErrorMessage: errorMessage,
-		isTimeout:    true,
-	}
-}
-
-// NewCryptoError create a new QuicError instance for a crypto error
-func NewCryptoError(tlsAlert uint8, errorMessage string) *QuicError {
-	return &QuicError{
-		ErrorCode:    0x100 + ErrorCode(tlsAlert),
-		ErrorMessage: errorMessage,
-	}
-}
-
-// NewApplicationError creates a new QuicError instance for an application error
-func NewApplicationError(errorCode ErrorCode, errorMessage string) *QuicError {
-	return &QuicError{
-		ErrorCode:          errorCode,
-		ErrorMessage:       errorMessage,
-		isApplicationError: true,
-	}
-}
-
-func (e *QuicError) Error() string {
-	if e.isApplicationError {
-		if len(e.ErrorMessage) == 0 {
-			return fmt.Sprintf("Application error %#x", uint64(e.ErrorCode))
-		}
-		return fmt.Sprintf("Application error %#x: %s", uint64(e.ErrorCode), e.ErrorMessage)
-	}
-	var str string
-	if e.isTimeout {
-		str = "Timeout"
-	} else {
-		str = e.ErrorCode.String()
-		if e.FrameType != 0 {
-			str += fmt.Sprintf(" (frame type: %#x)", e.FrameType)
-		}
+func (e *TransportError) Error() string {
+	str := e.ErrorCode.String()
+	if e.FrameType != 0 {
+		str += fmt.Sprintf(" (frame type: %#x)", e.FrameType)
 	}
 	msg := e.ErrorMessage
 	if len(msg) == 0 {
@@ -89,34 +46,46 @@ func (e *QuicError) Error() string {
 	return str + ": " + msg
 }
 
-// IsCryptoError says if this error is a crypto error
-func (e *QuicError) IsCryptoError() bool {
-	return e.ErrorCode.isCryptoError()
+type ApplicationError struct {
+	Remote       bool
+	ErrorCode    uint64
+	ErrorMessage string
 }
 
-// IsApplicationError says if this error is an application error
-func (e *QuicError) IsApplicationError() bool {
-	return e.isApplicationError
+var _ error = &ApplicationError{}
+
+func (e *ApplicationError) Is(target error) bool {
+	_, ok := target.(*ApplicationError)
+	return ok
 }
 
-// Temporary says if the error is temporary.
-func (e *QuicError) Temporary() bool {
-	return false
-}
-
-// Timeout says if this error is a timeout.
-func (e *QuicError) Timeout() bool {
-	return e.isTimeout
-}
-
-// ToQuicError converts an arbitrary error to a QuicError. It leaves QuicErrors
-// unchanged, and properly handles `ErrorCode`s.
-func ToQuicError(err error) *QuicError {
-	switch e := err.(type) {
-	case *QuicError:
-		return e
-	case ErrorCode:
-		return NewError(e, "")
+func (e *ApplicationError) Error() string {
+	if len(e.ErrorMessage) == 0 {
+		return fmt.Sprintf("Application error %#x", e.ErrorCode)
 	}
-	return NewError(InternalError, err.Error())
+	return fmt.Sprintf("Application error %#x: %s", e.ErrorCode, e.ErrorMessage)
+}
+
+type IdleTimeoutError struct{}
+
+var _ error = &IdleTimeoutError{}
+
+func (e *IdleTimeoutError) Timeout() bool   { return true }
+func (e *IdleTimeoutError) Temporary() bool { return false }
+func (e *IdleTimeoutError) Error() string   { return "timeout: no recent network activity" }
+func (e *IdleTimeoutError) Is(target error) bool {
+	_, ok := target.(*IdleTimeoutError)
+	return ok
+}
+
+type HandshakeTimeoutError struct{}
+
+var _ error = &HandshakeTimeoutError{}
+
+func (e *HandshakeTimeoutError) Timeout() bool   { return true }
+func (e *HandshakeTimeoutError) Temporary() bool { return false }
+func (e *HandshakeTimeoutError) Error() string   { return "timeout: handshake did not complete in time" }
+func (e *HandshakeTimeoutError) Is(target error) bool {
+	_, ok := target.(*HandshakeTimeoutError)
+	return ok
 }

--- a/internal/qerr/quic_error.go
+++ b/internal/qerr/quic_error.go
@@ -46,9 +46,12 @@ func (e *TransportError) Error() string {
 	return str + ": " + msg
 }
 
+// An ApplicationErrorCode is an application-defined error code.
+type ApplicationErrorCode uint64
+
 type ApplicationError struct {
 	Remote       bool
-	ErrorCode    uint64
+	ErrorCode    ApplicationErrorCode
 	ErrorMessage string
 }
 

--- a/internal/qerr/quic_error_test.go
+++ b/internal/qerr/quic_error_test.go
@@ -1,98 +1,104 @@
 package qerr
 
 import (
-	"io"
+	"errors"
+	"net"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("QUIC Transport Errors", func() {
-	It("has a string representation", func() {
-		err := NewError(FlowControlError, "foobar")
-		Expect(err.Timeout()).To(BeFalse())
-		Expect(err.IsApplicationError()).To(BeFalse())
-		Expect(err.Error()).To(Equal("FLOW_CONTROL_ERROR: foobar"))
+var _ = Describe("QUIC Errors", func() {
+	Context("Transport Errors", func() {
+		It("has a string representation", func() {
+			Expect((&TransportError{
+				ErrorCode:    FlowControlError,
+				ErrorMessage: "foobar",
+			}).Error()).To(Equal("FLOW_CONTROL_ERROR: foobar"))
+		})
+
+		It("has a string representation for empty error phrases", func() {
+			Expect((&TransportError{ErrorCode: FlowControlError}).Error()).To(Equal("FLOW_CONTROL_ERROR"))
+		})
+
+		It("includes the frame type, for errors without a message", func() {
+			Expect((&TransportError{
+				ErrorCode: FlowControlError,
+				FrameType: 0x1337,
+			}).Error()).To(Equal("FLOW_CONTROL_ERROR (frame type: 0x1337)"))
+		})
+
+		It("includes the frame type, for errors with a message", func() {
+			Expect((&TransportError{
+				ErrorCode:    FlowControlError,
+				FrameType:    0x1337,
+				ErrorMessage: "foobar",
+			}).Error()).To(Equal("FLOW_CONTROL_ERROR (frame type: 0x1337): foobar"))
+		})
+
+		It("works with error assertions", func() {
+			Expect(errors.Is(&TransportError{ErrorCode: FlowControlError}, &TransportError{})).To(BeTrue())
+			Expect(errors.Is(&TransportError{ErrorCode: FlowControlError}, &ApplicationError{})).To(BeFalse())
+		})
+
+		Context("crypto errors", func() {
+			It("has a string representation for errors with a message", func() {
+				err := NewCryptoError(0x42, "foobar")
+				Expect(err.Error()).To(Equal("CRYPTO_ERROR (0x142): foobar"))
+			})
+
+			It("has a string representation for errors without a message", func() {
+				err := NewCryptoError(0x2a, "")
+				Expect(err.Error()).To(Equal("CRYPTO_ERROR (0x12a): tls: bad certificate"))
+			})
+		})
 	})
 
-	It("has a string representation for empty error phrases", func() {
-		err := NewError(FlowControlError, "")
-		Expect(err.Error()).To(Equal("FLOW_CONTROL_ERROR"))
-	})
-
-	It("includes the frame type, for errors without a message", func() {
-		err := NewErrorWithFrameType(FlowControlError, 0x1337, "")
-		Expect(err.Error()).To(Equal("FLOW_CONTROL_ERROR (frame type: 0x1337)"))
-	})
-
-	It("includes the frame type, for errors with a message", func() {
-		err := NewErrorWithFrameType(FlowControlError, 0x1337, "foobar")
-		Expect(err.Error()).To(Equal("FLOW_CONTROL_ERROR (frame type: 0x1337): foobar"))
-	})
-
-	It("has a string representation for timeout errors", func() {
-		err := newTimeoutError("foobar")
-		Expect(err.Timeout()).To(BeTrue())
-		Expect(err.Error()).To(Equal("Timeout: foobar"))
-	})
-
-	Context("crypto errors", func() {
+	Context("Application Errors", func() {
 		It("has a string representation for errors with a message", func() {
-			err := NewCryptoError(0x42, "foobar")
-			Expect(err.Error()).To(Equal("CRYPTO_ERROR (0x142): foobar"))
+			Expect((&ApplicationError{
+				ErrorCode:    0x42,
+				ErrorMessage: "foobar",
+			}).Error()).To(Equal("Application error 0x42: foobar"))
 		})
 
 		It("has a string representation for errors without a message", func() {
-			err := NewCryptoError(0x2a, "")
-			Expect(err.Error()).To(Equal("CRYPTO_ERROR (0x12a): tls: bad certificate"))
+			Expect((&ApplicationError{
+				ErrorCode: 0x42,
+			}).Error()).To(Equal("Application error 0x42"))
 		})
 
-		It("says if an error is a crypto error", func() {
-			Expect(NewError(FlowControlError, "").IsCryptoError()).To(BeFalse())
-			err := NewCryptoError(42, "")
-			Expect(err.IsCryptoError()).To(BeTrue())
-			Expect(err.IsApplicationError()).To(BeFalse())
-		})
-	})
-
-	Context("application errors", func() {
-		It("has a string representation for errors with a message", func() {
-			err := NewApplicationError(0x42, "foobar")
-			Expect(err.IsApplicationError()).To(BeTrue())
-			Expect(err.Error()).To(Equal("Application error 0x42: foobar"))
-		})
-
-		It("has a string representation for errors without a message", func() {
-			err := NewApplicationError(0x42, "")
-			Expect(err.Error()).To(Equal("Application error 0x42"))
+		It("works with error assertions", func() {
+			Expect(errors.Is(&ApplicationError{ErrorCode: 0x1234}, &ApplicationError{})).To(BeTrue())
+			Expect(errors.Is(&ApplicationError{ErrorCode: 0x1234}, &TransportError{})).To(BeFalse())
 		})
 	})
 
-	Context("ErrorCode", func() {
-		It("works as error", func() {
-			var err error = StreamStateError
-			Expect(err).To(MatchError("STREAM_STATE_ERROR"))
+	Context("timeout errors", func() {
+		It("handshake timeouts", func() {
+			//nolint:gosimple // we need to assign to an interface here
+			var err error
+			err = &HandshakeTimeoutError{}
+			nerr, ok := err.(net.Error)
+			Expect(ok).To(BeTrue())
+			Expect(nerr.Timeout()).To(BeTrue())
+			Expect(nerr.Temporary()).To(BeFalse())
+			Expect(err.Error()).To(Equal("timeout: handshake did not complete in time"))
+			Expect(errors.Is(err, &HandshakeTimeoutError{})).To(BeTrue())
+			Expect(errors.Is(err, &IdleTimeoutError{})).To(BeFalse())
 		})
 
-		It("recognizes crypto errors", func() {
-			err := ErrorCode(0x100 + 0x2a)
-			Expect(err.Error()).To(Equal("CRYPTO_ERROR (0x12a): tls: bad certificate"))
-		})
-	})
-
-	Context("ToQuicError", func() {
-		It("leaves QuicError unchanged", func() {
-			err := NewError(TransportParameterError, "foo")
-			Expect(ToQuicError(err)).To(Equal(err))
-		})
-
-		It("wraps ErrorCode properly", func() {
-			var err error = FinalSizeError
-			Expect(ToQuicError(err)).To(Equal(NewError(FinalSizeError, "")))
-		})
-
-		It("changes default errors to InternalError", func() {
-			Expect(ToQuicError(io.EOF)).To(Equal(NewError(InternalError, "EOF")))
+		It("idle timeouts", func() {
+			//nolint:gosimple // we need to assign to an interface here
+			var err error
+			err = &IdleTimeoutError{}
+			nerr, ok := err.(net.Error)
+			Expect(ok).To(BeTrue())
+			Expect(nerr.Timeout()).To(BeTrue())
+			Expect(nerr.Temporary()).To(BeFalse())
+			Expect(err.Error()).To(Equal("timeout: no recent network activity"))
+			Expect(errors.Is(err, &HandshakeTimeoutError{})).To(BeFalse())
+			Expect(errors.Is(err, &IdleTimeoutError{})).To(BeTrue())
 		})
 	})
 })

--- a/internal/qerr/quic_error_test.go
+++ b/internal/qerr/quic_error_test.go
@@ -115,4 +115,26 @@ var _ = Describe("QUIC Errors", func() {
 			}).Error()).To(Equal("no compatible QUIC version found (we support [0x2 0x3], server offered [0x4 0x5 0x6])"))
 		})
 	})
+
+	Context("Stateless Reset errors", func() {
+		token := protocol.StatelessResetToken{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
+
+		It("is a Stateless Reset error", func() {
+			Expect(errors.Is(&StatelessResetError{Token: token}, &StatelessResetError{})).To(BeTrue())
+		})
+
+		It("has a string representation", func() {
+			Expect((&StatelessResetError{Token: token}).Error()).To(Equal("received a stateless reset with token 000102030405060708090a0b0c0d0e0f"))
+		})
+
+		It("is a net.Error", func() {
+			//nolint:gosimple // we need to assign to an interface here
+			var err error
+			err = &StatelessResetError{}
+			nerr, ok := err.(net.Error)
+			Expect(ok).To(BeTrue())
+			Expect(nerr.Timeout()).To(BeFalse())
+			Expect(nerr.Temporary()).To(BeTrue())
+		})
+	})
 })

--- a/internal/qerr/quic_error_test.go
+++ b/internal/qerr/quic_error_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 
+	"github.com/lucas-clemente/quic-go/internal/protocol"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -99,6 +100,19 @@ var _ = Describe("QUIC Errors", func() {
 			Expect(err.Error()).To(Equal("timeout: no recent network activity"))
 			Expect(errors.Is(err, &HandshakeTimeoutError{})).To(BeFalse())
 			Expect(errors.Is(err, &IdleTimeoutError{})).To(BeTrue())
+		})
+	})
+
+	Context("Version Negotiation errors", func() {
+		It("is a Version Negotiation error", func() {
+			Expect(errors.Is(&VersionNegotiationError{Ours: []protocol.VersionNumber{2, 3}}, &VersionNegotiationError{})).To(BeTrue())
+		})
+
+		It("has a string representation", func() {
+			Expect((&VersionNegotiationError{
+				Ours:   []protocol.VersionNumber{2, 3},
+				Theirs: []protocol.VersionNumber{4, 5, 6},
+			}).Error()).To(Equal("no compatible QUIC version found (we support [0x2 0x3], server offered [0x4 0x5 0x6])"))
 		})
 	})
 })

--- a/internal/wire/connection_close_frame_test.go
+++ b/internal/wire/connection_close_frame_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,8 +23,8 @@ var _ = Describe("CONNECTION_CLOSE Frame", func() {
 			frame, err := parseConnectionCloseFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.IsApplicationError).To(BeFalse())
-			Expect(frame.ErrorCode).To(Equal(qerr.ErrorCode(0x19)))
-			Expect(frame.FrameType).To(Equal(uint64(0x1337)))
+			Expect(frame.ErrorCode).To(BeEquivalentTo(0x19))
+			Expect(frame.FrameType).To(BeEquivalentTo(0x1337))
 			Expect(frame.ReasonPhrase).To(Equal(reason))
 			Expect(b.Len()).To(BeZero())
 		})
@@ -40,7 +39,7 @@ var _ = Describe("CONNECTION_CLOSE Frame", func() {
 			frame, err := parseConnectionCloseFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.IsApplicationError).To(BeTrue())
-			Expect(frame.ErrorCode).To(Equal(qerr.ErrorCode(0xcafe)))
+			Expect(frame.ErrorCode).To(BeEquivalentTo(0xcafe))
 			Expect(frame.ReasonPhrase).To(Equal(reason))
 			Expect(b.Len()).To(BeZero())
 		})

--- a/internal/wire/frame_parser.go
+++ b/internal/wire/frame_parser.go
@@ -26,7 +26,7 @@ func NewFrameParser(supportsDatagrams bool, v protocol.VersionNumber) FrameParse
 	}
 }
 
-// ParseNextFrame parses the next frame
+// ParseNext parses the next frame.
 // It skips PADDING frames.
 func (p *frameParser) ParseNext(r *bytes.Reader, encLevel protocol.EncryptionLevel) (Frame, error) {
 	for r.Len() != 0 {
@@ -38,7 +38,11 @@ func (p *frameParser) ParseNext(r *bytes.Reader, encLevel protocol.EncryptionLev
 
 		f, err := p.parseFrame(r, typeByte, encLevel)
 		if err != nil {
-			return nil, qerr.NewErrorWithFrameType(qerr.FrameEncodingError, uint64(typeByte), err.Error())
+			return nil, &qerr.TransportError{
+				FrameType:    uint64(typeByte),
+				ErrorCode:    qerr.FrameEncodingError,
+				ErrorMessage: err.Error(),
+			}
 		}
 		return f, nil
 	}

--- a/internal/wire/reset_stream_frame.go
+++ b/internal/wire/reset_stream_frame.go
@@ -11,7 +11,7 @@ import (
 // A ResetStreamFrame is a RESET_STREAM frame in QUIC
 type ResetStreamFrame struct {
 	StreamID  protocol.StreamID
-	ErrorCode qerr.ApplicationErrorCode
+	ErrorCode qerr.StreamErrorCode
 	FinalSize protocol.ByteCount
 }
 
@@ -39,7 +39,7 @@ func parseResetStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*ResetStr
 
 	return &ResetStreamFrame{
 		StreamID:  streamID,
-		ErrorCode: qerr.ApplicationErrorCode(errorCode),
+		ErrorCode: qerr.StreamErrorCode(errorCode),
 		FinalSize: byteOffset,
 	}, nil
 }

--- a/internal/wire/reset_stream_frame.go
+++ b/internal/wire/reset_stream_frame.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A ResetStreamFrame is a RESET_STREAM frame in QUIC
 type ResetStreamFrame struct {
 	StreamID  protocol.StreamID
-	ErrorCode protocol.ApplicationErrorCode
+	ErrorCode qerr.ApplicationErrorCode
 	FinalSize protocol.ByteCount
 }
 
@@ -38,7 +39,7 @@ func parseResetStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*ResetStr
 
 	return &ResetStreamFrame{
 		StreamID:  streamID,
-		ErrorCode: protocol.ApplicationErrorCode(errorCode),
+		ErrorCode: qerr.ApplicationErrorCode(errorCode),
 		FinalSize: byteOffset,
 	}, nil
 }

--- a/internal/wire/reset_stream_frame_test.go
+++ b/internal/wire/reset_stream_frame_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo"
@@ -22,7 +23,7 @@ var _ = Describe("RESET_STREAM frame", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
 			Expect(frame.FinalSize).To(Equal(protocol.ByteCount(0x987654321)))
-			Expect(frame.ErrorCode).To(Equal(protocol.ApplicationErrorCode(0x1337)))
+			Expect(frame.ErrorCode).To(Equal(qerr.ApplicationErrorCode(0x1337)))
 		})
 
 		It("errors on EOFs", func() {

--- a/internal/wire/reset_stream_frame_test.go
+++ b/internal/wire/reset_stream_frame_test.go
@@ -23,7 +23,7 @@ var _ = Describe("RESET_STREAM frame", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
 			Expect(frame.FinalSize).To(Equal(protocol.ByteCount(0x987654321)))
-			Expect(frame.ErrorCode).To(Equal(qerr.ApplicationErrorCode(0x1337)))
+			Expect(frame.ErrorCode).To(Equal(qerr.StreamErrorCode(0x1337)))
 		})
 
 		It("errors on EOFs", func() {

--- a/internal/wire/stop_sending_frame.go
+++ b/internal/wire/stop_sending_frame.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
 // A StopSendingFrame is a STOP_SENDING frame
 type StopSendingFrame struct {
 	StreamID  protocol.StreamID
-	ErrorCode protocol.ApplicationErrorCode
+	ErrorCode qerr.ApplicationErrorCode
 }
 
 // parseStopSendingFrame parses a STOP_SENDING frame
@@ -30,7 +31,7 @@ func parseStopSendingFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StopSend
 
 	return &StopSendingFrame{
 		StreamID:  protocol.StreamID(streamID),
-		ErrorCode: protocol.ApplicationErrorCode(errorCode),
+		ErrorCode: qerr.ApplicationErrorCode(errorCode),
 	}, nil
 }
 

--- a/internal/wire/stop_sending_frame.go
+++ b/internal/wire/stop_sending_frame.go
@@ -11,7 +11,7 @@ import (
 // A StopSendingFrame is a STOP_SENDING frame
 type StopSendingFrame struct {
 	StreamID  protocol.StreamID
-	ErrorCode qerr.ApplicationErrorCode
+	ErrorCode qerr.StreamErrorCode
 }
 
 // parseStopSendingFrame parses a STOP_SENDING frame
@@ -31,7 +31,7 @@ func parseStopSendingFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StopSend
 
 	return &StopSendingFrame{
 		StreamID:  protocol.StreamID(streamID),
-		ErrorCode: qerr.ApplicationErrorCode(errorCode),
+		ErrorCode: qerr.StreamErrorCode(errorCode),
 	}, nil
 }
 

--- a/internal/wire/stop_sending_frame_test.go
+++ b/internal/wire/stop_sending_frame_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo"
@@ -20,7 +21,7 @@ var _ = Describe("STOP_SENDING frame", func() {
 			frame, err := parseStopSendingFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdecafbad)))
-			Expect(frame.ErrorCode).To(Equal(protocol.ApplicationErrorCode(0x1337)))
+			Expect(frame.ErrorCode).To(Equal(qerr.ApplicationErrorCode(0x1337)))
 			Expect(b.Len()).To(BeZero())
 		})
 

--- a/internal/wire/stop_sending_frame_test.go
+++ b/internal/wire/stop_sending_frame_test.go
@@ -21,7 +21,7 @@ var _ = Describe("STOP_SENDING frame", func() {
 			frame, err := parseStopSendingFrame(b, versionIETFFrames)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdecafbad)))
-			Expect(frame.ErrorCode).To(Equal(qerr.ApplicationErrorCode(0x1337)))
+			Expect(frame.ErrorCode).To(Equal(qerr.StreamErrorCode(0x1337)))
 			Expect(b.Len()).To(BeZero())
 		})
 

--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
@@ -79,7 +78,7 @@ func parseStreamFrame(r *bytes.Reader, _ protocol.VersionNumber) (*StreamFrame, 
 		}
 	}
 	if frame.Offset+frame.DataLen() > protocol.MaxByteCount {
-		return nil, qerr.NewError(qerr.FrameEncodingError, "stream data overflows maximum offset")
+		return nil, errors.New("stream data overflows maximum offset")
 	}
 	return frame, nil
 }

--- a/internal/wire/stream_frame_test.go
+++ b/internal/wire/stream_frame_test.go
@@ -77,7 +77,7 @@ var _ = Describe("STREAM frame", func() {
 			data = append(data, []byte("foobar")...)
 			r := bytes.NewReader(data)
 			_, err := parseStreamFrame(r, versionIETFFrames)
-			Expect(err).To(MatchError("FRAME_ENCODING_ERROR: stream data overflows maximum offset"))
+			Expect(err).To(MatchError("stream data overflows maximum offset"))
 		})
 
 		It("rejects frames that claim to be longer than the packet size", func() {

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -90,7 +90,10 @@ type TransportParameters struct {
 // Unmarshal the transport parameters
 func (p *TransportParameters) Unmarshal(data []byte, sentBy protocol.Perspective) error {
 	if err := p.unmarshal(bytes.NewReader(data), sentBy, false); err != nil {
-		return qerr.NewError(qerr.TransportParameterError, err.Error())
+		return &qerr.TransportError{
+			ErrorCode:    qerr.TransportParameterError,
+			ErrorMessage: err.Error(),
+		}
 	}
 	return nil
 }
@@ -259,7 +262,7 @@ func (p *TransportParameters) readNumericTransportParameter(
 		return fmt.Errorf("error while reading transport parameter %d: %s", paramID, err)
 	}
 	if remainingLen-r.Len() != expectedLen {
-		return fmt.Errorf("inconsistent transport parameter length for %d", paramID)
+		return fmt.Errorf("inconsistent transport parameter length for transport parameter %#x", paramID)
 	}
 	//nolint:exhaustive // This only covers the numeric transport parameters.
 	switch paramID {

--- a/logging/interface.go
+++ b/logging/interface.go
@@ -50,9 +50,9 @@ type (
 	PreferredAddress = wire.PreferredAddress
 
 	// A TransportError is a transport-level error code.
-	TransportError = qerr.ErrorCode
+	TransportError = qerr.TransportErrorCode
 	// An ApplicationError is an application-defined error code.
-	ApplicationError = qerr.ErrorCode
+	ApplicationError = qerr.TransportErrorCode
 
 	// The RTTStats contain statistics used by the congestion controller.
 	RTTStats = utils.RTTStats

--- a/mock_packer_test.go
+++ b/mock_packer_test.go
@@ -79,6 +79,21 @@ func (mr *MockPackerMockRecorder) MaybePackProbePacket(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybePackProbePacket", reflect.TypeOf((*MockPacker)(nil).MaybePackProbePacket), arg0)
 }
 
+// PackApplicationClose mocks base method.
+func (m *MockPacker) PackApplicationClose(arg0 *qerr.ApplicationError) (*coalescedPacket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PackApplicationClose", arg0)
+	ret0, _ := ret[0].(*coalescedPacket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PackApplicationClose indicates an expected call of PackApplicationClose.
+func (mr *MockPackerMockRecorder) PackApplicationClose(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackApplicationClose", reflect.TypeOf((*MockPacker)(nil).PackApplicationClose), arg0)
+}
+
 // PackCoalescedPacket mocks base method.
 func (m *MockPacker) PackCoalescedPacket() (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
@@ -95,7 +110,7 @@ func (mr *MockPackerMockRecorder) PackCoalescedPacket() *gomock.Call {
 }
 
 // PackConnectionClose mocks base method.
-func (m *MockPacker) PackConnectionClose(arg0 *qerr.QuicError) (*coalescedPacket, error) {
+func (m *MockPacker) PackConnectionClose(arg0 *qerr.TransportError) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PackConnectionClose", arg0)
 	ret0, _ := ret[0].(*coalescedPacket)

--- a/mock_quic_session_test.go
+++ b/mock_quic_session_test.go
@@ -67,7 +67,7 @@ func (mr *MockQuicSessionMockRecorder) AcceptUniStream(arg0 interface{}) *gomock
 }
 
 // CloseWithError mocks base method.
-func (m *MockQuicSession) CloseWithError(arg0 ErrorCode, arg1 string) error {
+func (m *MockQuicSession) CloseWithError(arg0 ApplicationErrorCode, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloseWithError", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/mock_receive_stream_internal_test.go
+++ b/mock_receive_stream_internal_test.go
@@ -37,7 +37,7 @@ func (m *MockReceiveStreamI) EXPECT() *MockReceiveStreamIMockRecorder {
 }
 
 // CancelRead mocks base method.
-func (m *MockReceiveStreamI) CancelRead(arg0 ApplicationErrorCode) {
+func (m *MockReceiveStreamI) CancelRead(arg0 StreamErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelRead", arg0)
 }

--- a/mock_receive_stream_internal_test.go
+++ b/mock_receive_stream_internal_test.go
@@ -37,7 +37,7 @@ func (m *MockReceiveStreamI) EXPECT() *MockReceiveStreamIMockRecorder {
 }
 
 // CancelRead mocks base method.
-func (m *MockReceiveStreamI) CancelRead(arg0 ErrorCode) {
+func (m *MockReceiveStreamI) CancelRead(arg0 ApplicationErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelRead", arg0)
 }

--- a/mock_send_stream_internal_test.go
+++ b/mock_send_stream_internal_test.go
@@ -39,7 +39,7 @@ func (m *MockSendStreamI) EXPECT() *MockSendStreamIMockRecorder {
 }
 
 // CancelWrite mocks base method.
-func (m *MockSendStreamI) CancelWrite(arg0 ErrorCode) {
+func (m *MockSendStreamI) CancelWrite(arg0 ApplicationErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelWrite", arg0)
 }

--- a/mock_send_stream_internal_test.go
+++ b/mock_send_stream_internal_test.go
@@ -39,7 +39,7 @@ func (m *MockSendStreamI) EXPECT() *MockSendStreamIMockRecorder {
 }
 
 // CancelWrite mocks base method.
-func (m *MockSendStreamI) CancelWrite(arg0 ApplicationErrorCode) {
+func (m *MockSendStreamI) CancelWrite(arg0 StreamErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelWrite", arg0)
 }

--- a/mock_stream_internal_test.go
+++ b/mock_stream_internal_test.go
@@ -39,7 +39,7 @@ func (m *MockStreamI) EXPECT() *MockStreamIMockRecorder {
 }
 
 // CancelRead mocks base method.
-func (m *MockStreamI) CancelRead(arg0 ApplicationErrorCode) {
+func (m *MockStreamI) CancelRead(arg0 StreamErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelRead", arg0)
 }
@@ -51,7 +51,7 @@ func (mr *MockStreamIMockRecorder) CancelRead(arg0 interface{}) *gomock.Call {
 }
 
 // CancelWrite mocks base method.
-func (m *MockStreamI) CancelWrite(arg0 ApplicationErrorCode) {
+func (m *MockStreamI) CancelWrite(arg0 StreamErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelWrite", arg0)
 }

--- a/mock_stream_internal_test.go
+++ b/mock_stream_internal_test.go
@@ -39,7 +39,7 @@ func (m *MockStreamI) EXPECT() *MockStreamIMockRecorder {
 }
 
 // CancelRead mocks base method.
-func (m *MockStreamI) CancelRead(arg0 ErrorCode) {
+func (m *MockStreamI) CancelRead(arg0 ApplicationErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelRead", arg0)
 }
@@ -51,7 +51,7 @@ func (mr *MockStreamIMockRecorder) CancelRead(arg0 interface{}) *gomock.Call {
 }
 
 // CancelWrite mocks base method.
-func (m *MockStreamI) CancelWrite(arg0 ErrorCode) {
+func (m *MockStreamI) CancelWrite(arg0 ApplicationErrorCode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "CancelWrite", arg0)
 }

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -22,8 +22,13 @@ type statelessResetErr struct {
 	token protocol.StatelessResetToken
 }
 
-func (e statelessResetErr) Error() string {
+func (e *statelessResetErr) Error() string {
 	return fmt.Sprintf("received a stateless reset with token %x", e.token)
+}
+
+func (e *statelessResetErr) Is(target error) bool {
+	_, ok := target.(*statelessResetErr)
+	return ok
 }
 
 type zeroRTTQueue struct {
@@ -430,7 +435,7 @@ func (h *packetHandlerMap) maybeHandleStatelessReset(data []byte) bool {
 	copy(token[:], data[len(data)-16:])
 	if sess, ok := h.resetTokens[token]; ok {
 		h.logger.Debugf("Received a stateless reset with token %#x. Closing session.", token)
-		go sess.destroy(statelessResetErr{token: token})
+		go sess.destroy(&statelessResetErr{token: token})
 		return true
 	}
 	return false

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -18,19 +18,6 @@ import (
 	"github.com/lucas-clemente/quic-go/logging"
 )
 
-type statelessResetErr struct {
-	token protocol.StatelessResetToken
-}
-
-func (e *statelessResetErr) Error() string {
-	return fmt.Sprintf("received a stateless reset with token %x", e.token)
-}
-
-func (e *statelessResetErr) Is(target error) bool {
-	_, ok := target.(*statelessResetErr)
-	return ok
-}
-
 type zeroRTTQueue struct {
 	queue       []*receivedPacket
 	retireTimer *time.Timer
@@ -435,7 +422,7 @@ func (h *packetHandlerMap) maybeHandleStatelessReset(data []byte) bool {
 	copy(token[:], data[len(data)-16:])
 	if sess, ok := h.resetTokens[token]; ok {
 		h.logger.Debugf("Received a stateless reset with token %#x. Closing session.", token)
-		go sess.destroy(&statelessResetErr{token: token})
+		go sess.destroy(&StatelessResetError{Token: token})
 		return true
 	}
 	return false

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -373,10 +373,10 @@ var _ = Describe("Packet Handler Map", func() {
 						defer GinkgoRecover()
 						defer close(destroyed)
 						Expect(err).To(HaveOccurred())
-						var resetErr *statelessResetErr
+						var resetErr *StatelessResetError
 						Expect(errors.As(err, &resetErr)).To(BeTrue())
 						Expect(err.Error()).To(ContainSubstring("received a stateless reset"))
-						Expect(resetErr.token).To(Equal(token))
+						Expect(resetErr.Token).To(Equal(token))
 					})
 					packetChan <- packetToRead{data: packet}
 					Eventually(destroyed).Should(BeClosed())
@@ -393,10 +393,10 @@ var _ = Describe("Packet Handler Map", func() {
 					packetHandler.EXPECT().destroy(gomock.Any()).Do(func(err error) {
 						defer GinkgoRecover()
 						Expect(err).To(HaveOccurred())
-						var resetErr *statelessResetErr
+						var resetErr *StatelessResetError
 						Expect(errors.As(err, &resetErr)).To(BeTrue())
 						Expect(err.Error()).To(ContainSubstring("received a stateless reset"))
-						Expect(resetErr.token).To(Equal(token))
+						Expect(resetErr.Token).To(Equal(token))
 						close(destroyed)
 					})
 					packetChan <- packetToRead{data: packet}

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -373,7 +373,7 @@ var _ = Describe("Packet Handler Map", func() {
 						defer GinkgoRecover()
 						defer close(destroyed)
 						Expect(err).To(HaveOccurred())
-						var resetErr statelessResetErr
+						var resetErr *statelessResetErr
 						Expect(errors.As(err, &resetErr)).To(BeTrue())
 						Expect(err.Error()).To(ContainSubstring("received a stateless reset"))
 						Expect(resetErr.token).To(Equal(token))
@@ -393,7 +393,7 @@ var _ = Describe("Packet Handler Map", func() {
 					packetHandler.EXPECT().destroy(gomock.Any()).Do(func(err error) {
 						defer GinkgoRecover()
 						Expect(err).To(HaveOccurred())
-						var resetErr statelessResetErr
+						var resetErr *statelessResetErr
 						Expect(errors.As(err, &resetErr)).To(BeTrue())
 						Expect(err.Error()).To(ContainSubstring("received a stateless reset"))
 						Expect(resetErr.token).To(Equal(token))

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -216,7 +216,7 @@ func (p *packetPacker) PackConnectionClose(e *qerr.TransportError) (*coalescedPa
 
 // PackApplicationClose packs a packet that closes the connection with an application error.
 func (p *packetPacker) PackApplicationClose(e *qerr.ApplicationError) (*coalescedPacket, error) {
-	return p.packConnectionClose(true, e.ErrorCode, 0, e.ErrorMessage)
+	return p.packConnectionClose(true, uint64(e.ErrorCode), 0, e.ErrorMessage)
 }
 
 func (p *packetPacker) packConnectionClose(

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -20,7 +20,8 @@ type packer interface {
 	PackPacket() (*packedPacket, error)
 	MaybePackProbePacket(protocol.EncryptionLevel) (*packedPacket, error)
 	MaybePackAckPacket(handshakeConfirmed bool) (*packedPacket, error)
-	PackConnectionClose(*qerr.QuicError) (*coalescedPacket, error)
+	PackConnectionClose(*qerr.TransportError) (*coalescedPacket, error)
+	PackApplicationClose(*qerr.ApplicationError) (*coalescedPacket, error)
 
 	SetMaxPacketSize(protocol.ByteCount)
 	PackMTUProbePacket(ping ackhandler.Frame, size protocol.ByteCount) (*packedPacket, error)
@@ -203,14 +204,27 @@ func newPacketPacker(
 	}
 }
 
-// PackConnectionClose packs a packet that ONLY contains a ConnectionCloseFrame
-func (p *packetPacker) PackConnectionClose(quicErr *qerr.QuicError) (*coalescedPacket, error) {
+// PackConnectionClose packs a packet that closes the connection with a transport error.
+func (p *packetPacker) PackConnectionClose(e *qerr.TransportError) (*coalescedPacket, error) {
 	var reason string
 	// don't send details of crypto errors
-	if !quicErr.IsCryptoError() {
-		reason = quicErr.ErrorMessage
+	if !e.ErrorCode.IsCryptoError() {
+		reason = e.ErrorMessage
 	}
+	return p.packConnectionClose(false, uint64(e.ErrorCode), e.FrameType, reason)
+}
 
+// PackApplicationClose packs a packet that closes the connection with an application error.
+func (p *packetPacker) PackApplicationClose(e *qerr.ApplicationError) (*coalescedPacket, error) {
+	return p.packConnectionClose(true, e.ErrorCode, 0, e.ErrorMessage)
+}
+
+func (p *packetPacker) packConnectionClose(
+	isApplicationError bool,
+	errorCode uint64,
+	frameType uint64,
+	reason string,
+) (*coalescedPacket, error) {
 	var sealers [4]sealer
 	var hdrs [4]*wire.ExtendedHeader
 	var payloads [4]*payload
@@ -221,20 +235,17 @@ func (p *packetPacker) PackConnectionClose(quicErr *qerr.QuicError) (*coalescedP
 		if p.perspective == protocol.PerspectiveServer && encLevel == protocol.Encryption0RTT {
 			continue
 		}
-		quicErrToSend := quicErr
-		reasonPhrase := reason
-		if encLevel == protocol.EncryptionInitial || encLevel == protocol.EncryptionHandshake {
-			// don't send application errors in Initial or Handshake packets
-			if quicErr.IsApplicationError() {
-				quicErrToSend = qerr.NewError(qerr.ApplicationError, "")
-				reasonPhrase = ""
-			}
-		}
 		ccf := &wire.ConnectionCloseFrame{
-			IsApplicationError: quicErrToSend.IsApplicationError(),
-			ErrorCode:          quicErrToSend.ErrorCode,
-			FrameType:          quicErrToSend.FrameType,
-			ReasonPhrase:       reasonPhrase,
+			IsApplicationError: isApplicationError,
+			ErrorCode:          errorCode,
+			FrameType:          frameType,
+			ReasonPhrase:       reason,
+		}
+		// don't send application errors in Initial or Handshake packets
+		if isApplicationError && (encLevel == protocol.EncryptionInitial || encLevel == protocol.EncryptionHandshake) {
+			ccf.IsApplicationError = false
+			ccf.ErrorCode = uint64(qerr.ApplicationErrorErrorCode)
+			ccf.ReasonPhrase = ""
 		}
 		payload := &payload{
 			frames: []ackhandler.Frame{{Frame: ccf}},

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -186,9 +186,10 @@ var _ = Describe("Packet Unpacker", func() {
 		cs.EXPECT().GetHandshakeOpener().Return(opener, nil)
 		opener.EXPECT().DecryptHeader(gomock.Any(), gomock.Any(), gomock.Any())
 		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any())
-		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, qerr.CryptoBufferExceeded)
+		unpackErr := &qerr.TransportError{ErrorCode: qerr.CryptoBufferExceeded}
+		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, unpackErr)
 		_, err := unpacker.Unpack(hdr, time.Now(), append(hdrRaw, payload...))
-		Expect(err).To(MatchError(qerr.CryptoBufferExceeded))
+		Expect(err).To(MatchError(unpackErr))
 	})
 
 	It("defends against the timing side-channel when the reserved bits are wrong, for long header packets", func() {

--- a/qlog/frame.go
+++ b/qlog/frame.go
@@ -211,9 +211,9 @@ func marshalConnectionCloseFrame(enc *gojay.Encoder, f *logging.ConnectionCloseF
 	if errName := transportError(f.ErrorCode).String(); len(errName) > 0 {
 		enc.StringKey("error_code", errName)
 	} else {
-		enc.Uint64Key("error_code", uint64(f.ErrorCode))
+		enc.Uint64Key("error_code", f.ErrorCode)
 	}
-	enc.Uint64Key("raw_error_code", uint64(f.ErrorCode))
+	enc.Uint64Key("raw_error_code", f.ErrorCode)
 	enc.StringKey("reason", f.ReasonPhrase)
 }
 

--- a/qlog/frame_test.go
+++ b/qlog/frame_test.go
@@ -343,7 +343,7 @@ var _ = Describe("Frames", func() {
 	It("marshals CONNECTION_CLOSE frames, for transport error codes", func() {
 		check(
 			&logging.ConnectionCloseFrame{
-				ErrorCode:    qerr.FlowControlError,
+				ErrorCode:    uint64(qerr.FlowControlError),
 				ReasonPhrase: "lorem ipsum",
 			},
 			map[string]interface{}{

--- a/qlog/types.go
+++ b/qlog/types.go
@@ -180,7 +180,7 @@ func (t keyUpdateTrigger) String() string {
 type transportError uint64
 
 func (e transportError) String() string {
-	switch qerr.ErrorCode(e) {
+	switch qerr.TransportErrorCode(e) {
 	case qerr.NoError:
 		return "no_error"
 	case qerr.InternalError:
@@ -205,7 +205,7 @@ func (e transportError) String() string {
 		return "protocol_violation"
 	case qerr.InvalidToken:
 		return "invalid_token"
-	case qerr.ApplicationError:
+	case qerr.ApplicationErrorErrorCode:
 		return "application_error"
 	case qerr.CryptoBufferExceeded:
 		return "crypto_buffer_exceeded"

--- a/qlog/types_test.go
+++ b/qlog/types_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Types", func() {
 			Expect(transportError(qerr.ConnectionIDLimitError).String()).To(Equal("connection_id_limit_error"))
 			Expect(transportError(qerr.ProtocolViolation).String()).To(Equal("protocol_violation"))
 			Expect(transportError(qerr.InvalidToken).String()).To(Equal("invalid_token"))
-			Expect(transportError(qerr.ApplicationError).String()).To(Equal("application_error"))
+			Expect(transportError(qerr.ApplicationErrorErrorCode).String()).To(Equal("application_error"))
 			Expect(transportError(qerr.CryptoBufferExceeded).String()).To(Equal("crypto_buffer_exceeded"))
 			Expect(transportError(qerr.NoViablePathError).String()).To(Equal("no_viable_path"))
 			Expect(transportError(1337).String()).To(BeEmpty())

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
@@ -196,7 +197,7 @@ func (s *receiveStream) dequeueNextFrame() {
 	s.readPosInFrame = 0
 }
 
-func (s *receiveStream) CancelRead(errorCode protocol.ApplicationErrorCode) {
+func (s *receiveStream) CancelRead(errorCode qerr.ApplicationErrorCode) {
 	s.mutex.Lock()
 	completed := s.cancelReadImpl(errorCode)
 	s.mutex.Unlock()
@@ -207,7 +208,7 @@ func (s *receiveStream) CancelRead(errorCode protocol.ApplicationErrorCode) {
 	}
 }
 
-func (s *receiveStream) cancelReadImpl(errorCode protocol.ApplicationErrorCode) bool /* completed */ {
+func (s *receiveStream) cancelReadImpl(errorCode qerr.ApplicationErrorCode) bool /* completed */ {
 	if s.finRead || s.canceledRead || s.resetRemotely {
 		return false
 	}

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 
 	. "github.com/onsi/ginkgo"
@@ -572,10 +571,10 @@ var _ = Describe("Receive Stream", func() {
 				go func() {
 					defer GinkgoRecover()
 					_, err := strWithTimeout.Read([]byte{0})
-					Expect(err).To(MatchError("stream 1337 was reset with error code 1234"))
-					Expect(err).To(BeAssignableToTypeOf(streamCanceledError{}))
-					Expect(err.(streamCanceledError).Canceled()).To(BeTrue())
-					Expect(err.(streamCanceledError).ErrorCode()).To(Equal(qerr.ApplicationErrorCode(1234)))
+					Expect(err).To(MatchError(&StreamError{
+						StreamID:  streamID,
+						ErrorCode: 1234,
+					}))
 					close(done)
 				}()
 				Consistently(done).ShouldNot(BeClosed())
@@ -596,10 +595,10 @@ var _ = Describe("Receive Stream", func() {
 				)
 				Expect(str.handleResetStreamFrame(rst)).To(Succeed())
 				_, err := strWithTimeout.Read([]byte{0})
-				Expect(err).To(MatchError("stream 1337 was reset with error code 1234"))
-				Expect(err).To(BeAssignableToTypeOf(streamCanceledError{}))
-				Expect(err.(streamCanceledError).Canceled()).To(BeTrue())
-				Expect(err.(streamCanceledError).ErrorCode()).To(Equal(qerr.ApplicationErrorCode(1234)))
+				Expect(err).To(MatchError(&StreamError{
+					StreamID:  streamID,
+					ErrorCode: 1234,
+				}))
 			})
 
 			It("errors when receiving a RESET_STREAM with an inconsistent offset", func() {

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 
 	. "github.com/onsi/ginkgo"
@@ -574,7 +575,7 @@ var _ = Describe("Receive Stream", func() {
 					Expect(err).To(MatchError("stream 1337 was reset with error code 1234"))
 					Expect(err).To(BeAssignableToTypeOf(streamCanceledError{}))
 					Expect(err.(streamCanceledError).Canceled()).To(BeTrue())
-					Expect(err.(streamCanceledError).ErrorCode()).To(Equal(protocol.ApplicationErrorCode(1234)))
+					Expect(err.(streamCanceledError).ErrorCode()).To(Equal(qerr.ApplicationErrorCode(1234)))
 					close(done)
 				}()
 				Consistently(done).ShouldNot(BeClosed())
@@ -598,7 +599,7 @@ var _ = Describe("Receive Stream", func() {
 				Expect(err).To(MatchError("stream 1337 was reset with error code 1234"))
 				Expect(err).To(BeAssignableToTypeOf(streamCanceledError{}))
 				Expect(err.(streamCanceledError).Canceled()).To(BeTrue())
-				Expect(err.(streamCanceledError).ErrorCode()).To(Equal(protocol.ApplicationErrorCode(1234)))
+				Expect(err.(streamCanceledError).ErrorCode()).To(Equal(qerr.ApplicationErrorCode(1234)))
 			})
 
 			It("errors when receiving a RESET_STREAM with an inconsistent offset", func() {

--- a/send_stream.go
+++ b/send_stream.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/lucas-clemente/quic-go/internal/ackhandler"
-
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/utils"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
@@ -407,12 +407,12 @@ func (s *sendStream) Close() error {
 	return nil
 }
 
-func (s *sendStream) CancelWrite(errorCode protocol.ApplicationErrorCode) {
+func (s *sendStream) CancelWrite(errorCode qerr.ApplicationErrorCode) {
 	s.cancelWriteImpl(errorCode, fmt.Errorf("Write on stream %d canceled with error code %d", s.streamID, errorCode))
 }
 
 // must be called after locking the mutex
-func (s *sendStream) cancelWriteImpl(errorCode protocol.ApplicationErrorCode, writeErr error) {
+func (s *sendStream) cancelWriteImpl(errorCode qerr.ApplicationErrorCode, writeErr error) {
 	s.mutex.Lock()
 	if s.canceledWrite {
 		s.mutex.Unlock()

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/ackhandler"
 	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 
 	. "github.com/onsi/ginkgo"
@@ -865,7 +866,7 @@ var _ = Describe("Send Stream", func() {
 					Expect(err).To(MatchError("stream 1337 was reset with error code 123"))
 					Expect(err).To(BeAssignableToTypeOf(streamCanceledError{}))
 					Expect(err.(streamCanceledError).Canceled()).To(BeTrue())
-					Expect(err.(streamCanceledError).ErrorCode()).To(Equal(protocol.ApplicationErrorCode(123)))
+					Expect(err.(streamCanceledError).ErrorCode()).To(Equal(qerr.ApplicationErrorCode(123)))
 					close(done)
 				}()
 				waitForWrite()
@@ -887,7 +888,7 @@ var _ = Describe("Send Stream", func() {
 				Expect(err).To(MatchError("stream 1337 was reset with error code 123"))
 				Expect(err).To(BeAssignableToTypeOf(streamCanceledError{}))
 				Expect(err.(streamCanceledError).Canceled()).To(BeTrue())
-				Expect(err.(streamCanceledError).ErrorCode()).To(Equal(protocol.ApplicationErrorCode(123)))
+				Expect(err.(streamCanceledError).ErrorCode()).To(Equal(qerr.ApplicationErrorCode(123)))
 			})
 		})
 	})

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/ackhandler"
 	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 
 	. "github.com/onsi/ginkgo"
@@ -863,10 +862,10 @@ var _ = Describe("Send Stream", func() {
 				go func() {
 					defer GinkgoRecover()
 					_, err := str.Write(getData(5000))
-					Expect(err).To(MatchError("stream 1337 was reset with error code 123"))
-					Expect(err).To(BeAssignableToTypeOf(streamCanceledError{}))
-					Expect(err.(streamCanceledError).Canceled()).To(BeTrue())
-					Expect(err.(streamCanceledError).ErrorCode()).To(Equal(qerr.ApplicationErrorCode(123)))
+					Expect(err).To(MatchError(&StreamError{
+						StreamID:  streamID,
+						ErrorCode: 1234,
+					}))
 					close(done)
 				}()
 				waitForWrite()
@@ -885,10 +884,10 @@ var _ = Describe("Send Stream", func() {
 					ErrorCode: 123,
 				})
 				_, err := str.Write([]byte("foobar"))
-				Expect(err).To(MatchError("stream 1337 was reset with error code 123"))
-				Expect(err).To(BeAssignableToTypeOf(streamCanceledError{}))
-				Expect(err.(streamCanceledError).Canceled()).To(BeTrue())
-				Expect(err.(streamCanceledError).ErrorCode()).To(Equal(qerr.ApplicationErrorCode(123)))
+				Expect(err).To(MatchError(&StreamError{
+					StreamID:  streamID,
+					ErrorCode: 1234,
+				}))
 			})
 		})
 	})

--- a/server.go
+++ b/server.go
@@ -600,12 +600,12 @@ func (s *baseServer) sendConnectionRefused(remoteAddr net.Addr, hdr *wire.Header
 }
 
 // sendError sends the error as a response to the packet received with header hdr
-func (s *baseServer) sendError(remoteAddr net.Addr, hdr *wire.Header, sealer handshake.LongHeaderSealer, errorCode qerr.ErrorCode, info *packetInfo) error {
+func (s *baseServer) sendError(remoteAddr net.Addr, hdr *wire.Header, sealer handshake.LongHeaderSealer, errorCode qerr.TransportErrorCode, info *packetInfo) error {
 	packetBuffer := getPacketBuffer()
 	defer packetBuffer.Release()
 	buf := bytes.NewBuffer(packetBuffer.Data)
 
-	ccf := &wire.ConnectionCloseFrame{ErrorCode: errorCode}
+	ccf := &wire.ConnectionCloseFrame{ErrorCode: uint64(errorCode)}
 
 	replyHdr := &wire.ExtendedHeader{}
 	replyHdr.IsLongHeader = true

--- a/server_test.go
+++ b/server_test.go
@@ -508,7 +508,7 @@ var _ = Describe("Server", func() {
 					Expect(frames[0]).To(BeAssignableToTypeOf(&wire.ConnectionCloseFrame{}))
 					ccf := frames[0].(*logging.ConnectionCloseFrame)
 					Expect(ccf.IsApplicationError).To(BeFalse())
-					Expect(ccf.ErrorCode).To(Equal(qerr.InvalidToken))
+					Expect(ccf.ErrorCode).To(BeEquivalentTo(qerr.InvalidToken))
 				})
 				done := make(chan struct{})
 				conn.EXPECT().WriteTo(gomock.Any(), raddr).DoAndReturn(func(b []byte, _ net.Addr) (int, error) {
@@ -526,7 +526,7 @@ var _ = Describe("Server", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(f).To(BeAssignableToTypeOf(&wire.ConnectionCloseFrame{}))
 					ccf := f.(*wire.ConnectionCloseFrame)
-					Expect(ccf.ErrorCode).To(Equal(qerr.InvalidToken))
+					Expect(ccf.ErrorCode).To(BeEquivalentTo(qerr.InvalidToken))
 					Expect(ccf.ReasonPhrase).To(BeEmpty())
 					return len(b), nil
 				})

--- a/session.go
+++ b/session.go
@@ -1284,7 +1284,7 @@ func (s *session) handleConnectionCloseFrame(frame *wire.ConnectionCloseFrame) {
 	if frame.IsApplicationError {
 		s.closeRemote(&qerr.ApplicationError{
 			Remote:       true,
-			ErrorCode:    frame.ErrorCode,
+			ErrorCode:    qerr.ApplicationErrorCode(frame.ErrorCode),
 			ErrorMessage: frame.ReasonPhrase,
 		})
 		return
@@ -1477,7 +1477,7 @@ func (s *session) shutdown() {
 
 func (s *session) CloseWithError(code ErrorCode, desc string) error {
 	s.closeLocal(&qerr.ApplicationError{
-		ErrorCode:    uint64(code),
+		ErrorCode:    code,
 		ErrorMessage: desc,
 	})
 	<-s.ctx.Done()

--- a/session.go
+++ b/session.go
@@ -1483,7 +1483,7 @@ func (s *session) handleCloseError(closeErr *closeError) {
 	switch {
 	case errors.Is(e, qerr.ErrIdleTimeout),
 		errors.Is(e, qerr.ErrHandshakeTimeout),
-		errors.Is(e, &statelessResetErr{}),
+		errors.Is(e, &StatelessResetError{}),
 		errors.Is(e, &VersionNegotiationError{}),
 		errors.Is(e, &errCloseForRecreating{}),
 		errors.Is(e, &qerr.ApplicationError{}),
@@ -1503,7 +1503,7 @@ func (s *session) handleCloseError(closeErr *closeError) {
 
 	if s.tracer != nil && !errors.Is(e, &errCloseForRecreating{}) {
 		var (
-			resetErr       *statelessResetErr
+			resetErr       *StatelessResetError
 			vnErr          *VersionNegotiationError
 			transportErr   *qerr.TransportError
 			applicationErr *qerr.ApplicationError
@@ -1514,7 +1514,7 @@ func (s *session) handleCloseError(closeErr *closeError) {
 		case errors.Is(e, qerr.ErrHandshakeTimeout):
 			s.tracer.ClosedConnection(logging.NewTimeoutCloseReason(logging.TimeoutReasonHandshake))
 		case errors.As(e, &resetErr):
-			s.tracer.ClosedConnection(logging.NewStatelessResetCloseReason(resetErr.token))
+			s.tracer.ClosedConnection(logging.NewStatelessResetCloseReason(resetErr.Token))
 		case errors.As(e, &vnErr):
 			s.tracer.ClosedConnection(logging.NewVersionNegotiationError(vnErr.Theirs))
 		case errors.As(e, &applicationErr):

--- a/session.go
+++ b/session.go
@@ -123,12 +123,12 @@ type errCloseForRecreating struct {
 	nextVersion      protocol.VersionNumber
 }
 
-func (errCloseForRecreating) Error() string {
+func (e *errCloseForRecreating) Error() string {
 	return "closing session in order to recreate it"
 }
 
-func (errCloseForRecreating) Is(target error) bool {
-	_, ok := target.(errCloseForRecreating)
+func (e *errCloseForRecreating) Is(target error) bool {
+	_, ok := target.(*errCloseForRecreating)
 	return ok
 }
 
@@ -137,8 +137,13 @@ type errVersionNegotiation struct {
 	theirVersions []protocol.VersionNumber
 }
 
-func (e errVersionNegotiation) Error() string {
+func (e *errVersionNegotiation) Error() string {
 	return fmt.Sprintf("no compatible QUIC version found (we support %s, server offered %s)", e.ourVersions, e.theirVersions)
+}
+
+func (e *errVersionNegotiation) Is(target error) bool {
+	_, ok := target.(*errVersionNegotiation)
+	return ok
 }
 
 var sessionTracingID uint64        // to be accessed atomically
@@ -699,8 +704,8 @@ runLoop:
 		}
 	}
 
-	s.handleCloseError(closeErr)
-	if !errors.Is(closeErr.err, errCloseForRecreating{}) && s.tracer != nil {
+	s.handleCloseError(&closeErr)
+	if !errors.Is(closeErr.err, &errCloseForRecreating{}) && s.tracer != nil {
 		s.tracer.Close()
 	}
 	s.logger.Infof("Connection %s closed.", s.logID)
@@ -952,7 +957,10 @@ func (s *session) handleSinglePacket(p *receivedPacket, hdr *wire.Header) bool /
 			wasQueued = true
 			s.tryQueueingUndecryptablePacket(p, hdr)
 		case wire.ErrInvalidReservedBits:
-			s.closeLocal(qerr.NewError(qerr.ProtocolViolation, err.Error()))
+			s.closeLocal(&qerr.TransportError{
+				ErrorCode:    qerr.ProtocolViolation,
+				ErrorMessage: err.Error(),
+			})
 		case handshake.ErrDecryptionFailed:
 			// This might be a packet injected by an attacker. Drop it.
 			if s.tracer != nil {
@@ -1093,7 +1101,7 @@ func (s *session) handleVersionNegotiationPacket(p *receivedPacket) {
 	}
 	newVersion, ok := protocol.ChooseSupportedVersion(s.config.Versions, supportedVersions)
 	if !ok {
-		s.destroyImpl(errVersionNegotiation{
+		s.destroyImpl(&errVersionNegotiation{
 			ourVersions:   s.config.Versions,
 			theirVersions: supportedVersions,
 		})
@@ -1119,7 +1127,10 @@ func (s *session) handleUnpackedPacket(
 	packetSize protocol.ByteCount, // only for logging
 ) error {
 	if len(packet.data) == 0 {
-		return qerr.NewError(qerr.ProtocolViolation, "empty packet")
+		return &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "empty packet",
+		}
 	}
 
 	if !s.receivedFirstPacket {
@@ -1270,13 +1281,20 @@ func (s *session) handlePacket(p *receivedPacket) {
 }
 
 func (s *session) handleConnectionCloseFrame(frame *wire.ConnectionCloseFrame) {
-	var e error
 	if frame.IsApplicationError {
-		e = qerr.NewApplicationError(frame.ErrorCode, frame.ReasonPhrase)
-	} else {
-		e = qerr.NewError(frame.ErrorCode, frame.ReasonPhrase)
+		s.closeRemote(&qerr.ApplicationError{
+			Remote:       true,
+			ErrorCode:    frame.ErrorCode,
+			ErrorMessage: frame.ReasonPhrase,
+		})
+		return
 	}
-	s.closeRemote(e)
+	s.closeRemote(&qerr.TransportError{
+		Remote:       true,
+		ErrorCode:    qerr.TransportErrorCode(frame.ErrorCode),
+		FrameType:    frame.FrameType,
+		ErrorMessage: frame.ReasonPhrase,
+	})
 }
 
 func (s *session) handleCryptoFrame(frame *wire.CryptoFrame, encLevel protocol.EncryptionLevel) error {
@@ -1357,7 +1375,10 @@ func (s *session) handlePathChallengeFrame(frame *wire.PathChallengeFrame) {
 
 func (s *session) handleNewTokenFrame(frame *wire.NewTokenFrame) error {
 	if s.perspective == protocol.PerspectiveServer {
-		return qerr.NewError(qerr.ProtocolViolation, "Received NEW_TOKEN frame from the client.")
+		return &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "received NEW_TOKEN frame from the client",
+		}
 	}
 	if s.config.TokenStore != nil {
 		s.config.TokenStore.Put(s.tokenStoreKey, &ClientToken{data: frame.Token})
@@ -1375,7 +1396,10 @@ func (s *session) handleRetireConnectionIDFrame(f *wire.RetireConnectionIDFrame,
 
 func (s *session) handleHandshakeDoneFrame() error {
 	if s.perspective == protocol.PerspectiveServer {
-		return qerr.NewError(qerr.ProtocolViolation, "received a HANDSHAKE_DONE frame")
+		return &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "received a HANDSHAKE_DONE frame",
+		}
 	}
 	if !s.handshakeConfirmed {
 		s.handleHandshakeConfirmed()
@@ -1399,7 +1423,10 @@ func (s *session) handleAckFrame(frame *wire.AckFrame, encLevel protocol.Encrypt
 
 func (s *session) handleDatagramFrame(f *wire.DatagramFrame) error {
 	if f.Length(s.version) > protocol.MaxDatagramFrameSize {
-		return qerr.NewError(qerr.ProtocolViolation, "DATAGRAM frame too large")
+		return &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "DATAGRAM frame too large",
+		}
 	}
 	s.datagramQueue.HandleDatagramFrame(f)
 	return nil
@@ -1448,45 +1475,66 @@ func (s *session) shutdown() {
 	<-s.ctx.Done()
 }
 
-func (s *session) CloseWithError(code protocol.ApplicationErrorCode, desc string) error {
-	s.closeLocal(qerr.NewApplicationError(qerr.ErrorCode(code), desc))
+func (s *session) CloseWithError(code ErrorCode, desc string) error {
+	s.closeLocal(&qerr.ApplicationError{
+		ErrorCode:    uint64(code),
+		ErrorMessage: desc,
+	})
 	<-s.ctx.Done()
 	return nil
 }
 
-func (s *session) handleCloseError(closeErr closeError) {
-	if closeErr.err == nil {
-		closeErr.err = qerr.NewApplicationError(0, "")
+func (s *session) handleCloseError(closeErr *closeError) {
+	e := closeErr.err
+	if e == nil {
+		e = &qerr.ApplicationError{}
+	} else {
+		defer func() {
+			closeErr.err = e
+		}()
 	}
 
-	var quicErr *qerr.QuicError
-	var ok bool
-	if quicErr, ok = closeErr.err.(*qerr.QuicError); !ok {
-		quicErr = qerr.ToQuicError(closeErr.err)
+	switch {
+	case errors.Is(e, qerr.ErrIdleTimeout),
+		errors.Is(e, qerr.ErrHandshakeTimeout),
+		errors.Is(e, &statelessResetErr{}),
+		errors.Is(e, &errVersionNegotiation{}),
+		errors.Is(e, &errCloseForRecreating{}),
+		errors.Is(e, &qerr.ApplicationError{}),
+		errors.Is(e, &qerr.TransportError{}):
+	default:
+		e = &qerr.TransportError{
+			ErrorCode:    qerr.InternalError,
+			ErrorMessage: e.Error(),
+		}
 	}
 
-	s.streamsMap.CloseWithError(quicErr)
+	s.streamsMap.CloseWithError(e)
 	s.connIDManager.Close()
 	if s.datagramQueue != nil {
-		s.datagramQueue.CloseWithError(quicErr)
+		s.datagramQueue.CloseWithError(e)
 	}
 
-	if s.tracer != nil && !errors.Is(closeErr.err, errCloseForRecreating{}) {
-		var resetErr statelessResetErr
-		var vnErr errVersionNegotiation
+	if s.tracer != nil && !errors.Is(e, &errCloseForRecreating{}) {
+		var (
+			resetErr       *statelessResetErr
+			vnErr          *errVersionNegotiation
+			transportErr   *qerr.TransportError
+			applicationErr *qerr.ApplicationError
+		)
 		switch {
-		case errors.Is(closeErr.err, qerr.ErrIdleTimeout):
+		case errors.Is(e, qerr.ErrIdleTimeout):
 			s.tracer.ClosedConnection(logging.NewTimeoutCloseReason(logging.TimeoutReasonIdle))
-		case errors.Is(closeErr.err, qerr.ErrHandshakeTimeout):
+		case errors.Is(e, qerr.ErrHandshakeTimeout):
 			s.tracer.ClosedConnection(logging.NewTimeoutCloseReason(logging.TimeoutReasonHandshake))
-		case errors.As(closeErr.err, &resetErr):
+		case errors.As(e, &resetErr):
 			s.tracer.ClosedConnection(logging.NewStatelessResetCloseReason(resetErr.token))
-		case errors.As(closeErr.err, &vnErr):
+		case errors.As(e, &vnErr):
 			s.tracer.ClosedConnection(logging.NewVersionNegotiationError(vnErr.theirVersions))
-		case quicErr.IsApplicationError():
-			s.tracer.ClosedConnection(logging.NewApplicationCloseReason(quicErr.ErrorCode, closeErr.remote))
-		default:
-			s.tracer.ClosedConnection(logging.NewTransportCloseReason(quicErr.ErrorCode, closeErr.remote))
+		case errors.As(e, &applicationErr):
+			s.tracer.ClosedConnection(logging.NewApplicationCloseReason(logging.ApplicationError(applicationErr.ErrorCode), closeErr.remote))
+		case errors.As(e, &transportErr):
+			s.tracer.ClosedConnection(logging.NewTransportCloseReason(transportErr.ErrorCode, closeErr.remote))
 		}
 	}
 
@@ -1499,7 +1547,7 @@ func (s *session) handleCloseError(closeErr closeError) {
 		s.connIDGenerator.RemoveAll()
 		return
 	}
-	connClosePacket, err := s.sendConnectionClose(quicErr)
+	connClosePacket, err := s.sendConnectionClose(e)
 	if err != nil {
 		s.logger.Debugf("Error sending CONNECTION_CLOSE: %s", err)
 	}
@@ -1538,7 +1586,10 @@ func (s *session) restoreTransportParameters(params *wire.TransportParameters) {
 
 func (s *session) handleTransportParameters(params *wire.TransportParameters) {
 	if err := s.checkTransportParameters(params); err != nil {
-		s.closeLocal(err)
+		s.closeLocal(&qerr.TransportError{
+			ErrorCode:    qerr.TransportParameterError,
+			ErrorMessage: err.Error(),
+		})
 	}
 	s.peerParams = params
 	// On the client side we have to wait for handshake completion.
@@ -1561,7 +1612,7 @@ func (s *session) checkTransportParameters(params *wire.TransportParameters) err
 
 	// check the initial_source_connection_id
 	if !params.InitialSourceConnectionID.Equal(s.handshakeDestConnID) {
-		return qerr.NewError(qerr.TransportParameterError, fmt.Sprintf("expected initial_source_connection_id to equal %s, is %s", s.handshakeDestConnID, params.InitialSourceConnectionID))
+		return fmt.Errorf("expected initial_source_connection_id to equal %s, is %s", s.handshakeDestConnID, params.InitialSourceConnectionID)
 	}
 
 	if s.perspective == protocol.PerspectiveServer {
@@ -1569,17 +1620,17 @@ func (s *session) checkTransportParameters(params *wire.TransportParameters) err
 	}
 	// check the original_destination_connection_id
 	if !params.OriginalDestinationConnectionID.Equal(s.origDestConnID) {
-		return qerr.NewError(qerr.TransportParameterError, fmt.Sprintf("expected original_destination_connection_id to equal %s, is %s", s.origDestConnID, params.OriginalDestinationConnectionID))
+		return fmt.Errorf("expected original_destination_connection_id to equal %s, is %s", s.origDestConnID, params.OriginalDestinationConnectionID)
 	}
 	if s.retrySrcConnID != nil { // a Retry was performed
 		if params.RetrySourceConnectionID == nil {
-			return qerr.NewError(qerr.TransportParameterError, "missing retry_source_connection_id")
+			return errors.New("missing retry_source_connection_id")
 		}
 		if !(*params.RetrySourceConnectionID).Equal(*s.retrySrcConnID) {
-			return qerr.NewError(qerr.TransportParameterError, fmt.Sprintf("expected retry_source_connection_id to equal %s, is %s", s.retrySrcConnID, *params.RetrySourceConnectionID))
+			return fmt.Errorf("expected retry_source_connection_id to equal %s, is %s", s.retrySrcConnID, *params.RetrySourceConnectionID)
 		}
 	} else if params.RetrySourceConnectionID != nil {
-		return qerr.NewError(qerr.TransportParameterError, "received retry_source_connection_id, although no Retry was performed")
+		return errors.New("received retry_source_connection_id, although no Retry was performed")
 	}
 	return nil
 }
@@ -1774,8 +1825,21 @@ func (s *session) sendPackedPacket(packet *packedPacket, now time.Time) {
 	s.sendQueue.Send(packet.buffer)
 }
 
-func (s *session) sendConnectionClose(quicErr *qerr.QuicError) ([]byte, error) {
-	packet, err := s.packer.PackConnectionClose(quicErr)
+func (s *session) sendConnectionClose(e error) ([]byte, error) {
+	var packet *coalescedPacket
+	var err error
+	var transportErr *qerr.TransportError
+	var applicationErr *qerr.ApplicationError
+	if errors.As(e, &transportErr) {
+		packet, err = s.packer.PackConnectionClose(transportErr)
+	} else if errors.As(e, &applicationErr) {
+		packet, err = s.packer.PackApplicationClose(applicationErr)
+	} else {
+		packet, err = s.packer.PackConnectionClose(&qerr.TransportError{
+			ErrorCode:    qerr.InternalError,
+			ErrorMessage: fmt.Sprintf("session BUG: unspecified error type (msg: %s)", e.Error()),
+		})
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/session.go
+++ b/session.go
@@ -1475,7 +1475,7 @@ func (s *session) shutdown() {
 	<-s.ctx.Done()
 }
 
-func (s *session) CloseWithError(code ErrorCode, desc string) error {
+func (s *session) CloseWithError(code ApplicationErrorCode, desc string) error {
 	s.closeLocal(&qerr.ApplicationError{
 		ErrorCode:    code,
 		ErrorMessage: desc,

--- a/session_test.go
+++ b/session_test.go
@@ -658,7 +658,7 @@ var _ = Describe("Session", func() {
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			sessionRunner.EXPECT().Remove(gomock.Any()).AnyTimes()
 			cryptoSetup.EXPECT().Close()
-			sess.destroy(&statelessResetErr{token: token})
+			sess.destroy(&StatelessResetError{Token: token})
 		})
 	})
 

--- a/stream.go
+++ b/stream.go
@@ -9,7 +9,6 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/ackhandler"
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
-	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
@@ -86,16 +85,6 @@ type stream struct {
 }
 
 var _ Stream = &stream{}
-
-type streamCanceledError struct {
-	error
-	errorCode qerr.ApplicationErrorCode
-}
-
-func (streamCanceledError) Canceled() bool                         { return true }
-func (e streamCanceledError) ErrorCode() qerr.ApplicationErrorCode { return e.errorCode }
-
-var _ StreamError = &streamCanceledError{}
 
 // newStream creates a new Stream
 func newStream(streamID protocol.StreamID,

--- a/stream.go
+++ b/stream.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lucas-clemente/quic-go/internal/ackhandler"
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
@@ -88,11 +89,11 @@ var _ Stream = &stream{}
 
 type streamCanceledError struct {
 	error
-	errorCode protocol.ApplicationErrorCode
+	errorCode qerr.ApplicationErrorCode
 }
 
-func (streamCanceledError) Canceled() bool                             { return true }
-func (e streamCanceledError) ErrorCode() protocol.ApplicationErrorCode { return e.errorCode }
+func (streamCanceledError) Canceled() bool                         { return true }
+func (e streamCanceledError) ErrorCode() qerr.ApplicationErrorCode { return e.errorCode }
 
 var _ StreamError = &streamCanceledError{}
 

--- a/streams_map.go
+++ b/streams_map.go
@@ -209,7 +209,10 @@ func (m *streamsMap) DeleteStream(id protocol.StreamID) error {
 func (m *streamsMap) GetOrOpenReceiveStream(id protocol.StreamID) (receiveStreamI, error) {
 	str, err := m.getOrOpenReceiveStream(id)
 	if err != nil {
-		return nil, qerr.NewError(qerr.StreamStateError, err.Error())
+		return nil, &qerr.TransportError{
+			ErrorCode:    qerr.StreamStateError,
+			ErrorMessage: err.Error(),
+		}
 	}
 	return str, nil
 }
@@ -240,7 +243,10 @@ func (m *streamsMap) getOrOpenReceiveStream(id protocol.StreamID) (receiveStream
 func (m *streamsMap) GetOrOpenSendStream(id protocol.StreamID) (sendStreamI, error) {
 	str, err := m.getOrOpenSendStream(id)
 	if err != nil {
-		return nil, qerr.NewError(qerr.StreamStateError, err.Error())
+		return nil, &qerr.TransportError{
+			ErrorCode:    qerr.StreamStateError,
+			ErrorMessage: err.Error(),
+		}
 	}
 	return str, nil
 }

--- a/streams_map_incoming_bidi.go
+++ b/streams_map_incoming_bidi.go
@@ -145,7 +145,7 @@ func (m *incomingBidiStreamsMap) DeleteStream(num protocol.StreamNum) error {
 func (m *incomingBidiStreamsMap) deleteStream(num protocol.StreamNum) error {
 	if _, ok := m.streams[num]; !ok {
 		return streamError{
-			message: "Tried to delete unknown incoming stream %d",
+			message: "tried to delete unknown incoming stream %d",
 			nums:    []protocol.StreamNum{num},
 		}
 	}
@@ -156,7 +156,7 @@ func (m *incomingBidiStreamsMap) deleteStream(num protocol.StreamNum) error {
 		entry, ok := m.streams[num]
 		if ok && entry.shouldDelete {
 			return streamError{
-				message: "Tried to delete incoming stream %d multiple times",
+				message: "tried to delete incoming stream %d multiple times",
 				nums:    []protocol.StreamNum{num},
 			}
 		}

--- a/streams_map_incoming_generic.go
+++ b/streams_map_incoming_generic.go
@@ -143,7 +143,7 @@ func (m *incomingItemsMap) DeleteStream(num protocol.StreamNum) error {
 func (m *incomingItemsMap) deleteStream(num protocol.StreamNum) error {
 	if _, ok := m.streams[num]; !ok {
 		return streamError{
-			message: "Tried to delete unknown incoming stream %d",
+			message: "tried to delete unknown incoming stream %d",
 			nums:    []protocol.StreamNum{num},
 		}
 	}
@@ -154,7 +154,7 @@ func (m *incomingItemsMap) deleteStream(num protocol.StreamNum) error {
 		entry, ok := m.streams[num]
 		if ok && entry.shouldDelete {
 			return streamError{
-				message: "Tried to delete incoming stream %d multiple times",
+				message: "tried to delete incoming stream %d multiple times",
 				nums:    []protocol.StreamNum{num},
 			}
 		}

--- a/streams_map_incoming_generic_test.go
+++ b/streams_map_incoming_generic_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Streams Map (incoming)", func() {
 	It("errors when deleting a non-existing stream", func() {
 		err := m.DeleteStream(1337)
 		Expect(err).To(HaveOccurred())
-		Expect(err.(streamError).TestError()).To(MatchError("Tried to delete unknown incoming stream 1337"))
+		Expect(err.(streamError).TestError()).To(MatchError("tried to delete unknown incoming stream 1337"))
 	})
 
 	It("sends MAX_STREAMS frames when streams are deleted", func() {

--- a/streams_map_incoming_uni.go
+++ b/streams_map_incoming_uni.go
@@ -145,7 +145,7 @@ func (m *incomingUniStreamsMap) DeleteStream(num protocol.StreamNum) error {
 func (m *incomingUniStreamsMap) deleteStream(num protocol.StreamNum) error {
 	if _, ok := m.streams[num]; !ok {
 		return streamError{
-			message: "Tried to delete unknown incoming stream %d",
+			message: "tried to delete unknown incoming stream %d",
 			nums:    []protocol.StreamNum{num},
 		}
 	}
@@ -156,7 +156,7 @@ func (m *incomingUniStreamsMap) deleteStream(num protocol.StreamNum) error {
 		entry, ok := m.streams[num]
 		if ok && entry.shouldDelete {
 			return streamError{
-				message: "Tried to delete incoming stream %d multiple times",
+				message: "tried to delete incoming stream %d multiple times",
 				nums:    []protocol.StreamNum{num},
 			}
 		}

--- a/streams_map_outgoing_bidi.go
+++ b/streams_map_outgoing_bidi.go
@@ -157,7 +157,7 @@ func (m *outgoingBidiStreamsMap) DeleteStream(num protocol.StreamNum) error {
 
 	if _, ok := m.streams[num]; !ok {
 		return streamError{
-			message: "Tried to delete unknown outgoing stream %d",
+			message: "tried to delete unknown outgoing stream %d",
 			nums:    []protocol.StreamNum{num},
 		}
 	}

--- a/streams_map_outgoing_generic.go
+++ b/streams_map_outgoing_generic.go
@@ -155,7 +155,7 @@ func (m *outgoingItemsMap) DeleteStream(num protocol.StreamNum) error {
 
 	if _, ok := m.streams[num]; !ok {
 		return streamError{
-			message: "Tried to delete unknown outgoing stream %d",
+			message: "tried to delete unknown outgoing stream %d",
 			nums:    []protocol.StreamNum{num},
 		}
 	}

--- a/streams_map_outgoing_generic_test.go
+++ b/streams_map_outgoing_generic_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Streams Map (outgoing)", func() {
 		It("errors when deleting a non-existing stream", func() {
 			err := m.DeleteStream(1337)
 			Expect(err).To(HaveOccurred())
-			Expect(err.(streamError).TestError()).To(MatchError("Tried to delete unknown outgoing stream 1337"))
+			Expect(err.(streamError).TestError()).To(MatchError("tried to delete unknown outgoing stream 1337"))
 		})
 
 		It("errors when deleting a stream twice", func() {
@@ -97,7 +97,7 @@ var _ = Describe("Streams Map (outgoing)", func() {
 			Expect(m.DeleteStream(1)).To(Succeed())
 			err = m.DeleteStream(1)
 			Expect(err).To(HaveOccurred())
-			Expect(err.(streamError).TestError()).To(MatchError("Tried to delete unknown outgoing stream 1"))
+			Expect(err.(streamError).TestError()).To(MatchError("tried to delete unknown outgoing stream 1"))
 		})
 
 		It("closes all streams when CloseWithError is called", func() {

--- a/streams_map_outgoing_uni.go
+++ b/streams_map_outgoing_uni.go
@@ -157,7 +157,7 @@ func (m *outgoingUniStreamsMap) DeleteStream(num protocol.StreamNum) error {
 
 	if _, ok := m.streams[num]; !ok {
 		return streamError{
-			message: "Tried to delete unknown outgoing stream %d",
+			message: "tried to delete unknown outgoing stream %d",
 			nums:    []protocol.StreamNum{num},
 		}
 	}

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -7,9 +7,11 @@ import (
 	"net"
 
 	"github.com/golang/mock/gomock"
+
 	"github.com/lucas-clemente/quic-go/internal/flowcontrol"
 	"github.com/lucas-clemente/quic-go/internal/mocks"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 
 	. "github.com/onsi/ginkgo"
@@ -210,22 +212,22 @@ var _ = Describe("Streams Map", func() {
 
 				It("errors when deleting unknown incoming unidirectional streams", func() {
 					id := ids.firstIncomingUniStream + 4
-					Expect(m.DeleteStream(id)).To(MatchError(fmt.Sprintf("Tried to delete unknown incoming stream %d", id)))
+					Expect(m.DeleteStream(id)).To(MatchError(fmt.Sprintf("tried to delete unknown incoming stream %d", id)))
 				})
 
 				It("errors when deleting unknown outgoing unidirectional streams", func() {
 					id := ids.firstOutgoingUniStream + 4
-					Expect(m.DeleteStream(id)).To(MatchError(fmt.Sprintf("Tried to delete unknown outgoing stream %d", id)))
+					Expect(m.DeleteStream(id)).To(MatchError(fmt.Sprintf("tried to delete unknown outgoing stream %d", id)))
 				})
 
 				It("errors when deleting unknown incoming bidirectional streams", func() {
 					id := ids.firstIncomingBidiStream + 4
-					Expect(m.DeleteStream(id)).To(MatchError(fmt.Sprintf("Tried to delete unknown incoming stream %d", id)))
+					Expect(m.DeleteStream(id)).To(MatchError(fmt.Sprintf("tried to delete unknown incoming stream %d", id)))
 				})
 
 				It("errors when deleting unknown outgoing bidirectional streams", func() {
 					id := ids.firstOutgoingBidiStream + 4
-					Expect(m.DeleteStream(id)).To(MatchError(fmt.Sprintf("Tried to delete unknown outgoing stream %d", id)))
+					Expect(m.DeleteStream(id)).To(MatchError(fmt.Sprintf("tried to delete unknown outgoing stream %d", id)))
 				})
 			})
 
@@ -248,7 +250,10 @@ var _ = Describe("Streams Map", func() {
 					It("errors when the peer tries to open a higher outgoing bidirectional stream", func() {
 						id := ids.firstOutgoingBidiStream + 5*4
 						_, err := m.GetOrOpenSendStream(id)
-						Expect(err).To(MatchError(fmt.Sprintf("STREAM_STATE_ERROR: peer attempted to open stream %d", id)))
+						Expect(err).To(MatchError(&qerr.TransportError{
+							ErrorCode:    qerr.StreamStateError,
+							ErrorMessage: fmt.Sprintf("peer attempted to open stream %d", id),
+						}))
 					})
 
 					It("gets an outgoing unidirectional stream", func() {
@@ -264,7 +269,10 @@ var _ = Describe("Streams Map", func() {
 					It("errors when the peer tries to open a higher outgoing bidirectional stream", func() {
 						id := ids.firstOutgoingUniStream + 5*4
 						_, err := m.GetOrOpenSendStream(id)
-						Expect(err).To(MatchError(fmt.Sprintf("STREAM_STATE_ERROR: peer attempted to open stream %d", id)))
+						Expect(err).To(MatchError(&qerr.TransportError{
+							ErrorCode:    qerr.StreamStateError,
+							ErrorMessage: fmt.Sprintf("peer attempted to open stream %d", id),
+						}))
 					})
 
 					It("gets an incoming bidirectional stream", func() {
@@ -277,7 +285,10 @@ var _ = Describe("Streams Map", func() {
 					It("errors when trying to get an incoming unidirectional stream", func() {
 						id := ids.firstIncomingUniStream
 						_, err := m.GetOrOpenSendStream(id)
-						Expect(err).To(MatchError(fmt.Sprintf("STREAM_STATE_ERROR: peer attempted to open send stream %d", id)))
+						Expect(err).To(MatchError(&qerr.TransportError{
+							ErrorCode:    qerr.StreamStateError,
+							ErrorMessage: fmt.Sprintf("peer attempted to open send stream %d", id),
+						}))
 					})
 				})
 
@@ -295,7 +306,10 @@ var _ = Describe("Streams Map", func() {
 					It("errors when the peer tries to open a higher outgoing bidirectional stream", func() {
 						id := ids.firstOutgoingBidiStream + 5*4
 						_, err := m.GetOrOpenReceiveStream(id)
-						Expect(err).To(MatchError(fmt.Sprintf("STREAM_STATE_ERROR: peer attempted to open stream %d", id)))
+						Expect(err).To(MatchError(&qerr.TransportError{
+							ErrorCode:    qerr.StreamStateError,
+							ErrorMessage: fmt.Sprintf("peer attempted to open stream %d", id),
+						}))
 					})
 
 					It("gets an incoming bidirectional stream", func() {
@@ -315,7 +329,10 @@ var _ = Describe("Streams Map", func() {
 					It("errors when trying to get an outgoing unidirectional stream", func() {
 						id := ids.firstOutgoingUniStream
 						_, err := m.GetOrOpenReceiveStream(id)
-						Expect(err).To(MatchError(fmt.Sprintf("STREAM_STATE_ERROR: peer attempted to open receive stream %d", id)))
+						Expect(err).To(MatchError(&qerr.TransportError{
+							ErrorCode:    qerr.StreamStateError,
+							ErrorMessage: fmt.Sprintf("peer attempted to open receive stream %d", id),
+						}))
 					})
 				})
 			})


### PR DESCRIPTION
Fixes #2441.

This is a massive refactor changing the way we return QUIC errors. Calls to the session (and to streams) can now different errors, which can be checked with `errors.Is` / `errors.As`:
* `quic.TransportError`: for errors triggered by the QUIC transport (in many cases a misbehaving peer)
* `quic.ApplicationError`: for errors triggered by the application running on top of QUIC
* `quic.IdleTimeoutError`: when the peer goes away unexpectedly (this is a `net.Error` timeout error)
* `quic.HandshakeTimeoutError`: when the cryptographic handshake takes too long  (this is a `net.Error` timeout error)
* `quic.StatelessResetError`: when we receive a stateless reset  (this is a `net.Error` temporary error)
* `quic.VersionNegotiationError`: returned by the client, when there's no version overlap between the peers

In addition to that, streams that are canceled return a:
* `quic.StreamError`: both for local and remote cancellations

@mvdan, what do you think about this? Do the API changes here make sense to you?