### PR TITLE
Fill TLS field in http request

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -371,6 +371,8 @@ func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpac
 		return newStreamError(errorGeneralProtocolError, err)
 	}
 
+	copyTLS := sess.ConnectionState().TLS.ConnectionState
+	req.TLS = &copyTLS
 	req.RemoteAddr = sess.RemoteAddr().String()
 	req.Body = newRequestBody(str, onFrameError)
 


### PR DESCRIPTION
Right now TLS field not filled and that make impossible to identify clients in handlers.