### PR TITLE
remove a redundant error check

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -121,9 +121,7 @@ func setupHandler(www string) http.Handler {
 					err = errors.New("couldn't get uploaded file size")
 				}
 			}
-			if err != nil {
-				utils.DefaultLogger.Infof("Error receiving upload: %#v", err)
-			}
+			utils.DefaultLogger.Infof("Error receiving upload: %#v", err)
 		}
 		io.WriteString(w, `<html><body><form action="/demo/upload" method="post" enctype="multipart/form-data">
 				<input type="file" name="uploadfile"><br>


### PR DESCRIPTION
Hi there,

Thanks for this excellent implementation of QUIC in GO; I'm a beginner at learning it!

This is just a tiny fix, but according to a suggestion by an IDE, the `nil` checking of the `err` variable is actually unnecessary here :eyes:

![image](https://user-images.githubusercontent.com/44393661/123229009-df734a80-d510-11eb-9bf9-da7165d872d3.png)
