### PR TITLE
make it possible to parse a varint at the end of a reader

### DIFF
--- a/quicvarint/io.go
+++ b/quicvarint/io.go
@@ -31,7 +31,10 @@ func NewReader(r io.Reader) Reader {
 
 func (r *byteReader) ReadByte() (byte, error) {
 	var b [1]byte
-	_, err := r.Reader.Read(b[:])
+	n, err := r.Reader.Read(b[:])
+	if n == 1 && err == io.EOF {
+		err = nil
+	}
 	return b[0], err
 }
 


### PR DESCRIPTION
An `io.Reader` can read into the buffer and return the `io.EOF` in the same call. In fact, that's how the `quic.Stream` is implemented.
In that case, we shouldn't return an error from `quicvarint.Read`, otherwise the caller won't be able to parse a varint sent just before a stream was closed.