### PR TITLE
[WIP] Implement disabling QUIC bit greasing draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ fuzzing/*/suppressions
 fuzzing/*/corpus/
 
 gomock_reflect_*/
+
+*.coverprofile
+.idea/*

--- a/config_test.go
+++ b/config_test.go
@@ -81,6 +81,8 @@ var _ = Describe("Config", func() {
 				f.Set(reflect.ValueOf(true))
 			case "Tracer":
 				f.Set(reflect.ValueOf(mocklogging.NewMockTracer(mockCtrl)))
+			case "DisableQUICBitGreasing":
+				f.Set(reflect.ValueOf(false))
 			default:
 				Fail(fmt.Sprintf("all fields must be accounted for, but saw unknown field %q", fn))
 			}

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -88,7 +88,7 @@ var _ = Describe("MITM test", func() {
 
 					sendRandomPacketsOfSameType := func(conn net.PacketConn, remoteAddr net.Addr, raw []byte) {
 						defer GinkgoRecover()
-						hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+						hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false /* disableQUICBitGreasing */)
 						Expect(err).ToNot(HaveOccurred())
 						replyHdr := &wire.ExtendedHeader{
 							Header: wire.Header{
@@ -358,7 +358,7 @@ var _ = Describe("MITM test", func() {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false /* disableQUICBitGreasing */)
 							Expect(err).ToNot(HaveOccurred())
 
 							if hdr.Type != protocol.PacketTypeInitial {
@@ -384,7 +384,7 @@ var _ = Describe("MITM test", func() {
 						if dir == quicproxy.DirectionIncoming && !initialPacketIntercepted {
 							defer GinkgoRecover()
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false /* disableQUICBitGreasing */)
 							Expect(err).ToNot(HaveOccurred())
 
 							if hdr.Type != protocol.PacketTypeInitial {
@@ -409,7 +409,7 @@ var _ = Describe("MITM test", func() {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false /* disableQUICBitGreasing */)
 							Expect(err).ToNot(HaveOccurred())
 
 							if hdr.Type != protocol.PacketTypeInitial {
@@ -430,7 +430,7 @@ var _ = Describe("MITM test", func() {
 					clientAddr := clientConn.LocalAddr()
 					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
 						if dir == quicproxy.DirectionIncoming {
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false /* disableQUICBitGreasing */)
 							Expect(err).ToNot(HaveOccurred())
 							if hdr.Type != protocol.PacketTypeInitial {
 								return 0

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -36,7 +36,7 @@ var _ = Describe("0-RTT", func() {
 					RemoteAddr: fmt.Sprintf("localhost:%d", serverPort),
 					DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
 						for len(data) > 0 {
-							hdr, _, rest, err := wire.ParsePacket(data, 0)
+							hdr, _, rest, err := wire.ParsePacket(data, 0, false /* disableQUICBitGreasing */)
 							Expect(err).ToNot(HaveOccurred())
 							if hdr.Type == protocol.PacketType0RTT {
 								atomic.AddUint32(&num0RTTPackets, 1)
@@ -340,7 +340,7 @@ var _ = Describe("0-RTT", func() {
 				proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
 					RemoteAddr: fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port),
 					DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
-						hdr, _, _, err := wire.ParsePacket(data, 0)
+						hdr, _, _, err := wire.ParsePacket(data, 0, false /* disableQUICBitGreasing */)
 						Expect(err).ToNot(HaveOccurred())
 						if hdr.Type == protocol.PacketType0RTT {
 							atomic.AddUint32(&num0RTTPackets, 1)
@@ -348,7 +348,7 @@ var _ = Describe("0-RTT", func() {
 						return rtt / 2
 					},
 					DropPacket: func(_ quicproxy.Direction, data []byte) bool {
-						hdr, _, _, err := wire.ParsePacket(data, 0)
+						hdr, _, _, err := wire.ParsePacket(data, 0, false /* disableQUICBitGreasing */)
 						Expect(err).ToNot(HaveOccurred())
 						if hdr.Type == protocol.PacketType0RTT {
 							// drop 25% of the 0-RTT packets
@@ -383,7 +383,7 @@ var _ = Describe("0-RTT", func() {
 
 				countZeroRTTBytes := func(data []byte) (n protocol.ByteCount) {
 					for len(data) > 0 {
-						hdr, _, rest, err := wire.ParsePacket(data, 0)
+						hdr, _, rest, err := wire.ParsePacket(data, 0, false /* disableQUICBitGreasing */)
 						if err != nil {
 							return
 						}

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -48,7 +48,7 @@ var _ = Describe("QUIC Proxy", func() {
 	}
 
 	readPacketNumber := func(b []byte) protocol.PacketNumber {
-		hdr, data, _, err := wire.ParsePacket(b, 0)
+		hdr, data, _, err := wire.ParsePacket(b, 0, false /* disableQUICBitGreasing */)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		Expect(hdr.Type).To(Equal(protocol.PacketTypeInitial))
 		extHdr, err := hdr.ParseExtended(bytes.NewReader(data), protocol.VersionTLS)

--- a/interface.go
+++ b/interface.go
@@ -292,6 +292,11 @@ type Config struct {
 	// Datagrams will only be available when both peers enable datagram support.
 	EnableDatagrams bool
 	Tracer          logging.Tracer
+	// See https://quicwg.org/quic-bit-grease/draft-ietf-quic-bit-grease.html
+	// When disabled, server advertises additional transport parameter indicating
+	// that the second most significant bit need not be 1 (it should be 1 in case
+	// QUIC is being multiplexed with other UDP-based protocols)
+	DisableQUICBitGreasing bool
 }
 
 // ConnectionState records basic details about a QUIC connection

--- a/internal/wire/version_negotiation.go
+++ b/internal/wire/version_negotiation.go
@@ -10,8 +10,8 @@ import (
 )
 
 // ParseVersionNegotiationPacket parses a Version Negotiation packet.
-func ParseVersionNegotiationPacket(b *bytes.Reader) (*Header, []protocol.VersionNumber, error) {
-	hdr, err := parseHeader(b, 0)
+func ParseVersionNegotiationPacket(b *bytes.Reader, disableGreaseQUICBit bool) (*Header, []protocol.VersionNumber, error) {
+	hdr, err := parseHeader(b, 0, disableGreaseQUICBit)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/wire/version_negotiation_test.go
+++ b/internal/wire/version_negotiation_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Version Negotiation Packets", func() {
 			binary.BigEndian.PutUint32(data[len(data)-4:], uint32(v))
 		}
 		Expect(IsVersionNegotiationPacket(data)).To(BeTrue())
-		hdr, supportedVersions, err := ParseVersionNegotiationPacket(bytes.NewReader(data))
+		hdr, supportedVersions, err := ParseVersionNegotiationPacket(bytes.NewReader(data), false /* disableQUICGreasing */)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hdr.DestConnectionID).To(Equal(destConnID))
 		Expect(hdr.SrcConnectionID).To(Equal(srcConnID))
@@ -38,7 +38,7 @@ var _ = Describe("Version Negotiation Packets", func() {
 		versions := []protocol.VersionNumber{0x22334455, 0x33445566}
 		data, err := ComposeVersionNegotiation(connID, connID, versions)
 		Expect(err).ToNot(HaveOccurred())
-		_, _, err = ParseVersionNegotiationPacket(bytes.NewReader(data[:len(data)-2]))
+		_, _, err = ParseVersionNegotiationPacket(bytes.NewReader(data[:len(data)-2]), false /* disableQUICGreasing */)
 		Expect(err).To(MatchError("Version Negotiation packet has a version list with an invalid length"))
 	})
 
@@ -49,7 +49,7 @@ var _ = Describe("Version Negotiation Packets", func() {
 		Expect(err).ToNot(HaveOccurred())
 		// remove 8 bytes (two versions), since ComposeVersionNegotiation also added a reserved version number
 		data = data[:len(data)-8]
-		_, _, err = ParseVersionNegotiationPacket(bytes.NewReader(data))
+		_, _, err = ParseVersionNegotiationPacket(bytes.NewReader(data), false /* disableQUICGreasing */)
 		Expect(err).To(MatchError("Version Negotiation packet has empty version list"))
 	})
 
@@ -60,7 +60,7 @@ var _ = Describe("Version Negotiation Packets", func() {
 		data, err := ComposeVersionNegotiation(destConnID, srcConnID, versions)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(data[0] & 0x80).ToNot(BeZero())
-		hdr, supportedVersions, err := ParseVersionNegotiationPacket(bytes.NewReader(data))
+		hdr, supportedVersions, err := ParseVersionNegotiationPacket(bytes.NewReader(data), false /* disableQUICGreasing */)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hdr.DestConnectionID).To(Equal(destConnID))
 		Expect(hdr.SrcConnectionID).To(Equal(srcConnID))

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Packet packer", func() {
 	parsePacket := func(data []byte) []*wire.ExtendedHeader {
 		var hdrs []*wire.ExtendedHeader
 		for len(data) > 0 {
-			hdr, payload, rest, err := wire.ParsePacket(data, connID.Len())
+			hdr, payload, rest, err := wire.ParsePacket(data, connID.Len(), false /* disableQUICGreasing */)
 			Expect(err).ToNot(HaveOccurred())
 			r := bytes.NewReader(data)
 			extHdr, err := hdr.ParseExtended(r, version)
@@ -616,7 +616,7 @@ var _ = Describe("Packet packer", func() {
 				Expect(packet.packets).To(HaveLen(1))
 				// cut off the tag that the mock sealer added
 				// packet.buffer.Data = packet.buffer.Data[:packet.buffer.Len()-protocol.ByteCount(sealer.Overhead())]
-				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()))
+				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()), false /* disableQUICGreasing */)
 				Expect(err).ToNot(HaveOccurred())
 				r := bytes.NewReader(packet.buffer.Data)
 				extHdr, err := hdr.ParseExtended(r, packer.version)
@@ -656,7 +656,7 @@ var _ = Describe("Packet packer", func() {
 				Expect(err).ToNot(HaveOccurred())
 				// cut off the tag that the mock sealer added
 				packet.buffer.Data = packet.buffer.Data[:packet.buffer.Len()-protocol.ByteCount(sealer.Overhead())]
-				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()))
+				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()), false /* disableQUICGreasing */)
 				Expect(err).ToNot(HaveOccurred())
 				r := bytes.NewReader(packet.buffer.Data)
 				extHdr, err := hdr.ParseExtended(r, packer.version)
@@ -1158,10 +1158,10 @@ var _ = Describe("Packet packer", func() {
 				Expect(p.packets[1].EncryptionLevel()).To(Equal(protocol.Encryption1RTT))
 				Expect(p.packets[1].frames).To(HaveLen(1))
 				Expect(p.packets[1].frames[0].Frame.(*wire.StreamFrame).Data).To(Equal([]byte("foobar")))
-				hdr, _, rest, err := wire.ParsePacket(p.buffer.Data, 0)
+				hdr, _, rest, err := wire.ParsePacket(p.buffer.Data, 0, false /* disableQUICGreasing */)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hdr.Type).To(Equal(protocol.PacketTypeHandshake))
-				hdr, _, rest, err = wire.ParsePacket(rest, 0)
+				hdr, _, rest, err = wire.ParsePacket(rest, 0, false /* disableQUICGreasing */)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hdr.IsLongHeader).To(BeFalse())
 				Expect(rest).To(BeEmpty())
@@ -1206,7 +1206,7 @@ var _ = Describe("Packet packer", func() {
 				Expect(packet.packets).To(HaveLen(1))
 				// cut off the tag that the mock sealer added
 				// packet.buffer.Data = packet.buffer.Data[:packet.buffer.Len()-protocol.ByteCount(sealer.Overhead())]
-				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()))
+				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()), false /* disableQUICGreasing */)
 				Expect(err).ToNot(HaveOccurred())
 				r := bytes.NewReader(packet.buffer.Data)
 				extHdr, err := hdr.ParseExtended(r, packer.version)

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Packet Unpacker", func() {
 		if extHdr.Length > protocol.ByteCount(extHdr.PacketNumberLen) {
 			buf.Write(make([]byte, int(extHdr.Length)-int(extHdr.PacketNumberLen)))
 		}
-		hdr, _, _, err := wire.ParsePacket(buf.Bytes(), connID.Len())
+		hdr, _, _, err := wire.ParsePacket(buf.Bytes(), connID.Len(), false /* disableQUICGreasing */)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return hdr, buf.Bytes()[:hdrLen]
 	}

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -395,6 +395,8 @@ type eventTransportParameters struct {
 	PreferredAddress *preferredAddress
 
 	MaxDatagramFrameSize protocol.ByteCount
+
+	DisableGreaseQUICBit bool
 }
 
 func (e eventTransportParameters) Category() category { return categoryTransport }

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -273,6 +273,7 @@ func (t *connectionTracer) toTransportParameters(tp *wire.TransportParameters) *
 		InitialMaxStreamsUni:            int64(tp.MaxUniStreamNum),
 		PreferredAddress:                pa,
 		MaxDatagramFrameSize:            tp.MaxDatagramFrameSize,
+		DisableGreaseQUICBit:            tp.DisableGreaseQUICBit,
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -338,7 +338,7 @@ func (s *baseServer) handlePacketImpl(p *receivedPacket) bool /* is the buffer s
 	}
 	// If we're creating a new session, the packet will be passed to the session.
 	// The header will then be parsed again.
-	hdr, _, _, err := wire.ParsePacket(p.data, s.config.ConnectionIDLength)
+	hdr, _, _, err := wire.ParsePacket(p.data, s.config.ConnectionIDLength, s.config.DisableQUICBitGreasing)
 	if err != nil && err != wire.ErrUnsupportedVersion {
 		if s.config.Tracer != nil {
 			s.config.Tracer.DroppedPacket(p.remoteAddr, logging.PacketTypeNotDetermined, p.Size(), logging.PacketDropHeaderParseError)

--- a/session.go
+++ b/session.go
@@ -844,7 +844,7 @@ func (s *session) handlePacketImpl(rp *receivedPacket) bool {
 			p.data = data
 		}
 
-		hdr, packetData, rest, err := wire.ParsePacket(p.data, s.srcConnIDLen)
+		hdr, packetData, rest, err := wire.ParsePacket(p.data, s.srcConnIDLen, s.config.DisableQUICBitGreasing)
 		if err != nil {
 			if s.tracer != nil {
 				dropReason := logging.PacketDropHeaderParseError
@@ -1056,7 +1056,7 @@ func (s *session) handleVersionNegotiationPacket(p *receivedPacket) {
 		return
 	}
 
-	hdr, supportedVersions, err := wire.ParseVersionNegotiationPacket(bytes.NewReader(p.data))
+	hdr, supportedVersions, err := wire.ParseVersionNegotiationPacket(bytes.NewReader(p.data), s.config.DisableQUICBitGreasing)
 	if err != nil {
 		if s.tracer != nil {
 			s.tracer.DroppedPacket(logging.PacketTypeVersionNegotiation, p.Size(), logging.PacketDropHeaderParseError)


### PR DESCRIPTION
Fixes #3133

Implements the draft specification defined [here](https://datatracker.ietf.org/doc/draft-ietf-quic-bit-grease/)
1. Adds option to disable QUIC bit greasing on the server side
2. Adds additional transport parameter to indicate this extension (`0x2ab2`)
3. TODO: Add more unit tests (and integration tests as well?)

**NOTE**: Currently, it is the first iteration and more tests need to be written. So don't merge
