### PR TITLE
fix race when stream.Read and CancelRead are called concurrently

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -200,10 +200,12 @@ func (s *receiveStream) dequeueNextFrame() {
 func (s *receiveStream) CancelRead(errorCode StreamErrorCode) {
 	s.mutex.Lock()
 	completed := s.cancelReadImpl(errorCode)
+	if completed {
+		s.flowController.Abandon()
+	}
 	s.mutex.Unlock()
 
 	if completed {
-		s.flowController.Abandon()
 		s.sender.onStreamCompleted(s.streamID)
 	}
 }


### PR DESCRIPTION
Not sure if this is an actual bug or a misuse of the API, but this caused CI in go-libp2p-swarm to fail.

Bubbling up this change would fix https://github.com/libp2p/go-libp2p/issues/1144.
cc @Stebalien