### PR TITLE
fix comment about congestionWindow value

### DIFF
--- a/internal/congestion/cubic_sender.go
+++ b/internal/congestion/cubic_sender.go
@@ -41,7 +41,7 @@ type cubicSender struct {
 	// Used for stats collection of slowstartPacketsLost
 	lastCutbackExitedSlowstart bool
 
-	// Congestion window in packets.
+	// Congestion window in bytes.
 	congestionWindow protocol.ByteCount
 
 	// Slow start congestion window in bytes, aka ssthresh.


### PR DESCRIPTION
The comment about this field is wrong. I think it should be: "in bytes".