### PR TITLE
extend the HTTP/3 API for WebTransport support

### DIFF
--- a/http3/body.go
+++ b/http3/body.go
@@ -81,7 +81,7 @@ func (r *body) readImpl(b []byte) (int, error) {
 	if r.bytesRemainingInFrame == 0 {
 	parseLoop:
 		for {
-			frame, err := parseNextFrame(r.str)
+			frame, err := parseNextFrame(r.str, nil)
 			if err != nil {
 				return 0, err
 			}

--- a/http3/body.go
+++ b/http3/body.go
@@ -120,6 +120,10 @@ func (r *body) requestDone() {
 	r.reqDoneClosed = true
 }
 
+func (r *body) StreamID() quic.StreamID {
+	return r.str.StreamID()
+}
+
 func (r *body) Close() error {
 	r.requestDone()
 	// If the EOF was read, CancelRead() is a no-op.

--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -29,7 +29,7 @@ func (t bodyType) String() string {
 
 var _ = Describe("Body", func() {
 	var (
-		rb            *body
+		rb            io.ReadCloser
 		str           *mockquic.MockStream
 		buf           *bytes.Buffer
 		reqDone       chan struct{}
@@ -68,7 +68,7 @@ var _ = Describe("Body", func() {
 					rb = newRequestBody(str, errorCb)
 				case bodyTypeResponse:
 					reqDone = make(chan struct{})
-					rb = newResponseBody(str, reqDone, errorCb)
+					rb = newResponseBody(str, nil, reqDone, errorCb)
 				}
 			})
 

--- a/http3/client.go
+++ b/http3/client.go
@@ -316,7 +316,7 @@ func (c *client) doRequest(
 			res.Header.Add(hf.Name, hf.Value)
 		}
 	}
-	respBody := newResponseBody(str, reqDone, func() {
+	respBody := newResponseBody(str, c.conn, reqDone, func() {
 		c.conn.CloseWithError(quic.ApplicationErrorCode(errorFrameUnexpected), "")
 	})
 

--- a/http3/client.go
+++ b/http3/client.go
@@ -42,6 +42,7 @@ type roundTripperOpts struct {
 	DisableCompression bool
 	EnableDatagram     bool
 	MaxHeaderBytes     int64
+	AdditionalSettings map[uint64]uint64
 }
 
 // client is a HTTP3 client doing requests
@@ -130,7 +131,7 @@ func (c *client) setupConn() error {
 	buf := &bytes.Buffer{}
 	quicvarint.Write(buf, streamTypeControlStream)
 	// send the SETTINGS frame
-	(&settingsFrame{Datagram: c.opts.EnableDatagram}).Write(buf)
+	(&settingsFrame{Datagram: c.opts.EnableDatagram, Other: c.opts.AdditionalSettings}).Write(buf)
 	_, err = str.Write(buf.Bytes())
 	return err
 }

--- a/http3/client.go
+++ b/http3/client.go
@@ -43,7 +43,7 @@ type roundTripperOpts struct {
 	EnableDatagram     bool
 	MaxHeaderBytes     int64
 	AdditionalSettings map[uint64]uint64
-	StreamHijacker     func(FrameType, quic.Stream) (hijacked bool, err error)
+	StreamHijacker     func(FrameType, quic.Connection, quic.Stream) (hijacked bool, err error)
 }
 
 // client is a HTTP3 client doing requests
@@ -152,7 +152,7 @@ func (c *client) handleBidirectionalStreams() {
 		go func(str quic.Stream) {
 			for {
 				_, err := parseNextFrame(str, func(ft FrameType) (processed bool, err error) {
-					return c.opts.StreamHijacker(ft, str)
+					return c.opts.StreamHijacker(ft, c.conn, str)
 				})
 				if err == errHijacked {
 					return

--- a/http3/client.go
+++ b/http3/client.go
@@ -76,7 +76,9 @@ func newClient(hostname string, tlsConf *tls.Config, opts *roundTripperOpts, con
 	if len(conf.Versions) != 1 {
 		return nil, errors.New("can only use a single QUIC version for dialing a HTTP/3 connection")
 	}
-	conf.MaxIncomingStreams = -1 // don't allow any bidirectional streams
+	if conf.MaxIncomingStreams == 0 {
+		conf.MaxIncomingStreams = -1 // don't allow any bidirectional streams
+	}
 	conf.EnableDatagrams = opts.EnableDatagram
 	logger := utils.DefaultLogger.WithPrefix("h3 client")
 

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -429,7 +429,7 @@ var _ = Describe("Client", func() {
 			buf := &bytes.Buffer{}
 			rstr := mockquic.NewMockStream(mockCtrl)
 			rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-			rw := newResponseWriter(rstr, utils.DefaultLogger)
+			rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
 			rw.WriteHeader(status)
 			rw.Flush()
 			return buf.Bytes()
@@ -717,7 +717,7 @@ var _ = Describe("Client", func() {
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
 				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-				rw := newResponseWriter(rstr, utils.DefaultLogger)
+				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
 				rw.Header().Set("Content-Encoding", "gzip")
 				gz := gzip.NewWriter(rw)
 				gz.Write([]byte("gzipped response"))
@@ -743,7 +743,7 @@ var _ = Describe("Client", func() {
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
 				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-				rw := newResponseWriter(rstr, utils.DefaultLogger)
+				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
 				rw.Write([]byte("not gzipped"))
 				rw.Flush()
 				str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Client", func() {
 			})
 		}
 
-		It("resets streams other than the control stream and the QPACK streams", func() {
+		It("resets streams Other than the control stream and the QPACK streams", func() {
 			buf := &bytes.Buffer{}
 			quicvarint.Write(buf, 1337)
 			str := mockquic.NewMockStream(mockCtrl)

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -410,7 +410,7 @@ var _ = Describe("Client", func() {
 			fields := make(map[string]string)
 			decoder := qpack.NewDecoder(nil)
 
-			frame, err := parseNextFrame(str)
+			frame, err := parseNextFrame(str, nil)
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			ExpectWithOffset(1, frame).To(BeAssignableToTypeOf(&headersFrame{}))
 			headersFrame := frame.(*headersFrame)

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -2,6 +2,7 @@ package http3
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -10,14 +11,33 @@ import (
 	"github.com/lucas-clemente/quic-go/quicvarint"
 )
 
+// FrameType is the frame type of a HTTP/3 frame
+type FrameType uint64
+
+type unknownFrameHandlerFunc func(FrameType) (processed bool, err error)
+
 type frame interface{}
 
-func parseNextFrame(r io.Reader) (frame, error) {
+var errHijacked = errors.New("hijacked")
+
+func parseNextFrame(r io.Reader, unknownFrameHandler unknownFrameHandlerFunc) (frame, error) {
 	qr := quicvarint.NewReader(r)
 	for {
 		t, err := quicvarint.Read(qr)
 		if err != nil {
 			return nil, err
+		}
+		// Call the unknownFrameHandler for frames not defined in the HTTP/3 spec
+		if t > 0xd && unknownFrameHandler != nil {
+			hijacked, err := unknownFrameHandler(FrameType(t))
+			if err != nil {
+				return nil, err
+			}
+			// If the unknownFrameHandler didn't process the frame, it is our responsibility to skip it.
+			if hijacked {
+				return nil, errHijacked
+			}
+			continue
 		}
 		l, err := quicvarint.Read(qr)
 		if err != nil {
@@ -32,18 +52,13 @@ func parseNextFrame(r io.Reader) (frame, error) {
 		case 0x4:
 			return parseSettingsFrame(r, l)
 		case 0x3: // CANCEL_PUSH
-			fallthrough
 		case 0x5: // PUSH_PROMISE
-			fallthrough
 		case 0x7: // GOAWAY
-			fallthrough
 		case 0xd: // MAX_PUSH_ID
-			fallthrough
-		default:
-			// skip over unknown frames
-			if _, err := io.CopyN(ioutil.Discard, qr, int64(l)); err != nil {
-				return nil, err
-			}
+		}
+		// skip over unknown frames
+		if _, err := io.CopyN(ioutil.Discard, qr, int64(l)); err != nil {
+			return nil, err
 		}
 	}
 }

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -70,7 +70,7 @@ const settingDatagram = 0xffd277
 
 type settingsFrame struct {
 	Datagram bool
-	other    map[uint64]uint64 // all settings that we don't explicitly recognize
+	Other    map[uint64]uint64 // all settings that we don't explicitly recognize
 }
 
 func parseSettingsFrame(r io.Reader, l uint64) (*settingsFrame, error) {
@@ -108,13 +108,13 @@ func parseSettingsFrame(r io.Reader, l uint64) (*settingsFrame, error) {
 			}
 			frame.Datagram = val == 1
 		default:
-			if _, ok := frame.other[id]; ok {
+			if _, ok := frame.Other[id]; ok {
 				return nil, fmt.Errorf("duplicate setting: %d", id)
 			}
-			if frame.other == nil {
-				frame.other = make(map[uint64]uint64)
+			if frame.Other == nil {
+				frame.Other = make(map[uint64]uint64)
 			}
-			frame.other[id] = val
+			frame.Other[id] = val
 		}
 	}
 	return frame, nil
@@ -123,7 +123,7 @@ func parseSettingsFrame(r io.Reader, l uint64) (*settingsFrame, error) {
 func (f *settingsFrame) Write(b *bytes.Buffer) {
 	quicvarint.Write(b, 0x4)
 	var l protocol.ByteCount
-	for id, val := range f.other {
+	for id, val := range f.Other {
 		l += quicvarint.Len(id) + quicvarint.Len(val)
 	}
 	if f.Datagram {
@@ -134,7 +134,7 @@ func (f *settingsFrame) Write(b *bytes.Buffer) {
 		quicvarint.Write(b, settingDatagram)
 		quicvarint.Write(b, 1)
 	}
-	for id, val := range f.other {
+	for id, val := range f.Other {
 		quicvarint.Write(b, id)
 		quicvarint.Write(b, val)
 	}

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -85,8 +85,8 @@ var _ = Describe("Frames", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&settingsFrame{}))
 			sf := frame.(*settingsFrame)
-			Expect(sf.other).To(HaveKeyWithValue(uint64(13), uint64(37)))
-			Expect(sf.other).To(HaveKeyWithValue(uint64(0xdead), uint64(0xbeef)))
+			Expect(sf.Other).To(HaveKeyWithValue(uint64(13), uint64(37)))
+			Expect(sf.Other).To(HaveKeyWithValue(uint64(0xdead), uint64(0xbeef)))
 		})
 
 		It("rejects duplicate settings", func() {
@@ -102,7 +102,7 @@ var _ = Describe("Frames", func() {
 		})
 
 		It("writes", func() {
-			sf := &settingsFrame{other: map[uint64]uint64{
+			sf := &settingsFrame{Other: map[uint64]uint64{
 				1:  2,
 				99: 999,
 				13: 37,
@@ -115,7 +115,7 @@ var _ = Describe("Frames", func() {
 		})
 
 		It("errors on EOF", func() {
-			sf := &settingsFrame{other: map[uint64]uint64{
+			sf := &settingsFrame{Other: map[uint64]uint64{
 				13:         37,
 				0xdeadbeef: 0xdecafbad,
 			}}

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Frames", func() {
 		data = append(data, make([]byte, 0x42)...)
 		buf := bytes.NewBuffer(data)
 		(&dataFrame{Length: 0x1234}).Write(buf)
-		frame, err := parseNextFrame(buf)
+		frame, err := parseNextFrame(buf, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
 		Expect(frame.(*dataFrame).Length).To(Equal(uint64(0x1234)))
@@ -34,7 +34,7 @@ var _ = Describe("Frames", func() {
 		It("parses", func() {
 			data := appendVarInt(nil, 0) // type byte
 			data = appendVarInt(data, 0x1337)
-			frame, err := parseNextFrame(bytes.NewReader(data))
+			frame, err := parseNextFrame(bytes.NewReader(data), nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
 			Expect(frame.(*dataFrame).Length).To(Equal(uint64(0x1337)))
@@ -43,7 +43,7 @@ var _ = Describe("Frames", func() {
 		It("writes", func() {
 			buf := &bytes.Buffer{}
 			(&dataFrame{Length: 0xdeadbeef}).Write(buf)
-			frame, err := parseNextFrame(buf)
+			frame, err := parseNextFrame(buf, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
@@ -55,7 +55,7 @@ var _ = Describe("Frames", func() {
 		It("parses", func() {
 			data := appendVarInt(nil, 1) // type byte
 			data = appendVarInt(data, 0x1337)
-			frame, err := parseNextFrame(bytes.NewReader(data))
+			frame, err := parseNextFrame(bytes.NewReader(data), nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&headersFrame{}))
 			Expect(frame.(*headersFrame).Length).To(Equal(uint64(0x1337)))
@@ -64,7 +64,7 @@ var _ = Describe("Frames", func() {
 		It("writes", func() {
 			buf := &bytes.Buffer{}
 			(&headersFrame{Length: 0xdeadbeef}).Write(buf)
-			frame, err := parseNextFrame(buf)
+			frame, err := parseNextFrame(buf, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&headersFrame{}))
@@ -81,7 +81,7 @@ var _ = Describe("Frames", func() {
 			data := appendVarInt(nil, 4) // type byte
 			data = appendVarInt(data, uint64(len(settings)))
 			data = append(data, settings...)
-			frame, err := parseNextFrame(bytes.NewReader(data))
+			frame, err := parseNextFrame(bytes.NewReader(data), nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&settingsFrame{}))
 			sf := frame.(*settingsFrame)
@@ -97,7 +97,7 @@ var _ = Describe("Frames", func() {
 			data := appendVarInt(nil, 4) // type byte
 			data = appendVarInt(data, uint64(len(settings)))
 			data = append(data, settings...)
-			_, err := parseNextFrame(bytes.NewReader(data))
+			_, err := parseNextFrame(bytes.NewReader(data), nil)
 			Expect(err).To(MatchError("duplicate setting: 13"))
 		})
 
@@ -109,7 +109,7 @@ var _ = Describe("Frames", func() {
 			}}
 			buf := &bytes.Buffer{}
 			sf.Write(buf)
-			frame, err := parseNextFrame(buf)
+			frame, err := parseNextFrame(buf, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(Equal(sf))
 		})
@@ -123,13 +123,13 @@ var _ = Describe("Frames", func() {
 			sf.Write(buf)
 
 			data := buf.Bytes()
-			_, err := parseNextFrame(bytes.NewReader(data))
+			_, err := parseNextFrame(bytes.NewReader(data), nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			for i := range data {
 				b := make([]byte, i)
 				copy(b, data[:i])
-				_, err := parseNextFrame(bytes.NewReader(b))
+				_, err := parseNextFrame(bytes.NewReader(b), nil)
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})
@@ -141,7 +141,7 @@ var _ = Describe("Frames", func() {
 				data := appendVarInt(nil, 4) // type byte
 				data = appendVarInt(data, uint64(len(settings)))
 				data = append(data, settings...)
-				f, err := parseNextFrame(bytes.NewReader(data))
+				f, err := parseNextFrame(bytes.NewReader(data), nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(f).To(BeAssignableToTypeOf(&settingsFrame{}))
 				sf := f.(*settingsFrame)
@@ -156,7 +156,7 @@ var _ = Describe("Frames", func() {
 				data := appendVarInt(nil, 4) // type byte
 				data = appendVarInt(data, uint64(len(settings)))
 				data = append(data, settings...)
-				_, err := parseNextFrame(bytes.NewReader(data))
+				_, err := parseNextFrame(bytes.NewReader(data), nil)
 				Expect(err).To(MatchError(fmt.Sprintf("duplicate setting: %d", settingDatagram)))
 			})
 
@@ -166,7 +166,7 @@ var _ = Describe("Frames", func() {
 				data := appendVarInt(nil, 4) // type byte
 				data = appendVarInt(data, uint64(len(settings)))
 				data = append(data, settings...)
-				_, err := parseNextFrame(bytes.NewReader(data))
+				_, err := parseNextFrame(bytes.NewReader(data), nil)
 				Expect(err).To(MatchError("invalid value for H3_DATAGRAM: 1337"))
 			})
 
@@ -174,10 +174,55 @@ var _ = Describe("Frames", func() {
 				sf := &settingsFrame{Datagram: true}
 				buf := &bytes.Buffer{}
 				sf.Write(buf)
-				frame, err := parseNextFrame(buf)
+				frame, err := parseNextFrame(buf, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(frame).To(Equal(sf))
 			})
+		})
+	})
+
+	Context("hijacking", func() {
+		It("reads a frame without hijacking the stream", func() {
+			buf := &bytes.Buffer{}
+			quicvarint.Write(buf, 1337)
+			customFrameContents := []byte("foobar")
+			buf.Write(customFrameContents)
+
+			var called bool
+			_, err := parseNextFrame(buf, func(ft FrameType) (hijacked bool, err error) {
+				Expect(ft).To(BeEquivalentTo(1337))
+				called = true
+				b := make([]byte, 3)
+				_, err = io.ReadFull(buf, b)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(b)).To(Equal("foo"))
+				return true, nil
+			})
+			Expect(err).To(MatchError(errHijacked))
+			Expect(called).To(BeTrue())
+		})
+
+		It("reads a frame without hijacking the stream", func() {
+			buf := &bytes.Buffer{}
+			quicvarint.Write(buf, 1337)
+			customFrameContents := []byte("custom frame")
+			buf.Write(customFrameContents)
+			(&dataFrame{Length: 6}).Write(buf)
+			buf.WriteString("foobar")
+
+			var called bool
+			frame, err := parseNextFrame(buf, func(ft FrameType) (hijacked bool, err error) {
+				Expect(ft).To(BeEquivalentTo(1337))
+				called = true
+				b := make([]byte, len(customFrameContents))
+				_, err = io.ReadFull(buf, b)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(b)).To(Equal(string(customFrameContents)))
+				return false, nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame).To(Equal(&dataFrame{Length: 6}))
+			Expect(called).To(BeTrue())
 		})
 	})
 })

--- a/http3/request_test.go
+++ b/http3/request_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Request", func() {
 		}))
 	})
 
-	It("handles other headers", func() {
+	It("handles Other headers", func() {
 		headers := []qpack.HeaderField{
 			{Name: ":path", Value: "/foo"},
 			{Name: ":authority", Value: "quic.clemente.io"},

--- a/http3/request_writer_test.go
+++ b/http3/request_writer_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Request Writer", func() {
 	)
 
 	decode := func(str io.Reader) map[string]string {
-		frame, err := parseNextFrame(str)
+		frame, err := parseNextFrame(str, nil)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		ExpectWithOffset(1, frame).To(BeAssignableToTypeOf(&headersFrame{}))
 		headersFrame := frame.(*headersFrame)
@@ -85,7 +85,7 @@ var _ = Describe("Request Writer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(contentLength).To(BeNumerically(">", 0))
 
-		frame, err := parseNextFrame(strBuf)
+		frame, err := parseNextFrame(strBuf, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
 		Expect(frame.(*dataFrame).Length).To(BeEquivalentTo(6))
@@ -102,7 +102,7 @@ var _ = Describe("Request Writer", func() {
 		headerFields := decode(strBuf)
 		Expect(headerFields).To(HaveKeyWithValue(":method", "POST"))
 
-		frame, err := parseNextFrame(strBuf)
+		frame, err := parseNextFrame(strBuf, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
 		Expect(frame.(*dataFrame).Length).To(BeEquivalentTo(6))

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -119,6 +119,10 @@ func (w *responseWriter) DataStream() quic.Stream {
 	return w.stream
 }
 
+func (w *responseWriter) StreamID() quic.StreamID {
+	return w.stream.StreamID()
+}
+
 // copied from http2/http2.go
 // bodyAllowedForStatus reports whether a given response status code
 // permits a body. See RFC 2616, section 4.4.

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -23,6 +23,7 @@ type DataStreamer interface {
 }
 
 type responseWriter struct {
+	conn           quic.Connection
 	stream         quic.Stream // needed for DataStream()
 	bufferedStream *bufio.Writer
 
@@ -38,12 +39,14 @@ var (
 	_ http.ResponseWriter = &responseWriter{}
 	_ http.Flusher        = &responseWriter{}
 	_ DataStreamer        = &responseWriter{}
+	_ Hijacker            = &responseWriter{}
 )
 
-func newResponseWriter(stream quic.Stream, logger utils.Logger) *responseWriter {
+func newResponseWriter(stream quic.Stream, conn quic.Connection, logger utils.Logger) *responseWriter {
 	return &responseWriter{
 		header:         http.Header{},
 		stream:         stream,
+		conn:           conn,
 		bufferedStream: bufio.NewWriter(stream),
 		logger:         logger,
 	}
@@ -121,6 +124,10 @@ func (w *responseWriter) DataStream() quic.Stream {
 
 func (w *responseWriter) StreamID() quic.StreamID {
 	return w.stream.StreamID()
+}
+
+func (w *responseWriter) StreamCreator() StreamCreator {
+	return w.conn
 }
 
 // copied from http2/http2.go

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Response Writer", func() {
 		strBuf = &bytes.Buffer{}
 		str := mockquic.NewMockStream(mockCtrl)
 		str.EXPECT().Write(gomock.Any()).DoAndReturn(strBuf.Write).AnyTimes()
-		rw = newResponseWriter(str, utils.DefaultLogger)
+		rw = newResponseWriter(str, nil, utils.DefaultLogger)
 	})
 
 	decodeHeader := func(str io.Reader) map[string][]string {

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Response Writer", func() {
 		fields := make(map[string][]string)
 		decoder := qpack.NewDecoder(nil)
 
-		frame, err := parseNextFrame(str)
+		frame, err := parseNextFrame(str, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&headersFrame{}))
 		headersFrame := frame.(*headersFrame)
@@ -49,7 +49,7 @@ var _ = Describe("Response Writer", func() {
 	}
 
 	getData := func(str io.Reader) []byte {
-		frame, err := parseNextFrame(str)
+		frame, err := parseNextFrame(str, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(BeAssignableToTypeOf(&dataFrame{}))
 		df := frame.(*dataFrame)

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -51,6 +51,13 @@ type RoundTripper struct {
 	// It is invalid to specify any settings defined by the HTTP/3 draft and the datagram draft.
 	AdditionalSettings map[uint64]uint64
 
+	// When set, this callback is called for the first unknown frame parsed on a bidirectional stream.
+	// It is called right after parsing the frame type.
+	// Callers can either process the frame and return control of the stream back to HTTP/3
+	// (by returning hijacked false).
+	// Alternatively, callers can take over the QUIC stream (by returning hijacked true).
+	StreamHijacker func(FrameType, quic.Stream) (hijacked bool, err error)
+
 	// Dial specifies an optional dial function for creating QUIC
 	// connections for requests.
 	// If Dial is nil, quic.DialAddrEarlyContext will be used.
@@ -146,6 +153,7 @@ func (r *RoundTripper) getClient(hostname string, onlyCached bool) (http.RoundTr
 				EnableDatagram:     r.EnableDatagrams,
 				DisableCompression: r.DisableCompression,
 				MaxHeaderBytes:     r.MaxResponseHeaderBytes,
+				StreamHijacker:     r.StreamHijacker,
 			},
 			r.QuicConfig,
 			r.Dial,

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -56,7 +56,7 @@ type RoundTripper struct {
 	// Callers can either process the frame and return control of the stream back to HTTP/3
 	// (by returning hijacked false).
 	// Alternatively, callers can take over the QUIC stream (by returning hijacked true).
-	StreamHijacker func(FrameType, quic.Stream) (hijacked bool, err error)
+	StreamHijacker func(FrameType, quic.Connection, quic.Stream) (hijacked bool, err error)
 
 	// Dial specifies an optional dial function for creating QUIC
 	// connections for requests.

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -47,6 +47,10 @@ type RoundTripper struct {
 	// See https://www.ietf.org/archive/id/draft-schinazi-masque-h3-datagram-02.html.
 	EnableDatagrams bool
 
+	// Additional HTTP/3 settings.
+	// It is invalid to specify any settings defined by the HTTP/3 draft and the datagram draft.
+	AdditionalSettings map[uint64]uint64
+
 	// Dial specifies an optional dial function for creating QUIC
 	// connections for requests.
 	// If Dial is nil, quic.DialAddrEarlyContext will be used.

--- a/http3/server.go
+++ b/http3/server.go
@@ -503,7 +503,7 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	ctx = context.WithValue(ctx, ServerContextKey, s)
 	ctx = context.WithValue(ctx, http.LocalAddrContextKey, conn.LocalAddr())
 	req = req.WithContext(ctx)
-	r := newResponseWriter(str, s.logger)
+	r := newResponseWriter(str, conn, s.logger)
 	defer func() {
 		if !r.usedDataStream() {
 			r.Flush()

--- a/http3/server.go
+++ b/http3/server.go
@@ -140,9 +140,14 @@ type Server struct {
 	// a port different from the port the Server is listening on.
 	Port int
 
+	// Additional HTTP/3 settings.
+	// It is invalid to specify any settings defined by the HTTP/3 draft and the datagram draft.
+	AdditionalSettings map[uint64]uint64
+
 	mutex     sync.RWMutex
 	listeners map[*quic.EarlyListener]listenerInfo
-	closed    utils.AtomicBool
+
+	closed utils.AtomicBool
 
 	altSvcHeader string
 
@@ -345,7 +350,7 @@ func (s *Server) handleConn(conn quic.EarlyConnection) {
 	}
 	buf := &bytes.Buffer{}
 	quicvarint.Write(buf, streamTypeControlStream) // stream type
-	(&settingsFrame{Datagram: s.EnableDatagrams}).Write(buf)
+	(&settingsFrame{Datagram: s.EnableDatagrams, Other: s.AdditionalSettings}).Write(buf)
 	str.Write(buf.Bytes())
 
 	go s.handleUnidirectionalStreams(conn)

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Server", func() {
 			fields := make(map[string][]string)
 			decoder := qpack.NewDecoder(nil)
 
-			frame, err := parseNextFrame(str)
+			frame, err := parseNextFrame(str, nil)
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			ExpectWithOffset(1, frame).To(BeAssignableToTypeOf(&headersFrame{}))
 			headersFrame := frame.(*headersFrame)

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -296,7 +296,7 @@ var _ = Describe("Server", func() {
 				})
 			}
 
-			It("reset streams other than the control stream and the QPACK streams", func() {
+			It("reset streams Other than the control stream and the QPACK streams", func() {
 				buf := &bytes.Buffer{}
 				quicvarint.Write(buf, 1337)
 				str := mockquic.NewMockStream(mockCtrl)


### PR DESCRIPTION
Builds on top of #3360. Only provides support for bidirectional streams at the moment.

To support WebTransport, we need to be able to "hijack" a stream after reading a HTTP/3 frame of type 0x41. The WebTransport implementation then takes over the stream and writes on the QUIC stream directly.

We also need to be able to "hijack" the connection: After we receive a WebTransport upgrade request from the client, we establish a WebTransport connection. On this connection, it is possible to open new streams (that's why we need the `http3.StreamCreator`).

A work-in-progress implementation of WebTransport has been started here: https://github.com/marten-seemann/webtransport-go.

cc @ydnar @adriancable