### PR TITLE
Change "HTTP/3" to "HTTP/3.0".

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -330,7 +330,7 @@ func (c *client) doRequest(req *http.Request, str quic.Stream, opt RoundTripOpt,
 
 	connState := qtls.ToTLSConnectionState(c.conn.ConnectionState().TLS)
 	res := &http.Response{
-		Proto:      "HTTP/3",
+		Proto:      "HTTP/3.0",
 		ProtoMajor: 3,
 		Header:     http.Header{},
 		TLS:        &connState,

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -742,7 +742,7 @@ var _ = Describe("Client", func() {
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
 			rsp, err := client.RoundTripOpt(req, RoundTripOpt{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(rsp.Proto).To(Equal("HTTP/3"))
+			Expect(rsp.Proto).To(Equal("HTTP/3.0"))
 			Expect(rsp.ProtoMajor).To(Equal(3))
 			Expect(rsp.StatusCode).To(Equal(418))
 		})

--- a/http3/request.go
+++ b/http3/request.go
@@ -74,7 +74,7 @@ func requestFromHeaders(headers []qpack.HeaderField) (*http.Request, error) {
 		u.Host = authority
 		requestURI = authority
 	} else {
-		protocol = "HTTP/3"
+		protocol = "HTTP/3.0"
 		u, err = url.ParseRequestURI(path)
 		if err != nil {
 			return nil, err

--- a/http3/request_test.go
+++ b/http3/request_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Request", func() {
 		Expect(req.Method).To(Equal("GET"))
 		Expect(req.URL.Path).To(Equal("/foo"))
 		Expect(req.URL.Host).To(BeEmpty())
-		Expect(req.Proto).To(Equal("HTTP/3"))
+		Expect(req.Proto).To(Equal("HTTP/3.0"))
 		Expect(req.ProtoMajor).To(Equal(3))
 		Expect(req.ProtoMinor).To(BeZero())
 		Expect(req.ContentLength).To(Equal(int64(42)))


### PR DESCRIPTION
See https://github.com/caddyserver/caddy/issues/4819 for context.

go's `http.ParseHTTPVersion` is unable to parse `HTTP/3`.  This causes issues when using caddy as a reverse proxy to a go fastcgi server using `net/http/fcgi`.

Found instances of "HTTP/3" to change using grep:

```
grep -r '"HTTP/3"' *
```