### PR TITLE
add support for Go 1.17 (tip)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/marten-seemann/qpack v0.2.1
 	github.com/marten-seemann/qtls-go1-15 v0.1.4
 	github.com/marten-seemann/qtls-go1-16 v0.1.3
+	github.com/marten-seemann/qtls-go1-17 v0.1.0-alpha.1
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/marten-seemann/qtls-go1-15 v0.1.4 h1:RehYMOyRW8hPVEja1KBVsFVNSm35Jj9M
 github.com/marten-seemann/qtls-go1-15 v0.1.4/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
 github.com/marten-seemann/qtls-go1-16 v0.1.3 h1:XEZ1xGorVy9u+lJq+WXNE+hiqRYLNvJGYmwfwKQN2gU=
 github.com/marten-seemann/qtls-go1-16 v0.1.3/go.mod h1:gNpI2Ol+lRS3WwSOtIUUtRwZEQMXjYK+dQSBFbethAk=
+github.com/marten-seemann/qtls-go1-17 v0.1.0-alpha.1 h1:LRFa3YRSlOAf9y56Szfhlh60CQrIMBSK/rneZD1gtuk=
+github.com/marten-seemann/qtls-go1-17 v0.1.0-alpha.1/go.mod h1:lQDiKZDfPagLmg1zMtEgoBMSTAORq6M08lBogD5FtBY=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/qtls/go116.go
+++ b/internal/qtls/go116.go
@@ -1,4 +1,5 @@
 // +build go1.16
+// +build !go1.17
 
 package qtls
 
@@ -9,7 +10,7 @@ import (
 	"net"
 	"unsafe"
 
-	qtls "github.com/marten-seemann/qtls-go1-16"
+	"github.com/marten-seemann/qtls-go1-16"
 )
 
 type (

--- a/internal/qtls/go117.go
+++ b/internal/qtls/go117.go
@@ -1,3 +1,114 @@
 // +build go1.17
 
-"quic-go doesn't build on Go 1.17 yet."
+package qtls
+
+import (
+	"crypto"
+	"crypto/cipher"
+	"crypto/tls"
+	"net"
+	"unsafe"
+
+	"github.com/marten-seemann/qtls-go1-17"
+)
+
+type (
+	// Alert is a TLS alert
+	Alert = qtls.Alert
+	// A Certificate is qtls.Certificate.
+	Certificate = qtls.Certificate
+	// CertificateRequestInfo contains inforamtion about a certificate request.
+	CertificateRequestInfo = qtls.CertificateRequestInfo
+	// A CipherSuiteTLS13 is a cipher suite for TLS 1.3
+	CipherSuiteTLS13 = qtls.CipherSuiteTLS13
+	// ClientHelloInfo contains information about a ClientHello.
+	ClientHelloInfo = qtls.ClientHelloInfo
+	// ClientSessionCache is a cache used for session resumption.
+	ClientSessionCache = qtls.ClientSessionCache
+	// ClientSessionState is a state needed for session resumption.
+	ClientSessionState = qtls.ClientSessionState
+	// A Config is a qtls.Config.
+	Config = qtls.Config
+	// A Conn is a qtls.Conn.
+	Conn = qtls.Conn
+	// ConnectionState contains information about the state of the connection.
+	ConnectionState = qtls.ConnectionStateWith0RTT
+	// EncryptionLevel is the encryption level of a message.
+	EncryptionLevel = qtls.EncryptionLevel
+	// Extension is a TLS extension
+	Extension = qtls.Extension
+	// ExtraConfig is the qtls.ExtraConfig
+	ExtraConfig = qtls.ExtraConfig
+	// RecordLayer is a qtls RecordLayer.
+	RecordLayer = qtls.RecordLayer
+)
+
+const (
+	// EncryptionHandshake is the Handshake encryption level
+	EncryptionHandshake = qtls.EncryptionHandshake
+	// Encryption0RTT is the 0-RTT encryption level
+	Encryption0RTT = qtls.Encryption0RTT
+	// EncryptionApplication is the application data encryption level
+	EncryptionApplication = qtls.EncryptionApplication
+)
+
+// CipherSuiteName gets the name of a cipher suite.
+func CipherSuiteName(id uint16) string {
+	return qtls.CipherSuiteName(id)
+}
+
+// HkdfExtract generates a pseudorandom key for use with Expand from an input secret and an optional independent salt.
+func HkdfExtract(hash crypto.Hash, newSecret, currentSecret []byte) []byte {
+	return qtls.HkdfExtract(hash, newSecret, currentSecret)
+}
+
+// HkdfExpandLabel HKDF expands a label
+func HkdfExpandLabel(hash crypto.Hash, secret, hashValue []byte, label string, L int) []byte {
+	return qtls.HkdfExpandLabel(hash, secret, hashValue, label, L)
+}
+
+// AEADAESGCMTLS13 creates a new AES-GCM AEAD for TLS 1.3
+func AEADAESGCMTLS13(key, fixedNonce []byte) cipher.AEAD {
+	return qtls.AEADAESGCMTLS13(key, fixedNonce)
+}
+
+// Client returns a new TLS client side connection.
+func Client(conn net.Conn, config *Config, extraConfig *ExtraConfig) *Conn {
+	return qtls.Client(conn, config, extraConfig)
+}
+
+// Server returns a new TLS server side connection.
+func Server(conn net.Conn, config *Config, extraConfig *ExtraConfig) *Conn {
+	return qtls.Server(conn, config, extraConfig)
+}
+
+func GetConnectionState(conn *Conn) ConnectionState {
+	return conn.ConnectionStateWith0RTT()
+}
+
+// ToTLSConnectionState extracts the tls.ConnectionState
+func ToTLSConnectionState(cs ConnectionState) tls.ConnectionState {
+	return cs.ConnectionState
+}
+
+type cipherSuiteTLS13 struct {
+	ID     uint16
+	KeyLen int
+	AEAD   func(key, fixedNonce []byte) cipher.AEAD
+	Hash   crypto.Hash
+}
+
+//go:linkname cipherSuiteTLS13ByID github.com/marten-seemann/qtls-go1-16.cipherSuiteTLS13ByID
+func cipherSuiteTLS13ByID(id uint16) *cipherSuiteTLS13
+
+// CipherSuiteTLS13ByID gets a TLS 1.3 cipher suite.
+func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
+	val := cipherSuiteTLS13ByID(id)
+	cs := (*cipherSuiteTLS13)(unsafe.Pointer(val))
+	return &qtls.CipherSuiteTLS13{
+		ID:     cs.ID,
+		KeyLen: cs.KeyLen,
+		AEAD:   cs.AEAD,
+		Hash:   cs.Hash,
+	}
+}

--- a/internal/qtls/go118.go
+++ b/internal/qtls/go118.go
@@ -1,0 +1,3 @@
+// +build go1.18
+
+"quic-go doesn't build on Go 1.18 yet."


### PR DESCRIPTION
@mvdan Ready for Go 1.17 beta1! All we have to do is rebase the qtls repository onto the beta1 Go commit. Assuming that there won't be any significant changes to crypto/tls, that should be trivial.