### PR TITLE
Benchmark to reproduce slowness

### DIFF
--- a/benchmark/benchmark_wrapped_test.go
+++ b/benchmark/benchmark_wrapped_test.go
@@ -1,0 +1,100 @@
+package benchmark
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+
+	"github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/testdata"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Benchmark with wrapper", func() {
+	for i := range protocol.SupportedVersions {
+		version := protocol.SupportedVersions[i]
+
+		Context(fmt.Sprintf("with version %s", version), func() {
+			var data []byte
+			var dataLen int
+
+			BeforeEach(func() {
+				dataLen = size * /* MB */ 1e6
+				data = make([]byte, dataLen)
+				rand.Read(data) // no need to check for an error. math.Rand.Read never errors
+			})
+
+			Measure("transferring a file", func(b Benchmarker) {
+				var ln quic.Listener
+				serverAddr := make(chan net.Addr)
+				handshakeChan := make(chan struct{})
+
+				go func() {
+					defer GinkgoRecover()
+					// start the client
+					addr := <-serverAddr
+					sess, err := quic.DialAddr(
+						addr.String(),
+						&tls.Config{InsecureSkipVerify: true, NextProtos: []string{"benchmark"}},
+						&quic.Config{Versions: []protocol.VersionNumber{version}},
+					)
+					Expect(err).ToNot(HaveOccurred())
+					close(handshakeChan)
+					str, err := sess.OpenStream()
+					Expect(err).ToNot(HaveOccurred())
+					_, err = str.Write(data)
+					Expect(err).ToNot(HaveOccurred())
+					err = str.Close()
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				var err error
+				tlsConf := testdata.GetTLSConfig()
+				tlsConf.NextProtos = []string{"benchmark"}
+				packetConn, err := net.ListenPacket("udp", "localhost:0")
+				Expect(err).ToNot(HaveOccurred())
+				wrapped := &wrapperConn{
+					PacketConn: packetConn,
+					msgs:       make(chan msg),
+					direct:     false,
+				}
+				go wrapped.loop()
+				ln, err = quic.Listen(
+					wrapped,
+					tlsConf,
+					&quic.Config{Versions: []protocol.VersionNumber{version}},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				serverAddr <- ln.Addr()
+				sess, err := ln.Accept(context.Background())
+				Expect(err).ToNot(HaveOccurred())
+				// wait for the client to complete the handshake before sending the data
+				// this should not be necessary, but due to timing issues on the CIs, this is necessary to avoid sending too many undecryptable packets
+				<-handshakeChan
+				str, err := sess.AcceptStream(context.Background())
+				Expect(err).ToNot(HaveOccurred())
+
+				buf := &bytes.Buffer{}
+				// measure the time it takes to download the dataLen bytes
+				// note we're measuring the time for the transfer, i.e. excluding the handshake
+				runtime := b.Time("transfer time", func() {
+					_, err := io.Copy(buf, str)
+					Expect(err).NotTo(HaveOccurred())
+				})
+				Expect(buf.Bytes()).To(Equal(data))
+
+				b.RecordValue("transfer rate [MB/s]", float64(dataLen)/1e6/runtime.Seconds())
+
+				ln.Close()
+				sess.CloseWithError(0, "")
+			}, 3)
+		})
+	}
+})

--- a/benchmark/wrapper_conn_test.go
+++ b/benchmark/wrapper_conn_test.go
@@ -1,0 +1,60 @@
+package benchmark
+
+import (
+	"net"
+	"syscall"
+)
+
+type msg struct {
+	n    int
+	buf  []byte
+	addr net.Addr
+	err  error
+}
+
+type wrapperConn struct {
+	net.PacketConn
+	msgs   chan msg
+	direct bool
+}
+
+func (w *wrapperConn) loop() {
+	if w.direct {
+		return
+	}
+	buf := make([]byte, 1500)
+	for {
+		n, addr, err := w.PacketConn.ReadFrom(buf)
+		w.msgs <- msg{
+			n:    n,
+			buf:  buf,
+			addr: addr,
+			err:  err,
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (w *wrapperConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	if w.direct {
+		return w.PacketConn.ReadFrom(b)
+	}
+
+	msg := <-w.msgs
+	n := msg.n
+	if l := len(b); l < n {
+		n = l
+	}
+	copy(b, msg.buf[:n])
+	return n, msg.addr, msg.err
+}
+
+func (w *wrapperConn) SetReadBuffer(size int) error {
+	return w.PacketConn.(*net.UDPConn).SetReadBuffer(size)
+}
+
+func (w *wrapperConn) SyscallConn() (syscall.RawConn, error) {
+	return w.PacketConn.(*net.UDPConn).SyscallConn()
+}


### PR DESCRIPTION
This is in relation to https://github.com/syncthing/syncthing/issues/7636

I've wrote a minimal reproducer that reproduces this issue.
I cannot understand why a wrapper connection as implemented below would have such a dramatic impact on quic's performance.
It seems to have close to no effect on standard UDPs performance.

There is a `direct: false` flag on line 66 (https://github.com/lucas-clemente/quic-go/pull/3172/files#diff-0e0b4af59631d95ab56a75a2017c5e35e77b75354a8c85f22ca2ce83c1042ce1R66) that controls whether packet delivery happens directly, or via a channel.
Seems that packet delivery via a channel cuts the performance by 20x.