### PR TITLE
improve code coverage of random number generator test

### DIFF
--- a/internal/utils/rand_test.go
+++ b/internal/utils/rand_test.go
@@ -9,7 +9,7 @@ var _ = Describe("Rand", func() {
 	It("generates random numbers", func() {
 		const (
 			num = 1000
-			max = 123456
+			max = 12345678
 		)
 
 		var values [num]int32


### PR DESCRIPTION
This change makes it more likely that https://github.com/lucas-clemente/quic-go/blob/d4293fb274084bc8fda54d39941c1856cf00d3ed/internal/utils/rand.go#L25-L27 is executed, as the value `max` is reduced by passing in a higher `n`.