### PR TITLE
don't ignore errors that occur when the TLS ClientHello is generated

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -190,6 +190,7 @@ type connection struct {
 	clientHelloWritten    <-chan *wire.TransportParameters
 	earlyConnReadyChan    chan struct{}
 	handshakeCompleteChan chan struct{} // is closed when the handshake completes
+	sentFirstPacket       bool
 	handshakeComplete     bool
 	handshakeConfirmed    bool
 
@@ -1519,6 +1520,12 @@ func (s *connection) handleCloseError(closeErr *closeError) {
 		s.connIDGenerator.RemoveAll()
 		return
 	}
+	// Don't send out any CONNECTION_CLOSE if this is an error that occurred
+	// before we even sent out the first packet.
+	if s.perspective == protocol.PerspectiveClient && !s.sentFirstPacket {
+		s.connIDGenerator.RemoveAll()
+		return
+	}
 	connClosePacket, err := s.sendConnectionClose(e)
 	if err != nil {
 		s.logger.Debugf("Error sending CONNECTION_CLOSE: %s", err)
@@ -1760,6 +1767,7 @@ func (s *connection) sendPacket() (bool, error) {
 		if err != nil || packet == nil {
 			return false, err
 		}
+		s.sentFirstPacket = true
 		s.logCoalescedPacket(packet)
 		for _, p := range packet.packets {
 			if s.firstAckElicitingPacketAfterIdleSentTime.IsZero() && p.IsAckEliciting() {

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -113,7 +113,8 @@ type cryptoSetup struct {
 
 	zeroRTTParameters      *wire.TransportParameters
 	clientHelloWritten     bool
-	clientHelloWrittenChan chan<- *wire.TransportParameters
+	clientHelloWrittenChan chan struct{} // is closed as soon as the ClientHello is written
+	zeroRTTParametersChan  chan<- *wire.TransportParameters
 
 	rttStats *utils.RTTStats
 
@@ -238,7 +239,7 @@ func newCryptoSetup(
 		tracer.UpdatedKeyFromTLS(protocol.EncryptionInitial, protocol.PerspectiveServer)
 	}
 	extHandler := newExtensionHandler(tp.Marshal(perspective), perspective, version)
-	clientHelloWrittenChan := make(chan *wire.TransportParameters, 1)
+	zeroRTTParametersChan := make(chan *wire.TransportParameters, 1)
 	cs := &cryptoSetup{
 		tlsConf:                   tlsConf,
 		initialStream:             initialStream,
@@ -257,7 +258,8 @@ func newCryptoSetup(
 		perspective:               perspective,
 		handshakeDone:             make(chan struct{}),
 		alertChan:                 make(chan uint8),
-		clientHelloWrittenChan:    clientHelloWrittenChan,
+		clientHelloWrittenChan:    make(chan struct{}),
+		zeroRTTParametersChan:     zeroRTTParametersChan,
 		messageChan:               make(chan []byte, 100),
 		isReadingHandshakeMessage: make(chan struct{}),
 		closeChan:                 make(chan struct{}),
@@ -279,7 +281,7 @@ func newCryptoSetup(
 		GetAppDataForSessionState:  cs.marshalDataForSessionState,
 		SetAppDataFromSessionState: cs.handleDataFromSessionState,
 	}
-	return cs, clientHelloWrittenChan
+	return cs, zeroRTTParametersChan
 }
 
 func (h *cryptoSetup) ChangeConnectionID(id protocol.ConnectionID) {
@@ -309,6 +311,15 @@ func (h *cryptoSetup) RunHandshake() {
 		close(handshakeComplete)
 	}()
 
+	if h.perspective == protocol.PerspectiveClient {
+		select {
+		case err := <-handshakeErrChan:
+			h.onError(0, err.Error())
+			return
+		case <-h.clientHelloWrittenChan:
+		}
+	}
+
 	select {
 	case <-handshakeComplete: // return when the handshake is done
 		h.mutex.Lock()
@@ -325,7 +336,13 @@ func (h *cryptoSetup) RunHandshake() {
 }
 
 func (h *cryptoSetup) onError(alert uint8, message string) {
-	h.runner.OnError(qerr.NewCryptoError(alert, message))
+	var err error
+	if alert == 0 {
+		err = &qerr.TransportError{ErrorCode: qerr.InternalError, ErrorMessage: message}
+	} else {
+		err = qerr.NewCryptoError(alert, message)
+	}
+	h.runner.OnError(err)
 }
 
 // Close closes the crypto setup.
@@ -646,12 +663,13 @@ func (h *cryptoSetup) WriteRecord(p []byte) (int, error) {
 		n, err := h.initialStream.Write(p)
 		if !h.clientHelloWritten && h.perspective == protocol.PerspectiveClient {
 			h.clientHelloWritten = true
+			close(h.clientHelloWrittenChan)
 			if h.zeroRTTSealer != nil && h.zeroRTTParameters != nil {
 				h.logger.Debugf("Doing 0-RTT.")
-				h.clientHelloWrittenChan <- h.zeroRTTParameters
+				h.zeroRTTParametersChan <- h.zeroRTTParameters
 			} else {
 				h.logger.Debugf("Not doing 0-RTT.")
-				h.clientHelloWrittenChan <- nil
+				h.zeroRTTParametersChan <- nil
 			}
 		}
 		return n, err


### PR DESCRIPTION
Recreating #3420 due to wrong merge method used there. Fixes #3419.