### PR TITLE
add env to disable the receive buffer warning

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -9,6 +9,8 @@ import (
 	"hash"
 	"log"
 	"net"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -122,6 +124,9 @@ func newPacketHandlerMap(
 ) (packetHandlerManager, error) {
 	if err := setReceiveBuffer(c, logger); err != nil {
 		receiveBufferWarningOnce.Do(func() {
+			if disable, _ := strconv.ParseBool(os.Getenv("QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING")); disable {
+				return
+			}
 			log.Printf("%s. See https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size for details.", err)
 		})
 	}


### PR DESCRIPTION
If the env QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING is set to true
(as defined by strconv.ParseBool()), the receive buffer warning
will not be printed out.

Resolves #3338