### PR TITLE
Permit underlying conn to implement batch interface directly

### DIFF
--- a/conn_oob.go
+++ b/conn_oob.go
@@ -115,6 +115,7 @@ func newConn(c OOBCapablePacketConn) (*oobConn, error) {
 	}
 
 	var bc batchConn
+	// Allows applications to pass in a connection that already satisfies batchConn interface
 	if ibc, ok := c.(batchConn); ok {
 		bc = ibc
 	} else {

--- a/conn_oob.go
+++ b/conn_oob.go
@@ -114,8 +114,10 @@ func newConn(c OOBCapablePacketConn) (*oobConn, error) {
 		}
 	}
 
+	// Allows callers to pass in a connection that already satisfies batchConn interface
+	// to make use of the optimisation. Otherwise, ipv4.NewPacketConn would unwrap the file descriptor 
+	// via SyscallConn(), and read it that way, which might not be what the caller wants.
 	var bc batchConn
-	// Allows applications to pass in a connection that already satisfies batchConn interface
 	if ibc, ok := c.(batchConn); ok {
 		bc = ibc
 	} else {

--- a/conn_oob.go
+++ b/conn_oob.go
@@ -115,7 +115,7 @@ func newConn(c OOBCapablePacketConn) (*oobConn, error) {
 	}
 
 	// Allows callers to pass in a connection that already satisfies batchConn interface
-	// to make use of the optimisation. Otherwise, ipv4.NewPacketConn would unwrap the file descriptor 
+	// to make use of the optimisation. Otherwise, ipv4.NewPacketConn would unwrap the file descriptor
 	// via SyscallConn(), and read it that way, which might not be what the caller wants.
 	var bc batchConn
 	if ibc, ok := c.(batchConn); ok {

--- a/conn_oob.go
+++ b/conn_oob.go
@@ -113,9 +113,17 @@ func newConn(c OOBCapablePacketConn) (*oobConn, error) {
 			return nil, errors.New("activating packet info failed for both IPv4 and IPv6")
 		}
 	}
+
+	var bc batchConn
+	if ibc, ok := c.(batchConn); ok {
+		bc = ibc
+	} else {
+		bc = ipv4.NewPacketConn(c)
+	}
+
 	oobConn := &oobConn{
 		OOBCapablePacketConn: c,
-		batchConn:            ipv4.NewPacketConn(c),
+		batchConn:            bc,
 		messages:             make([]ipv4.Message, batchSize),
 		readPos:              batchSize,
 	}


### PR DESCRIPTION
This is so that (ab)users of the package that do packet filtering to filter out stun packets before they reach quic, could still use ReadBatch.

In my implementation I simply read len(ms) packets instead of 1 off the buffer channel.

Doubt there is much gain in that, as it's all userspace already, but nice to be able to take this code path to pick up other related optimisations.