### PR TITLE
remove CipherSuiteName and HkdfExtract for Go 1.17

### DIFF
--- a/internal/qtls/go117.go
+++ b/internal/qtls/go117.go
@@ -52,16 +52,6 @@ const (
 	EncryptionApplication = qtls.EncryptionApplication
 )
 
-// CipherSuiteName gets the name of a cipher suite.
-func CipherSuiteName(id uint16) string {
-	return qtls.CipherSuiteName(id)
-}
-
-// HkdfExtract generates a pseudorandom key for use with Expand from an input secret and an optional independent salt.
-func HkdfExtract(hash crypto.Hash, newSecret, currentSecret []byte) []byte {
-	return qtls.HkdfExtract(hash, newSecret, currentSecret)
-}
-
 // AEADAESGCMTLS13 creates a new AES-GCM AEAD for TLS 1.3
 func AEADAESGCMTLS13(key, fixedNonce []byte) cipher.AEAD {
 	return qtls.AEADAESGCMTLS13(key, fixedNonce)


### PR DESCRIPTION
This mirrors #3173 and #3174, which we didn't apply to Go 1.17.