### PR TITLE
Ability to strictly prioritize streams, defaulting to round-robin

### DIFF
--- a/framer_test.go
+++ b/framer_test.go
@@ -219,8 +219,8 @@ var _ = Describe("Framer", func() {
 		})
 
 		It("re-queues a stream at the end, if it has enough data", func() {
-			streamGetter.EXPECT().GetOrOpenSendStream(id1).Return(stream1, nil).Times(2)
-			streamGetter.EXPECT().GetOrOpenSendStream(id2).Return(stream2, nil)
+			streamGetter.EXPECT().GetOrOpenSendStream(id1).Return(stream1, nil).Times(3)
+			streamGetter.EXPECT().GetOrOpenSendStream(id2).Return(stream2, nil).Times(2)
 			f11 := &wire.StreamFrame{StreamID: id1, Data: []byte("foobar")}
 			f12 := &wire.StreamFrame{StreamID: id1, Data: []byte("foobaz")}
 			f2 := &wire.StreamFrame{StreamID: id2, Data: []byte("raboof")}

--- a/interface.go
+++ b/interface.go
@@ -134,6 +134,11 @@ type SendStream interface {
 	// some data was successfully written.
 	// A zero value for t means Write will not time out.
 	SetWriteDeadline(t time.Time) error
+
+	// Set the priority of this stream, relative to other streams.
+	// During congestion, the stream with the higher priority will be sent first.
+	// If two streams have the same priority, they will be round-robined.
+	SetPriority(priority int)
 }
 
 // A Connection is a QUIC connection between two peers.

--- a/internal/mocks/quic/stream.go
+++ b/internal/mocks/quic/stream.go
@@ -174,3 +174,15 @@ func (mr *MockStreamMockRecorder) Write(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockStream)(nil).Write), arg0)
 }
+
+// SetPriority mocks base method.
+func (m *MockStream) SetPriority(arg0 int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPriority", arg0)
+}
+
+// SetPriority indicates an expected call of SetPriority.
+func (mr *MockStreamMockRecorder) SetPriority(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPriority", reflect.TypeOf((*MockStream)(nil).SetPriority), arg0)
+}

--- a/mock_send_stream_internal_test.go
+++ b/mock_send_stream_internal_test.go
@@ -121,6 +121,18 @@ func (mr *MockSendStreamIMockRecorder) Write(p interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockSendStreamI)(nil).Write), p)
 }
 
+// SetPriority mocks base method.
+func (m *MockSendStreamI) SetPriority(p int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPriority", p)
+}
+
+// SetPriority indicates an expected call of SetPriority.
+func (mr *MockSendStreamIMockRecorder) SetPriority(p interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPriority", reflect.TypeOf((*MockSendStreamI)(nil).SetPriority), p)
+}
+
 // closeForShutdown mocks base method.
 func (m *MockSendStreamI) closeForShutdown(arg0 error) {
 	m.ctrl.T.Helper()
@@ -180,11 +192,13 @@ func (m *MockSendStreamI) updateSendWindow(arg0 protocol.ByteCount) {
 	m.ctrl.Call(m, "updateSendWindow", arg0)
 }
 
-func (m *MockSendStreamI) SetPriority(p int) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetPriority", p)
+// updateSendWindow indicates an expected call of updateSendWindow.
+func (mr *MockSendStreamIMockRecorder) updateSendWindow(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateSendWindow", reflect.TypeOf((*MockSendStreamI)(nil).updateSendWindow), arg0)
 }
 
+// getPriority mocks base method.
 func (m *MockSendStreamI) getPriority() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getPriority")
@@ -192,8 +206,8 @@ func (m *MockSendStreamI) getPriority() int {
 	return ret0
 }
 
-// updateSendWindow indicates an expected call of updateSendWindow.
-func (mr *MockSendStreamIMockRecorder) updateSendWindow(arg0 interface{}) *gomock.Call {
+// getPriority indicates an expected call of getPriority.
+func (mr *MockSendStreamIMockRecorder) getPriority() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateSendWindow", reflect.TypeOf((*MockSendStreamI)(nil).updateSendWindow), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getPriority", reflect.TypeOf((*MockSendStreamI)(nil).getPriority))
 }

--- a/mock_send_stream_internal_test.go
+++ b/mock_send_stream_internal_test.go
@@ -180,6 +180,18 @@ func (m *MockSendStreamI) updateSendWindow(arg0 protocol.ByteCount) {
 	m.ctrl.Call(m, "updateSendWindow", arg0)
 }
 
+func (m *MockSendStreamI) SetPriority(p int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPriority", p)
+}
+
+func (m *MockSendStreamI) getPriority() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getPriority")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
 // updateSendWindow indicates an expected call of updateSendWindow.
 func (mr *MockSendStreamIMockRecorder) updateSendWindow(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()

--- a/mock_stream_internal_test.go
+++ b/mock_stream_internal_test.go
@@ -176,6 +176,18 @@ func (mr *MockStreamIMockRecorder) Write(p interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockStreamI)(nil).Write), p)
 }
 
+// SetPriority mocks base method.
+func (m *MockStreamI) SetPriority(arg0 int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPriority", arg0)
+}
+
+// CancelWrite indicates an expected call of CancelWrite.
+func (mr *MockStreamIMockRecorder) SetPriority(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPriority", reflect.TypeOf((*MockStreamI)(nil).SetPriority), arg0)
+}
+
 // closeForShutdown mocks base method.
 func (m *MockStreamI) closeForShutdown(arg0 error) {
 	m.ctrl.T.Helper()

--- a/send_stream.go
+++ b/send_stream.go
@@ -21,6 +21,7 @@ type sendStreamI interface {
 	popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Frame, bool)
 	closeForShutdown(error)
 	updateSendWindow(protocol.ByteCount)
+	getPriority() int
 }
 
 type sendStream struct {
@@ -56,6 +57,8 @@ type sendStream struct {
 	flowController flowcontrol.StreamFlowController
 
 	version protocol.VersionNumber
+
+	priority int
 }
 
 var (
@@ -493,4 +496,12 @@ func (s *sendStream) signalWrite() {
 	case s.writeChan <- struct{}{}:
 	default:
 	}
+}
+
+func (s *sendStream) getPriority() int {
+	return s.priority
+}
+
+func (s *sendStream) SetPriority(priority int) {
+	s.priority = priority
 }

--- a/stream.go
+++ b/stream.go
@@ -62,6 +62,7 @@ type streamI interface {
 	handleStopSendingFrame(*wire.StopSendingFrame)
 	popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Frame, bool)
 	updateSendWindow(protocol.ByteCount)
+	getPriority() int
 }
 
 var (
@@ -146,4 +147,12 @@ func (s *stream) checkIfCompleted() {
 	if s.sendStreamCompleted && s.receiveStreamCompleted {
 		s.sender.onStreamCompleted(s.StreamID())
 	}
+}
+
+func (s *stream) getPriority() int {
+	return s.sendStream.getPriority()
+}
+
+func (s *stream) SetPriority(priority int) {
+	s.sendStream.SetPriority(priority)
 }


### PR DESCRIPTION
Only applies when the congestion window is full. This gives applications a way to specify which streams should be sent first under poor network conditions.