### PR TITLE
allow hijacking quic.Stream

### DIFF
--- a/http3/body.go
+++ b/http3/body.go
@@ -20,9 +20,10 @@ type StreamCreator interface {
 
 var _ StreamCreator = quic.Connection(nil)
 
-// A Hijacker allows hijacking of the stream creating part of a quic.Session from a http.Response.Body.
+// A Hijacker allows hijacking of the stream and stream creating part of a quic.Session from a http.Response.Body.
 // It is used by WebTransport to create WebTransport streams after a session has been established.
 type Hijacker interface {
+	Stream() quic.Stream
 	StreamCreator() StreamCreator
 }
 
@@ -66,6 +67,10 @@ func newResponseBody(str quic.Stream, conn quic.Connection, done chan<- struct{}
 		},
 		conn: conn,
 	}
+}
+
+func (r *hijackableBody) Stream() quic.Stream {
+	return r.body.str
 }
 
 func (r *hijackableBody) StreamCreator() StreamCreator {

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -126,6 +126,10 @@ func (w *responseWriter) StreamID() quic.StreamID {
 	return w.stream.StreamID()
 }
 
+func (w *responseWriter) Stream() quic.Stream {
+	return w.stream
+}
+
 func (w *responseWriter) StreamCreator() StreamCreator {
 	return w.conn
 }


### PR DESCRIPTION
Currently, there is no way to know if the hijacked stream is closed, so this PR makes hijackable quic.Stream.

Here is an example of webtransport server. The client side has a similar implementation.
```go
func (s *WebTransportServer) Upgrade(w http.ResponseWriter, r *http.Request) (*Conn, error) {
	// ....

	hijacker := w.(http3.Hijacker)
	qconn := hijacker.StreamCreator()
	ctx := hijacker.Stream().Context() // to notice the stream state for WebTransport session.
	return newWebTransportConn(ctx, qconn)
}
```
