### PR TITLE
protect against concurrent use of Stream.Read

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -47,6 +47,7 @@ type receiveStream struct {
 	resetRemotely     bool // set when HandleResetStreamFrame() is called
 
 	readChan chan struct{}
+	readOnce chan struct{} // cap: 1, to protect against concurrent use of Read
 	deadline time.Time
 
 	flowController flowcontrol.StreamFlowController
@@ -70,6 +71,7 @@ func newReceiveStream(
 		flowController: flowController,
 		frameQueue:     newFrameSorter(),
 		readChan:       make(chan struct{}, 1),
+		readOnce:       make(chan struct{}, 1),
 		finalOffset:    protocol.MaxByteCount,
 		version:        version,
 	}
@@ -81,6 +83,12 @@ func (s *receiveStream) StreamID() protocol.StreamID {
 
 // Read implements io.Reader. It is not thread safe!
 func (s *receiveStream) Read(p []byte) (int, error) {
+	// Concurrent use of Read is not permitted (and doesn't make any sense),
+	// but sometimes people do it anyway.
+	// Make sure that we only execute one call at any given time to avoid hard to debug failures.
+	s.readOnce <- struct{}{}
+	defer func() { <-s.readOnce }()
+
 	s.mutex.Lock()
 	completed, n, err := s.readImpl(p)
 	s.mutex.Unlock()
@@ -105,7 +113,7 @@ func (s *receiveStream) readImpl(p []byte) (bool /*stream completed */, int, err
 		return false, 0, s.closeForShutdownErr
 	}
 
-	bytesRead := 0
+	var bytesRead int
 	var deadlineTimer *utils.Timer
 	for bytesRead < len(p) {
 		if s.currentFrame == nil || s.readPosInFrame >= len(s.currentFrame) {


### PR DESCRIPTION
Concurrent use of Read is not permitted (and doesn't make any sense), but sometimes people do it anyway.

In this case, it's easy and cheap enough to protect against misuse of the API, and means we don't have to debug failures that look like quic-go bugs but are really bugs in the user's code. See #3376 for an example.