### PR TITLE
Fix typo *connections

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -486,7 +486,7 @@ func ListenAndServeQUIC(addr, certFile, keyFile string, handler http.Handler) er
 }
 
 // ListenAndServe listens on the given network address for both, TLS and QUIC
-// connetions in parallel. It returns if one of the two returns an error.
+// connections in parallel. It returns if one of the two returns an error.
 // http.DefaultServeMux is used when handler is nil.
 // The correct Alt-Svc headers for QUIC are set.
 func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error {


### PR DESCRIPTION
Hi there, 👋

I guess that "connetions" should be "connections."

Thanks,