### PR TITLE
remove the http3.DataStreamer

### DIFF
--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -222,45 +222,6 @@ var _ = Describe("Server", func() {
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"500"}))
 		})
 
-		It("doesn't close the stream if the handler called DataStream()", func() {
-			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				str := w.(DataStreamer).DataStream()
-				str.Write([]byte("foobar"))
-			})
-
-			rspWritten := make(chan struct{})
-			setRequest(encodeRequest(exampleGetRequest))
-			str.EXPECT().Context().Return(reqContext)
-			str.EXPECT().Write([]byte("foobar")).Do(func(b []byte) (int, error) {
-				close(rspWritten)
-				return len(b), nil
-			})
-			// don't EXPECT CancelRead()
-
-			ctrlStr := mockquic.NewMockStream(mockCtrl)
-			ctrlStr.EXPECT().Write(gomock.Any()).AnyTimes()
-			conn.EXPECT().OpenUniStream().Return(ctrlStr, nil)
-			conn.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
-				<-rspWritten
-				return nil, errors.New("done")
-			})
-			conn.EXPECT().AcceptStream(gomock.Any()).Return(str, nil)
-			conn.EXPECT().AcceptStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.Stream, error) {
-				<-rspWritten
-				return nil, errors.New("done")
-			})
-
-			done := make(chan struct{})
-			go func() {
-				defer GinkgoRecover()
-				defer close(done)
-				s.handleConn(conn)
-			}()
-			Eventually(rspWritten).Should(BeClosed())
-			time.Sleep(50 * time.Millisecond) // make sure that after str.Write there are no further calls to stream methods
-			Eventually(done).Should(BeClosed())
-		})
-
 		Context("hijacking bidirectional streams", func() {
 			var conn *mockquic.MockEarlyConnection
 			testDone := make(chan struct{})


### PR DESCRIPTION
This interface was never really useful: It allowed converting the HTTP stream into a bare QUIC stream in the HTTP handler (server-side, that is), but it didn't allow the equivalent thing on the client side.

It also doesn't look like there's any interest in this function. [Searching GitHub](https://github.com/search?q=http3.DataStreamer+language%3AGo&type=Code) for `http3.DataStreamer` yields 5 results across 4 repos, which have 6 GitHub stars (in total!).