### PR TITLE
Fix returning incorrect url.URL in HTTP/3 extended CONNECT method

### DIFF
--- a/http3/request.go
+++ b/http3/request.go
@@ -60,11 +60,16 @@ func requestFromHeaders(headers []qpack.HeaderField) (*http.Request, error) {
 	var err error
 
 	if isConnect {
-		u = &url.URL{
-			Scheme: scheme,
-			Host:   authority,
-			Path:   path,
+		if path != "" {
+			u, err = url.ParseRequestURI(path)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			u = &url.URL{}
 		}
+		u.Scheme = scheme
+		u.Host = authority
 		requestURI = authority
 	} else {
 		protocol = "HTTP/3"

--- a/http3/request_test.go
+++ b/http3/request_test.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("Request", func() {
 	It("populates request", func() {
 		headers := []qpack.HeaderField{
-			{Name: ":path", Value: "/foo"},
+			{Name: ":path", Value: "/foo?foo=bar"},
 			{Name: ":authority", Value: "quic.clemente.io"},
 			{Name: ":method", Value: "GET"},
 			{Name: "content-length", Value: "42"},
@@ -21,6 +21,7 @@ var _ = Describe("Request", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(req.Method).To(Equal("GET"))
 		Expect(req.URL.Path).To(Equal("/foo"))
+		Expect(req.URL.RawQuery).To(Equal("foo=bar"))
 		Expect(req.URL.Host).To(BeEmpty())
 		Expect(req.Proto).To(Equal("HTTP/3"))
 		Expect(req.ProtoMajor).To(Equal(3))
@@ -29,7 +30,7 @@ var _ = Describe("Request", func() {
 		Expect(req.Header).To(BeEmpty())
 		Expect(req.Body).To(BeNil())
 		Expect(req.Host).To(Equal("quic.clemente.io"))
-		Expect(req.RequestURI).To(Equal("/foo"))
+		Expect(req.RequestURI).To(Equal("/foo?foo=bar"))
 		Expect(req.TLS).ToNot(BeNil())
 	})
 

--- a/http3/request_test.go
+++ b/http3/request_test.go
@@ -146,13 +146,13 @@ var _ = Describe("Request", func() {
 				{Name: ":scheme", Value: "ftp"},
 				{Name: ":method", Value: http.MethodConnect},
 				{Name: ":authority", Value: "quic.clemente.io"},
-				{Name: ":path", Value: "/foo"},
+				{Name: ":path", Value: "/foo?foo=bar"},
 			}
 			req, err := requestFromHeaders(headers)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(req.Method).To(Equal(http.MethodConnect))
 			Expect(req.Proto).To(Equal("webtransport"))
-			Expect(req.URL.String()).To(Equal("ftp://quic.clemente.io/foo"))
+			Expect(req.URL.String()).To(Equal("ftp://quic.clemente.io/foo?foo=bar"))
 		})
 
 		It("errors with missing scheme", func() {


### PR DESCRIPTION
Currently, quic-go returns `url.URL.Path` that contains url query when a request is Extended CONNECT method.