### PR TITLE
implement a new API to let servers control client address verification

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,7 +46,7 @@ func populateServerConfig(config *Config) *Config {
 		config.MaxRetryTokenAge = protocol.RetryTokenValidity
 	}
 	if config.RequireAddressValidation == nil {
-		config.RequireAddressValidation = func(net.Addr) bool { return true }
+		config.RequireAddressValidation = func(net.Addr) bool { return false }
 	}
 	return config
 }

--- a/config.go
+++ b/config.go
@@ -2,11 +2,11 @@ package quic
 
 import (
 	"errors"
+	"net"
 	"time"
 
-	"github.com/lucas-clemente/quic-go/internal/utils"
-
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
 )
 
 // Clone clones a Config
@@ -39,8 +39,14 @@ func populateServerConfig(config *Config) *Config {
 	if config.ConnectionIDLength == 0 {
 		config.ConnectionIDLength = protocol.DefaultConnectionIDLength
 	}
-	if config.AcceptToken == nil {
-		config.AcceptToken = defaultAcceptToken
+	if config.MaxTokenAge == 0 {
+		config.MaxTokenAge = protocol.TokenValidity
+	}
+	if config.MaxRetryTokenAge == 0 {
+		config.MaxRetryTokenAge = protocol.RetryTokenValidity
+	}
+	if config.RequireAddressValidation == nil {
+		config.RequireAddressValidation = func(net.Addr) bool { return true }
 	}
 	return config
 }
@@ -104,7 +110,9 @@ func populateConfig(config *Config) *Config {
 		Versions:                         versions,
 		HandshakeIdleTimeout:             handshakeIdleTimeout,
 		MaxIdleTimeout:                   idleTimeout,
-		AcceptToken:                      config.AcceptToken,
+		MaxTokenAge:                      config.MaxTokenAge,
+		MaxRetryTokenAge:                 config.MaxRetryTokenAge,
+		RequireAddressValidation:         config.RequireAddressValidation,
 		KeepAlivePeriod:                  config.KeepAlivePeriod,
 		InitialStreamReceiveWindow:       initialStreamReceiveWindow,
 		MaxStreamReceiveWindow:           maxStreamReceiveWindow,

--- a/fuzzing/tokens/fuzz.go
+++ b/fuzzing/tokens/fuzz.go
@@ -2,7 +2,6 @@ package tokens
 
 import (
 	"encoding/binary"
-	"fmt"
 	"math/rand"
 	"net"
 	"time"
@@ -77,7 +76,6 @@ func newToken(tg *handshake.TokenGenerator, data []byte) int {
 	if token.OriginalDestConnectionID != nil || token.RetrySrcConnectionID != nil {
 		panic("didn't expect connection IDs")
 	}
-	checkAddr(token.RemoteAddr, addr)
 	return 1
 }
 
@@ -140,22 +138,5 @@ func newRetryToken(tg *handshake.TokenGenerator, data []byte) int {
 	if !token.RetrySrcConnectionID.Equal(retrySrcConnID) {
 		panic("retry src conn ID doesn't match")
 	}
-	checkAddr(token.RemoteAddr, addr)
 	return 1
-}
-
-func checkAddr(tokenAddr string, addr net.Addr) {
-	if udpAddr, ok := addr.(*net.UDPAddr); ok {
-		// For UDP addresses, we encode only the IP (not the port).
-		if ip := udpAddr.IP.String(); tokenAddr != ip {
-			fmt.Printf("%s vs %s", tokenAddr, ip)
-			panic("wrong remote address for a net.UDPAddr")
-		}
-		return
-	}
-
-	if tokenAddr != addr.String() {
-		fmt.Printf("%s vs %s", tokenAddr, addr.String())
-		panic("wrong remote address")
-	}
 }

--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -41,8 +41,8 @@ var _ = Describe("Handshake drop tests", func() {
 			HandshakeIdleTimeout: timeout,
 			Versions:             []protocol.VersionNumber{version},
 		})
-		if !doRetry {
-			conf.AcceptToken = func(net.Addr, *quic.Token) bool { return true }
+		if doRetry {
+			conf.RequireAddressValidation = func(net.Addr) bool { return true }
 		}
 		var tlsConf *tls.Config
 		if longCertChain {

--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -37,13 +37,11 @@ var _ = Describe("Handshake drop tests", func() {
 
 	startListenerAndProxy := func(dropCallback quicproxy.DropCallback, doRetry bool, longCertChain bool, version protocol.VersionNumber) {
 		conf := getQuicConfig(&quic.Config{
-			MaxIdleTimeout:       timeout,
-			HandshakeIdleTimeout: timeout,
-			Versions:             []protocol.VersionNumber{version},
+			MaxIdleTimeout:           timeout,
+			HandshakeIdleTimeout:     timeout,
+			Versions:                 []protocol.VersionNumber{version},
+			RequireAddressValidation: func(net.Addr) bool { return doRetry },
 		})
-		if doRetry {
-			conf.RequireAddressValidation = func(net.Addr) bool { return true }
-		}
 		var tlsConf *tls.Config
 		if longCertChain {
 			tlsConf = getTLSConfigWithLongCertChain()

--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -112,9 +112,7 @@ var _ = Describe("Handshake RTT tests", func() {
 	})
 
 	It("establishes a connection in 1 RTT when the server doesn't require a token", func() {
-		serverConfig.AcceptToken = func(_ net.Addr, _ *quic.Token) bool {
-			return true
-		}
+		serverConfig.RequireAddressValidation = func(net.Addr) bool { return false }
 		runServerAndProxy()
 		_, err := quic.DialAddr(
 			fmt.Sprintf("localhost:%d", proxy.LocalAddr().(*net.UDPAddr).Port),
@@ -126,9 +124,7 @@ var _ = Describe("Handshake RTT tests", func() {
 	})
 
 	It("establishes a connection in 2 RTTs if a HelloRetryRequest is performed", func() {
-		serverConfig.AcceptToken = func(_ net.Addr, _ *quic.Token) bool {
-			return true
-		}
+		serverConfig.RequireAddressValidation = func(net.Addr) bool { return false }
 		serverTLSConfig.CurvePreferences = []tls.CurveID{tls.CurveP384}
 		runServerAndProxy()
 		_, err := quic.DialAddr(
@@ -138,22 +134,5 @@ var _ = Describe("Handshake RTT tests", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 		expectDurationInRTTs(2)
-	})
-
-	It("doesn't complete the handshake when the server never accepts the token", func() {
-		serverConfig.AcceptToken = func(_ net.Addr, _ *quic.Token) bool {
-			return false
-		}
-		clientConfig.HandshakeIdleTimeout = 500 * time.Millisecond
-		runServerAndProxy()
-		_, err := quic.DialAddr(
-			fmt.Sprintf("localhost:%d", proxy.LocalAddr().(*net.UDPAddr).Port),
-			getTLSClientConfig(),
-			clientConfig,
-		)
-		Expect(err).To(HaveOccurred())
-		nerr, ok := err.(net.Error)
-		Expect(ok).To(BeTrue())
-		Expect(nerr.Timeout()).To(BeTrue())
 	})
 })

--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -101,6 +101,7 @@ var _ = Describe("Handshake RTT tests", func() {
 	// 1 RTT for verifying the source address
 	// 1 RTT for the TLS handshake
 	It("is forward-secure after 2 RTTs", func() {
+		serverConfig.RequireAddressValidation = func(net.Addr) bool { return true }
 		runServerAndProxy()
 		_, err := quic.DialAddr(
 			fmt.Sprintf("localhost:%d", proxy.LocalAddr().(*net.UDPAddr).Port),
@@ -112,7 +113,6 @@ var _ = Describe("Handshake RTT tests", func() {
 	})
 
 	It("establishes a connection in 1 RTT when the server doesn't require a token", func() {
-		serverConfig.RequireAddressValidation = func(net.Addr) bool { return false }
 		runServerAndProxy()
 		_, err := quic.DialAddr(
 			fmt.Sprintf("localhost:%d", proxy.LocalAddr().(*net.UDPAddr).Port),
@@ -124,7 +124,6 @@ var _ = Describe("Handshake RTT tests", func() {
 	})
 
 	It("establishes a connection in 2 RTTs if a HelloRetryRequest is performed", func() {
-		serverConfig.RequireAddressValidation = func(net.Addr) bool { return false }
 		serverTLSConfig.CurvePreferences = []tls.CurveID{tls.CurveP384}
 		runServerAndProxy()
 		_, err := quic.DialAddr(

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -344,7 +344,6 @@ var _ = Describe("Handshake tests", func() {
 		}
 
 		BeforeEach(func() {
-			serverConfig.RequireAddressValidation = func(net.Addr) bool { return false }
 			var err error
 			// start the server, but don't call Accept
 			server, err = quic.ListenAddr("localhost:0", getTLSConfig(), serverConfig)
@@ -474,8 +473,6 @@ var _ = Describe("Handshake tests", func() {
 
 	Context("using tokens", func() {
 		It("uses tokens provided in NEW_TOKEN frames", func() {
-			serverConfig.RequireAddressValidation = func(net.Addr) bool { return false }
-
 			server, err := quic.ListenAddr("localhost:0", getTLSConfig(), serverConfig)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -344,12 +344,7 @@ var _ = Describe("Handshake tests", func() {
 		}
 
 		BeforeEach(func() {
-			serverConfig.AcceptToken = func(addr net.Addr, token *quic.Token) bool {
-				if token != nil {
-					Expect(token.IsRetryToken).To(BeFalse())
-				}
-				return true
-			}
+			serverConfig.RequireAddressValidation = func(net.Addr) bool { return false }
 			var err error
 			// start the server, but don't call Accept
 			server, err = quic.ListenAddr("localhost:0", getTLSConfig(), serverConfig)
@@ -479,13 +474,7 @@ var _ = Describe("Handshake tests", func() {
 
 	Context("using tokens", func() {
 		It("uses tokens provided in NEW_TOKEN frames", func() {
-			tokenChan := make(chan *quic.Token, 100)
-			serverConfig.AcceptToken = func(addr net.Addr, token *quic.Token) bool {
-				if token != nil && !token.IsRetryToken {
-					tokenChan <- token
-				}
-				return true
-			}
+			serverConfig.RequireAddressValidation = func(net.Addr) bool { return false }
 
 			server, err := quic.ListenAddr("localhost:0", getTLSConfig(), serverConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -509,7 +498,6 @@ var _ = Describe("Handshake tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(gets).To(Receive())
 			Eventually(puts).Should(Receive())
-			Expect(tokenChan).ToNot(Receive())
 			// received a token. Close this connection.
 			Expect(conn.CloseWithError(0, "")).To(Succeed())
 
@@ -529,17 +517,13 @@ var _ = Describe("Handshake tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer conn.CloseWithError(0, "")
 			Expect(gets).To(Receive())
-			Expect(tokenChan).To(Receive())
 
 			Eventually(done).Should(BeClosed())
 		})
 
 		It("rejects invalid Retry token with the INVALID_TOKEN error", func() {
-			tokenChan := make(chan *quic.Token, 10)
-			serverConfig.AcceptToken = func(addr net.Addr, token *quic.Token) bool {
-				tokenChan <- token
-				return false
-			}
+			serverConfig.RequireAddressValidation = func(net.Addr) bool { return true }
+			serverConfig.MaxRetryTokenAge = time.Nanosecond
 
 			server, err := quic.ListenAddr("localhost:0", getTLSConfig(), serverConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -554,18 +538,6 @@ var _ = Describe("Handshake tests", func() {
 			var transportErr *quic.TransportError
 			Expect(errors.As(err, &transportErr)).To(BeTrue())
 			Expect(transportErr.ErrorCode).To(Equal(quic.InvalidToken))
-			// Receiving a Retry might lead the client to measure a very small RTT.
-			// Then, it sometimes would retransmit the ClientHello before receiving the ServerHello.
-			Expect(len(tokenChan)).To(BeNumerically(">=", 2))
-			token := <-tokenChan
-			Expect(token).To(BeNil())
-			token = <-tokenChan
-			Expect(token).ToNot(BeNil())
-			// If the ClientHello was retransmitted, make sure that it contained the same Retry token.
-			for i := 2; i < len(tokenChan); i++ {
-				Expect(<-tokenChan).To(Equal(token))
-			}
-			Expect(token.IsRetryToken).To(BeTrue())
 		})
 	})
 

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -347,6 +347,7 @@ var _ = Describe("MITM test", func() {
 				// as it has already accepted a retry.
 				// TODO: determine behavior when server does not send Retry packets
 				It("fails when a forged Retry packet with modified srcConnID is sent to client", func() {
+					serverConfig.RequireAddressValidation = func(net.Addr) bool { return true }
 					var initialPacketIntercepted bool
 					done := make(chan struct{})
 					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -29,24 +29,27 @@ var _ = Describe("MITM test", func() {
 			const connIDLen = 6 // explicitly set the connection ID length, so the proxy can parse it
 
 			var (
-				proxy                        *quicproxy.QuicProxy
 				serverUDPConn, clientUDPConn *net.UDPConn
 				serverConn                   quic.Connection
 				serverConfig                 *quic.Config
 			)
 
-			startServerAndProxy := func(delayCb quicproxy.DelayCallback, dropCb quicproxy.DropCallback) {
+			startServerAndProxy := func(delayCb quicproxy.DelayCallback, dropCb quicproxy.DropCallback) (proxyPort int, closeFn func()) {
 				addr, err := net.ResolveUDPAddr("udp", "localhost:0")
 				Expect(err).ToNot(HaveOccurred())
 				serverUDPConn, err = net.ListenUDP("udp", addr)
 				Expect(err).ToNot(HaveOccurred())
 				ln, err := quic.Listen(serverUDPConn, getTLSConfig(), serverConfig)
 				Expect(err).ToNot(HaveOccurred())
+				done := make(chan struct{})
 				go func() {
 					defer GinkgoRecover()
+					defer close(done)
 					var err error
 					serverConn, err = ln.Accept(context.Background())
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						return
+					}
 					str, err := serverConn.OpenUniStream()
 					Expect(err).ToNot(HaveOccurred())
 					_, err = str.Write(PRData)
@@ -54,12 +57,18 @@ var _ = Describe("MITM test", func() {
 					Expect(str.Close()).To(Succeed())
 				}()
 				serverPort := ln.Addr().(*net.UDPAddr).Port
-				proxy, err = quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+				proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
 					RemoteAddr:  fmt.Sprintf("localhost:%d", serverPort),
 					DelayPacket: delayCb,
 					DropPacket:  dropCb,
 				})
 				Expect(err).ToNot(HaveOccurred())
+				return proxy.LocalPort(), func() {
+					proxy.Close()
+					ln.Close()
+					serverUDPConn.Close()
+					<-done
+				}
 			}
 
 			BeforeEach(func() {
@@ -79,8 +88,6 @@ var _ = Describe("MITM test", func() {
 					// Test shutdown is tricky due to the proxy. Just wait for a bit.
 					time.Sleep(50 * time.Millisecond)
 					Expect(clientUDPConn.Close()).To(Succeed())
-					Expect(serverUDPConn.Close()).To(Succeed())
-					Expect(proxy.Close()).To(Succeed())
 				})
 
 				Context("injecting invalid packets", func() {
@@ -120,13 +127,14 @@ var _ = Describe("MITM test", func() {
 					}
 
 					runTest := func(delayCb quicproxy.DelayCallback) {
-						startServerAndProxy(delayCb, nil)
-						raddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", proxy.LocalPort()))
+						proxyPort, closeFn := startServerAndProxy(delayCb, nil)
+						defer closeFn()
+						raddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", proxyPort))
 						Expect(err).ToNot(HaveOccurred())
 						conn, err := quic.Dial(
 							clientUDPConn,
 							raddr,
-							fmt.Sprintf("localhost:%d", proxy.LocalPort()),
+							fmt.Sprintf("localhost:%d", proxyPort),
 							getTLSClientConfig(),
 							getQuicConfig(&quic.Config{
 								Versions:           []protocol.VersionNumber{version},
@@ -166,13 +174,14 @@ var _ = Describe("MITM test", func() {
 				})
 
 				runTest := func(dropCb quicproxy.DropCallback) {
-					startServerAndProxy(nil, dropCb)
-					raddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", proxy.LocalPort()))
+					proxyPort, closeFn := startServerAndProxy(nil, dropCb)
+					defer closeFn()
+					raddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", proxyPort))
 					Expect(err).ToNot(HaveOccurred())
 					conn, err := quic.Dial(
 						clientUDPConn,
 						raddr,
-						fmt.Sprintf("localhost:%d", proxy.LocalPort()),
+						fmt.Sprintf("localhost:%d", proxyPort),
 						getTLSClientConfig(),
 						getQuicConfig(&quic.Config{
 							Versions:           []protocol.VersionNumber{version},
@@ -283,65 +292,14 @@ var _ = Describe("MITM test", func() {
 
 				const rtt = 20 * time.Millisecond
 
-				// AfterEach closes the proxy, but each function is responsible
-				// for closing client and server connections
-				AfterEach(func() {
-					// Test shutdown is tricky due to the proxy. Just wait for a bit.
-					time.Sleep(50 * time.Millisecond)
-					Expect(proxy.Close()).To(Succeed())
-				})
-
-				// sendForgedVersionNegotiationPacket sends a fake VN packet with no supported versions
-				// from serverUDPConn to client's remoteAddr
-				// expects hdr from an Initial packet intercepted from client
-				sendForgedVersionNegotationPacket := func(conn net.PacketConn, remoteAddr net.Addr, hdr *wire.Header) {
-					// Create fake version negotiation packet with no supported versions
-					versions := []protocol.VersionNumber{}
-					packet := wire.ComposeVersionNegotiation(hdr.SrcConnectionID, hdr.DestConnectionID, versions)
-
-					// Send the packet
-					_, err := conn.WriteTo(packet, remoteAddr)
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				// sendForgedRetryPacket sends a fake Retry packet with a modified srcConnID
-				// from serverUDPConn to client's remoteAddr
-				// expects hdr from an Initial packet intercepted from client
-				sendForgedRetryPacket := func(conn net.PacketConn, remoteAddr net.Addr, hdr *wire.Header) {
-					var x byte = 0x12
-					fakeSrcConnID := protocol.ConnectionID{x, x, x, x, x, x, x, x}
-					retryPacket := testutils.ComposeRetryPacket(fakeSrcConnID, hdr.SrcConnectionID, hdr.DestConnectionID, []byte("token"), hdr.Version)
-
-					_, err := conn.WriteTo(retryPacket, remoteAddr)
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				// Send a forged Initial packet with no frames to client
-				// expects hdr from an Initial packet intercepted from client
-				sendForgedInitialPacket := func(conn net.PacketConn, remoteAddr net.Addr, hdr *wire.Header) {
-					initialPacket := testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, nil)
-					_, err := conn.WriteTo(initialPacket, remoteAddr)
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				// Send a forged Initial packet with ACK for random packet to client
-				// expects hdr from an Initial packet intercepted from client
-				sendForgedInitialPacketWithAck := func(conn net.PacketConn, remoteAddr net.Addr, hdr *wire.Header) {
-					// Fake Initial with ACK for packet 2 (unsent)
-					ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 2, Largest: 2}}}
-					initialPacket := testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, []wire.Frame{ack})
-					_, err := conn.WriteTo(initialPacket, remoteAddr)
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				runTest := func(delayCb quicproxy.DelayCallback) error {
-					startServerAndProxy(delayCb, nil)
-					raddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", proxy.LocalPort()))
+				runTest := func(delayCb quicproxy.DelayCallback) (closeFn func(), err error) {
+					proxyPort, closeFn := startServerAndProxy(delayCb, nil)
+					raddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("localhost:%d", proxyPort))
 					Expect(err).ToNot(HaveOccurred())
 					_, err = quic.Dial(
 						clientUDPConn,
 						raddr,
-						fmt.Sprintf("localhost:%d", proxy.LocalPort()),
+						fmt.Sprintf("localhost:%d", proxyPort),
 						getTLSClientConfig(),
 						getQuicConfig(&quic.Config{
 							Versions:             []protocol.VersionNumber{version},
@@ -349,11 +307,12 @@ var _ = Describe("MITM test", func() {
 							HandshakeIdleTimeout: 2 * time.Second,
 						}),
 					)
-					return err
+					return closeFn, err
 				}
 
 				// fails immediately because client connection closes when it can't find compatible version
 				It("fails when a forged version negotiation packet is sent to client", func() {
+					done := make(chan struct{})
 					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
@@ -365,14 +324,23 @@ var _ = Describe("MITM test", func() {
 								return 0
 							}
 
-							sendForgedVersionNegotationPacket(serverUDPConn, clientUDPConn.LocalAddr(), hdr)
+							// Create fake version negotiation packet with no supported versions
+							versions := []protocol.VersionNumber{}
+							packet := wire.ComposeVersionNegotiation(hdr.SrcConnectionID, hdr.DestConnectionID, versions)
+
+							// Send the packet
+							_, err = serverUDPConn.WriteTo(packet, clientUDPConn.LocalAddr())
+							Expect(err).ToNot(HaveOccurred())
+							close(done)
 						}
 						return rtt / 2
 					}
-					err := runTest(delayCb)
+					closeFn, err := runTest(delayCb)
+					defer closeFn()
 					Expect(err).To(HaveOccurred())
 					vnErr := &quic.VersionNegotiationError{}
 					Expect(errors.As(err, &vnErr)).To(BeTrue())
+					Eventually(done).Should(BeClosed())
 				})
 
 				// times out, because client doesn't accept subsequent real retry packets from server
@@ -380,9 +348,11 @@ var _ = Describe("MITM test", func() {
 				// TODO: determine behavior when server does not send Retry packets
 				It("fails when a forged Retry packet with modified srcConnID is sent to client", func() {
 					var initialPacketIntercepted bool
+					done := make(chan struct{})
 					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
 						if dir == quicproxy.DirectionIncoming && !initialPacketIntercepted {
 							defer GinkgoRecover()
+							defer close(done)
 
 							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
 							Expect(err).ToNot(HaveOccurred())
@@ -392,59 +362,82 @@ var _ = Describe("MITM test", func() {
 							}
 
 							initialPacketIntercepted = true
-							sendForgedRetryPacket(serverUDPConn, clientUDPConn.LocalAddr(), hdr)
+							fakeSrcConnID := protocol.ConnectionID{0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12}
+							retryPacket := testutils.ComposeRetryPacket(fakeSrcConnID, hdr.SrcConnectionID, hdr.DestConnectionID, []byte("token"), hdr.Version)
+
+							_, err = serverUDPConn.WriteTo(retryPacket, clientUDPConn.LocalAddr())
+							Expect(err).ToNot(HaveOccurred())
 						}
 						return rtt / 2
 					}
-					err := runTest(delayCb)
+					closeFn, err := runTest(delayCb)
+					defer closeFn()
 					Expect(err).To(HaveOccurred())
 					Expect(err.(net.Error).Timeout()).To(BeTrue())
+					Eventually(done).Should(BeClosed())
 				})
 
 				// times out, because client doesn't accept real retry packets from server because
 				// it has already accepted an initial.
 				// TODO: determine behavior when server does not send Retry packets
 				It("fails when a forged initial packet is sent to client", func() {
+					done := make(chan struct{})
+					var injected bool
 					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
 
 							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
 							Expect(err).ToNot(HaveOccurred())
-
-							if hdr.Type != protocol.PacketTypeInitial {
+							if hdr.Type != protocol.PacketTypeInitial || injected {
 								return 0
 							}
-
-							sendForgedInitialPacket(serverUDPConn, clientUDPConn.LocalAddr(), hdr)
+							defer close(done)
+							injected = true
+							initialPacket := testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, nil)
+							_, err = serverUDPConn.WriteTo(initialPacket, clientUDPConn.LocalAddr())
+							Expect(err).ToNot(HaveOccurred())
 						}
 						return rtt
 					}
-					err := runTest(delayCb)
+					closeFn, err := runTest(delayCb)
+					defer closeFn()
 					Expect(err).To(HaveOccurred())
 					Expect(err.(net.Error).Timeout()).To(BeTrue())
+					Eventually(done).Should(BeClosed())
 				})
 
 				// client connection closes immediately on receiving ack for unsent packet
 				It("fails when a forged initial packet with ack for unsent packet is sent to client", func() {
-					clientAddr := clientUDPConn.LocalAddr()
+					done := make(chan struct{})
+					var injected bool
 					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
 						if dir == quicproxy.DirectionIncoming {
+							defer GinkgoRecover()
+
 							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
 							Expect(err).ToNot(HaveOccurred())
-							if hdr.Type != protocol.PacketTypeInitial {
+							if hdr.Type != protocol.PacketTypeInitial || injected {
 								return 0
 							}
-							sendForgedInitialPacketWithAck(serverUDPConn, clientAddr, hdr)
+							defer close(done)
+							injected = true
+							// Fake Initial with ACK for packet 2 (unsent)
+							ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 2, Largest: 2}}}
+							initialPacket := testutils.ComposeInitialPacket(hdr.DestConnectionID, hdr.SrcConnectionID, hdr.Version, hdr.DestConnectionID, []wire.Frame{ack})
+							_, err = serverUDPConn.WriteTo(initialPacket, clientUDPConn.LocalAddr())
+							Expect(err).ToNot(HaveOccurred())
 						}
 						return rtt
 					}
-					err := runTest(delayCb)
+					closeFn, err := runTest(delayCb)
+					defer closeFn()
 					Expect(err).To(HaveOccurred())
 					var transportErr *quic.TransportError
 					Expect(errors.As(err, &transportErr)).To(BeTrue())
 					Expect(transportErr.ErrorCode).To(Equal(quic.ProtocolViolation))
 					Expect(transportErr.ErrorMessage).To(ContainSubstring("received ACK for an unsent packet"))
+					Eventually(done).Should(BeClosed())
 				})
 			})
 		})

--- a/integrationtests/self/packetization_test.go
+++ b/integrationtests/self/packetization_test.go
@@ -26,9 +26,9 @@ var _ = Describe("Packetization", func() {
 			"localhost:0",
 			getTLSConfig(),
 			getQuicConfig(&quic.Config{
-				AcceptToken:             func(net.Addr, *quic.Token) bool { return true },
-				DisablePathMTUDiscovery: true,
-				Tracer:                  newTracer(func() logging.ConnectionTracer { return serverTracer }),
+				RequireAddressValidation: func(net.Addr) bool { return false },
+				DisablePathMTUDiscovery:  true,
+				Tracer:                   newTracer(func() logging.ConnectionTracer { return serverTracer }),
 			}),
 		)
 		Expect(err).ToNot(HaveOccurred())

--- a/integrationtests/self/packetization_test.go
+++ b/integrationtests/self/packetization_test.go
@@ -26,9 +26,8 @@ var _ = Describe("Packetization", func() {
 			"localhost:0",
 			getTLSConfig(),
 			getQuicConfig(&quic.Config{
-				RequireAddressValidation: func(net.Addr) bool { return false },
-				DisablePathMTUDiscovery:  true,
-				Tracer:                   newTracer(func() logging.ConnectionTracer { return serverTracer }),
+				DisablePathMTUDiscovery: true,
+				Tracer:                  newTracer(func() logging.ConnectionTracer { return serverTracer }),
 			}),
 		)
 		Expect(err).ToNot(HaveOccurred())

--- a/integrationtests/self/self_suite_test.go
+++ b/integrationtests/self/self_suite_test.go
@@ -17,7 +17,9 @@ import (
 	mrand "math/rand"
 	"net"
 	"os"
+	"runtime/pprof"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -294,7 +296,14 @@ var _ = BeforeEach(func() {
 	}
 })
 
+func areHandshakesRunning() bool {
+	var b bytes.Buffer
+	pprof.Lookup("goroutine").WriteTo(&b, 1)
+	return strings.Contains(b.String(), "RunHandshake")
+}
+
 var _ = AfterEach(func() {
+	Expect(areHandshakesRunning()).To(BeFalse())
 	if debugLog() {
 		logFile, err := os.Create(logFileName)
 		Expect(err).ToNot(HaveOccurred())

--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -1,14 +1,11 @@
 package self_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	mrand "math/rand"
 	"net"
-	"runtime/pprof"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -43,12 +40,6 @@ func (c *faultyConn) WriteTo(p []byte, addr net.Addr) (int, error) {
 		return c.PacketConn.WriteTo(p, addr)
 	}
 	return 0, io.ErrClosedPipe
-}
-
-func areHandshakesRunning() bool {
-	var b bytes.Buffer
-	pprof.Lookup("goroutine").WriteTo(&b, 1)
-	return strings.Contains(b.String(), "RunHandshake")
 }
 
 var _ = Describe("Timeout tests", func() {
@@ -381,14 +372,6 @@ var _ = Describe("Timeout tests", func() {
 
 	Context("faulty packet conns", func() {
 		const handshakeTimeout = time.Second / 2
-
-		BeforeEach(func() {
-			Expect(areHandshakesRunning()).To(BeFalse())
-		})
-
-		AfterEach(func() {
-			Expect(areHandshakesRunning()).To(BeFalse())
-		})
 
 		runServer := func(ln quic.Listener) error {
 			conn, err := ln.Accept(context.Background())

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -56,7 +56,7 @@ var _ = Describe("0-RTT", func() {
 				tlsConf := getTLSConfig()
 				if serverConf == nil {
 					serverConf = getQuicConfig(&quic.Config{
-						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
+						RequireAddressValidation: func(net.Addr) bool { return false },
 					})
 					serverConf.Versions = []protocol.VersionNumber{version}
 				}
@@ -197,9 +197,9 @@ var _ = Describe("0-RTT", func() {
 						"localhost:0",
 						tlsConf,
 						getQuicConfig(&quic.Config{
-							Versions:    []protocol.VersionNumber{version},
-							AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-							Tracer:      newTracer(func() logging.ConnectionTracer { return tracer }),
+							Versions:                 []protocol.VersionNumber{version},
+							RequireAddressValidation: func(net.Addr) bool { return false },
+							Tracer:                   newTracer(func() logging.ConnectionTracer { return tracer }),
 						}),
 					)
 					Expect(err).ToNot(HaveOccurred())
@@ -255,9 +255,9 @@ var _ = Describe("0-RTT", func() {
 					"localhost:0",
 					tlsConf,
 					getQuicConfig(&quic.Config{
-						Versions:    []protocol.VersionNumber{version},
-						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-						Tracer:      newTracer(func() logging.ConnectionTracer { return tracer }),
+						Versions:                 []protocol.VersionNumber{version},
+						RequireAddressValidation: func(net.Addr) bool { return false },
+						Tracer:                   newTracer(func() logging.ConnectionTracer { return tracer }),
 					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
@@ -452,8 +452,8 @@ var _ = Describe("0-RTT", func() {
 			It("doesn't reject 0-RTT when the server's transport stream limit increased", func() {
 				const maxStreams = 1
 				tlsConf, clientConf := dialAndReceiveSessionTicket(getQuicConfig(&quic.Config{
-					MaxIncomingUniStreams: maxStreams,
-					AcceptToken:           func(_ net.Addr, _ *quic.Token) bool { return true },
+					MaxIncomingUniStreams:    maxStreams,
+					RequireAddressValidation: func(net.Addr) bool { return false },
 				}))
 
 				tracer := newPacketTracer()
@@ -461,10 +461,10 @@ var _ = Describe("0-RTT", func() {
 					"localhost:0",
 					tlsConf,
 					getQuicConfig(&quic.Config{
-						Versions:              []protocol.VersionNumber{version},
-						AcceptToken:           func(_ net.Addr, _ *quic.Token) bool { return true },
-						MaxIncomingUniStreams: maxStreams + 1,
-						Tracer:                newTracer(func() logging.ConnectionTracer { return tracer }),
+						Versions:                 []protocol.VersionNumber{version},
+						RequireAddressValidation: func(net.Addr) bool { return false },
+						MaxIncomingUniStreams:    maxStreams + 1,
+						Tracer:                   newTracer(func() logging.ConnectionTracer { return tracer }),
 					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
@@ -498,8 +498,8 @@ var _ = Describe("0-RTT", func() {
 			It("rejects 0-RTT when the server's stream limit decreased", func() {
 				const maxStreams = 42
 				tlsConf, clientConf := dialAndReceiveSessionTicket(getQuicConfig(&quic.Config{
-					MaxIncomingStreams: maxStreams,
-					AcceptToken:        func(_ net.Addr, _ *quic.Token) bool { return true },
+					MaxIncomingStreams:       maxStreams,
+					RequireAddressValidation: func(net.Addr) bool { return false },
 				}))
 
 				tracer := newPacketTracer()
@@ -507,10 +507,10 @@ var _ = Describe("0-RTT", func() {
 					"localhost:0",
 					tlsConf,
 					getQuicConfig(&quic.Config{
-						Versions:           []protocol.VersionNumber{version},
-						AcceptToken:        func(_ net.Addr, _ *quic.Token) bool { return true },
-						MaxIncomingStreams: maxStreams - 1,
-						Tracer:             newTracer(func() logging.ConnectionTracer { return tracer }),
+						Versions:                 []protocol.VersionNumber{version},
+						RequireAddressValidation: func(net.Addr) bool { return false },
+						MaxIncomingStreams:       maxStreams - 1,
+						Tracer:                   newTracer(func() logging.ConnectionTracer { return tracer }),
 					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
@@ -537,9 +537,9 @@ var _ = Describe("0-RTT", func() {
 					"localhost:0",
 					tlsConf,
 					getQuicConfig(&quic.Config{
-						Versions:    []protocol.VersionNumber{version},
-						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-						Tracer:      newTracer(func() logging.ConnectionTracer { return tracer }),
+						Versions:                 []protocol.VersionNumber{version},
+						RequireAddressValidation: func(net.Addr) bool { return false },
+						Tracer:                   newTracer(func() logging.ConnectionTracer { return tracer }),
 					}),
 				)
 				Expect(err).ToNot(HaveOccurred())
@@ -560,16 +560,16 @@ var _ = Describe("0-RTT", func() {
 				func(addFlowControlLimit func(*quic.Config, uint64)) {
 					tracer := newPacketTracer()
 					firstConf := getQuicConfig(&quic.Config{
-						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-						Versions:    []protocol.VersionNumber{version},
+						RequireAddressValidation: func(net.Addr) bool { return false },
+						Versions:                 []protocol.VersionNumber{version},
 					})
 					addFlowControlLimit(firstConf, 3)
 					tlsConf, clientConf := dialAndReceiveSessionTicket(firstConf)
 
 					secondConf := getQuicConfig(&quic.Config{
-						Versions:    []protocol.VersionNumber{version},
-						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-						Tracer:      newTracer(func() logging.ConnectionTracer { return tracer }),
+						Versions:                 []protocol.VersionNumber{version},
+						RequireAddressValidation: func(net.Addr) bool { return false },
+						Tracer:                   newTracer(func() logging.ConnectionTracer { return tracer }),
 					})
 					addFlowControlLimit(secondConf, 100)
 					ln, err := quic.ListenAddrEarly(
@@ -722,9 +722,9 @@ var _ = Describe("0-RTT", func() {
 					"localhost:0",
 					tlsConf,
 					getQuicConfig(&quic.Config{
-						Versions:    []protocol.VersionNumber{version},
-						AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-						Tracer:      newTracer(func() logging.ConnectionTracer { return tracer }),
+						Versions:                 []protocol.VersionNumber{version},
+						RequireAddressValidation: func(net.Addr) bool { return false },
+						Tracer:                   newTracer(func() logging.ConnectionTracer { return tracer }),
 					}),
 				)
 				Expect(err).ToNot(HaveOccurred())

--- a/internal/handshake/token_generator.go
+++ b/internal/handshake/token_generator.go
@@ -1,6 +1,7 @@
 package handshake
 
 import (
+	"bytes"
 	"encoding/asn1"
 	"fmt"
 	"io"
@@ -17,12 +18,16 @@ const (
 
 // A Token is derived from the client address and can be used to verify the ownership of this address.
 type Token struct {
-	IsRetryToken bool
-	RemoteAddr   string
-	SentTime     time.Time
+	IsRetryToken      bool
+	SentTime          time.Time
+	encodedRemoteAddr []byte
 	// only set for retry tokens
 	OriginalDestConnectionID protocol.ConnectionID
 	RetrySrcConnectionID     protocol.ConnectionID
+}
+
+func (t *Token) ValidateRemoteAddr(addr net.Addr) bool {
+	return bytes.Equal(encodeRemoteAddr(addr), t.encodedRemoteAddr)
 }
 
 // token is the struct that is used for ASN1 serialization and deserialization
@@ -101,9 +106,9 @@ func (g *TokenGenerator) DecodeToken(encrypted []byte) (*Token, error) {
 		return nil, fmt.Errorf("rest when unpacking token: %d", len(rest))
 	}
 	token := &Token{
-		IsRetryToken: t.IsRetryToken,
-		RemoteAddr:   decodeRemoteAddr(t.RemoteAddr),
-		SentTime:     time.Unix(0, t.Timestamp),
+		IsRetryToken:      t.IsRetryToken,
+		SentTime:          time.Unix(0, t.Timestamp),
+		encodedRemoteAddr: t.RemoteAddr,
 	}
 	if t.IsRetryToken {
 		token.OriginalDestConnectionID = protocol.ConnectionID(t.OriginalDestConnectionID)
@@ -118,17 +123,4 @@ func encodeRemoteAddr(remoteAddr net.Addr) []byte {
 		return append([]byte{tokenPrefixIP}, udpAddr.IP...)
 	}
 	return append([]byte{tokenPrefixString}, []byte(remoteAddr.String())...)
-}
-
-// decodeRemoteAddr decodes the remote address saved in the token
-func decodeRemoteAddr(data []byte) string {
-	// data will never be empty for a token that we generated.
-	// Check it to be on the safe side
-	if len(data) == 0 {
-		return ""
-	}
-	if data[0] == tokenPrefixIP {
-		return net.IP(data[1:]).String()
-	}
-	return string(data[1:])
 }

--- a/interop/server/main.go
+++ b/interop/server/main.go
@@ -44,8 +44,8 @@ func main() {
 	}
 	// a quic.Config that doesn't do a Retry
 	quicConf := &quic.Config{
-		AcceptToken: func(_ net.Addr, _ *quic.Token) bool { return true },
-		Tracer:      qlog.NewTracer(getLogWriter),
+		RequireAddressValidation: func(net.Addr) bool { return testcase == "retry" },
+		Tracer:                   qlog.NewTracer(getLogWriter),
 	}
 	cert, err := tls.LoadX509KeyPair("/certs/cert.pem", "/certs/priv.key")
 	if err != nil {
@@ -58,14 +58,10 @@ func main() {
 	}
 
 	switch testcase {
-	case "versionnegotiation", "handshake", "transfer", "resumption", "zerortt", "multiconnect":
+	case "versionnegotiation", "handshake", "retry", "transfer", "resumption", "zerortt", "multiconnect":
 		err = runHTTP09Server(quicConf)
 	case "chacha20":
 		tlsConf.CipherSuites = []uint16{tls.TLS_CHACHA20_POLY1305_SHA256}
-		err = runHTTP09Server(quicConf)
-	case "retry":
-		// By default, quic-go performs a Retry on every incoming connection.
-		quicConf.AcceptToken = nil
 		err = runHTTP09Server(quicConf)
 	case "http3":
 		err = runHTTP3Server(quicConf)


### PR DESCRIPTION
Fixes #3494.

This PR makes 2 changes:
1. It implements the new API suggested in #3494.
2. It disables address verification by default. This means that, unless configured otherwise, the QUIC handshake will take a single RTT. This is in line with providing safe defaults, as we implement the 3x amplification  protection.

@mholt, would be happy about your feedback on this PR!