### PR TITLE
http3: fix listening on both QUIC and TCP

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -708,19 +708,20 @@ func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error 
 	tlsConn := tls.NewListener(tcpConn, config)
 	defer tlsConn.Close()
 
-	// Start the servers
-	httpServer := &http.Server{}
-	quicServer := &Server{
-		TLSConfig: config,
-	}
-
 	if handler == nil {
 		handler = http.DefaultServeMux
 	}
-	httpServer.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		quicServer.SetQuicHeaders(w.Header())
-		handler.ServeHTTP(w, r)
-	})
+	// Start the servers
+	quicServer := &Server{
+		TLSConfig: config,
+		Handler:   handler,
+	}
+	httpServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			quicServer.SetQuicHeaders(w.Header())
+			handler.ServeHTTP(w, r)
+		}),
+	}
 
 	hErr := make(chan error)
 	qErr := make(chan error)


### PR DESCRIPTION
Hi, I  found an issue with the `-tcp` option in example not working.

```sh
% cd example
% go run ./main.go -tcp
```

```sh
% cd example/client
% go run ./main.go -q https://localhost:6121/demo/tile
GET https://localhost:6121/demo/tile
client Starting new connection to localhost ([::]:56076 -> 127.0.0.1:6121), source connection ID (empty), destination connection ID 3b2948435331ca22, version v1
Got response for https://localhost:6121/demo/tile: &http.Response{Status:"404 Not Found", StatusCode:404, Proto:"HTTP/3.0", ProtoMajor:3, ProtoMinor:0, Header:http.Header{"Content-Type":[]string{"text/plain; charset=utf-8"}, "X-Content-Type-Options":[]string{"nosniff"}}, Body:(*http3.hijackableBody)(0x14000298040), ContentLength:-1, TransferEncoding:[]string(nil), Close:false, Uncompressed:false, Trailer:http.Header(nil), Request:(*http.Request)(nil), TLS:(*tls.ConnectionState)(0x140002aa000)}
Response Body: 19 bytes
client Closing connection with error: Application error 0x100
client Connection 3b2948435331ca22 closed.

```

As shown above, a request for QUIC returns 404 Not Found.
The cause of the problem is that the http3.Server is not configured with a Handler.

Applying this pull request will return 200 OK as follows.

```sh
% go run ./main.go -q https://localhost:6121/demo/tile
GET https://localhost:6121/demo/tile
client Starting new connection to localhost ([::]:64885 -> 127.0.0.1:6121), source connection ID (empty), destination connection ID e35d6be0ca052bac51b466c0717d63a9df45f5b9, version v1
Got response for https://localhost:6121/demo/tile: &http.Response{Status:"200 OK", StatusCode:200, Proto:"HTTP/3.0", ProtoMajor:3, ProtoMinor:0, Header:http.Header{}, Body:(*http3.hijackableBody)(0x14000032080), ContentLength:-1, TransferEncoding:[]string(nil), Close:false, Uncompressed:false, Trailer:http.Header(nil), Request:(*http.Request)(nil), TLS:(*tls.ConnectionState)(0x14000102000)}
Response Body: 83 bytes
client Closing connection with error: Application error 0x100
client Connection e35d6be0ca052bac51b466c0717d63a9df45f5b9 closed.
```