### PR TITLE
Fix compilation with gccgo

### DIFF
--- a/.github/workflows/gccgo.yml
+++ b/.github/workflows/gccgo.yml
@@ -1,0 +1,14 @@
+on: [push, pull_request]
+jobs:
+  gccgo:
+    runs-on: ubuntu-latest
+    name: "gccgo Build"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install build utils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib gccgo
+      - run: go-10 version
+      - name: Run build
+        run: go-10 build example/main.go

--- a/internal/qtls/gc115.go
+++ b/internal/qtls/gc115.go
@@ -1,0 +1,26 @@
+// +build go1.15
+// +build !go1.16
+// +build gc
+
+package qtls
+
+import (
+	"unsafe"
+
+	qtls "github.com/marten-seemann/qtls-go1-15"
+)
+
+//go:linkname cipherSuiteTLS13ByID github.com/marten-seemann/qtls-go1-15.cipherSuiteTLS13ByID
+func cipherSuiteTLS13ByID(id uint16) *cipherSuiteTLS13
+
+// CipherSuiteTLS13ByID gets a TLS 1.3 cipher suite.
+func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
+	val := cipherSuiteTLS13ByID(id)
+	cs := (*cipherSuiteTLS13)(unsafe.Pointer(val))
+	return &qtls.CipherSuiteTLS13{
+		ID:     cs.ID,
+		KeyLen: cs.KeyLen,
+		AEAD:   cs.AEAD,
+		Hash:   cs.Hash,
+	}
+}

--- a/internal/qtls/gc116.go
+++ b/internal/qtls/gc116.go
@@ -1,0 +1,25 @@
+// +build go1.16
+// +build gc
+
+package qtls
+
+import (
+	"unsafe"
+
+	qtls "github.com/marten-seemann/qtls-go1-16"
+)
+
+//go:linkname cipherSuiteTLS13ByID github.com/marten-seemann/qtls-go1-16.cipherSuiteTLS13ByID
+func cipherSuiteTLS13ByID(id uint16) *cipherSuiteTLS13
+
+// CipherSuiteTLS13ByID gets a TLS 1.3 cipher suite.
+func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
+	val := cipherSuiteTLS13ByID(id)
+	cs := (*cipherSuiteTLS13)(unsafe.Pointer(val))
+	return &qtls.CipherSuiteTLS13{
+		ID:     cs.ID,
+		KeyLen: cs.KeyLen,
+		AEAD:   cs.AEAD,
+		Hash:   cs.Hash,
+	}
+}

--- a/internal/qtls/gccgo115.go
+++ b/internal/qtls/gccgo115.go
@@ -1,0 +1,26 @@
+// +build go1.15
+// +build !go1.16
+// +build gccgo
+
+package qtls
+
+import (
+	"unsafe"
+
+	qtls "github.com/marten-seemann/qtls-go1-15"
+)
+
+//go:linkname cipherSuiteTLS13ByID "github_0com_1marten_x2dseemann_1qtls_x2dgo1_x2d15.cipherSuiteTLS13ByID"
+func cipherSuiteTLS13ByID(id uint16) *cipherSuiteTLS13
+
+// CipherSuiteTLS13ByID gets a TLS 1.3 cipher suite.
+func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
+	val := cipherSuiteTLS13ByID(id)
+	cs := (*cipherSuiteTLS13)(unsafe.Pointer(val))
+	return &qtls.CipherSuiteTLS13{
+		ID:     cs.ID,
+		KeyLen: cs.KeyLen,
+		AEAD:   cs.AEAD,
+		Hash:   cs.Hash,
+	}
+}

--- a/internal/qtls/gccgo116.go
+++ b/internal/qtls/gccgo116.go
@@ -1,0 +1,25 @@
+// +build go1.16
+// +build gccgo
+
+package qtls
+
+import (
+	"unsafe"
+
+	qtls "github.com/marten-seemann/qtls-go1-16"
+)
+
+//go:linkname cipherSuiteTLS13ByID "github_0com_1marten_x2dseemann_1qtls_x2dgo1_x2d16.cipherSuiteTLS13ByID"
+func cipherSuiteTLS13ByID(id uint16) *cipherSuiteTLS13
+
+// CipherSuiteTLS13ByID gets a TLS 1.3 cipher suite.
+func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
+	val := cipherSuiteTLS13ByID(id)
+	cs := (*cipherSuiteTLS13)(unsafe.Pointer(val))
+	return &qtls.CipherSuiteTLS13{
+		ID:     cs.ID,
+		KeyLen: cs.KeyLen,
+		AEAD:   cs.AEAD,
+		Hash:   cs.Hash,
+	}
+}

--- a/internal/qtls/go115.go
+++ b/internal/qtls/go115.go
@@ -8,7 +8,6 @@ import (
 	"crypto/cipher"
 	"crypto/tls"
 	"net"
-	"unsafe"
 
 	qtls "github.com/marten-seemann/qtls-go1-15"
 )
@@ -97,19 +96,4 @@ type cipherSuiteTLS13 struct {
 	KeyLen int
 	AEAD   func(key, fixedNonce []byte) cipher.AEAD
 	Hash   crypto.Hash
-}
-
-//go:linkname cipherSuiteTLS13ByID github.com/marten-seemann/qtls-go1-15.cipherSuiteTLS13ByID
-func cipherSuiteTLS13ByID(id uint16) *cipherSuiteTLS13
-
-// CipherSuiteTLS13ByID gets a TLS 1.3 cipher suite.
-func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
-	val := cipherSuiteTLS13ByID(id)
-	cs := (*cipherSuiteTLS13)(unsafe.Pointer(val))
-	return &qtls.CipherSuiteTLS13{
-		ID:     cs.ID,
-		KeyLen: cs.KeyLen,
-		AEAD:   cs.AEAD,
-		Hash:   cs.Hash,
-	}
 }

--- a/internal/qtls/go116.go
+++ b/internal/qtls/go116.go
@@ -7,7 +7,6 @@ import (
 	"crypto/cipher"
 	"crypto/tls"
 	"net"
-	"unsafe"
 
 	qtls "github.com/marten-seemann/qtls-go1-16"
 )
@@ -96,19 +95,4 @@ type cipherSuiteTLS13 struct {
 	KeyLen int
 	AEAD   func(key, fixedNonce []byte) cipher.AEAD
 	Hash   crypto.Hash
-}
-
-//go:linkname cipherSuiteTLS13ByID github.com/marten-seemann/qtls-go1-16.cipherSuiteTLS13ByID
-func cipherSuiteTLS13ByID(id uint16) *cipherSuiteTLS13
-
-// CipherSuiteTLS13ByID gets a TLS 1.3 cipher suite.
-func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
-	val := cipherSuiteTLS13ByID(id)
-	cs := (*cipherSuiteTLS13)(unsafe.Pointer(val))
-	return &qtls.CipherSuiteTLS13{
-		ID:     cs.ID,
-		KeyLen: cs.KeyLen,
-		AEAD:   cs.AEAD,
-		Hash:   cs.Hash,
-	}
 }


### PR DESCRIPTION
gccgo handles `//go:linkname` directive differently from gc compiler. This PR adds conditional compiled code to make the package can be built with gccgo.

As for CI, a preliminary workflow for build test is added. However, currently `ubuntu-latest` only ships `gccgo` package that implements go 1.14, which is too old. Ubuntu 21.04 has the updated `gccgo` that implements go 1.16, but we have to wait for GitHub.

Fixes #3168.