### PR TITLE
add support for QUIC v1, RFC 9000

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,8 @@
 [![Windows Build Status](https://img.shields.io/appveyor/ci/lucas-clemente/quic-go/master.svg?style=flat-square&label=windows+build)](https://ci.appveyor.com/project/lucas-clemente/quic-go/branch/master)
 [![Code Coverage](https://img.shields.io/codecov/c/github/lucas-clemente/quic-go/master.svg?style=flat-square)](https://codecov.io/gh/lucas-clemente/quic-go/)
 
-quic-go is an implementation of the [QUIC](https://en.wikipedia.org/wiki/QUIC) protocol in Go. It implements the [IETF QUIC draft-29](https://tools.ietf.org/html/draft-ietf-quic-transport-29), [draft-32](https://tools.ietf.org/html/draft-ietf-quic-transport-32) and [draft-34](https://tools.ietf.org/html/draft-ietf-quic-transport-34).
-
-## Version compatibility
-
-Since quic-go is under active development, there's no guarantee that two builds of different commits are interoperable. The QUIC version used in the *master* branch is just a placeholder, and should not be considered stable.
-
-When using quic-go as a library, please always use a [tagged release](https://github.com/lucas-clemente/quic-go/releases). Only these releases use the official draft version numbers.
+quic-go is an implementation of the [QUIC protocol, RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000) protocol in Go.
+In addition to RFC 9000, it currently implements the [IETF QUIC draft-29](https://tools.ietf.org/html/draft-ietf-quic-transport-29), [draft-32](https://tools.ietf.org/html/draft-ietf-quic-transport-32) and [draft-34](https://tools.ietf.org/html/draft-ietf-quic-transport-34). Support for draft versions will be eventually be dropped, as these are phased out of the ecosystem.
 
 ## Guides
 

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -67,8 +67,8 @@ var _ = Describe("Client", func() {
 		var dialAddrCalled bool
 		dialAddr = func(_ string, tlsConf *tls.Config, quicConf *quic.Config) (quic.EarlySession, error) {
 			Expect(quicConf).To(Equal(defaultQuicConfig))
-			Expect(tlsConf.NextProtos).To(Equal([]string{nextProtoH3Draft29}))
-			Expect(quicConf.Versions).To(Equal([]protocol.VersionNumber{protocol.VersionTLS}))
+			Expect(tlsConf.NextProtos).To(Equal([]string{nextProtoH3}))
+			Expect(quicConf.Versions).To(Equal([]protocol.VersionNumber{protocol.Version1}))
 			dialAddrCalled = true
 			return nil, errors.New("test done")
 		}
@@ -107,7 +107,7 @@ var _ = Describe("Client", func() {
 		) (quic.EarlySession, error) {
 			Expect(hostname).To(Equal("localhost:1337"))
 			Expect(tlsConfP.ServerName).To(Equal(tlsConf.ServerName))
-			Expect(tlsConfP.NextProtos).To(Equal([]string{nextProtoH3Draft29}))
+			Expect(tlsConfP.NextProtos).To(Equal([]string{nextProtoH3}))
 			Expect(quicConfP.MaxIdleTimeout).To(Equal(quicConf.MaxIdleTimeout))
 			dialAddrCalled = true
 			return nil, errors.New("test done")

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -18,7 +18,7 @@ const (
 
 // The version numbers, making grepping easier
 const (
-	VersionTLS      VersionNumber = 0x51474fff
+	VersionTLS      VersionNumber = 0x1
 	VersionWhatever VersionNumber = math.MaxUint32 - 1 // for when the version doesn't matter
 	VersionUnknown  VersionNumber = math.MaxUint32
 	VersionDraft29  VersionNumber = 0xff00001d
@@ -29,7 +29,7 @@ const (
 
 // SupportedVersions lists the versions that the server supports
 // must be in sorted descending order
-var SupportedVersions = []VersionNumber{VersionTLS}
+var SupportedVersions = []VersionNumber{Version1, VersionDraft34, VersionDraft32, VersionDraft29}
 
 // IsValidVersion says if the version is known to quic-go
 func IsValidVersion(v VersionNumber) bool {

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -14,10 +14,10 @@ var _ = Describe("Version", func() {
 		Expect(IsValidVersion(VersionTLS)).To(BeTrue())
 		Expect(IsValidVersion(VersionWhatever)).To(BeFalse())
 		Expect(IsValidVersion(VersionUnknown)).To(BeFalse())
-		Expect(IsValidVersion(VersionDraft29)).To(BeFalse())
-		Expect(IsValidVersion(VersionDraft32)).To(BeFalse())
-		Expect(IsValidVersion(VersionDraft34)).To(BeFalse())
-		Expect(IsValidVersion(Version1)).To(BeFalse())
+		Expect(IsValidVersion(VersionDraft29)).To(BeTrue())
+		Expect(IsValidVersion(VersionDraft32)).To(BeTrue())
+		Expect(IsValidVersion(VersionDraft34)).To(BeTrue())
+		Expect(IsValidVersion(Version1)).To(BeTrue())
 		Expect(IsValidVersion(1234)).To(BeFalse())
 	})
 
@@ -47,6 +47,7 @@ var _ = Describe("Version", func() {
 	})
 
 	It("has supported versions in sorted order", func() {
+		Expect(SupportedVersions[0]).To(Equal(Version1))
 		for i := 1; i < len(SupportedVersions)-1; i++ {
 			Expect(SupportedVersions[i]).To(BeNumerically(">", SupportedVersions[i+1]))
 		}


### PR DESCRIPTION
Fixes #3186.

The proposal is to use QUIC draft version numbers on master. This means that from now on, two arbitrary commits from master must be compatible with each other. It also means that we'll finally be able to tag releases directly on master, instead of creating a separate release branch every time.