### PR TITLE
fix race when stream.Read and CancelRead are called concurrently

### DIFF
--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -109,7 +109,10 @@ func (c *streamFlowController) AddBytesRead(n protocol.ByteCount) {
 }
 
 func (c *streamFlowController) Abandon() {
-	if unread := c.highestReceived - c.bytesRead; unread > 0 {
+	c.mutex.Lock()
+	unread := c.highestReceived - c.bytesRead
+	c.mutex.Unlock()
+	if unread > 0 {
 		c.connection.AddBytesRead(unread)
 	}
 }


### PR DESCRIPTION
This is an alternative to #3240, moving the lock logic into the flow controller.
It also adds an integration test that is able to reliably reproduce the race condition.

Fixes #3239. Closes #3240.