### PR TITLE
Expose quic server closed err

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -255,9 +255,6 @@ func (s *Server) serveImpl(startListener func() (quic.EarlyListener, error)) err
 	for {
 		conn, err := ln.Accept(context.Background())
 		if err != nil {
-			if errors.Is(err, quic.ErrServerClosed) {
-				return http.ErrServerClosed
-			}
 			return err
 		}
 		go s.handleConn(conn)

--- a/http3/server.go
+++ b/http3/server.go
@@ -255,6 +255,9 @@ func (s *Server) serveImpl(startListener func() (quic.EarlyListener, error)) err
 	for {
 		conn, err := ln.Accept(context.Background())
 		if err != nil {
+			if errors.Is(err, quic.ErrServerClosed) {
+				return http.ErrServerClosed
+			}
 			return err
 		}
 		go s.handleConn(conn)

--- a/server.go
+++ b/server.go
@@ -20,6 +20,9 @@ import (
 	"github.com/lucas-clemente/quic-go/logging"
 )
 
+// ErrServerClosed is returned by the Listener or EarlyListener's Accept method after a call to Close.
+var ErrServerClosed = errors.New("quic: Server closed")
+
 // packetHandler handles packets
 type packetHandler interface {
 	handlePacket(*receivedPacket)
@@ -284,7 +287,7 @@ func (s *baseServer) Close() error {
 		return nil
 	}
 	if s.serverError == nil {
-		s.serverError = errors.New("server closed")
+		s.serverError = ErrServerClosed
 	}
 	// If the server was started with ListenAddr, we created the packet conn.
 	// We need to close it in order to make the go routine reading from that conn return.


### PR DESCRIPTION
To provide a way to check whether a returned error is expected or not from `quic.Listener` and `http3.Server`.