### PR TITLE
quicvarint: export Min and Max constants

### DIFF
--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -9,6 +9,12 @@ import (
 
 // taken from the QUIC draft
 const (
+	// Min is the minimum value allowed for a QUIC varint.
+	Min = 0
+
+	// Max is the maximum allowed value for a QUIC varint (2^62-1).
+	Max = maxVarInt8
+
 	maxVarInt1 = 63
 	maxVarInt2 = 16383
 	maxVarInt4 = 1073741823

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -8,6 +8,16 @@ import (
 )
 
 var _ = Describe("Varint encoding / decoding", func() {
+	Context("limits", func() {
+		Specify("Min == 0", func() {
+			Expect(Min).To(Equal(0))
+		})
+
+		Specify("Max == 2^62-1", func() {
+			Expect(Max).To(Equal(1<<62 - 1))
+		})
+	})
+
 	Context("decoding", func() {
 		It("reads a 1 byte number", func() {
 			b := bytes.NewReader([]byte{0b00011001})

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -14,7 +14,8 @@ var _ = Describe("Varint encoding / decoding", func() {
 		})
 
 		Specify("Max == 2^62-1", func() {
-			Expect(Max).To(Equal(1<<62 - 1))
+			const max = 1<<62 - 1
+			Expect(Max).To(Equal(max))
 		})
 	})
 

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -14,8 +14,7 @@ var _ = Describe("Varint encoding / decoding", func() {
 		})
 
 		Specify("Max == 2^62-1", func() {
-			const max = 1<<62 - 1
-			Expect(Max).To(Equal(max))
+			Expect(uint64(Max)).To(Equal(uint64(1<<62 - 1)))
 		})
 	})
 


### PR DESCRIPTION
This is a cherry-pick from a WIP branch that adds two exported constants: `quicvarint.Min` and `quicvarint.Max`.