### PR TITLE
remove unneeded network from custom dial function used in HTTP/3

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -34,7 +34,7 @@ var defaultQuicConfig = &quic.Config{
 	Versions:           []protocol.VersionNumber{protocol.VersionTLS},
 }
 
-type dialFunc func(ctx context.Context, network, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)
+type dialFunc func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)
 
 var dialAddr = quic.DialAddrEarlyContext
 
@@ -101,7 +101,7 @@ func newClient(hostname string, tlsConf *tls.Config, opts *roundTripperOpts, con
 func (c *client) dial(ctx context.Context) error {
 	var err error
 	if c.dialer != nil {
-		c.conn, err = c.dialer(ctx, "udp", c.hostname, c.tlsConf, c.config)
+		c.conn, err = c.dialer(ctx, c.hostname, c.tlsConf, c.config)
 	} else {
 		c.conn, err = dialAddr(ctx, c.hostname, c.tlsConf, c.config)
 	}

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -121,9 +121,8 @@ var _ = Describe("Client", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
 		defer cancel()
 		var dialerCalled bool
-		dialer := func(ctxP context.Context, network, address string, tlsConfP *tls.Config, quicConfP *quic.Config) (quic.EarlyConnection, error) {
+		dialer := func(ctxP context.Context, address string, tlsConfP *tls.Config, quicConfP *quic.Config) (quic.EarlyConnection, error) {
 			Expect(ctxP).To(Equal(ctx))
-			Expect(network).To(Equal("udp"))
 			Expect(address).To(Equal("localhost:1337"))
 			Expect(tlsConfP.ServerName).To(Equal("foo.bar"))
 			Expect(quicConfP.MaxIdleTimeout).To(Equal(quicConf.MaxIdleTimeout))

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -50,7 +50,7 @@ type RoundTripper struct {
 	// Dial specifies an optional dial function for creating QUIC
 	// connections for requests.
 	// If Dial is nil, quic.DialAddrEarlyContext will be used.
-	Dial func(ctx context.Context, network, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)
+	Dial func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)
 
 	// MaxResponseHeaderBytes specifies a limit on how many response bytes are
 	// allowed in the server's response header.

--- a/http3/roundtrip_test.go
+++ b/http3/roundtrip_test.go
@@ -127,7 +127,7 @@ var _ = Describe("RoundTripper", func() {
 
 		It("uses the custom dialer, if provided", func() {
 			var dialed bool
-			dialer := func(_ context.Context, _, _ string, tlsCfgP *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
+			dialer := func(_ context.Context, _ string, tlsCfgP *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
 				dialed = true
 				return nil, errors.New("handshake error")
 			}


### PR DESCRIPTION
Note that we haven't yet released the latest breaking change to `http3.RoundTripper.Dial` (https://github.com/lucas-clemente/quic-go/pull/3359).

With this change, one can now use `quic.DialAddrEarlyContext` directly.