### PR TITLE
add a logging.NullTracer and logging.NullConnectionTracer

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,7 @@ coverage:
     - internal/utils/newconnectionid_linkedlist.go
     - internal/utils/packetinterval_linkedlist.go
     - internal/utils/linkedlist/linkedlist.go
-    - logging/null_connection_tracer.go
+    - logging/null_tracer.go
     - fuzzing/
     - metrics/
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,7 @@ coverage:
     - internal/utils/newconnectionid_linkedlist.go
     - internal/utils/packetinterval_linkedlist.go
     - internal/utils/linkedlist/linkedlist.go
+    - logging/null_connection_tracer.go
     - fuzzing/
     - metrics/
   status:

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -50,7 +50,7 @@ func (c *tokenStore) Pop(key string) *quic.ClientToken {
 }
 
 type versionNegotiationTracer struct {
-	connTracer
+	logging.NullConnectionTracer
 
 	loggedVersions                 bool
 	receivedVersionNegotiation     bool

--- a/integrationtests/self/key_update_test.go
+++ b/integrationtests/self/key_update_test.go
@@ -45,7 +45,7 @@ func countKeyPhases() (sent, received int) {
 }
 
 type keyUpdateConnTracer struct {
-	connTracer
+	logging.NullConnectionTracer
 }
 
 func (t *keyUpdateConnTracer) SentPacket(hdr *logging.ExtendedHeader, size logging.ByteCount, ack *logging.AckFrame, frames []logging.Frame) {

--- a/integrationtests/self/self_suite_test.go
+++ b/integrationtests/self/self_suite_test.go
@@ -15,7 +15,6 @@ import (
 	"log"
 	"math/big"
 	mrand "math/rand"
-	"net"
 	"os"
 	"runtime/pprof"
 	"strconv"
@@ -328,6 +327,7 @@ func scaleDuration(d time.Duration) time.Duration {
 }
 
 type tracer struct {
+	logging.NullTracer
 	createNewConnTracer func() logging.ConnectionTracer
 }
 
@@ -340,48 +340,6 @@ func newTracer(c func() logging.ConnectionTracer) logging.Tracer {
 func (t *tracer) TracerForConnection(context.Context, logging.Perspective, logging.ConnectionID) logging.ConnectionTracer {
 	return t.createNewConnTracer()
 }
-func (t *tracer) SentPacket(net.Addr, *logging.Header, logging.ByteCount, []logging.Frame) {}
-func (t *tracer) DroppedPacket(net.Addr, logging.PacketType, logging.ByteCount, logging.PacketDropReason) {
-}
-
-type connTracer struct{}
-
-var _ logging.ConnectionTracer = &connTracer{}
-
-func (t *connTracer) StartedConnection(local, remote net.Addr, srcConnID, destConnID logging.ConnectionID) {
-}
-
-func (t *connTracer) NegotiatedVersion(chosen logging.VersionNumber, clientVersions, serverVersions []logging.VersionNumber) {
-}
-func (t *connTracer) ClosedConnection(error)                                   {}
-func (t *connTracer) SentTransportParameters(*logging.TransportParameters)     {}
-func (t *connTracer) ReceivedTransportParameters(*logging.TransportParameters) {}
-func (t *connTracer) RestoredTransportParameters(*logging.TransportParameters) {}
-func (t *connTracer) SentPacket(hdr *logging.ExtendedHeader, size logging.ByteCount, ack *logging.AckFrame, frames []logging.Frame) {
-}
-func (t *connTracer) ReceivedVersionNegotiationPacket(*logging.Header, []logging.VersionNumber) {}
-func (t *connTracer) ReceivedRetry(*logging.Header)                                             {}
-func (t *connTracer) ReceivedPacket(hdr *logging.ExtendedHeader, size logging.ByteCount, frames []logging.Frame) {
-}
-func (t *connTracer) BufferedPacket(logging.PacketType)                                             {}
-func (t *connTracer) DroppedPacket(logging.PacketType, logging.ByteCount, logging.PacketDropReason) {}
-func (t *connTracer) UpdatedMetrics(rttStats *logging.RTTStats, cwnd, bytesInFlight logging.ByteCount, packetsInFlight int) {
-}
-
-func (t *connTracer) AcknowledgedPacket(logging.EncryptionLevel, logging.PacketNumber) {}
-func (t *connTracer) LostPacket(logging.EncryptionLevel, logging.PacketNumber, logging.PacketLossReason) {
-}
-func (t *connTracer) UpdatedCongestionState(logging.CongestionState)                     {}
-func (t *connTracer) UpdatedPTOCount(value uint32)                                       {}
-func (t *connTracer) UpdatedKeyFromTLS(logging.EncryptionLevel, logging.Perspective)     {}
-func (t *connTracer) UpdatedKey(generation logging.KeyPhase, remote bool)                {}
-func (t *connTracer) DroppedEncryptionLevel(logging.EncryptionLevel)                     {}
-func (t *connTracer) DroppedKey(logging.KeyPhase)                                        {}
-func (t *connTracer) SetLossTimer(logging.TimerType, logging.EncryptionLevel, time.Time) {}
-func (t *connTracer) LossTimerExpired(logging.TimerType, logging.EncryptionLevel)        {}
-func (t *connTracer) LossTimerCanceled()                                                 {}
-func (t *connTracer) Debug(string, string)                                               {}
-func (t *connTracer) Close()                                                             {}
 
 type packet struct {
 	time   time.Time
@@ -390,7 +348,7 @@ type packet struct {
 }
 
 type packetTracer struct {
-	connTracer
+	logging.NullConnectionTracer
 	closed     chan struct{}
 	sent, rcvd []packet
 }

--- a/logging/null_connection_tracer.go
+++ b/logging/null_connection_tracer.go
@@ -1,0 +1,45 @@
+package logging
+
+import (
+	"net"
+	"time"
+)
+
+// The NullConnectionTracer is a ConnectionTracer that does nothing.
+// It is useful for embedding. Don't modify this variable!
+var NullConnectionTracer ConnectionTracer = &nullConnectionTracer{}
+
+type nullConnectionTracer struct{}
+
+var _ ConnectionTracer = &nullConnectionTracer{}
+
+func (n nullConnectionTracer) StartedConnection(local, remote net.Addr, srcConnID, destConnID ConnectionID) {
+}
+
+func (n nullConnectionTracer) NegotiatedVersion(chosen VersionNumber, clientVersions, serverVersions []VersionNumber) {
+}
+func (n nullConnectionTracer) ClosedConnection(err error)                                         {}
+func (n nullConnectionTracer) SentTransportParameters(*TransportParameters)                       {}
+func (n nullConnectionTracer) ReceivedTransportParameters(*TransportParameters)                   {}
+func (n nullConnectionTracer) RestoredTransportParameters(*TransportParameters)                   {}
+func (n nullConnectionTracer) SentPacket(*ExtendedHeader, ByteCount, *AckFrame, []Frame)          {}
+func (n nullConnectionTracer) ReceivedVersionNegotiationPacket(*Header, []VersionNumber)          {}
+func (n nullConnectionTracer) ReceivedRetry(*Header)                                              {}
+func (n nullConnectionTracer) ReceivedPacket(hdr *ExtendedHeader, size ByteCount, frames []Frame) {}
+func (n nullConnectionTracer) BufferedPacket(PacketType)                                          {}
+func (n nullConnectionTracer) DroppedPacket(PacketType, ByteCount, PacketDropReason)              {}
+func (n nullConnectionTracer) UpdatedMetrics(rttStats *RTTStats, cwnd, bytesInFlight ByteCount, packetsInFlight int) {
+}
+func (n nullConnectionTracer) AcknowledgedPacket(EncryptionLevel, PacketNumber)            {}
+func (n nullConnectionTracer) LostPacket(EncryptionLevel, PacketNumber, PacketLossReason)  {}
+func (n nullConnectionTracer) UpdatedCongestionState(CongestionState)                      {}
+func (n nullConnectionTracer) UpdatedPTOCount(uint32)                                      {}
+func (n nullConnectionTracer) UpdatedKeyFromTLS(EncryptionLevel, Perspective)              {}
+func (n nullConnectionTracer) UpdatedKey(keyPhase KeyPhase, remote bool)                   {}
+func (n nullConnectionTracer) DroppedEncryptionLevel(EncryptionLevel)                      {}
+func (n nullConnectionTracer) DroppedKey(KeyPhase)                                         {}
+func (n nullConnectionTracer) SetLossTimer(TimerType, EncryptionLevel, time.Time)          {}
+func (n nullConnectionTracer) LossTimerExpired(timerType TimerType, level EncryptionLevel) {}
+func (n nullConnectionTracer) LossTimerCanceled()                                          {}
+func (n nullConnectionTracer) Close()                                                      {}
+func (n nullConnectionTracer) Debug(name, msg string)                                      {}

--- a/logging/null_tracer.go
+++ b/logging/null_tracer.go
@@ -1,17 +1,29 @@
 package logging
 
 import (
+	"context"
 	"net"
 	"time"
 )
 
-// The NullConnectionTracer is a ConnectionTracer that does nothing.
-// It is useful for embedding. Don't modify this variable!
-var NullConnectionTracer ConnectionTracer = &nullConnectionTracer{}
+var (
+	// The NullTracer is a Tracer that does nothing.
+	// It is useful for embedding. Don't modify this variable!
+	NullTracer Tracer = &nullTracer{}
+	// The NullConnectionTracer is a ConnectionTracer that does nothing.
+	// It is useful for embedding. Don't modify this variable!
+	NullConnectionTracer ConnectionTracer = &nullConnectionTracer{}
+)
+
+type nullTracer struct{}
+
+func (n nullTracer) TracerForConnection(context.Context, Perspective, ConnectionID) ConnectionTracer {
+	return NullConnectionTracer
+}
+func (n nullTracer) SentPacket(net.Addr, *Header, ByteCount, []Frame)                {}
+func (n nullTracer) DroppedPacket(net.Addr, PacketType, ByteCount, PacketDropReason) {}
 
 type nullConnectionTracer struct{}
-
-var _ ConnectionTracer = &nullConnectionTracer{}
 
 func (n nullConnectionTracer) StartedConnection(local, remote net.Addr, srcConnID, destConnID ConnectionID) {
 }

--- a/logging/null_tracer.go
+++ b/logging/null_tracer.go
@@ -6,52 +6,47 @@ import (
 	"time"
 )
 
-var (
-	// The NullTracer is a Tracer that does nothing.
-	// It is useful for embedding. Don't modify this variable!
-	NullTracer Tracer = &nullTracer{}
-	// The NullConnectionTracer is a ConnectionTracer that does nothing.
-	// It is useful for embedding. Don't modify this variable!
-	NullConnectionTracer ConnectionTracer = &nullConnectionTracer{}
-)
+// The NullTracer is a Tracer that does nothing.
+// It is useful for embedding.
+type NullTracer struct{}
 
-type nullTracer struct{}
-
-func (n nullTracer) TracerForConnection(context.Context, Perspective, ConnectionID) ConnectionTracer {
-	return NullConnectionTracer
+func (n NullTracer) TracerForConnection(context.Context, Perspective, ConnectionID) ConnectionTracer {
+	return NullConnectionTracer{}
 }
-func (n nullTracer) SentPacket(net.Addr, *Header, ByteCount, []Frame)                {}
-func (n nullTracer) DroppedPacket(net.Addr, PacketType, ByteCount, PacketDropReason) {}
+func (n NullTracer) SentPacket(net.Addr, *Header, ByteCount, []Frame)                {}
+func (n NullTracer) DroppedPacket(net.Addr, PacketType, ByteCount, PacketDropReason) {}
 
-type nullConnectionTracer struct{}
+// The NullConnectionTracer is a ConnectionTracer that does nothing.
+// It is useful for embedding.
+type NullConnectionTracer struct{}
 
-func (n nullConnectionTracer) StartedConnection(local, remote net.Addr, srcConnID, destConnID ConnectionID) {
+func (n NullConnectionTracer) StartedConnection(local, remote net.Addr, srcConnID, destConnID ConnectionID) {
 }
 
-func (n nullConnectionTracer) NegotiatedVersion(chosen VersionNumber, clientVersions, serverVersions []VersionNumber) {
+func (n NullConnectionTracer) NegotiatedVersion(chosen VersionNumber, clientVersions, serverVersions []VersionNumber) {
 }
-func (n nullConnectionTracer) ClosedConnection(err error)                                         {}
-func (n nullConnectionTracer) SentTransportParameters(*TransportParameters)                       {}
-func (n nullConnectionTracer) ReceivedTransportParameters(*TransportParameters)                   {}
-func (n nullConnectionTracer) RestoredTransportParameters(*TransportParameters)                   {}
-func (n nullConnectionTracer) SentPacket(*ExtendedHeader, ByteCount, *AckFrame, []Frame)          {}
-func (n nullConnectionTracer) ReceivedVersionNegotiationPacket(*Header, []VersionNumber)          {}
-func (n nullConnectionTracer) ReceivedRetry(*Header)                                              {}
-func (n nullConnectionTracer) ReceivedPacket(hdr *ExtendedHeader, size ByteCount, frames []Frame) {}
-func (n nullConnectionTracer) BufferedPacket(PacketType)                                          {}
-func (n nullConnectionTracer) DroppedPacket(PacketType, ByteCount, PacketDropReason)              {}
-func (n nullConnectionTracer) UpdatedMetrics(rttStats *RTTStats, cwnd, bytesInFlight ByteCount, packetsInFlight int) {
+func (n NullConnectionTracer) ClosedConnection(err error)                                         {}
+func (n NullConnectionTracer) SentTransportParameters(*TransportParameters)                       {}
+func (n NullConnectionTracer) ReceivedTransportParameters(*TransportParameters)                   {}
+func (n NullConnectionTracer) RestoredTransportParameters(*TransportParameters)                   {}
+func (n NullConnectionTracer) SentPacket(*ExtendedHeader, ByteCount, *AckFrame, []Frame)          {}
+func (n NullConnectionTracer) ReceivedVersionNegotiationPacket(*Header, []VersionNumber)          {}
+func (n NullConnectionTracer) ReceivedRetry(*Header)                                              {}
+func (n NullConnectionTracer) ReceivedPacket(hdr *ExtendedHeader, size ByteCount, frames []Frame) {}
+func (n NullConnectionTracer) BufferedPacket(PacketType)                                          {}
+func (n NullConnectionTracer) DroppedPacket(PacketType, ByteCount, PacketDropReason)              {}
+func (n NullConnectionTracer) UpdatedMetrics(rttStats *RTTStats, cwnd, bytesInFlight ByteCount, packetsInFlight int) {
 }
-func (n nullConnectionTracer) AcknowledgedPacket(EncryptionLevel, PacketNumber)            {}
-func (n nullConnectionTracer) LostPacket(EncryptionLevel, PacketNumber, PacketLossReason)  {}
-func (n nullConnectionTracer) UpdatedCongestionState(CongestionState)                      {}
-func (n nullConnectionTracer) UpdatedPTOCount(uint32)                                      {}
-func (n nullConnectionTracer) UpdatedKeyFromTLS(EncryptionLevel, Perspective)              {}
-func (n nullConnectionTracer) UpdatedKey(keyPhase KeyPhase, remote bool)                   {}
-func (n nullConnectionTracer) DroppedEncryptionLevel(EncryptionLevel)                      {}
-func (n nullConnectionTracer) DroppedKey(KeyPhase)                                         {}
-func (n nullConnectionTracer) SetLossTimer(TimerType, EncryptionLevel, time.Time)          {}
-func (n nullConnectionTracer) LossTimerExpired(timerType TimerType, level EncryptionLevel) {}
-func (n nullConnectionTracer) LossTimerCanceled()                                          {}
-func (n nullConnectionTracer) Close()                                                      {}
-func (n nullConnectionTracer) Debug(name, msg string)                                      {}
+func (n NullConnectionTracer) AcknowledgedPacket(EncryptionLevel, PacketNumber)            {}
+func (n NullConnectionTracer) LostPacket(EncryptionLevel, PacketNumber, PacketLossReason)  {}
+func (n NullConnectionTracer) UpdatedCongestionState(CongestionState)                      {}
+func (n NullConnectionTracer) UpdatedPTOCount(uint32)                                      {}
+func (n NullConnectionTracer) UpdatedKeyFromTLS(EncryptionLevel, Perspective)              {}
+func (n NullConnectionTracer) UpdatedKey(keyPhase KeyPhase, remote bool)                   {}
+func (n NullConnectionTracer) DroppedEncryptionLevel(EncryptionLevel)                      {}
+func (n NullConnectionTracer) DroppedKey(KeyPhase)                                         {}
+func (n NullConnectionTracer) SetLossTimer(TimerType, EncryptionLevel, time.Time)          {}
+func (n NullConnectionTracer) LossTimerExpired(timerType TimerType, level EncryptionLevel) {}
+func (n NullConnectionTracer) LossTimerCanceled()                                          {}
+func (n NullConnectionTracer) Close()                                                      {}
+func (n NullConnectionTracer) Debug(name, msg string)                                      {}


### PR DESCRIPTION
The `NullTracer` and the `NullConnectionTracer` can be embedded, to make it easier to access just a few of the calls.