### PR TITLE
http3: add exported Settings type

### DIFF
--- a/http3/body.go
+++ b/http3/body.go
@@ -60,7 +60,7 @@ func (r *body) readImpl(b []byte) (int, error) {
 				// skip HEADERS frames
 				continue
 			case *dataFrame:
-				r.bytesRemainingInFrame = f.Length
+				r.bytesRemainingInFrame = f.len
 				break parseLoop
 			default:
 				r.onFrameError()

--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -149,9 +149,9 @@ var _ = Describe("Body", func() {
 			})
 
 			It("errors on unexpected frames, and calls the error callback", func() {
-				(&settingsFrame{}).Write(buf)
+				Settings{}.Write(buf)
 				_, err := rb.Read([]byte{0})
-				Expect(err).To(MatchError("peer sent an unexpected frame: *http3.settingsFrame"))
+				Expect(err).To(MatchError("peer sent an unexpected frame: http3.Settings"))
 				Expect(errorCbCalled).To(BeTrue())
 			})
 

--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Body", func() {
 
 	getDataFrame := func(data []byte) []byte {
 		b := &bytes.Buffer{}
-		(&dataFrame{Length: uint64(len(data))}).Write(b)
+		(&dataFrame{len: uint64(len(data))}).Write(b)
 		b.Write(data)
 		return b.Bytes()
 	}
@@ -132,7 +132,7 @@ var _ = Describe("Body", func() {
 
 			It("skips HEADERS frames", func() {
 				buf.Write(getDataFrame([]byte("foo")))
-				(&headersFrame{Length: 10}).Write(buf)
+				(&headersFrame{len: 10}).Write(buf)
 				buf.Write(make([]byte, 10))
 				buf.Write(getDataFrame([]byte("bar")))
 				b := make([]byte, 6)

--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Body", func() {
 
 	getDataFrame := func(data []byte) []byte {
 		b := &bytes.Buffer{}
-		(&dataFrame{len: uint64(len(data))}).Write(b)
+		(&dataFrame{len: uint64(len(data))}).writeFrame(b)
 		b.Write(data)
 		return b.Bytes()
 	}
@@ -132,7 +132,7 @@ var _ = Describe("Body", func() {
 
 			It("skips HEADERS frames", func() {
 				buf.Write(getDataFrame([]byte("foo")))
-				(&headersFrame{len: 10}).Write(buf)
+				(&headersFrame{len: 10}).writeFrame(buf)
 				buf.Write(make([]byte, 10))
 				buf.Write(getDataFrame([]byte("bar")))
 				b := make([]byte, 6)
@@ -149,7 +149,7 @@ var _ = Describe("Body", func() {
 			})
 
 			It("errors on unexpected frames, and calls the error callback", func() {
-				Settings{}.Write(buf)
+				Settings{}.writeFrame(buf)
 				_, err := rb.Read([]byte{0})
 				Expect(err).To(MatchError("peer sent an unexpected frame: http3.Settings"))
 				Expect(errorCbCalled).To(BeTrue())

--- a/http3/client.go
+++ b/http3/client.go
@@ -136,7 +136,7 @@ func (c *client) setupSession() error {
 	// send the SETTINGS frame
 	settings := Settings{}
 	if c.opts.EnableDatagram {
-		settings[SettingDatagram] = 1
+		settings.EnableDatagrams()
 	}
 	settings.writeFrame(buf)
 	_, err = str.Write(buf.Bytes())
@@ -182,23 +182,12 @@ func (c *client) handleUnidirectionalStreams() {
 				c.session.CloseWithError(quic.ApplicationErrorCode(errorMissingSettings), "")
 				return
 			}
-			// TODO(ydnar): an extension should handle validate the H3_DATAGRAM setting.
-			// H3_DATAGRAM changed from 0x276 to 0xffd276 in draft 01:
-			// https://datatracker.ietf.org/doc/draft-ietf-masque-h3-datagram/01/
-			switch settings[SettingDatagram] {
-			case 0:
-				return
-			case 1:
-				// If datagram support was enabled on our side as well as on the server side,
-				// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
-				// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
-				if c.opts.EnableDatagram && !c.session.ConnectionState().SupportsDatagrams {
-					c.session.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), "missing QUIC Datagram support")
-				}
-			default:
-				c.session.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), fmt.Sprintf("invalid value for H3_DATAGRAM: %d", settings[SettingDatagram]))
+			// If datagram support was enabled on our side as well as on the server side,
+			// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
+			// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
+			if settings.DatagramsEnabled() && c.opts.EnableDatagram && !c.session.ConnectionState().SupportsDatagrams {
+				c.session.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), "missing QUIC Datagram support")
 			}
-
 		}()
 	}
 }

--- a/http3/client.go
+++ b/http3/client.go
@@ -299,10 +299,10 @@ func (c *client) doRequest(
 	if !ok {
 		return nil, newConnError(errorFrameUnexpected, errors.New("expected first frame to be a HEADERS frame"))
 	}
-	if hf.Length > c.maxHeaderBytes() {
-		return nil, newStreamError(errorFrameError, fmt.Errorf("HEADERS frame too large: %d bytes (max: %d)", hf.Length, c.maxHeaderBytes()))
+	if hf.len > c.maxHeaderBytes() {
+		return nil, newStreamError(errorFrameError, fmt.Errorf("HEADERS frame too large: %d bytes (max: %d)", hf.len, c.maxHeaderBytes()))
 	}
-	headerBlock := make([]byte, hf.Length)
+	headerBlock := make([]byte, hf.len)
 	if _, err := io.ReadFull(str, headerBlock); err != nil {
 		return nil, newStreamError(errorRequestIncomplete, err)
 	}

--- a/http3/client.go
+++ b/http3/client.go
@@ -138,7 +138,7 @@ func (c *client) setupSession() error {
 	if c.opts.EnableDatagram {
 		settings[SettingDatagram] = 1
 	}
-	settings.WriteFrame(buf)
+	settings.Write(buf)
 	_, err = str.Write(buf.Bytes())
 	return err
 }

--- a/http3/client.go
+++ b/http3/client.go
@@ -138,7 +138,7 @@ func (c *client) setupSession() error {
 	if c.opts.EnableDatagram {
 		settings[SettingDatagram] = 1
 	}
-	settings.Write(buf)
+	settings.writeFrame(buf)
 	_, err = str.Write(buf.Bytes())
 	return err
 }

--- a/http3/client.go
+++ b/http3/client.go
@@ -134,7 +134,11 @@ func (c *client) setupSession() error {
 	buf := &bytes.Buffer{}
 	quicvarint.Write(buf, streamTypeControlStream)
 	// send the SETTINGS frame
-	(&settingsFrame{Datagram: c.opts.EnableDatagram}).Write(buf)
+	settings := Settings{}
+	if c.opts.EnableDatagram {
+		settings[SettingDatagram] = 1
+	}
+	settings.WriteFrame(buf)
 	_, err = str.Write(buf.Bytes())
 	return err
 }
@@ -173,20 +177,28 @@ func (c *client) handleUnidirectionalStreams() {
 				c.session.CloseWithError(quic.ApplicationErrorCode(errorFrameError), "")
 				return
 			}
-			sf, ok := f.(*settingsFrame)
+			settings, ok := f.(Settings)
 			if !ok {
 				c.session.CloseWithError(quic.ApplicationErrorCode(errorMissingSettings), "")
 				return
 			}
-			if !sf.Datagram {
+			// TODO(ydnar): an extension should handle validate the H3_DATAGRAM setting.
+			// H3_DATAGRAM changed from 0x276 to 0xffd276 in draft 01:
+			// https://datatracker.ietf.org/doc/draft-ietf-masque-h3-datagram/01/
+			switch settings[SettingDatagram] {
+			case 0:
 				return
+			case 1:
+				// If datagram support was enabled on our side as well as on the server side,
+				// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
+				// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
+				if c.opts.EnableDatagram && !c.session.ConnectionState().SupportsDatagrams {
+					c.session.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), "missing QUIC Datagram support")
+				}
+			default:
+				c.session.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), fmt.Sprintf("invalid value for H3_DATAGRAM: %d", settings[SettingDatagram]))
 			}
-			// If datagram support was enabled on our side as well as on the server side,
-			// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
-			// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
-			if c.opts.EnableDatagram && !c.session.ConnectionState().SupportsDatagrams {
-				c.session.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), "missing QUIC Datagram support")
-			}
+
 		}()
 	}
 }

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Client", func() {
 		It("parses the SETTINGS frame", func() {
 			buf := &bytes.Buffer{}
 			quicvarint.Write(buf, streamTypeControlStream)
-			(&settingsFrame{}).Write(buf)
+			Settings{}.Write(buf)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 			sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
@@ -311,7 +311,7 @@ var _ = Describe("Client", func() {
 			buf := &bytes.Buffer{}
 			quicvarint.Write(buf, streamTypeControlStream)
 			b := &bytes.Buffer{}
-			(&settingsFrame{}).Write(b)
+			Settings{}.Write(b)
 			buf.Write(b.Bytes()[:b.Len()-1])
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -360,7 +360,7 @@ var _ = Describe("Client", func() {
 			client.opts.EnableDatagram = true
 			buf := &bytes.Buffer{}
 			quicvarint.Write(buf, streamTypeControlStream)
-			(&settingsFrame{Datagram: true}).Write(buf)
+			(Settings{SettingDatagram: 1}).Write(buf)
 			controlStr := mockquic.NewMockStream(mockCtrl)
 			controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 			sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {

--- a/http3/frame.go
+++ b/http3/frame.go
@@ -1,0 +1,42 @@
+package http3
+
+import "fmt"
+
+const (
+	FrameTypeData          FrameType = 0x0
+	FrameTypeHeaders       FrameType = 0x1
+	FrameTypeCancelPush    FrameType = 0x3
+	FrameTypeSettings      FrameType = 0x4
+	FrameTypePushPromise   FrameType = 0x5
+	FrameTypeGoAway        FrameType = 0x7
+	FrameTypeMaxPushID     FrameType = 0xd
+	FrameTypeDuplicatePush FrameType = 0xe
+)
+
+// A FrameType represents an HTTP/3 frame type.
+// https://www.ietf.org/archive/id/draft-ietf-quic-http-34.html#name-frame-definitions
+type FrameType uint64
+
+// String returns the IETF registered name for t if available.
+func (t FrameType) String() string {
+	switch t {
+	case FrameTypeData:
+		return "DATA"
+	case FrameTypeHeaders:
+		return "HEADERS"
+	case FrameTypeCancelPush:
+		return "CANCEL_PUSH"
+	case FrameTypeSettings:
+		return "SETTINGS"
+	case FrameTypePushPromise:
+		return "PUSH_PROMISE"
+	case FrameTypeGoAway:
+		return "GO_AWAY"
+	case FrameTypeMaxPushID:
+		return "MAX_PUSH_ID"
+	case FrameTypeDuplicatePush:
+		return "DUPLICATE_PUSH"
+	default:
+		return fmt.Sprintf("H3 frame type 0x%x", uint64(t))
+	}
+}

--- a/http3/frame.go
+++ b/http3/frame.go
@@ -37,6 +37,6 @@ func (t FrameType) String() string {
 	case FrameTypeDuplicatePush:
 		return "DUPLICATE_PUSH"
 	default:
-		return fmt.Sprintf("0x%x", uint64(t))
+		return fmt.Sprintf("%#x", uint64(t))
 	}
 }

--- a/http3/frame.go
+++ b/http3/frame.go
@@ -3,14 +3,14 @@ package http3
 import "fmt"
 
 const (
-	FrameTypeData          FrameType = 0x0
-	FrameTypeHeaders       FrameType = 0x1
-	FrameTypeCancelPush    FrameType = 0x3
-	FrameTypeSettings      FrameType = 0x4
-	FrameTypePushPromise   FrameType = 0x5
-	FrameTypeGoAway        FrameType = 0x7
-	FrameTypeMaxPushID     FrameType = 0xd
-	FrameTypeDuplicatePush FrameType = 0xe
+	FrameTypeData          FrameType = 0x00
+	FrameTypeHeaders       FrameType = 0x01
+	FrameTypeCancelPush    FrameType = 0x03
+	FrameTypeSettings      FrameType = 0x04
+	FrameTypePushPromise   FrameType = 0x05
+	FrameTypeGoAway        FrameType = 0x07
+	FrameTypeMaxPushID     FrameType = 0x0d
+	FrameTypeDuplicatePush FrameType = 0x0e
 )
 
 // A FrameType represents an HTTP/3 frame type.

--- a/http3/frame.go
+++ b/http3/frame.go
@@ -37,6 +37,6 @@ func (t FrameType) String() string {
 	case FrameTypeDuplicatePush:
 		return "DUPLICATE_PUSH"
 	default:
-		return fmt.Sprintf("H3 frame type 0x%x", uint64(t))
+		return fmt.Sprintf("0x%x", uint64(t))
 	}
 }

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -23,22 +23,22 @@ func parseNextFrame(r io.Reader) (frame, error) {
 		return nil, err
 	}
 
-	switch t {
-	case 0x0:
+	switch FrameType(t) {
+	case FrameTypeData:
 		return &dataFrame{Length: l}, nil
-	case 0x1:
-		return &headersFrame{Length: l}, nil
-	case 0x4:
+	case FrameTypeHeaders:
+		return &headersFrame{length: l}, nil
+	case FrameTypeSettings:
 		return parseSettingsFrame(r, l)
-	case 0x3: // CANCEL_PUSH
+	case FrameTypeCancelPush:
 		fallthrough
-	case 0x5: // PUSH_PROMISE
+	case FrameTypePushPromise:
 		fallthrough
-	case 0x7: // GOAWAY
+	case FrameTypeGoAway:
 		fallthrough
-	case 0xd: // MAX_PUSH_ID
+	case FrameTypeMaxPushID:
 		fallthrough
-	case 0xe: // DUPLICATE_PUSH
+	case FrameTypeDuplicatePush:
 		fallthrough
 	default:
 		// skip over unknown frames

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -51,7 +51,7 @@ type dataFrame struct {
 }
 
 func (f *dataFrame) writeFrame(w quicvarint.Writer) {
-	quicvarint.Write(w, 0x0)
+	quicvarint.Write(w, uint64(FrameTypeData))
 	quicvarint.Write(w, f.len)
 }
 
@@ -60,6 +60,6 @@ type headersFrame struct {
 }
 
 func (f *headersFrame) writeFrame(w quicvarint.Writer) {
-	quicvarint.Write(w, 0x1)
+	quicvarint.Write(w, uint64(FrameTypeHeaders))
 	quicvarint.Write(w, f.len)
 }

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -50,7 +50,7 @@ type dataFrame struct {
 	len uint64
 }
 
-func (f *dataFrame) Write(w quicvarint.Writer) {
+func (f *dataFrame) writeFrame(w quicvarint.Writer) {
 	quicvarint.Write(w, 0x0)
 	quicvarint.Write(w, f.len)
 }
@@ -59,7 +59,7 @@ type headersFrame struct {
 	len uint64
 }
 
-func (f *headersFrame) Write(w quicvarint.Writer) {
+func (f *headersFrame) writeFrame(w quicvarint.Writer) {
 	quicvarint.Write(w, 0x1)
 	quicvarint.Write(w, f.len)
 }

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -22,9 +22,9 @@ func parseNextFrame(r io.Reader) (frame, error) {
 
 	switch FrameType(t) {
 	case FrameTypeData:
-		return &dataFrame{Length: l}, nil
+		return &dataFrame{len: l}, nil
 	case FrameTypeHeaders:
-		return &headersFrame{Length: l}, nil
+		return &headersFrame{len: l}, nil
 	case FrameTypeSettings:
 		return parseSettingsFramePayload(r, l)
 	case FrameTypeCancelPush:
@@ -47,19 +47,19 @@ func parseNextFrame(r io.Reader) (frame, error) {
 }
 
 type dataFrame struct {
-	Length uint64
+	len uint64
 }
 
 func (f *dataFrame) Write(w quicvarint.Writer) {
 	quicvarint.Write(w, 0x0)
-	quicvarint.Write(w, f.Length)
+	quicvarint.Write(w, f.len)
 }
 
 type headersFrame struct {
-	Length uint64
+	len uint64
 }
 
 func (f *headersFrame) Write(w quicvarint.Writer) {
 	quicvarint.Write(w, 0x1)
-	quicvarint.Write(w, f.Length)
+	quicvarint.Write(w, f.len)
 }

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -2,11 +2,9 @@ package http3
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 
-	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
@@ -29,7 +27,7 @@ func parseNextFrame(r io.Reader) (frame, error) {
 	case FrameTypeHeaders:
 		return &headersFrame{Length: l}, nil
 	case FrameTypeSettings:
-		return parseSettingsFrame(r, l)
+		return parseSettingsFramePayload(r, l)
 	case FrameTypeCancelPush:
 		fallthrough
 	case FrameTypePushPromise:
@@ -65,78 +63,4 @@ type headersFrame struct {
 func (f *headersFrame) Write(b *bytes.Buffer) {
 	quicvarint.Write(b, 0x1)
 	quicvarint.Write(b, f.Length)
-}
-
-const settingDatagram = 0x276
-
-type settingsFrame struct {
-	Datagram bool
-	other    map[uint64]uint64 // all settings that we don't explicitly recognize
-}
-
-func parseSettingsFrame(r io.Reader, l uint64) (*settingsFrame, error) {
-	if l > 8*(1<<10) {
-		return nil, fmt.Errorf("unexpected size for SETTINGS frame: %d", l)
-	}
-	buf := make([]byte, l)
-	if _, err := io.ReadFull(r, buf); err != nil {
-		if err == io.ErrUnexpectedEOF {
-			return nil, io.EOF
-		}
-		return nil, err
-	}
-	frame := &settingsFrame{}
-	b := bytes.NewReader(buf)
-	var readDatagram bool
-	for b.Len() > 0 {
-		id, err := quicvarint.Read(b)
-		if err != nil { // should not happen. We allocated the whole frame already.
-			return nil, err
-		}
-		val, err := quicvarint.Read(b)
-		if err != nil { // should not happen. We allocated the whole frame already.
-			return nil, err
-		}
-
-		switch id {
-		case settingDatagram:
-			if readDatagram {
-				return nil, fmt.Errorf("duplicate setting: %d", id)
-			}
-			readDatagram = true
-			if val != 0 && val != 1 {
-				return nil, fmt.Errorf("invalid value for H3_DATAGRAM: %d", val)
-			}
-			frame.Datagram = val == 1
-		default:
-			if _, ok := frame.other[id]; ok {
-				return nil, fmt.Errorf("duplicate setting: %d", id)
-			}
-			if frame.other == nil {
-				frame.other = make(map[uint64]uint64)
-			}
-			frame.other[id] = val
-		}
-	}
-	return frame, nil
-}
-
-func (f *settingsFrame) Write(b *bytes.Buffer) {
-	quicvarint.Write(b, 0x4)
-	var l protocol.ByteCount
-	for id, val := range f.other {
-		l += quicvarint.Len(id) + quicvarint.Len(val)
-	}
-	if f.Datagram {
-		l += quicvarint.Len(settingDatagram) + quicvarint.Len(1)
-	}
-	quicvarint.Write(b, uint64(l))
-	if f.Datagram {
-		quicvarint.Write(b, settingDatagram)
-		quicvarint.Write(b, 1)
-	}
-	for id, val := range f.other {
-		quicvarint.Write(b, id)
-		quicvarint.Write(b, val)
-	}
 }

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -7,7 +7,9 @@ import (
 	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
-type frame interface{}
+type frame interface {
+	writeFrame(quicvarint.Writer)
+}
 
 func parseNextFrame(r io.Reader) (frame, error) {
 	qr := quicvarint.NewReader(r)

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -1,7 +1,6 @@
 package http3
 
 import (
-	"bytes"
 	"io"
 	"io/ioutil"
 
@@ -51,16 +50,16 @@ type dataFrame struct {
 	Length uint64
 }
 
-func (f *dataFrame) Write(b *bytes.Buffer) {
-	quicvarint.Write(b, 0x0)
-	quicvarint.Write(b, f.Length)
+func (f *dataFrame) Write(w quicvarint.Writer) {
+	quicvarint.Write(w, 0x0)
+	quicvarint.Write(w, f.Length)
 }
 
 type headersFrame struct {
 	Length uint64
 }
 
-func (f *headersFrame) Write(b *bytes.Buffer) {
-	quicvarint.Write(b, 0x1)
-	quicvarint.Write(b, f.Length)
+func (f *headersFrame) Write(w quicvarint.Writer) {
+	quicvarint.Write(w, 0x1)
+	quicvarint.Write(w, f.Length)
 }

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -27,7 +27,7 @@ func parseNextFrame(r io.Reader) (frame, error) {
 	case FrameTypeData:
 		return &dataFrame{Length: l}, nil
 	case FrameTypeHeaders:
-		return &headersFrame{length: l}, nil
+		return &headersFrame{Length: l}, nil
 	case FrameTypeSettings:
 		return parseSettingsFrame(r, l)
 	case FrameTypeCancelPush:

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Frames", func() {
 
 		Context("H3_DATAGRAM", func() {
 			It("reads the H3_DATAGRAM value", func() {
-				settings := appendVarInt(nil, SettingDatagram)
+				settings := appendVarInt(nil, uint64(SettingDatagram))
 				settings = appendVarInt(settings, 1)
 				data := appendVarInt(nil, 4) // type byte
 				data = appendVarInt(data, uint64(len(settings)))
@@ -149,9 +149,9 @@ var _ = Describe("Frames", func() {
 			})
 
 			It("rejects duplicate H3_DATAGRAM entries", func() {
-				settings := appendVarInt(nil, SettingDatagram)
+				settings := appendVarInt(nil, uint64(SettingDatagram))
 				settings = appendVarInt(settings, 1)
-				settings = appendVarInt(settings, SettingDatagram)
+				settings = appendVarInt(settings, uint64(SettingDatagram))
 				settings = appendVarInt(settings, 1)
 				data := appendVarInt(nil, 4) // type byte
 				data = appendVarInt(data, uint64(len(settings)))
@@ -162,7 +162,7 @@ var _ = Describe("Frames", func() {
 
 			It("rejects invalid values for the H3_DATAGRAM entry", func() {
 				Skip("TODO: H3 settings validation should happen elsewhere")
-				settings := appendVarInt(nil, SettingDatagram)
+				settings := appendVarInt(nil, uint64(SettingDatagram))
 				settings = appendVarInt(settings, 1337)
 				data := appendVarInt(nil, 4) // type byte
 				data = appendVarInt(data, uint64(len(settings)))

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -23,11 +23,11 @@ var _ = Describe("Frames", func() {
 		data = appendVarInt(data, 0x42)
 		data = append(data, make([]byte, 0x42)...)
 		buf := bytes.NewBuffer(data)
-		(&dataFrame{Length: 0x1234}).Write(buf)
+		(&dataFrame{len: 0x1234}).Write(buf)
 		frame, err := parseNextFrame(buf)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
-		Expect(frame.(*dataFrame).Length).To(Equal(uint64(0x1234)))
+		Expect(frame.(*dataFrame).len).To(Equal(uint64(0x1234)))
 	})
 
 	Context("DATA frames", func() {
@@ -37,17 +37,17 @@ var _ = Describe("Frames", func() {
 			frame, err := parseNextFrame(bytes.NewReader(data))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
-			Expect(frame.(*dataFrame).Length).To(Equal(uint64(0x1337)))
+			Expect(frame.(*dataFrame).len).To(Equal(uint64(0x1337)))
 		})
 
 		It("writes", func() {
 			buf := &bytes.Buffer{}
-			(&dataFrame{Length: 0xdeadbeef}).Write(buf)
+			(&dataFrame{len: 0xdeadbeef}).Write(buf)
 			frame, err := parseNextFrame(buf)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
-			Expect(frame.(*dataFrame).Length).To(Equal(uint64(0xdeadbeef)))
+			Expect(frame.(*dataFrame).len).To(Equal(uint64(0xdeadbeef)))
 		})
 	})
 
@@ -58,17 +58,17 @@ var _ = Describe("Frames", func() {
 			frame, err := parseNextFrame(bytes.NewReader(data))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&headersFrame{}))
-			Expect(frame.(*headersFrame).Length).To(Equal(uint64(0x1337)))
+			Expect(frame.(*headersFrame).len).To(Equal(uint64(0x1337)))
 		})
 
 		It("writes", func() {
 			buf := &bytes.Buffer{}
-			(&headersFrame{Length: 0xdeadbeef}).Write(buf)
+			(&headersFrame{len: 0xdeadbeef}).Write(buf)
 			frame, err := parseNextFrame(buf)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&headersFrame{}))
-			Expect(frame.(*headersFrame).Length).To(Equal(uint64(0xdeadbeef)))
+			Expect(frame.(*headersFrame).len).To(Equal(uint64(0xdeadbeef)))
 		})
 	})
 

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -161,8 +161,17 @@ var _ = Describe("Frames", func() {
 			})
 
 			It("rejects invalid values for the H3_DATAGRAM entry", func() {
-				Skip("TODO: H3 settings validation should happen elsewhere")
 				settings := appendVarInt(nil, uint64(SettingDatagram))
+				settings = appendVarInt(settings, 1337)
+				data := appendVarInt(nil, 4) // type byte
+				data = appendVarInt(data, uint64(len(settings)))
+				data = append(data, settings...)
+				_, err := parseNextFrame(bytes.NewReader(data))
+				Expect(err).To(MatchError("invalid value for H3_DATAGRAM: 1337"))
+			})
+
+			It("rejects invalid values for the H3_DATAGRAM (draft 00) entry", func() {
+				settings := appendVarInt(nil, uint64(SettingDatagramDraft00))
 				settings = appendVarInt(settings, 1337)
 				data := appendVarInt(nil, 4) // type byte
 				data = appendVarInt(data, uint64(len(settings)))

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Frames", func() {
 		data = appendVarInt(data, 0x42)
 		data = append(data, make([]byte, 0x42)...)
 		buf := bytes.NewBuffer(data)
-		(&dataFrame{len: 0x1234}).Write(buf)
+		(&dataFrame{len: 0x1234}).writeFrame(buf)
 		frame, err := parseNextFrame(buf)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
@@ -42,7 +42,7 @@ var _ = Describe("Frames", func() {
 
 		It("writes", func() {
 			buf := &bytes.Buffer{}
-			(&dataFrame{len: 0xdeadbeef}).Write(buf)
+			(&dataFrame{len: 0xdeadbeef}).writeFrame(buf)
 			frame, err := parseNextFrame(buf)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(err).ToNot(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("Frames", func() {
 
 		It("writes", func() {
 			buf := &bytes.Buffer{}
-			(&headersFrame{len: 0xdeadbeef}).Write(buf)
+			(&headersFrame{len: 0xdeadbeef}).writeFrame(buf)
 			frame, err := parseNextFrame(buf)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(err).ToNot(HaveOccurred())
@@ -108,7 +108,7 @@ var _ = Describe("Frames", func() {
 				13: 37,
 			}
 			buf := &bytes.Buffer{}
-			settings.Write(buf)
+			settings.writeFrame(buf)
 			parsed, err := parseNextFrame(buf)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(parsed).To(Equal(settings))
@@ -120,7 +120,7 @@ var _ = Describe("Frames", func() {
 				0xdeadbeef: 0xdecafbad,
 			}
 			buf := &bytes.Buffer{}
-			settings.Write(buf)
+			settings.writeFrame(buf)
 
 			data := buf.Bytes()
 			_, err := parseNextFrame(bytes.NewReader(data))
@@ -174,7 +174,7 @@ var _ = Describe("Frames", func() {
 			It("writes the H3_DATAGRAM setting", func() {
 				settings := Settings{SettingDatagram: 1}
 				buf := &bytes.Buffer{}
-				settings.Write(buf)
+				settings.writeFrame(buf)
 				frame, err := parseNextFrame(buf)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(frame).To(Equal(settings))

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -85,8 +85,8 @@ var _ = Describe("Frames", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(Settings{}))
 			s := frame.(Settings)
-			Expect(s).To(HaveKeyWithValue(Setting(13), uint64(37)))
-			Expect(s).To(HaveKeyWithValue(Setting(0xdead), uint64(0xbeef)))
+			Expect(s).To(HaveKeyWithValue(SettingID(13), uint64(37)))
+			Expect(s).To(HaveKeyWithValue(SettingID(0xdead), uint64(0xbeef)))
 		})
 
 		It("rejects duplicate settings", func() {

--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -66,7 +66,7 @@ func (w *requestWriter) WriteRequest(str quic.Stream, req *http.Request, gzip bo
 				}
 			}
 			buf := &bytes.Buffer{}
-			(&dataFrame{Length: uint64(n)}).Write(buf)
+			(&dataFrame{len: uint64(n)}).Write(buf)
 			if _, err := str.Write(buf.Bytes()); err != nil {
 				w.logger.Errorf("Error writing request: %s", err)
 				return
@@ -100,7 +100,7 @@ func (w *requestWriter) writeHeaders(wr io.Writer, req *http.Request, gzip bool)
 	}
 
 	buf := &bytes.Buffer{}
-	hf := headersFrame{Length: uint64(w.headerBuf.Len())}
+	hf := headersFrame{len: uint64(w.headerBuf.Len())}
 	hf.Write(buf)
 	if _, err := wr.Write(buf.Bytes()); err != nil {
 		return err

--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -66,7 +66,7 @@ func (w *requestWriter) WriteRequest(str quic.Stream, req *http.Request, gzip bo
 				}
 			}
 			buf := &bytes.Buffer{}
-			(&dataFrame{len: uint64(n)}).Write(buf)
+			(&dataFrame{len: uint64(n)}).writeFrame(buf)
 			if _, err := str.Write(buf.Bytes()); err != nil {
 				w.logger.Errorf("Error writing request: %s", err)
 				return
@@ -101,7 +101,7 @@ func (w *requestWriter) writeHeaders(wr io.Writer, req *http.Request, gzip bool)
 
 	buf := &bytes.Buffer{}
 	hf := headersFrame{len: uint64(w.headerBuf.Len())}
-	hf.Write(buf)
+	hf.writeFrame(buf)
 	if _, err := wr.Write(buf.Bytes()); err != nil {
 		return err
 	}

--- a/http3/request_writer_test.go
+++ b/http3/request_writer_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Request Writer", func() {
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		ExpectWithOffset(1, frame).To(BeAssignableToTypeOf(&headersFrame{}))
 		headersFrame := frame.(*headersFrame)
-		data := make([]byte, headersFrame.Length)
+		data := make([]byte, headersFrame.len)
 		_, err = io.ReadFull(str, data)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		decoder := qpack.NewDecoder(nil)
@@ -88,7 +88,7 @@ var _ = Describe("Request Writer", func() {
 		frame, err := parseNextFrame(strBuf)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
-		Expect(frame.(*dataFrame).Length).To(BeEquivalentTo(6))
+		Expect(frame.(*dataFrame).len).To(BeEquivalentTo(6))
 	})
 
 	It("writes a POST request, if the Body returns an EOF immediately", func() {
@@ -105,7 +105,7 @@ var _ = Describe("Request Writer", func() {
 		frame, err := parseNextFrame(strBuf)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
-		Expect(frame.(*dataFrame).Length).To(BeEquivalentTo(6))
+		Expect(frame.(*dataFrame).len).To(BeEquivalentTo(6))
 	})
 
 	It("sends cookies", func() {

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -74,7 +74,7 @@ func (w *responseWriter) WriteHeader(status int) {
 	}
 
 	buf := &bytes.Buffer{}
-	(&headersFrame{len: uint64(headers.Len())}).Write(buf)
+	(&headersFrame{len: uint64(headers.Len())}).writeFrame(buf)
 	w.logger.Infof("Responding with %d", status)
 	if _, err := w.bufferedStream.Write(buf.Bytes()); err != nil {
 		w.logger.Errorf("could not write headers frame: %s", err.Error())
@@ -96,7 +96,7 @@ func (w *responseWriter) Write(p []byte) (int, error) {
 	}
 	df := &dataFrame{len: uint64(len(p))}
 	buf := &bytes.Buffer{}
-	df.Write(buf)
+	df.writeFrame(buf)
 	if _, err := w.bufferedStream.Write(buf.Bytes()); err != nil {
 		return 0, err
 	}

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -74,7 +74,7 @@ func (w *responseWriter) WriteHeader(status int) {
 	}
 
 	buf := &bytes.Buffer{}
-	(&headersFrame{Length: uint64(headers.Len())}).Write(buf)
+	(&headersFrame{len: uint64(headers.Len())}).Write(buf)
 	w.logger.Infof("Responding with %d", status)
 	if _, err := w.bufferedStream.Write(buf.Bytes()); err != nil {
 		w.logger.Errorf("could not write headers frame: %s", err.Error())
@@ -94,7 +94,7 @@ func (w *responseWriter) Write(p []byte) (int, error) {
 	if !bodyAllowedForStatus(w.status) {
 		return 0, http.ErrBodyNotAllowed
 	}
-	df := &dataFrame{Length: uint64(len(p))}
+	df := &dataFrame{len: uint64(len(p))}
 	buf := &bytes.Buffer{}
 	df.Write(buf)
 	if _, err := w.bufferedStream.Write(buf.Bytes()); err != nil {

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Response Writer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&headersFrame{}))
 		headersFrame := frame.(*headersFrame)
-		data := make([]byte, headersFrame.Length)
+		data := make([]byte, headersFrame.len)
 		_, err = io.ReadFull(str, data)
 		Expect(err).ToNot(HaveOccurred())
 		hfs, err := decoder.DecodeFull(data)
@@ -53,7 +53,7 @@ var _ = Describe("Response Writer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
 		df := frame.(*dataFrame)
-		data := make([]byte, df.Length)
+		data := make([]byte, df.len)
 		_, err = io.ReadFull(str, data)
 		Expect(err).ToNot(HaveOccurred())
 		return data

--- a/http3/server.go
+++ b/http3/server.go
@@ -240,7 +240,7 @@ func (s *Server) handleConn(sess quic.EarlySession) {
 	if s.EnableDatagrams {
 		settings[SettingDatagram] = 1
 	}
-	settings.WriteFrame(buf)
+	settings.Write(buf)
 	str.Write(buf.Bytes())
 
 	go s.handleUnidirectionalStreams(sess)

--- a/http3/server.go
+++ b/http3/server.go
@@ -350,10 +350,10 @@ func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpac
 	if !ok {
 		return newConnError(errorFrameUnexpected, errors.New("expected first frame to be a HEADERS frame"))
 	}
-	if hf.Length > s.maxHeaderBytes() {
-		return newStreamError(errorFrameError, fmt.Errorf("HEADERS frame too large: %d bytes (max: %d)", hf.Length, s.maxHeaderBytes()))
+	if hf.len > s.maxHeaderBytes() {
+		return newStreamError(errorFrameError, fmt.Errorf("HEADERS frame too large: %d bytes (max: %d)", hf.len, s.maxHeaderBytes()))
 	}
-	headerBlock := make([]byte, hf.Length)
+	headerBlock := make([]byte, hf.len)
 	if _, err := io.ReadFull(str, headerBlock); err != nil {
 		return newStreamError(errorRequestIncomplete, err)
 	}

--- a/http3/server.go
+++ b/http3/server.go
@@ -236,7 +236,11 @@ func (s *Server) handleConn(sess quic.EarlySession) {
 	}
 	buf := &bytes.Buffer{}
 	quicvarint.Write(buf, streamTypeControlStream) // stream type
-	(&settingsFrame{Datagram: s.EnableDatagrams}).Write(buf)
+	settings := Settings{}
+	if s.EnableDatagrams {
+		settings[SettingDatagram] = 1
+	}
+	settings.WriteFrame(buf)
 	str.Write(buf.Bytes())
 
 	go s.handleUnidirectionalStreams(sess)
@@ -305,19 +309,26 @@ func (s *Server) handleUnidirectionalStreams(sess quic.EarlySession) {
 				sess.CloseWithError(quic.ApplicationErrorCode(errorFrameError), "")
 				return
 			}
-			sf, ok := f.(*settingsFrame)
+			settings, ok := f.(Settings)
 			if !ok {
 				sess.CloseWithError(quic.ApplicationErrorCode(errorMissingSettings), "")
 				return
 			}
-			if !sf.Datagram {
+			// TODO(ydnar): an extension should handle validate the H3_DATAGRAM setting.
+			// H3_DATAGRAM changed from 0x276 to 0xffd276 in draft 01:
+			// https://datatracker.ietf.org/doc/draft-ietf-masque-h3-datagram/01/
+			switch settings[SettingDatagram] {
+			case 0:
 				return
-			}
-			// If datagram support was enabled on our side as well as on the client side,
-			// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
-			// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
-			if s.EnableDatagrams && !sess.ConnectionState().SupportsDatagrams {
-				sess.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), "missing QUIC Datagram support")
+			case 1:
+				// If datagram support was enabled on our side as well as on the client side,
+				// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
+				// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
+				if s.EnableDatagrams && !sess.ConnectionState().SupportsDatagrams {
+					sess.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), "missing QUIC Datagram support")
+				}
+			default:
+				sess.CloseWithError(quic.ApplicationErrorCode(errorSettingsError), fmt.Sprintf("invalid value for H3_DATAGRAM: %d", settings[SettingDatagram]))
 			}
 		}(str)
 	}

--- a/http3/server.go
+++ b/http3/server.go
@@ -240,7 +240,7 @@ func (s *Server) handleConn(sess quic.EarlySession) {
 	if s.EnableDatagrams {
 		settings[SettingDatagram] = 1
 	}
-	settings.Write(buf)
+	settings.writeFrame(buf)
 	str.Write(buf.Bytes())
 
 	go s.handleUnidirectionalStreams(sess)

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Server", func() {
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			ExpectWithOffset(1, frame).To(BeAssignableToTypeOf(&headersFrame{}))
 			headersFrame := frame.(*headersFrame)
-			data := make([]byte, headersFrame.Length)
+			data := make([]byte, headersFrame.len)
 			_, err = io.ReadFull(str, data)
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			hfs, err := decoder.DecodeFull(data)
@@ -401,7 +401,7 @@ var _ = Describe("Server", func() {
 
 				requestData := encodeRequest(exampleGetRequest)
 				buf := &bytes.Buffer{}
-				(&dataFrame{Length: 6}).Write(buf) // add a body
+				(&dataFrame{len: 6}).Write(buf) // add a body
 				buf.Write([]byte("foobar"))
 				responseBuf := &bytes.Buffer{}
 				setRequest(append(requestData, buf.Bytes()...))
@@ -425,7 +425,7 @@ var _ = Describe("Server", func() {
 
 				requestData := encodeRequest(exampleGetRequest)
 				buf := &bytes.Buffer{}
-				(&dataFrame{Length: 6}).Write(buf) // add a body
+				(&dataFrame{len: 6}).Write(buf) // add a body
 				buf.Write([]byte("foobar"))
 				responseBuf := &bytes.Buffer{}
 				setRequest(append(requestData, buf.Bytes()...))

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Server", func() {
 			It("parses the SETTINGS frame", func() {
 				buf := &bytes.Buffer{}
 				quicvarint.Write(buf, streamTypeControlStream)
-				Settings{}.Write(buf)
+				Settings{}.writeFrame(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
@@ -275,7 +275,7 @@ var _ = Describe("Server", func() {
 			It("errors when the first frame on the control stream is not a SETTINGS frame", func() {
 				buf := &bytes.Buffer{}
 				quicvarint.Write(buf, streamTypeControlStream)
-				(&dataFrame{}).Write(buf)
+				(&dataFrame{}).writeFrame(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
@@ -299,7 +299,7 @@ var _ = Describe("Server", func() {
 				buf := &bytes.Buffer{}
 				quicvarint.Write(buf, streamTypeControlStream)
 				b := &bytes.Buffer{}
-				Settings{}.Write(b)
+				Settings{}.writeFrame(b)
 				buf.Write(b.Bytes()[:b.Len()-1])
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -323,7 +323,7 @@ var _ = Describe("Server", func() {
 			It("errors when the client opens a push stream", func() {
 				buf := &bytes.Buffer{}
 				quicvarint.Write(buf, streamTypePushStream)
-				(&dataFrame{}).Write(buf)
+				(&dataFrame{}).writeFrame(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
@@ -347,7 +347,7 @@ var _ = Describe("Server", func() {
 				s.EnableDatagrams = true
 				buf := &bytes.Buffer{}
 				quicvarint.Write(buf, streamTypeControlStream)
-				(Settings{SettingDatagram: 1}).Write(buf)
+				(Settings{SettingDatagram: 1}).writeFrame(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
@@ -401,7 +401,7 @@ var _ = Describe("Server", func() {
 
 				requestData := encodeRequest(exampleGetRequest)
 				buf := &bytes.Buffer{}
-				(&dataFrame{len: 6}).Write(buf) // add a body
+				(&dataFrame{len: 6}).writeFrame(buf) // add a body
 				buf.Write([]byte("foobar"))
 				responseBuf := &bytes.Buffer{}
 				setRequest(append(requestData, buf.Bytes()...))
@@ -425,7 +425,7 @@ var _ = Describe("Server", func() {
 
 				requestData := encodeRequest(exampleGetRequest)
 				buf := &bytes.Buffer{}
-				(&dataFrame{len: 6}).Write(buf) // add a body
+				(&dataFrame{len: 6}).writeFrame(buf) // add a body
 				buf.Write([]byte("foobar"))
 				responseBuf := &bytes.Buffer{}
 				setRequest(append(requestData, buf.Bytes()...))
@@ -459,7 +459,7 @@ var _ = Describe("Server", func() {
 				})
 
 				buf := &bytes.Buffer{}
-				(&dataFrame{}).Write(buf)
+				(&dataFrame{}).writeFrame(buf)
 				setRequest(buf.Bytes())
 				str.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
 					return len(p), nil

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Server", func() {
 			It("parses the SETTINGS frame", func() {
 				buf := &bytes.Buffer{}
 				quicvarint.Write(buf, streamTypeControlStream)
-				(&settingsFrame{}).Write(buf)
+				Settings{}.Write(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
@@ -299,7 +299,7 @@ var _ = Describe("Server", func() {
 				buf := &bytes.Buffer{}
 				quicvarint.Write(buf, streamTypeControlStream)
 				b := &bytes.Buffer{}
-				(&settingsFrame{}).Write(b)
+				Settings{}.Write(b)
 				buf.Write(b.Bytes()[:b.Len()-1])
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
@@ -347,7 +347,7 @@ var _ = Describe("Server", func() {
 				s.EnableDatagrams = true
 				buf := &bytes.Buffer{}
 				quicvarint.Write(buf, streamTypeControlStream)
-				(&settingsFrame{Datagram: true}).Write(buf)
+				(Settings{SettingDatagram: 1}).Write(buf)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				sess.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -11,8 +11,6 @@ import (
 )
 
 const (
-	FrameTypeSettings = 0x4
-
 	// https://www.ietf.org/archive/id/draft-ietf-masque-h3-datagram-02.html#name-http-settings-parameter
 	SettingDatagram = 0xffd276
 
@@ -27,13 +25,13 @@ func (s Setting) String() string {
 	case SettingDatagram:
 		return "H3_DATAGRAM"
 	default:
-		return fmt.Sprintf("H3 SETTING 0x%x", s)
+		return fmt.Sprintf("H3 setting 0x%x", uint64(s))
 	}
 }
 
 type Settings map[Setting]uint64
 
-func (s Settings) FrameType() uint64 {
+func (s Settings) FrameType() FrameType {
 	return FrameTypeSettings
 }
 

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -1,0 +1,116 @@
+package http3
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/quicvarint"
+)
+
+const (
+	FrameTypeSettings = 0x4
+
+	// https://www.ietf.org/archive/id/draft-ietf-masque-h3-datagram-02.html#name-http-settings-parameter
+	SettingDatagram = 0xffd276
+
+	// https://datatracker.ietf.org/doc/draft-ietf-masque-h3-datagram/00/
+	SettingDatagramDraft00 = 0x276
+)
+
+type Setting uint64
+
+func (s Setting) String() string {
+	switch s {
+	case SettingDatagram:
+		return "H3_DATAGRAM"
+	default:
+		return fmt.Sprintf("H3 SETTING 0x%x", s)
+	}
+}
+
+type Settings map[Setting]uint64
+
+func (s Settings) FrameType() uint64 {
+	return FrameTypeSettings
+}
+
+func (s Settings) FrameLength() protocol.ByteCount {
+	var len protocol.ByteCount
+	for id, val := range s {
+		len += quicvarint.Len(uint64(id)) + quicvarint.Len(val)
+	}
+	return len
+}
+
+func (s Settings) WriteFrame(w io.Writer) error {
+	qw := quicvarint.NewWriter(w)
+	quicvarint.Write(qw, uint64(s.FrameType()))
+	quicvarint.Write(qw, uint64(s.FrameLength()))
+	ids := make([]Setting, 0, len(s))
+	for id := range s {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return i < j })
+	for _, id := range ids {
+		quicvarint.Write(qw, uint64(id))
+		quicvarint.Write(qw, s[id])
+	}
+	return nil
+}
+
+func (s Settings) UnmarshalFrame(b []byte) error {
+	if len(b) > 8*(1<<10) {
+		return fmt.Errorf("unexpected size for SETTINGS frame: %d", len(b))
+	}
+	*(&s) = Settings{}
+	r := bytes.NewReader(b)
+	for r.Len() > 0 {
+		id, err := quicvarint.Read(r)
+		if err != nil { // should not happen. We allocated the whole frame already.
+			return err
+		}
+		val, err := quicvarint.Read(r)
+		if err != nil { // should not happen. We allocated the whole frame already.
+			return err
+		}
+
+		if _, ok := s[Setting(id)]; ok {
+			return fmt.Errorf("duplicate setting: %d", id)
+		}
+		s[Setting(id)] = val
+	}
+	return nil
+}
+
+func ReadSettingsFrame(r io.Reader, l uint64) (Settings, error) {
+	if l > 8*(1<<10) {
+		return nil, fmt.Errorf("unexpected size for SETTINGS frame: %d", l)
+	}
+	buf := make([]byte, l)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		if err == io.ErrUnexpectedEOF {
+			return nil, io.EOF
+		}
+		return nil, err
+	}
+	s := Settings{}
+	b := bytes.NewReader(buf)
+	for b.Len() > 0 {
+		id, err := quicvarint.Read(b)
+		if err != nil { // should not happen. We allocated the whole frame already.
+			return nil, err
+		}
+		val, err := quicvarint.Read(b)
+		if err != nil { // should not happen. We allocated the whole frame already.
+			return nil, err
+		}
+		if _, ok := s[Setting(id)]; ok {
+			return nil, fmt.Errorf("duplicate setting: %d", id)
+		}
+		s[Setting(id)] = val
+	}
+	return s, nil
+}

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -50,7 +50,7 @@ func (s Settings) frameLength() protocol.ByteCount {
 	return len
 }
 
-func (s Settings) Write(w quicvarint.Writer) error {
+func (s Settings) writeFrame(w quicvarint.Writer) {
 	quicvarint.Write(w, uint64(s.frameType()))
 	quicvarint.Write(w, uint64(s.frameLength()))
 	ids := make([]SettingID, 0, len(s))
@@ -62,7 +62,6 @@ func (s Settings) Write(w quicvarint.Writer) error {
 		quicvarint.Write(w, uint64(id))
 		quicvarint.Write(w, s[id])
 	}
-	return nil
 }
 
 func parseSettingsFramePayload(r io.Reader, len uint64) (Settings, error) {

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -55,7 +55,7 @@ func (s Settings) EnableDatagrams() {
 	s[SettingDatagramDraft00] = 1 // TODO: remove this when the value for H3_DATAGRAM stabilizes
 }
 
-// DatagramsEnabled returns true if any of the values for H3_DATAGRAM are set to 1.
+// DatagramsEnabled returns true if any of H3_DATAGRAM setting(s) are set to 1.
 func (s Settings) DatagramsEnabled() bool {
 	return s[SettingDatagram] == 1 || s[SettingDatagramDraft00] == 1
 }

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -114,6 +114,9 @@ func parseSettingsFramePayload(r io.Reader, len uint64) (Settings, error) {
 			return nil, fmt.Errorf("duplicate setting: %d", id)
 		}
 		switch id {
+		case SettingQPACKMaxTableCapacity,
+			SettingMaxFieldSectionSize,
+			SettingQPACKBlockedStreams:
 		case SettingDatagram, SettingDatagramDraft00:
 			if val != 0 && val != 1 {
 				return nil, fmt.Errorf("invalid value for H3_DATAGRAM: %d", val)

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -38,7 +38,7 @@ func (id SettingID) String() string {
 	case SettingDatagramDraft00:
 		return "H3_DATAGRAM (draft 00)"
 	default:
-		return fmt.Sprintf("0x%x", uint64(id))
+		return fmt.Sprintf("%#x", uint64(id))
 	}
 }
 

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -37,11 +37,12 @@ func (id SettingID) String() string {
 // and MUST NOT be sent subsequently.
 type Settings map[SettingID]uint64
 
-func (s Settings) FrameType() FrameType {
+// TODO: export the frame handling methods?
+func (s Settings) frameType() FrameType {
 	return FrameTypeSettings
 }
 
-func (s Settings) FrameLength() protocol.ByteCount {
+func (s Settings) frameLength() protocol.ByteCount {
 	var len protocol.ByteCount
 	for id, val := range s {
 		len += quicvarint.Len(uint64(id)) + quicvarint.Len(val)
@@ -50,8 +51,8 @@ func (s Settings) FrameLength() protocol.ByteCount {
 }
 
 func (s Settings) Write(w quicvarint.Writer) error {
-	quicvarint.Write(w, uint64(s.FrameType()))
-	quicvarint.Write(w, uint64(s.FrameLength()))
+	quicvarint.Write(w, uint64(s.frameType()))
+	quicvarint.Write(w, uint64(s.frameLength()))
 	ids := make([]SettingID, 0, len(s))
 	for id := range s {
 		ids = append(ids, id)

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -43,7 +43,7 @@ func (s Settings) FrameLength() protocol.ByteCount {
 	return len
 }
 
-func (s Settings) WriteFrame(w quicvarint.Writer) error {
+func (s Settings) Write(w quicvarint.Writer) error {
 	quicvarint.Write(w, uint64(s.FrameType()))
 	quicvarint.Write(w, uint64(s.FrameLength()))
 	ids := make([]Setting, 0, len(s))

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -18,15 +18,15 @@ const (
 	SettingDatagramDraft00 = 0x276
 )
 
-// A Setting represents an individual HTTP/3 setting identifier.
-type Setting uint64
+// A SettingID represents an individual HTTP/3 setting identifier.
+type SettingID uint64
 
-func (s Setting) String() string {
-	switch s {
+func (id SettingID) String() string {
+	switch id {
 	case SettingDatagram:
 		return "H3_DATAGRAM"
 	default:
-		return fmt.Sprintf("H3 setting 0x%x", uint64(s))
+		return fmt.Sprintf("H3 setting 0x%x", uint64(id))
 	}
 }
 
@@ -35,7 +35,7 @@ func (s Setting) String() string {
 // SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream.
 // A SETTINGS frame MUST be sent as the first frame of each control stream by each peer,
 // and MUST NOT be sent subsequently.
-type Settings map[Setting]uint64
+type Settings map[SettingID]uint64
 
 func (s Settings) FrameType() FrameType {
 	return FrameTypeSettings
@@ -52,7 +52,7 @@ func (s Settings) FrameLength() protocol.ByteCount {
 func (s Settings) Write(w quicvarint.Writer) error {
 	quicvarint.Write(w, uint64(s.FrameType()))
 	quicvarint.Write(w, uint64(s.FrameLength()))
-	ids := make([]Setting, 0, len(s))
+	ids := make([]SettingID, 0, len(s))
 	for id := range s {
 		ids = append(ids, id)
 	}
@@ -87,10 +87,10 @@ func parseSettingsFramePayload(r io.Reader, len uint64) (Settings, error) {
 			return nil, err
 		}
 
-		if _, ok := s[Setting(id)]; ok {
+		if _, ok := s[SettingID(id)]; ok {
 			return nil, fmt.Errorf("duplicate setting: %d", id)
 		}
-		s[Setting(id)] = val
+		s[SettingID(id)] = val
 	}
 	return s, nil
 }

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -11,6 +11,10 @@ import (
 )
 
 const (
+	SettingQPACKMaxTableCapacity SettingID = 0x01
+	SettingMaxFieldSectionSize   SettingID = 0x06
+	SettingQPACKBlockedStreams   SettingID = 0x07
+
 	// https://www.ietf.org/archive/id/draft-ietf-masque-h3-datagram-02.html#name-http-settings-parameter
 	SettingDatagram SettingID = 0xffd276
 
@@ -23,6 +27,12 @@ type SettingID uint64
 
 func (id SettingID) String() string {
 	switch id {
+	case SettingQPACKMaxTableCapacity:
+		return "QPACK_MAX_TABLE_CAPACITY"
+	case SettingMaxFieldSectionSize:
+		return "MAX_FIELD_SECTION_SIZE"
+	case SettingQPACKBlockedStreams:
+		return "QPACK_BLOCKED_STREAMS"
 	case SettingDatagram:
 		return "H3_DATAGRAM"
 	case SettingDatagramDraft00:

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -12,10 +12,10 @@ import (
 
 const (
 	// https://www.ietf.org/archive/id/draft-ietf-masque-h3-datagram-02.html#name-http-settings-parameter
-	SettingDatagram = 0xffd276
+	SettingDatagram SettingID = 0xffd276
 
 	// https://datatracker.ietf.org/doc/draft-ietf-masque-h3-datagram/00/
-	SettingDatagramDraft00 = 0x276
+	SettingDatagramDraft00 SettingID = 0x276
 )
 
 // A SettingID represents an individual HTTP/3 setting identifier.
@@ -25,6 +25,8 @@ func (id SettingID) String() string {
 	switch id {
 	case SettingDatagram:
 		return "H3_DATAGRAM"
+	case SettingDatagramDraft00:
+		return "H3_DATAGRAM (draft 00)"
 	default:
 		return fmt.Sprintf("H3 setting 0x%x", uint64(id))
 	}

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -49,6 +49,17 @@ func (id SettingID) String() string {
 // and MUST NOT be sent subsequently.
 type Settings map[SettingID]uint64
 
+// EnableDatagrams adds the necessary HTTP/3 setting(s) to signal support for the HTTP/3 datagram draft.
+func (s Settings) EnableDatagrams() {
+	s[SettingDatagram] = 1
+	s[SettingDatagramDraft00] = 1 // TODO: remove this when the value for H3_DATAGRAM stabilizes
+}
+
+// DatagramsEnabled returns true if any of the values for H3_DATAGRAM are set to 1.
+func (s Settings) DatagramsEnabled() bool {
+	return s[SettingDatagram] == 1 || s[SettingDatagramDraft00] == 1
+}
+
 // TODO: export the frame handling methods?
 func (s Settings) frameType() FrameType {
 	return FrameTypeSettings

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -118,6 +118,7 @@ func parseSettingsFramePayload(r io.Reader, len uint64) (Settings, error) {
 			if val != 0 && val != 1 {
 				return nil, fmt.Errorf("invalid value for H3_DATAGRAM: %d", val)
 			}
+		default:
 		}
 		s[id] = val
 	}

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -38,7 +38,7 @@ func (id SettingID) String() string {
 	case SettingDatagramDraft00:
 		return "H3_DATAGRAM (draft 00)"
 	default:
-		return fmt.Sprintf("H3 setting 0x%x", uint64(id))
+		return fmt.Sprintf("0x%x", uint64(id))
 	}
 }
 

--- a/http3/settings.go
+++ b/http3/settings.go
@@ -18,6 +18,7 @@ const (
 	SettingDatagramDraft00 = 0x276
 )
 
+// A Setting represents an individual HTTP/3 setting identifier.
 type Setting uint64
 
 func (s Setting) String() string {
@@ -29,6 +30,11 @@ func (s Setting) String() string {
 	}
 }
 
+// Settings represent HTTP/3 settings, which convey configuration parameters that
+// affect how endpoints communicate, such as preferences and constraints on peer behavior.
+// SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream.
+// A SETTINGS frame MUST be sent as the first frame of each control stream by each peer,
+// and MUST NOT be sent subsequently.
 type Settings map[Setting]uint64
 
 func (s Settings) FrameType() FrameType {


### PR DESCRIPTION
Add a new exported `http3.Settings` type as a prerequisite for building HTTP/3 extensions like WebTransport (#3191). Builds on #3233.

- `Settings` replaces the existing `settingsFrame` type.
- New exported `SettingID` and `FrameType` types (both uint64)
- Adds support for the new `H3_DATAGRAM` [setting value](https://www.ietf.org/archive/id/draft-ietf-masque-h3-datagram-03.html#name-http-3-settings-parameter) (`0xffd276`).
- Retains compatibility with previous `H3_DATAGRAM` value (`0x276`) via a shim.
