### PR TITLE
remove unused StripGreasedVersions function

### DIFF
--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -121,14 +121,3 @@ func GetGreasedVersions(supported []VersionNumber) []VersionNumber {
 	copy(greased[randPos+1:], supported[randPos:])
 	return greased
 }
-
-// StripGreasedVersions strips all greased versions from a slice of versions
-func StripGreasedVersions(versions []VersionNumber) []VersionNumber {
-	realVersions := make([]VersionNumber, 0, len(versions))
-	for _, v := range versions {
-		if v&0x0f0f0f0f != 0x0a0a0a0a {
-			realVersions = append(realVersions, v)
-		}
-	}
-	return realVersions
-}

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -99,15 +99,6 @@ var _ = Describe("Version", func() {
 			Expect(isReservedVersion(greased[0])).To(BeTrue())
 		})
 
-		It("strips greased versions", func() {
-			v := SupportedVersions[0]
-			greased := GetGreasedVersions([]VersionNumber{v})
-			Expect(greased).To(HaveLen(2))
-			stripped := StripGreasedVersions(greased)
-			Expect(stripped).To(HaveLen(1))
-			Expect(stripped[0]).To(Equal(v))
-		})
-
 		It("creates greased lists of version numbers", func() {
 			supported := []VersionNumber{10, 18, 29}
 			for _, v := range supported {


### PR DESCRIPTION
Such a function would defeat the purpose of greasing. Fortunately, we didn't actually use it anywhere.