### PR TITLE
prevent go mod vendor from stumbling over the Go 1.18 file

### DIFF
--- a/internal/qtls/go118.go
+++ b/internal/qtls/go118.go
@@ -1,3 +1,5 @@
 // +build go1.18
 
-"quic-go doesn't build on Go 1.18 yet."
+package qtls
+
+var _ int = "quic-go doesn't build on Go 1.18 yet."


### PR DESCRIPTION
Fixes #3194.