### PR TITLE
add a AllowConnectionWindowIncrease config option

### DIFF
--- a/config.go
+++ b/config.go
@@ -110,6 +110,7 @@ func populateConfig(config *Config) *Config {
 		MaxStreamReceiveWindow:           maxStreamReceiveWindow,
 		InitialConnectionReceiveWindow:   initialConnectionReceiveWindow,
 		MaxConnectionReceiveWindow:       maxConnectionReceiveWindow,
+		AllowConnectionWindowIncrease:    config.AllowConnectionWindowIncrease,
 		MaxIncomingStreams:               maxIncomingStreams,
 		MaxIncomingUniStreams:            maxIncomingUniStreams,
 		ConnectionIDLength:               config.ConnectionIDLength,

--- a/config_test.go
+++ b/config_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Config", func() {
 			var calledAcceptToken, calledAllowConnectionWindowIncrease bool
 			c1 := &Config{
 				AcceptToken:                   func(_ net.Addr, _ *Token) bool { calledAcceptToken = true; return true },
-				AllowConnectionWindowIncrease: func(Session, int) bool { calledAllowConnectionWindowIncrease = true; return true },
+				AllowConnectionWindowIncrease: func(Session, uint64) bool { calledAllowConnectionWindowIncrease = true; return true },
 			}
 			c2 := c1.Clone()
 			c2.AcceptToken(&net.UDPAddr{}, &Token{})

--- a/config_test.go
+++ b/config_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Config", func() {
 			}
 
 			switch fn := typ.Field(i).Name; fn {
-			case "AcceptToken", "GetLogWriter":
+			case "AcceptToken", "GetLogWriter", "AllowConnectionWindowIncrease":
 				// Can't compare functions.
 			case "Versions":
 				f.Set(reflect.ValueOf([]VersionNumber{1, 2, 3}))
@@ -100,13 +100,16 @@ var _ = Describe("Config", func() {
 
 	Context("cloning", func() {
 		It("clones function fields", func() {
-			var calledAcceptToken bool
+			var calledAcceptToken, calledAllowConnectionWindowIncrease bool
 			c1 := &Config{
-				AcceptToken: func(_ net.Addr, _ *Token) bool { calledAcceptToken = true; return true },
+				AcceptToken:                   func(_ net.Addr, _ *Token) bool { calledAcceptToken = true; return true },
+				AllowConnectionWindowIncrease: func(Session, int) bool { calledAllowConnectionWindowIncrease = true; return true },
 			}
 			c2 := c1.Clone()
 			c2.AcceptToken(&net.UDPAddr{}, &Token{})
 			Expect(calledAcceptToken).To(BeTrue())
+			c2.AllowConnectionWindowIncrease(nil, 1234)
+			Expect(calledAllowConnectionWindowIncrease).To(BeTrue())
 		})
 
 		It("clones non-function fields", func() {

--- a/interface.go
+++ b/interface.go
@@ -270,6 +270,8 @@ type Config struct {
 	// to increase the connection flow control window.
 	// If set, the caller can prevent an increase of the window. Typically, it would do so to
 	// limit the memory usage.
+	// To avoid deadlocks, it is not valid to call other functions on the session or on streams
+	// in this callback.
 	AllowConnectionWindowIncrease func(sess Session, delta uint64) bool
 	// MaxIncomingStreams is the maximum number of concurrent bidirectional streams that a peer is allowed to open.
 	// Values above 2^60 are invalid.

--- a/interface.go
+++ b/interface.go
@@ -266,6 +266,11 @@ type Config struct {
 	// MaxConnectionReceiveWindow is the connection-level flow control window for receiving data.
 	// If this value is zero, it will default to 15 MB.
 	MaxConnectionReceiveWindow uint64
+	// AllowConnectionWindowIncrease is called every time the connection flow controller attempts
+	// to increase the connection flow control window.
+	// If set, the caller can prevent an increase of the window. Typically, it would do so to
+	// limit the memory usage.
+	AllowConnectionWindowIncrease func(sess Session, delta int) bool
 	// MaxIncomingStreams is the maximum number of concurrent bidirectional streams that a peer is allowed to open.
 	// Values above 2^60 are invalid.
 	// If not set, it will default to 100.

--- a/interface.go
+++ b/interface.go
@@ -270,7 +270,7 @@ type Config struct {
 	// to increase the connection flow control window.
 	// If set, the caller can prevent an increase of the window. Typically, it would do so to
 	// limit the memory usage.
-	AllowConnectionWindowIncrease func(sess Session, delta int) bool
+	AllowConnectionWindowIncrease func(sess Session, delta uint64) bool
 	// MaxIncomingStreams is the maximum number of concurrent bidirectional streams that a peer is allowed to open.
 	// Values above 2^60 are invalid.
 	// If not set, it will default to 100.

--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -24,6 +24,7 @@ func NewConnectionFlowController(
 	receiveWindow protocol.ByteCount,
 	maxReceiveWindow protocol.ByteCount,
 	queueWindowUpdate func(),
+	allowWindowIncrease func(size protocol.ByteCount) bool,
 	rttStats *utils.RTTStats,
 	logger utils.Logger,
 ) ConnectionFlowController {
@@ -33,6 +34,7 @@ func NewConnectionFlowController(
 			receiveWindow:        receiveWindow,
 			receiveWindowSize:    receiveWindow,
 			maxReceiveWindowSize: maxReceiveWindow,
+			allowWindowIncrease:  allowWindowIncrease,
 			logger:               logger,
 		},
 		queueWindowUpdate: queueWindowUpdate,
@@ -85,13 +87,16 @@ func (c *connectionFlowController) EnsureMinimumWindowSize(inc protocol.ByteCoun
 	c.mutex.Lock()
 	if inc > c.receiveWindowSize {
 		c.logger.Debugf("Increasing receive flow control window for the connection to %d kB, in response to stream flow control window increase", c.receiveWindowSize/(1<<10))
-		c.receiveWindowSize = utils.MinByteCount(inc, c.maxReceiveWindowSize)
+		newSize := utils.MinByteCount(inc, c.maxReceiveWindowSize)
+		if delta := newSize - c.receiveWindowSize; delta > 0 && c.allowWindowIncrease(delta) {
+			c.receiveWindowSize = newSize
+		}
 		c.startNewAutoTuningEpoch(time.Now())
 	}
 	c.mutex.Unlock()
 }
 
-// The flow controller is reset when 0-RTT is rejected.
+// Reset rests the flow controller. This happens when 0-RTT is rejected.
 // All stream data is invalidated, it's if we had never opened a stream and never sent any data.
 // At that point, we only have sent stream data, but we didn't have the keys to open 1-RTT keys yet.
 func (c *connectionFlowController) Reset() error {

--- a/internal/flowcontrol/connection_flow_controller_test.go
+++ b/internal/flowcontrol/connection_flow_controller_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Connection Flow controller", func() {
 		controller.rttStats = &utils.RTTStats{}
 		controller.logger = utils.DefaultLogger
 		controller.queueWindowUpdate = func() { queuedWindowUpdate = true }
+		controller.allowWindowIncrease = func(protocol.ByteCount) bool { return true }
 	})
 
 	Context("Constructor", func() {
@@ -36,7 +37,13 @@ var _ = Describe("Connection Flow controller", func() {
 			receiveWindow := protocol.ByteCount(2000)
 			maxReceiveWindow := protocol.ByteCount(3000)
 
-			fc := NewConnectionFlowController(receiveWindow, maxReceiveWindow, nil, rttStats, utils.DefaultLogger).(*connectionFlowController)
+			fc := NewConnectionFlowController(
+				receiveWindow,
+				maxReceiveWindow,
+				nil,
+				func(protocol.ByteCount) bool { return true },
+				rttStats,
+				utils.DefaultLogger).(*connectionFlowController)
 			Expect(fc.receiveWindow).To(Equal(receiveWindow))
 			Expect(fc.maxReceiveWindowSize).To(Equal(maxReceiveWindow))
 		})
@@ -78,6 +85,11 @@ var _ = Describe("Connection Flow controller", func() {
 			})
 
 			It("auto-tunes the window", func() {
+				var allowed protocol.ByteCount
+				controller.allowWindowIncrease = func(size protocol.ByteCount) bool {
+					allowed = size
+					return true
+				}
 				oldOffset := controller.bytesRead
 				oldWindowSize := controller.receiveWindowSize
 				rtt := scaleDuration(20 * time.Millisecond)
@@ -89,6 +101,23 @@ var _ = Describe("Connection Flow controller", func() {
 				offset := controller.GetWindowUpdate()
 				newWindowSize := controller.receiveWindowSize
 				Expect(newWindowSize).To(Equal(2 * oldWindowSize))
+				Expect(offset).To(Equal(oldOffset + dataRead + newWindowSize))
+				Expect(allowed).To(Equal(oldWindowSize))
+			})
+
+			It("doesn't auto-tune the window if it's not allowed", func() {
+				controller.allowWindowIncrease = func(protocol.ByteCount) bool { return false }
+				oldOffset := controller.bytesRead
+				oldWindowSize := controller.receiveWindowSize
+				rtt := scaleDuration(20 * time.Millisecond)
+				setRtt(rtt)
+				controller.epochStartTime = time.Now().Add(-time.Millisecond)
+				controller.epochStartOffset = oldOffset
+				dataRead := oldWindowSize/2 + 1
+				controller.AddBytesRead(dataRead)
+				offset := controller.GetWindowUpdate()
+				newWindowSize := controller.receiveWindowSize
+				Expect(newWindowSize).To(Equal(oldWindowSize))
 				Expect(offset).To(Equal(oldOffset + dataRead + newWindowSize))
 			})
 		})

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -21,8 +21,15 @@ var _ = Describe("Stream Flow controller", func() {
 		queuedWindowUpdate = false
 		rttStats := &utils.RTTStats{}
 		controller = &streamFlowController{
-			streamID:   10,
-			connection: NewConnectionFlowController(1000, 1000, func() {}, rttStats, utils.DefaultLogger).(*connectionFlowController),
+			streamID: 10,
+			connection: NewConnectionFlowController(
+				1000,
+				1000,
+				func() {},
+				func(protocol.ByteCount) bool { return true },
+				rttStats,
+				utils.DefaultLogger,
+			).(*connectionFlowController),
 		}
 		controller.maxReceiveWindowSize = 10000
 		controller.rttStats = rttStats
@@ -37,7 +44,7 @@ var _ = Describe("Stream Flow controller", func() {
 		const sendWindow protocol.ByteCount = 4000
 
 		It("sets the send and receive windows", func() {
-			cc := NewConnectionFlowController(0, 0, nil, nil, utils.DefaultLogger)
+			cc := NewConnectionFlowController(0, 0, nil, func(protocol.ByteCount) bool { return true }, nil, utils.DefaultLogger)
 			fc := NewStreamFlowController(5, cc, receiveWindow, maxReceiveWindow, sendWindow, nil, rttStats, utils.DefaultLogger).(*streamFlowController)
 			Expect(fc.streamID).To(Equal(protocol.StreamID(5)))
 			Expect(fc.receiveWindow).To(Equal(receiveWindow))
@@ -52,7 +59,7 @@ var _ = Describe("Stream Flow controller", func() {
 				queued = true
 			}
 
-			cc := NewConnectionFlowController(receiveWindow, maxReceiveWindow, func() {}, nil, utils.DefaultLogger)
+			cc := NewConnectionFlowController(receiveWindow, maxReceiveWindow, func() {}, func(protocol.ByteCount) bool { return true }, nil, utils.DefaultLogger)
 			fc := NewStreamFlowController(5, cc, receiveWindow, maxReceiveWindow, sendWindow, queueWindowUpdate, rttStats, utils.DefaultLogger).(*streamFlowController)
 			fc.AddBytesRead(receiveWindow)
 			Expect(queued).To(BeTrue())
@@ -190,6 +197,11 @@ var _ = Describe("Stream Flow controller", func() {
 			})
 
 			It("tells the connection flow controller when the window was auto-tuned", func() {
+				var allowed protocol.ByteCount
+				controller.connection.(*connectionFlowController).allowWindowIncrease = func(size protocol.ByteCount) bool {
+					allowed = size
+					return true
+				}
 				oldOffset := controller.bytesRead
 				setRtt(scaleDuration(20 * time.Millisecond))
 				controller.epochStartOffset = oldOffset
@@ -198,7 +210,22 @@ var _ = Describe("Stream Flow controller", func() {
 				offset := controller.GetWindowUpdate()
 				Expect(offset).To(Equal(oldOffset + 55 + 2*oldWindowSize))
 				Expect(controller.receiveWindowSize).To(Equal(2 * oldWindowSize))
+				Expect(allowed).To(Equal(oldWindowSize))
 				Expect(controller.connection.(*connectionFlowController).receiveWindowSize).To(Equal(protocol.ByteCount(float64(controller.receiveWindowSize) * protocol.ConnectionFlowControlMultiplier)))
+			})
+
+			It("doesn't increase the connection flow control window if it's not allowed", func() {
+				oldOffset := controller.bytesRead
+				oldConnectionSize := controller.connection.(*connectionFlowController).receiveWindowSize
+				controller.connection.(*connectionFlowController).allowWindowIncrease = func(protocol.ByteCount) bool { return false }
+				setRtt(scaleDuration(20 * time.Millisecond))
+				controller.epochStartOffset = oldOffset
+				controller.epochStartTime = time.Now().Add(-time.Millisecond)
+				controller.AddBytesRead(55)
+				offset := controller.GetWindowUpdate()
+				Expect(offset).To(Equal(oldOffset + 55 + 2*oldWindowSize))
+				Expect(controller.receiveWindowSize).To(Equal(2 * oldWindowSize))
+				Expect(controller.connection.(*connectionFlowController).receiveWindowSize).To(Equal(oldConnectionSize))
 			})
 
 			It("sends a connection-level window update when a large stream is abandoned", func() {

--- a/session.go
+++ b/session.go
@@ -506,7 +506,12 @@ func (s *session) preSetup() {
 		protocol.ByteCount(s.config.InitialConnectionReceiveWindow),
 		protocol.ByteCount(s.config.MaxConnectionReceiveWindow),
 		s.onHasConnectionWindowUpdate,
-		func(protocol.ByteCount) bool { return true },
+		func(size protocol.ByteCount) bool {
+			if s.config.AllowConnectionWindowIncrease == nil {
+				return true
+			}
+			return s.config.AllowConnectionWindowIncrease(s, int(size))
+		},
 		s.rttStats,
 		s.logger,
 	)

--- a/session.go
+++ b/session.go
@@ -506,6 +506,7 @@ func (s *session) preSetup() {
 		protocol.ByteCount(s.config.InitialConnectionReceiveWindow),
 		protocol.ByteCount(s.config.MaxConnectionReceiveWindow),
 		s.onHasConnectionWindowUpdate,
+		func(protocol.ByteCount) bool { return true },
 		s.rttStats,
 		s.logger,
 	)

--- a/session.go
+++ b/session.go
@@ -510,7 +510,7 @@ func (s *session) preSetup() {
 			if s.config.AllowConnectionWindowIncrease == nil {
 				return true
 			}
-			return s.config.AllowConnectionWindowIncrease(s, int(size))
+			return s.config.AllowConnectionWindowIncrease(s, uint64(size))
 		},
 		s.rttStats,
 		s.logger,


### PR DESCRIPTION
This option can be used to limit the memory consumption of a QUIC connection. When set, the application can decide if the connection flow control window is increased.

Note that this only applies to the connection flow control window, not to stream windows. However, stream windows are limited by the connection window (the sum of outstanding data on all streams must not exceed the connection window), so this actually does limit the memory usage.

cc @vyzo