### PR TITLE
remove the SkipSchemeCheck RoundTripOpt

### DIFF
--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 
 	"golang.org/x/net/http/httpguts"
 )
@@ -64,9 +64,6 @@ type RoundTripOpt struct {
 	// OnlyCachedConn controls whether the RoundTripper may create a new QUIC connection.
 	// If set true and no cached connection is available, RoundTrip will return ErrNoCachedConn.
 	OnlyCachedConn bool
-	// SkipSchemeCheck controls whether we check if the scheme is https.
-	// This allows the use of different schemes, e.g. masque://target.example.com:443/.
-	SkipSchemeCheck bool
 }
 
 var _ roundTripCloser = &RoundTripper{}
@@ -100,7 +97,7 @@ func (r *RoundTripper) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.
 				}
 			}
 		}
-	} else if !opt.SkipSchemeCheck {
+	} else {
 		closeRequestBody(req)
 		return nil, fmt.Errorf("http3: unsupported protocol scheme: %s", req.URL.Scheme)
 	}

--- a/http3/roundtrip_test.go
+++ b/http3/roundtrip_test.go
@@ -179,15 +179,6 @@ var _ = Describe("RoundTripper", func() {
 			Expect(req.Body.(*mockBody).closed).To(BeTrue())
 		})
 
-		It("allow non-https schemes if SkipSchemeCheck is set", func() {
-			req, err := http.NewRequest("GET", "masque://www.example.org/", nil)
-			Expect(err).ToNot(HaveOccurred())
-			_, err = rt.RoundTrip(req)
-			Expect(err).To(MatchError("http3: unsupported protocol scheme: masque"))
-			_, err = rt.RoundTripOpt(req, RoundTripOpt{SkipSchemeCheck: true, OnlyCachedConn: true})
-			Expect(err).To(MatchError("http3: no cached connection was available"))
-		})
-
 		It("rejects requests without a URL", func() {
 			req1.URL = nil
 			req1.Body = &mockBody{}


### PR DESCRIPTION
This option was needed for an early draft version of MASQUE.
MASQUE now uses the https scheme.