### PR TITLE
do not embed http.Server in http3.Server

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -185,7 +185,8 @@ func main() {
 				err = http3.ListenAndServe(bCap, certFile, keyFile, handler)
 			} else {
 				server := http3.Server{
-					Server:     &http.Server{Handler: handler, Addr: bCap},
+					Handler:    handler,
+					Addr:       bCap,
 					QuicConfig: quicConf,
 				}
 				err = server.ListenAndServeTLS(testdata.GetCertificatePaths())

--- a/integrationtests/self/hotswap_test.go
+++ b/integrationtests/self/hotswap_test.go
@@ -87,18 +87,14 @@ var _ = Describe("HTTP3 Server hotswap test", func() {
 		})
 
 		server1 = &http3.Server{
-			Server: &http.Server{
-				Handler:   mux1,
-				TLSConfig: testdata.GetTLSConfig(),
-			},
+			Handler:    mux1,
+			TLSConfig:  testdata.GetTLSConfig(),
 			QuicConfig: getQuicConfig(&quic.Config{Versions: versions}),
 		}
 
 		server2 = &http3.Server{
-			Server: &http.Server{
-				Handler:   mux2,
-				TLSConfig: testdata.GetTLSConfig(),
-			},
+			Handler:    mux2,
+			TLSConfig:  testdata.GetTLSConfig(),
 			QuicConfig: getQuicConfig(&quic.Config{Versions: versions}),
 		}
 

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -68,10 +68,8 @@ var _ = Describe("HTTP tests", func() {
 		})
 
 		server = &http3.Server{
-			Server: &http.Server{
-				Handler:   mux,
-				TLSConfig: testdata.GetTLSConfig(),
-			},
+			Handler:    mux,
+			TLSConfig:  testdata.GetTLSConfig(),
 			QuicConfig: getQuicConfig(&quic.Config{Versions: versions}),
 		}
 

--- a/interop/server/main.go
+++ b/interop/server/main.go
@@ -94,10 +94,8 @@ func runHTTP09Server(quicConf *quic.Config) error {
 
 func runHTTP3Server(quicConf *quic.Config) error {
 	server := http3.Server{
-		Server: &http.Server{
-			Addr:      ":443",
-			TLSConfig: tlsConf,
-		},
+		Addr:       ":443",
+		TLSConfig:  tlsConf,
 		QuicConfig: quicConf,
 	}
 	http.DefaultServeMux.Handle("/", http.FileServer(http.Dir("/www")))


### PR DESCRIPTION
This change removes the embedded http.Server struct from http3.Server. It slightly changes some error behavior, in particular, it mandates TLSConfig for methods that create QUIC listeners.

Before this change, only Addr, TLSConfig, Handler and MaxHeaderBytes options were used from the http.Server. These are now defined directly in http3.Server with an improved documentation.