### PR TITLE
return error on SendMessage when session is closed

### DIFF
--- a/session.go
+++ b/session.go
@@ -1963,8 +1963,7 @@ func (s *session) SendMessage(p []byte) error {
 	}
 	f.Data = make([]byte, len(p))
 	copy(f.Data, p)
-	s.datagramQueue.AddAndWait(f)
-	return nil
+	return s.datagramQueue.AddAndWait(f)
 }
 
 func (s *session) ReceiveMessage() ([]byte, error) {


### PR DESCRIPTION
Returns the error from `AddAndWait` to the user of `SendMessage` e.g. when the session is closed.