### PR TITLE
cancel the PTO timer when all Handshake packets are acknowledged

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -536,6 +536,13 @@ func (h *sentPacketHandler) setLossDetectionTimer() {
 	// PTO alarm
 	ptoTime, encLevel, ok := h.getPTOTimeAndSpace()
 	if !ok {
+		if !oldAlarm.IsZero() {
+			h.alarm = time.Time{}
+			h.logger.Debugf("Canceling loss detection timer. No PTO needed..")
+			if h.tracer != nil {
+				h.tracer.LossTimerCanceled()
+			}
+		}
 		return
 	}
 	h.alarm = ptoTime


### PR DESCRIPTION
This can lead to busy-looping if the following contrived situation occurs:
1. The server receives the first Initial from the client. It continues the handshake by sending its first flight.
2. The RTT is longer than 200ms. The server retransmit the Initial packets it sent after 200ms.
3. We never receive an ACK for the Initial packets (not exactly sure why this is necessary though).
3. The RTT is longer than 400ms. The retransmits the Handshake packets it sent after another 200ms.
4. None of these packets is actually lost. The server receives an ACK for all Handshake packets sent. Now the following happens:
     1. First the Initial keys are dropped because we decrypted the first Handshake packet. Crucially, this happens before any packet contents are processed. This triggers a timer reset, which sets a PTO timer based on the last Handshake packet sent.
     2. Now the ACK is processed, acknowledging all Handshake packets. There are no outstanding packets now, except for the 1-RTT packet sent in the first flight. We don't retransmit that one though until the handshake completes. At this point we need to make sure to cancel the timer set in the step before.