### PR TITLE
Clone TLS conf in newClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -231,6 +231,8 @@ func newClient(
 ) (*client, error) {
 	if tlsConf == nil {
 		tlsConf = &tls.Config{}
+	} else {
+		tlsConf = tlsConf.Clone()
 	}
 	if tlsConf.ServerName == "" {
 		sni := host


### PR DESCRIPTION
Fixes #3394

- I searched for other potential places in non-tests where this was happening, and this is the only one I found. In other places, it's appropriately cloned already.
- I took a look at the unit tests, but it seems out of place with a specific client test in that file given the harness (BeforeEach) and the other tests. Also it would be very fragile to changes, and likely not catch other instances. I'd recommend taking a look at running integration tests with `-race` in case you're not already doing that. Or let me know if you already a unit test approach in mind.

Obligatory thanks for maintaining this amazing library.