### PR TITLE
fix unreachable code after log.Fatal in fuzzing corpus generator

### DIFF
--- a/fuzzing/handshake/cmd/corpus.go
+++ b/fuzzing/handshake/cmd/corpus.go
@@ -60,9 +60,9 @@ func newRunner(client, server *handshake.CryptoSetup) *runner {
 func (r *runner) OnReceivedParams(*wire.TransportParameters) {}
 func (r *runner) OnHandshakeComplete()                       {}
 func (r *runner) OnError(err error) {
-	log.Fatal("runner error:", err)
 	(*r.client).Close()
 	(*r.server).Close()
+	log.Fatal("runner error:", err)
 }
 func (r *runner) DropKeys(protocol.EncryptionLevel) {}
 


### PR DESCRIPTION
https://pkg.go.dev/log#Fatal
> Fatal is equivalent to Print() followed by a call to os.Exit(1).

see https://go.dev/play/p/fWIT3Iobb0A for example:
```go
package main

import (
	"fmt"
	"log"
)

func main() {
	log.Fatalf("print and exit")
	fmt.Println("will not execute")
}

/* output
2009/11/10 23:00:00 print and exit

Program exited.
*/

```