### PR TITLE
prevent quic-go from building on Go 1.17

### DIFF
--- a/internal/qtls/go117.go
+++ b/internal/qtls/go117.go
@@ -1,0 +1,3 @@
+// +build go1.17
+
+"quic-go doesn't build on Go 1.17 yet."


### PR DESCRIPTION
It looks like Go 1.17 won't introduce any changes to the structs for which we assert that they're identical between qtls and crypto/tls. That means that in principle, it would be possible to build quic-go using Go 1.17. We should prevent this, as users might expect Go 1.17 crypto/tls to take effect, which they don't as long as we don't create an updated qtls version.

cc @mvdan

The error message will look like this:
```bash
❯ go1.17 test
# github.com/lucas-clemente/quic-go/
internal/qtls/go117.go:3:1: expected 'package', found "quic-go doesn't build on Go 1.17 yet."
```
