### PR TITLE
pass frame / stream type parsing errors to the hijacker callbacks

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -43,8 +43,8 @@ type roundTripperOpts struct {
 	EnableDatagram     bool
 	MaxHeaderBytes     int64
 	AdditionalSettings map[uint64]uint64
-	StreamHijacker     func(FrameType, quic.Connection, quic.Stream) (hijacked bool, err error)
-	UniStreamHijacker  func(StreamType, quic.Connection, quic.ReceiveStream) (hijacked bool)
+	StreamHijacker     func(FrameType, quic.Connection, quic.Stream, error) (hijacked bool, err error)
+	UniStreamHijacker  func(StreamType, quic.Connection, quic.ReceiveStream, error) (hijacked bool)
 }
 
 // client is a HTTP3 client doing requests
@@ -151,18 +151,16 @@ func (c *client) handleBidirectionalStreams() {
 			return
 		}
 		go func(str quic.Stream) {
-			for {
-				_, err := parseNextFrame(str, func(ft FrameType) (processed bool, err error) {
-					return c.opts.StreamHijacker(ft, c.conn, str)
-				})
-				if err == errHijacked {
-					return
-				}
-				if err != nil {
-					c.logger.Debugf("error handling stream: %s", err)
-				}
-				c.conn.CloseWithError(quic.ApplicationErrorCode(errorFrameUnexpected), "received HTTP/3 frame on bidirectional stream")
+			_, err := parseNextFrame(str, func(ft FrameType, e error) (processed bool, err error) {
+				return c.opts.StreamHijacker(ft, c.conn, str, e)
+			})
+			if err == errHijacked {
+				return
 			}
+			if err != nil {
+				c.logger.Debugf("error handling stream: %s", err)
+			}
+			c.conn.CloseWithError(quic.ApplicationErrorCode(errorFrameUnexpected), "received HTTP/3 frame on bidirectional stream")
 		}(str)
 	}
 }
@@ -178,6 +176,9 @@ func (c *client) handleUnidirectionalStreams() {
 		go func(str quic.ReceiveStream) {
 			streamType, err := quicvarint.Read(quicvarint.NewReader(str))
 			if err != nil {
+				if c.opts.UniStreamHijacker != nil && c.opts.UniStreamHijacker(StreamType(streamType), c.conn, str, err) {
+					return
+				}
 				c.logger.Debugf("reading stream type on stream %d failed: %s", str.StreamID(), err)
 				return
 			}
@@ -193,7 +194,7 @@ func (c *client) handleUnidirectionalStreams() {
 				c.conn.CloseWithError(quic.ApplicationErrorCode(errorIDError), "")
 				return
 			default:
-				if c.opts.UniStreamHijacker != nil && c.opts.UniStreamHijacker(StreamType(streamType), c.conn, str) {
+				if c.opts.UniStreamHijacker != nil && c.opts.UniStreamHijacker(StreamType(streamType), c.conn, str, nil) {
 					return
 				}
 				str.CancelRead(quic.StreamErrorCode(errorStreamCreationError))

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -33,11 +33,10 @@ func parseNextFrame(r io.Reader, unknownFrameHandler unknownFrameHandlerFunc) (f
 			if err != nil {
 				return nil, err
 			}
-			// If the unknownFrameHandler didn't process the frame, it is our responsibility to skip it.
 			if hijacked {
 				return nil, errHijacked
 			}
-			continue
+			// If the unknownFrameHandler didn't process the frame, it is our responsibility to skip it.
 		}
 		l, err := quicvarint.Read(qr)
 		if err != nil {

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -206,6 +206,7 @@ var _ = Describe("Frames", func() {
 			buf := &bytes.Buffer{}
 			quicvarint.Write(buf, 1337)
 			customFrameContents := []byte("custom frame")
+			quicvarint.Write(buf, uint64(len(customFrameContents)))
 			buf.Write(customFrameContents)
 			(&dataFrame{Length: 6}).Write(buf)
 			buf.WriteString("foobar")
@@ -214,10 +215,6 @@ var _ = Describe("Frames", func() {
 			frame, err := parseNextFrame(buf, func(ft FrameType) (hijacked bool, err error) {
 				Expect(ft).To(BeEquivalentTo(1337))
 				called = true
-				b := make([]byte, len(customFrameContents))
-				_, err = io.ReadFull(buf, b)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(b)).To(Equal(string(customFrameContents)))
 				return false, nil
 			})
 			Expect(err).ToNot(HaveOccurred())

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -2,6 +2,7 @@ package http3
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 
@@ -10,6 +11,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
 
 var _ = Describe("Frames", func() {
 	appendVarInt := func(b []byte, val uint64) []byte {
@@ -189,13 +194,27 @@ var _ = Describe("Frames", func() {
 			buf.Write(customFrameContents)
 
 			var called bool
-			_, err := parseNextFrame(buf, func(ft FrameType) (hijacked bool, err error) {
+			_, err := parseNextFrame(buf, func(ft FrameType, e error) (hijacked bool, err error) {
+				Expect(e).ToNot(HaveOccurred())
 				Expect(ft).To(BeEquivalentTo(1337))
 				called = true
 				b := make([]byte, 3)
 				_, err = io.ReadFull(buf, b)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(b)).To(Equal("foo"))
+				return true, nil
+			})
+			Expect(err).To(MatchError(errHijacked))
+			Expect(called).To(BeTrue())
+		})
+
+		It("passes on errors that occur when reading the frame type", func() {
+			testErr := errors.New("test error")
+			var called bool
+			_, err := parseNextFrame(errReader{err: testErr}, func(ft FrameType, e error) (hijacked bool, err error) {
+				Expect(e).To(MatchError(testErr))
+				Expect(ft).To(BeZero())
+				called = true
 				return true, nil
 			})
 			Expect(err).To(MatchError(errHijacked))
@@ -212,7 +231,8 @@ var _ = Describe("Frames", func() {
 			buf.WriteString("foobar")
 
 			var called bool
-			frame, err := parseNextFrame(buf, func(ft FrameType) (hijacked bool, err error) {
+			frame, err := parseNextFrame(buf, func(ft FrameType, e error) (hijacked bool, err error) {
+				Expect(e).ToNot(HaveOccurred())
 				Expect(ft).To(BeEquivalentTo(1337))
 				called = true
 				return false, nil

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -53,7 +53,7 @@ type RoundTripper struct {
 
 	// When set, this callback is called for the first unknown frame parsed on a bidirectional stream.
 	// It is called right after parsing the frame type.
-	// Callers can either process the frame and return control of the stream back to HTTP/3
+	// Callers can either ignore the frame and return control of the stream back to HTTP/3
 	// (by returning hijacked false).
 	// Alternatively, callers can take over the QUIC stream (by returning hijacked true).
 	StreamHijacker func(FrameType, quic.Connection, quic.Stream) (hijacked bool, err error)

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -53,13 +53,17 @@ type RoundTripper struct {
 
 	// When set, this callback is called for the first unknown frame parsed on a bidirectional stream.
 	// It is called right after parsing the frame type.
+	// If parsing the frame type fails, the error is passed to the callback.
+	// In that case, the frame type will not be set.
 	// Callers can either ignore the frame and return control of the stream back to HTTP/3
 	// (by returning hijacked false).
 	// Alternatively, callers can take over the QUIC stream (by returning hijacked true).
-	StreamHijacker func(FrameType, quic.Connection, quic.Stream) (hijacked bool, err error)
+	StreamHijacker func(FrameType, quic.Connection, quic.Stream, error) (hijacked bool, err error)
 
 	// When set, this callback is called for unknown unidirectional stream of unknown stream type.
-	UniStreamHijacker func(StreamType, quic.Connection, quic.ReceiveStream) (hijacked bool)
+	// If parsing the stream type fails, the error is passed to the callback.
+	// In that case, the stream type will not be set.
+	UniStreamHijacker func(StreamType, quic.Connection, quic.ReceiveStream, error) (hijacked bool)
 
 	// Dial specifies an optional dial function for creating QUIC
 	// connections for requests.

--- a/http3/server.go
+++ b/http3/server.go
@@ -178,7 +178,7 @@ type Server struct {
 
 	// StreamHijacker, when set, is called for the first unknown frame parsed on a bidirectional stream.
 	// It is called right after parsing the frame type.
-	// Callers can either process the frame and return control of the stream back to HTTP/3
+	// Callers can either ignore the frame and return control of the stream back to HTTP/3
 	// (by returning hijacked false).
 	// Alternatively, callers can take over the QUIC stream (by returning hijacked true).
 	StreamHijacker func(FrameType, quic.Connection, quic.Stream) (hijacked bool, err error)


### PR DESCRIPTION
When a stream is reset, we might not have received the frame / stream type yet. The callback might be able to identify if it was a stream intended for that application by analyzing the stream reset error.

This will allow us to resolve https://github.com/marten-seemann/go-libp2p-webtransport/issues/3. The WebTransport implementation can determine if the stream reset error code is in the [WebTransport error code range](https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-02.html#name-http-3-error-code-registrat).

@ydnar @hareku Thoughts?