### PR TITLE
use go install to install Ginkgo on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,7 @@ jobs:
       - checkout
       - run:
           name: "Setup build environment"
-          command: |
-            go get github.com/onsi/ginkgo/ginkgo
-            go get github.com/onsi/gomega
+          command: go install github.com/onsi/ginkgo/ginkgo
       - run:
           name: "Build infos"
           command: go version


### PR DESCRIPTION
This should fix our CircleCI build, which apparently has been broken since the Ginkgo v1.16.2 release.