### PR TITLE
introduce a http3.RoundTripOpt to prevent closing of request stream

### DIFF
--- a/http3/conn.go
+++ b/http3/conn.go
@@ -1,0 +1,21 @@
+package http3
+
+import "github.com/lucas-clemente/quic-go"
+
+type ConnState struct {
+	SupportsDatagram bool
+}
+
+type Conn struct {
+	conn quic.Connection
+
+	supportsDatagram bool
+}
+
+func (c *Conn) State() ConnState {
+	return ConnState{SupportsDatagram: c.supportsDatagram}
+}
+
+func (c *Conn) SendDatagram(b []byte) error {
+	return c.conn.SendMessage(b)
+}

--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -38,7 +38,7 @@ func newRequestWriter(logger utils.Logger) *requestWriter {
 	}
 }
 
-func (w *requestWriter) WriteRequest(str quic.Stream, req *http.Request, gzip bool) error {
+func (w *requestWriter) WriteRequest(str quic.Stream, req *http.Request, dontCloseStr, gzip bool) error {
 	buf := &bytes.Buffer{}
 	if err := w.writeHeaders(buf, req, gzip); err != nil {
 		return err
@@ -48,7 +48,9 @@ func (w *requestWriter) WriteRequest(str quic.Stream, req *http.Request, gzip bo
 	}
 	// TODO: add support for trailers
 	if req.Body == nil {
-		str.Close()
+		if !dontCloseStr {
+			str.Close()
+		}
 		return nil
 	}
 
@@ -84,7 +86,9 @@ func (w *requestWriter) WriteRequest(str quic.Stream, req *http.Request, gzip bo
 				return
 			}
 		}
-		str.Close()
+		if !dontCloseStr {
+			str.Close()
+		}
 	}()
 
 	return nil

--- a/http3/roundtrip_test.go
+++ b/http3/roundtrip_test.go
@@ -20,7 +20,7 @@ type mockClient struct {
 	closed bool
 }
 
-func (m *mockClient) RoundTrip(req *http.Request) (*http.Response, error) {
+func (m *mockClient) RoundTripOpt(req *http.Request, _ RoundTripOpt) (*http.Response, error) {
 	return &http.Response{Request: req}, nil
 }
 

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Server", func() {
 			closed := make(chan struct{})
 			str.EXPECT().Close().Do(func() { close(closed) })
 			rw := newRequestWriter(utils.DefaultLogger)
-			Expect(rw.WriteRequest(str, req, false)).To(Succeed())
+			Expect(rw.WriteRequest(str, req, false, false)).To(Succeed())
 			Eventually(closed).Should(BeClosed())
 			return buf.Bytes()
 		}


### PR DESCRIPTION
Fixes #3396.

cc @hareku 