### PR TITLE
add (Session).Perspective() method

### DIFF
--- a/closed_session.go
+++ b/closed_session.go
@@ -89,7 +89,7 @@ func (s *closedLocalSession) destroy(error) {
 	})
 }
 
-func (s *closedLocalSession) getPerspective() protocol.Perspective {
+func (s *closedLocalSession) Perspective() Perspective {
 	return s.perspective
 }
 
@@ -106,7 +106,7 @@ func newClosedRemoteSession(pers protocol.Perspective) packetHandler {
 	return &closedRemoteSession{perspective: pers}
 }
 
-func (s *closedRemoteSession) handlePacket(*receivedPacket)         {}
-func (s *closedRemoteSession) shutdown()                            {}
-func (s *closedRemoteSession) destroy(error)                        {}
-func (s *closedRemoteSession) getPerspective() protocol.Perspective { return s.perspective }
+func (s *closedRemoteSession) handlePacket(*receivedPacket) {}
+func (s *closedRemoteSession) shutdown()                    {}
+func (s *closedRemoteSession) destroy(error)                {}
+func (s *closedRemoteSession) Perspective() Perspective     { return s.perspective }

--- a/closed_session_test.go
+++ b/closed_session_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Closed local session", func() {
 	})
 
 	It("tells its perspective", func() {
-		Expect(sess.getPerspective()).To(Equal(protocol.PerspectiveClient))
+		Expect(sess.Perspective()).To(Equal(protocol.PerspectiveClient))
 		// stop the session
 		sess.shutdown()
 	})

--- a/interface.go
+++ b/interface.go
@@ -25,6 +25,16 @@ const (
 	Version1 = protocol.Version1
 )
 
+// Perspective determines if a session is acting as a server or client.
+type Perspective = protocol.Perspective
+
+const (
+	// PerspectiveServer indicates a server connection
+	PerspectiveServer = protocol.PerspectiveServer
+	// PerspectiveClient indicates a client connection
+	PerspectiveClient = protocol.PerspectiveClient
+)
+
 // A Token can be used to verify the ownership of the client address.
 type Token struct {
 	// IsRetryToken encodes how the client received the token. There are two ways:
@@ -183,6 +193,8 @@ type Session interface {
 	// CloseWithError closes the connection with an error.
 	// The error string will be sent to the peer.
 	CloseWithError(ApplicationErrorCode, string) error
+	// Perspective returns whether the connection is acting on behalf of a client or a server.
+	Perspective() Perspective
 	// The context is cancelled when the session is closed.
 	// Warning: This API should not be considered stable and might change soon.
 	Context() context.Context

--- a/internal/mocks/quic/early_session.go
+++ b/internal/mocks/quic/early_session.go
@@ -11,6 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	quic "github.com/lucas-clemente/quic-go"
+	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
 	qerr "github.com/lucas-clemente/quic-go/internal/qerr"
 )
 
@@ -209,6 +210,20 @@ func (m *MockEarlySession) OpenUniStreamSync(arg0 context.Context) (quic.SendStr
 func (mr *MockEarlySessionMockRecorder) OpenUniStreamSync(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenUniStreamSync", reflect.TypeOf((*MockEarlySession)(nil).OpenUniStreamSync), arg0)
+}
+
+// Perspective mocks base method.
+func (m *MockEarlySession) Perspective() protocol.Perspective {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Perspective")
+	ret0, _ := ret[0].(protocol.Perspective)
+	return ret0
+}
+
+// Perspective indicates an expected call of Perspective.
+func (mr *MockEarlySessionMockRecorder) Perspective() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Perspective", reflect.TypeOf((*MockEarlySession)(nil).Perspective))
 }
 
 // ReceiveMessage mocks base method.

--- a/mock_packet_handler_test.go
+++ b/mock_packet_handler_test.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	protocol "github.com/lucas-clemente/quic-go/internal/protocol"
 )
 
 // MockPacketHandler is a mock of PacketHandler interface.
@@ -34,6 +33,20 @@ func (m *MockPacketHandler) EXPECT() *MockPacketHandlerMockRecorder {
 	return m.recorder
 }
 
+// Perspective mocks base method.
+func (m *MockPacketHandler) Perspective() Perspective {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Perspective")
+	ret0, _ := ret[0].(Perspective)
+	return ret0
+}
+
+// Perspective indicates an expected call of Perspective.
+func (mr *MockPacketHandlerMockRecorder) Perspective() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Perspective", reflect.TypeOf((*MockPacketHandler)(nil).Perspective))
+}
+
 // destroy mocks base method.
 func (m *MockPacketHandler) destroy(arg0 error) {
 	m.ctrl.T.Helper()
@@ -44,20 +57,6 @@ func (m *MockPacketHandler) destroy(arg0 error) {
 func (mr *MockPacketHandlerMockRecorder) destroy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "destroy", reflect.TypeOf((*MockPacketHandler)(nil).destroy), arg0)
-}
-
-// getPerspective mocks base method.
-func (m *MockPacketHandler) getPerspective() protocol.Perspective {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getPerspective")
-	ret0, _ := ret[0].(protocol.Perspective)
-	return ret0
-}
-
-// getPerspective indicates an expected call of getPerspective.
-func (mr *MockPacketHandlerMockRecorder) getPerspective() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getPerspective", reflect.TypeOf((*MockPacketHandler)(nil).getPerspective))
 }
 
 // handlePacket mocks base method.

--- a/mock_quic_session_test.go
+++ b/mock_quic_session_test.go
@@ -224,6 +224,20 @@ func (mr *MockQuicSessionMockRecorder) OpenUniStreamSync(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenUniStreamSync", reflect.TypeOf((*MockQuicSession)(nil).OpenUniStreamSync), arg0)
 }
 
+// Perspective mocks base method.
+func (m *MockQuicSession) Perspective() Perspective {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Perspective")
+	ret0, _ := ret[0].(Perspective)
+	return ret0
+}
+
+// Perspective indicates an expected call of Perspective.
+func (mr *MockQuicSessionMockRecorder) Perspective() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Perspective", reflect.TypeOf((*MockQuicSession)(nil).Perspective))
+}
+
 // ReceiveMessage mocks base method.
 func (m *MockQuicSession) ReceiveMessage() ([]byte, error) {
 	m.ctrl.T.Helper()
@@ -291,20 +305,6 @@ func (m *MockQuicSession) earlySessionReady() <-chan struct{} {
 func (mr *MockQuicSessionMockRecorder) earlySessionReady() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "earlySessionReady", reflect.TypeOf((*MockQuicSession)(nil).earlySessionReady))
-}
-
-// getPerspective mocks base method.
-func (m *MockQuicSession) getPerspective() protocol.Perspective {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getPerspective")
-	ret0, _ := ret[0].(protocol.Perspective)
-	return ret0
-}
-
-// getPerspective indicates an expected call of getPerspective.
-func (mr *MockQuicSessionMockRecorder) getPerspective() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getPerspective", reflect.TypeOf((*MockQuicSession)(nil).getPerspective))
 }
 
 // handlePacket mocks base method.

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -30,9 +30,9 @@ func (h *zeroRTTQueue) handlePacket(p *receivedPacket) {
 		h.queue = append(h.queue, p)
 	}
 }
-func (h *zeroRTTQueue) shutdown()                            {}
-func (h *zeroRTTQueue) destroy(error)                        {}
-func (h *zeroRTTQueue) getPerspective() protocol.Perspective { return protocol.PerspectiveClient }
+func (h *zeroRTTQueue) shutdown()                {}
+func (h *zeroRTTQueue) destroy(error)            {}
+func (h *zeroRTTQueue) Perspective() Perspective { return protocol.PerspectiveClient }
 func (h *zeroRTTQueue) EnqueueAll(sess packetHandler) {
 	for _, p := range h.queue {
 		sess.handlePacket(p)
@@ -275,7 +275,7 @@ func (h *packetHandlerMap) CloseServer() {
 	h.server = nil
 	var wg sync.WaitGroup
 	for _, entry := range h.handlers {
-		if entry.packetHandler.getPerspective() == protocol.PerspectiveServer {
+		if entry.packetHandler.Perspective() == protocol.PerspectiveServer {
 			wg.Add(1)
 			go func(handler packetHandler) {
 				// blocks until the CONNECTION_CLOSE has been sent and the run-loop has stopped

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -253,9 +253,9 @@ var _ = Describe("Packet Handler Map", func() {
 			It("closes all server sessions", func() {
 				handler.SetServer(NewMockUnknownPacketHandler(mockCtrl))
 				clientSess := NewMockPacketHandler(mockCtrl)
-				clientSess.EXPECT().getPerspective().Return(protocol.PerspectiveClient)
+				clientSess.EXPECT().Perspective().Return(protocol.PerspectiveClient)
 				serverSess := NewMockPacketHandler(mockCtrl)
-				serverSess.EXPECT().getPerspective().Return(protocol.PerspectiveServer)
+				serverSess.EXPECT().Perspective().Return(protocol.PerspectiveServer)
 				serverSess.EXPECT().shutdown()
 
 				handler.Add(protocol.ConnectionID{1, 1, 1, 1}, clientSess)

--- a/server.go
+++ b/server.go
@@ -25,7 +25,7 @@ type packetHandler interface {
 	handlePacket(*receivedPacket)
 	shutdown()
 	destroy(error)
-	getPerspective() protocol.Perspective
+	Perspective() Perspective
 }
 
 type unknownPacketHandler interface {
@@ -46,7 +46,7 @@ type quicSession interface {
 	earlySessionReady() <-chan struct{}
 	handlePacket(*receivedPacket)
 	GetVersion() protocol.VersionNumber
-	getPerspective() protocol.Perspective
+	Perspective() Perspective
 	run() error
 	destroy(error)
 	shutdown()

--- a/server_test.go
+++ b/server_test.go
@@ -872,7 +872,7 @@ var _ = Describe("Server", func() {
 
 				// make the go routine return
 				phm.EXPECT().CloseServer()
-				sess.EXPECT().getPerspective().MaxTimes(2) // once for every conn ID
+				sess.EXPECT().Perspective().MaxTimes(2) // once for every conn ID
 				Expect(serv.Close()).To(Succeed())
 				Eventually(done).Should(BeClosed())
 			})
@@ -1161,7 +1161,7 @@ var _ = Describe("Server", func() {
 
 			// make the go routine return
 			phm.EXPECT().CloseServer()
-			sess.EXPECT().getPerspective().MaxTimes(2) // once for every conn ID
+			sess.EXPECT().Perspective().MaxTimes(2) // once for every conn ID
 			Expect(serv.Close()).To(Succeed())
 			Eventually(done).Should(BeClosed())
 		})

--- a/session.go
+++ b/session.go
@@ -1980,7 +1980,7 @@ func (s *session) RemoteAddr() net.Addr {
 	return s.conn.RemoteAddr()
 }
 
-func (s *session) getPerspective() protocol.Perspective {
+func (s *session) Perspective() Perspective {
 	return s.perspective
 }
 


### PR DESCRIPTION
Currently the only way to determine if a `quic.Session` is operating in client or server mode is to open or receive a stream, and get the stream ID. This PR exposes a `Perspective` method, which allows callers to determine if the session is operating on behalf of a server or a client.

- The existing `getPerspective` method is renamed to `Perspective`.
- `quic.Perspective` is a type alias for `protocol.Perspective`.
- Same for the `PerspectiveServer` and `PerspectiveClient` constants.