### PR TITLE
http3: ignore context after response when using DontCloseRequestStream

### DIFF
--- a/http3/body.go
+++ b/http3/body.go
@@ -110,7 +110,9 @@ func (r *hijackableBody) requestDone() {
 	if r.reqDoneClosed || r.reqDone == nil {
 		return
 	}
-	close(r.reqDone)
+	if r.reqDone != nil {
+		close(r.reqDone)
+	}
 	r.reqDoneClosed = true
 }
 

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -84,6 +84,7 @@ type RoundTripOpt struct {
 	// If set true and no cached connection is available, RoundTripOpt will return ErrNoCachedConn.
 	OnlyCachedConn bool
 	// DontCloseRequestStream controls whether the request stream is closed after sending the request.
+	// If set, context cancellations have no effect after the response headers are received.
 	DontCloseRequestStream bool
 }
 


### PR DESCRIPTION
In WebTransport, the request stream is kept alive for the lifetime of the WebTransport session (and used to communicate shutdown of that session).

This leads to problems when using a `ctx` in `Roundtrip`. The following code should be valid, using `ctx` to control cancelation of the WebTransport handshake:
```go
ctx, cancel := context.WithCancel(context.Background())
req = req.WithContext(ctx)
rsp, _ := rountripper.RoundTrip(req)
cancel()
```

However, it also resets the request stream (and thereby closes the WebTransport session) as soon as the WebTransport handshake completes.