### PR TITLE
add a OnStreamDone callback to quic.Config

### DIFF
--- a/config.go
+++ b/config.go
@@ -113,6 +113,7 @@ func populateConfig(config *Config) *Config {
 		AllowConnectionWindowIncrease:    config.AllowConnectionWindowIncrease,
 		MaxIncomingStreams:               maxIncomingStreams,
 		MaxIncomingUniStreams:            maxIncomingUniStreams,
+		OnStreamDone:                     config.OnStreamDone,
 		ConnectionIDLength:               config.ConnectionIDLength,
 		StatelessResetKey:                config.StatelessResetKey,
 		TokenStore:                       config.TokenStore,

--- a/config_test.go
+++ b/config_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Config", func() {
 			}
 
 			switch fn := typ.Field(i).Name; fn {
-			case "AcceptToken", "GetLogWriter", "AllowConnectionWindowIncrease":
+			case "AcceptToken", "GetLogWriter", "AllowConnectionWindowIncrease", "OnStreamDone":
 				// Can't compare functions.
 			case "Versions":
 				f.Set(reflect.ValueOf([]VersionNumber{1, 2, 3}))
@@ -134,12 +134,16 @@ var _ = Describe("Config", func() {
 	Context("populating", func() {
 		It("populates function fields", func() {
 			var calledAcceptToken bool
+			var calledStreamDoneWith StreamID
 			c1 := &Config{
-				AcceptToken: func(_ net.Addr, _ *Token) bool { calledAcceptToken = true; return true },
+				AcceptToken:  func(_ net.Addr, _ *Token) bool { calledAcceptToken = true; return true },
+				OnStreamDone: func(id StreamID) { calledStreamDoneWith = id },
 			}
 			c2 := populateConfig(c1)
 			c2.AcceptToken(&net.UDPAddr{}, &Token{})
+			c2.OnStreamDone(1337)
 			Expect(calledAcceptToken).To(BeTrue())
+			Expect(calledStreamDoneWith).To(BeEquivalentTo(1337))
 		})
 
 		It("copies non-function fields", func() {

--- a/config_test.go
+++ b/config_test.go
@@ -137,11 +137,11 @@ var _ = Describe("Config", func() {
 			var calledStreamDoneWith StreamID
 			c1 := &Config{
 				AcceptToken:  func(_ net.Addr, _ *Token) bool { calledAcceptToken = true; return true },
-				OnStreamDone: func(id StreamID) { calledStreamDoneWith = id },
+				OnStreamDone: func(_ Connection, id StreamID) { calledStreamDoneWith = id },
 			}
 			c2 := populateConfig(c1)
 			c2.AcceptToken(&net.UDPAddr{}, &Token{})
-			c2.OnStreamDone(1337)
+			c2.OnStreamDone(nil, 1337)
 			Expect(calledAcceptToken).To(BeTrue())
 			Expect(calledStreamDoneWith).To(BeEquivalentTo(1337))
 		})

--- a/connection.go
+++ b/connection.go
@@ -1968,7 +1968,7 @@ func (s *connection) onStreamCompleted(id protocol.StreamID) {
 		s.closeLocal(err)
 	}
 	if s.config.OnStreamDone != nil {
-		s.config.OnStreamDone(id)
+		s.config.OnStreamDone(s, id)
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -1967,6 +1967,9 @@ func (s *connection) onStreamCompleted(id protocol.StreamID) {
 	if err := s.streamsMap.DeleteStream(id); err != nil {
 		s.closeLocal(err)
 	}
+	if s.config.OnStreamDone != nil {
+		s.config.OnStreamDone(id)
+	}
 }
 
 func (s *connection) SendMessage(p []byte) error {

--- a/interface.go
+++ b/interface.go
@@ -283,7 +283,7 @@ type Config struct {
 	// or the one direction (for unidirectional streams).
 	// To avoid deadlocks, it is not valid to call other functions on the connection or on streams
 	// in this callback.
-	OnStreamDone func(StreamID)
+	OnStreamDone func(Connection, StreamID)
 	// The StatelessResetKey is used to generate stateless reset tokens.
 	// If no key is configured, sending of stateless resets is disabled.
 	StatelessResetKey []byte

--- a/interface.go
+++ b/interface.go
@@ -279,6 +279,11 @@ type Config struct {
 	// If not set, it will default to 100.
 	// If set to a negative value, it doesn't allow any unidirectional streams.
 	MaxIncomingUniStreams int64
+	// OnStreamDone is called when a stream is closed or reset in both directions (for bidirectional streams),
+	// or the one direction (for unidirectional streams).
+	// To avoid deadlocks, it is not valid to call other functions on the connection or on streams
+	// in this callback.
+	OnStreamDone func(StreamID)
 	// The StatelessResetKey is used to generate stateless reset tokens.
 	// If no key is configured, sending of stateless resets is disabled.
 	StatelessResetKey []byte

--- a/streams_map_generic_helper.go
+++ b/streams_map_generic_helper.go
@@ -11,8 +11,9 @@ import (
 // This definition must be in a file that Genny doesn't process.
 type item interface {
 	generic.Type
+	StreamID() protocol.StreamID
 	updateSendWindow(protocol.ByteCount)
 	closeForShutdown(error)
 }
 
-const streamTypeGeneric protocol.StreamType = protocol.StreamTypeUni
+const streamTypeGeneric = protocol.StreamTypeUni

--- a/streams_map_incoming_bidi.go
+++ b/streams_map_incoming_bidi.go
@@ -181,11 +181,14 @@ func (m *incomingBidiStreamsMap) deleteStream(num protocol.StreamNum) error {
 	return nil
 }
 
-func (m *incomingBidiStreamsMap) CloseWithError(err error) {
+// CloseWithError closes the map.
+// The callback is called for every stream that is removed.
+func (m *incomingBidiStreamsMap) CloseWithError(cb func(protocol.StreamID), err error) {
 	m.mutex.Lock()
 	m.closeErr = err
 	for _, entry := range m.streams {
 		entry.stream.closeForShutdown(err)
+		cb(entry.stream.StreamID())
 	}
 	m.mutex.Unlock()
 	close(m.newStreamChan)

--- a/streams_map_incoming_generic.go
+++ b/streams_map_incoming_generic.go
@@ -179,11 +179,14 @@ func (m *incomingItemsMap) deleteStream(num protocol.StreamNum) error {
 	return nil
 }
 
-func (m *incomingItemsMap) CloseWithError(err error) {
+// CloseWithError closes the map.
+// The callback is called for every stream that is removed.
+func (m *incomingItemsMap) CloseWithError(cb func(protocol.StreamID), err error) {
 	m.mutex.Lock()
 	m.closeErr = err
 	for _, entry := range m.streams {
 		entry.stream.closeForShutdown(err)
+		cb(entry.stream.StreamID())
 	}
 	m.mutex.Unlock()
 	close(m.newStreamChan)

--- a/streams_map_incoming_uni.go
+++ b/streams_map_incoming_uni.go
@@ -181,11 +181,14 @@ func (m *incomingUniStreamsMap) deleteStream(num protocol.StreamNum) error {
 	return nil
 }
 
-func (m *incomingUniStreamsMap) CloseWithError(err error) {
+// CloseWithError closes the map.
+// The callback is called for every stream that is removed.
+func (m *incomingUniStreamsMap) CloseWithError(cb func(protocol.StreamID), err error) {
 	m.mutex.Lock()
 	m.closeErr = err
 	for _, entry := range m.streams {
 		entry.stream.closeForShutdown(err)
+		cb(entry.stream.StreamID())
 	}
 	m.mutex.Unlock()
 	close(m.newStreamChan)

--- a/streams_map_outgoing_bidi.go
+++ b/streams_map_outgoing_bidi.go
@@ -211,11 +211,14 @@ func (m *outgoingBidiStreamsMap) unblockOpenSync() {
 	}
 }
 
-func (m *outgoingBidiStreamsMap) CloseWithError(err error) {
+// CloseWithError closes the map.
+// The callback is called for every stream that is removed.
+func (m *outgoingBidiStreamsMap) CloseWithError(cb func(protocol.StreamID), err error) {
 	m.mutex.Lock()
 	m.closeErr = err
 	for _, str := range m.streams {
 		str.closeForShutdown(err)
+		cb(str.StreamID())
 	}
 	for _, c := range m.openQueue {
 		if c != nil {

--- a/streams_map_outgoing_generic.go
+++ b/streams_map_outgoing_generic.go
@@ -209,11 +209,14 @@ func (m *outgoingItemsMap) unblockOpenSync() {
 	}
 }
 
-func (m *outgoingItemsMap) CloseWithError(err error) {
+// CloseWithError closes the map.
+// The callback is called for every stream that is removed.
+func (m *outgoingItemsMap) CloseWithError(cb func(protocol.StreamID), err error) {
 	m.mutex.Lock()
 	m.closeErr = err
 	for _, str := range m.streams {
 		str.closeForShutdown(err)
+		cb(str.StreamID())
 	}
 	for _, c := range m.openQueue {
 		if c != nil {

--- a/streams_map_outgoing_uni.go
+++ b/streams_map_outgoing_uni.go
@@ -211,11 +211,14 @@ func (m *outgoingUniStreamsMap) unblockOpenSync() {
 	}
 }
 
-func (m *outgoingUniStreamsMap) CloseWithError(err error) {
+// CloseWithError closes the map.
+// The callback is called for every stream that is removed.
+func (m *outgoingUniStreamsMap) CloseWithError(cb func(protocol.StreamID), err error) {
 	m.mutex.Lock()
 	m.closeErr = err
 	for _, str := range m.streams {
 		str.closeForShutdown(err)
+		cb(str.StreamID())
 	}
 	for _, c := range m.openQueue {
 		if c != nil {

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Streams Map", func() {
 
 			BeforeEach(func() {
 				mockSender = NewMockStreamSender(mockCtrl)
-				m = newStreamsMap(mockSender, newFlowController, MaxBidiStreamNum, MaxUniStreamNum, perspective, protocol.VersionWhatever).(*streamsMap)
+				m = newStreamsMap(mockSender, newFlowController, MaxBidiStreamNum, MaxUniStreamNum, func(protocol.StreamID) {}, perspective, protocol.VersionWhatever).(*streamsMap)
 			})
 
 			Context("opening", func() {


### PR DESCRIPTION
In WebTransport we need to keep a map of streams belonging to one WebTransport session (multiple WebTransport sessions can share the same QUIC connection). This is a requirement, since we need to close all streams when a WebTransport session is closed.

Since we don't want to keep an unbounded map, we want to remove closed streams from that map. Unfortunately, this is not trivial. One way to implement this would be to observe when the user reads the EOF or a stream reset error from the stream (for the stream's read side), and when the stream's write side context is canceled (consuming one Go routine per stream). In addition to the huge Go routine resource requirement, this feels very brittle.

The alternative is the `quic.Config.OnStreamDone` callback. It is called as soon as the stream is removed from quic-go's internal streams map. In WebTransport, we'd use this callback to clean up finished streams from the the webtransport-go streams map.

I'm not in love with this solution, but I think it's cleaner than the approach described above. Happy for suggestions for alternatives.