### PR TITLE
use a single Go routine to send copies of CONNECTION_CLOSE packets

### DIFF
--- a/closed_conn.go
+++ b/closed_conn.go
@@ -1,6 +1,7 @@
 package quic
 
 import (
+	"math/bits"
 	"sync"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
@@ -68,10 +69,8 @@ func (s *closedLocalConn) handlePacketImpl(_ *receivedPacket) {
 	s.counter++
 	// exponential backoff
 	// only send a CONNECTION_CLOSE for the 1st, 2nd, 4th, 8th, 16th, ... packet arriving
-	for n := s.counter; n > 1; n = n / 2 {
-		if n%2 != 0 {
-			return
-		}
+	if bits.OnesCount64(s.counter) != 1 {
+		return
 	}
 	s.logger.Debugf("Received %d packets after sending CONNECTION_CLOSE. Retransmitting.", s.counter)
 	if err := s.conn.Write(s.connClosePacket); err != nil {

--- a/closed_conn.go
+++ b/closed_conn.go
@@ -2,7 +2,7 @@ package quic
 
 import (
 	"math/bits"
-	"sync"
+	"net"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
@@ -12,85 +12,38 @@ import (
 // When receiving packets for such a connection, we need to retransmit the packet containing the CONNECTION_CLOSE frame,
 // with an exponential backoff.
 type closedLocalConn struct {
-	conn            sendConn
-	connClosePacket []byte
-
-	closeOnce sync.Once
-	closeChan chan struct{} // is closed when the connection is closed or destroyed
-
-	receivedPackets chan *receivedPacket
-	counter         uint64 // number of packets received
-
+	counter     uint32
 	perspective protocol.Perspective
+	logger      utils.Logger
 
-	logger utils.Logger
+	sendPacket func(net.Addr, *packetInfo)
 }
 
 var _ packetHandler = &closedLocalConn{}
 
 // newClosedLocalConn creates a new closedLocalConn and runs it.
-func newClosedLocalConn(
-	conn sendConn,
-	connClosePacket []byte,
-	perspective protocol.Perspective,
-	logger utils.Logger,
-) packetHandler {
-	s := &closedLocalConn{
-		conn:            conn,
-		connClosePacket: connClosePacket,
-		perspective:     perspective,
-		logger:          logger,
-		closeChan:       make(chan struct{}),
-		receivedPackets: make(chan *receivedPacket, 64),
-	}
-	go s.run()
-	return s
-}
-
-func (s *closedLocalConn) run() {
-	for {
-		select {
-		case p := <-s.receivedPackets:
-			s.handlePacketImpl(p)
-		case <-s.closeChan:
-			return
-		}
+func newClosedLocalConn(sendPacket func(net.Addr, *packetInfo), pers protocol.Perspective, logger utils.Logger) packetHandler {
+	return &closedLocalConn{
+		sendPacket:  sendPacket,
+		perspective: pers,
+		logger:      logger,
 	}
 }
 
-func (s *closedLocalConn) handlePacket(p *receivedPacket) {
-	select {
-	case s.receivedPackets <- p:
-	default:
-	}
-}
-
-func (s *closedLocalConn) handlePacketImpl(_ *receivedPacket) {
-	s.counter++
+func (c *closedLocalConn) handlePacket(p *receivedPacket) {
+	c.counter++
 	// exponential backoff
 	// only send a CONNECTION_CLOSE for the 1st, 2nd, 4th, 8th, 16th, ... packet arriving
-	if bits.OnesCount64(s.counter) != 1 {
+	if bits.OnesCount32(c.counter) != 1 {
 		return
 	}
-	s.logger.Debugf("Received %d packets after sending CONNECTION_CLOSE. Retransmitting.", s.counter)
-	if err := s.conn.Write(s.connClosePacket); err != nil {
-		s.logger.Debugf("Error retransmitting CONNECTION_CLOSE: %s", err)
-	}
+	c.logger.Debugf("Received %d packets after sending CONNECTION_CLOSE. Retransmitting.", c.counter)
+	c.sendPacket(p.remoteAddr, p.info)
 }
 
-func (s *closedLocalConn) shutdown() {
-	s.destroy(nil)
-}
-
-func (s *closedLocalConn) destroy(error) {
-	s.closeOnce.Do(func() {
-		close(s.closeChan)
-	})
-}
-
-func (s *closedLocalConn) getPerspective() protocol.Perspective {
-	return s.perspective
-}
+func (c *closedLocalConn) shutdown()                            {}
+func (c *closedLocalConn) destroy(error)                        {}
+func (c *closedLocalConn) getPerspective() protocol.Perspective { return c.perspective }
 
 // A closedRemoteConn is a connection that was closed remotely.
 // For such a connection, we might receive reordered packets that were sent before the CONNECTION_CLOSE.

--- a/conn_id_generator.go
+++ b/conn_id_generator.go
@@ -20,7 +20,7 @@ type connIDGenerator struct {
 	getStatelessResetToken func(protocol.ConnectionID) protocol.StatelessResetToken
 	removeConnectionID     func(protocol.ConnectionID)
 	retireConnectionID     func(protocol.ConnectionID)
-	replaceWithClosed      func(protocol.ConnectionID, packetHandler)
+	replaceWithClosed      func([]protocol.ConnectionID, packetHandler)
 	queueControlFrame      func(wire.Frame)
 
 	version protocol.VersionNumber
@@ -33,7 +33,7 @@ func newConnIDGenerator(
 	getStatelessResetToken func(protocol.ConnectionID) protocol.StatelessResetToken,
 	removeConnectionID func(protocol.ConnectionID),
 	retireConnectionID func(protocol.ConnectionID),
-	replaceWithClosed func(protocol.ConnectionID, packetHandler),
+	replaceWithClosed func([]protocol.ConnectionID, packetHandler),
 	queueControlFrame func(wire.Frame),
 	version protocol.VersionNumber,
 ) *connIDGenerator {
@@ -131,10 +131,12 @@ func (m *connIDGenerator) RemoveAll() {
 }
 
 func (m *connIDGenerator) ReplaceWithClosed(handler packetHandler) {
+	connIDs := make([]protocol.ConnectionID, 0, len(m.activeSrcConnIDs)+1)
 	if m.initialClientDestConnID != nil {
-		m.replaceWithClosed(m.initialClientDestConnID, handler)
+		connIDs = append(connIDs, m.initialClientDestConnID)
 	}
 	for _, connID := range m.activeSrcConnIDs {
-		m.replaceWithClosed(connID, handler)
+		connIDs = append(connIDs, connID)
 	}
+	m.replaceWithClosed(connIDs, handler)
 }

--- a/conn_id_generator.go
+++ b/conn_id_generator.go
@@ -20,7 +20,7 @@ type connIDGenerator struct {
 	getStatelessResetToken func(protocol.ConnectionID) protocol.StatelessResetToken
 	removeConnectionID     func(protocol.ConnectionID)
 	retireConnectionID     func(protocol.ConnectionID)
-	replaceWithClosed      func([]protocol.ConnectionID, packetHandler)
+	replaceWithClosed      func([]protocol.ConnectionID, protocol.Perspective, []byte)
 	queueControlFrame      func(wire.Frame)
 
 	version protocol.VersionNumber
@@ -33,7 +33,7 @@ func newConnIDGenerator(
 	getStatelessResetToken func(protocol.ConnectionID) protocol.StatelessResetToken,
 	removeConnectionID func(protocol.ConnectionID),
 	retireConnectionID func(protocol.ConnectionID),
-	replaceWithClosed func([]protocol.ConnectionID, packetHandler),
+	replaceWithClosed func([]protocol.ConnectionID, protocol.Perspective, []byte),
 	queueControlFrame func(wire.Frame),
 	version protocol.VersionNumber,
 ) *connIDGenerator {
@@ -130,7 +130,7 @@ func (m *connIDGenerator) RemoveAll() {
 	}
 }
 
-func (m *connIDGenerator) ReplaceWithClosed(handler packetHandler) {
+func (m *connIDGenerator) ReplaceWithClosed(pers protocol.Perspective, connClose []byte) {
 	connIDs := make([]protocol.ConnectionID, 0, len(m.activeSrcConnIDs)+1)
 	if m.initialClientDestConnID != nil {
 		connIDs = append(connIDs, m.initialClientDestConnID)
@@ -138,5 +138,5 @@ func (m *connIDGenerator) ReplaceWithClosed(handler packetHandler) {
 	for _, connID := range m.activeSrcConnIDs {
 		connIDs = append(connIDs, connID)
 	}
-	m.replaceWithClosed(connIDs, handler)
+	m.replaceWithClosed(connIDs, pers, connClose)
 }

--- a/conn_id_generator_test.go
+++ b/conn_id_generator_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Connection ID Generator", func() {
 		addedConnIDs       []protocol.ConnectionID
 		retiredConnIDs     []protocol.ConnectionID
 		removedConnIDs     []protocol.ConnectionID
-		replacedWithClosed map[string]packetHandler
+		replacedWithClosed []protocol.ConnectionID
 		queuedFrames       []wire.Frame
 		g                  *connIDGenerator
 	)
@@ -32,7 +32,7 @@ var _ = Describe("Connection ID Generator", func() {
 		retiredConnIDs = nil
 		removedConnIDs = nil
 		queuedFrames = nil
-		replacedWithClosed = make(map[string]packetHandler)
+		replacedWithClosed = nil
 		g = newConnIDGenerator(
 			initialConnID,
 			initialClientDestConnID,
@@ -40,10 +40,8 @@ var _ = Describe("Connection ID Generator", func() {
 			connIDToToken,
 			func(c protocol.ConnectionID) { removedConnIDs = append(removedConnIDs, c) },
 			func(c protocol.ConnectionID) { retiredConnIDs = append(retiredConnIDs, c) },
-			func(cs []protocol.ConnectionID, h packetHandler) {
-				for _, c := range cs {
-					replacedWithClosed[string(c)] = h
-				}
+			func(cs []protocol.ConnectionID, _ protocol.Perspective, _ []byte) {
+				replacedWithClosed = append(replacedWithClosed, cs...)
 			},
 			func(f wire.Frame) { queuedFrames = append(queuedFrames, f) },
 			protocol.VersionDraft29,
@@ -178,14 +176,13 @@ var _ = Describe("Connection ID Generator", func() {
 	It("replaces with a closed connection for all connection IDs", func() {
 		Expect(g.SetMaxActiveConnIDs(5)).To(Succeed())
 		Expect(queuedFrames).To(HaveLen(4))
-		sess := NewMockPacketHandler(mockCtrl)
-		g.ReplaceWithClosed(sess)
+		g.ReplaceWithClosed(protocol.PerspectiveClient, []byte("foobar"))
 		Expect(replacedWithClosed).To(HaveLen(6)) // initial conn ID, initial client dest conn id, and newly issued ones
-		Expect(replacedWithClosed).To(HaveKeyWithValue(string(initialClientDestConnID), sess))
-		Expect(replacedWithClosed).To(HaveKeyWithValue(string(initialConnID), sess))
+		Expect(replacedWithClosed).To(ContainElement(initialClientDestConnID))
+		Expect(replacedWithClosed).To(ContainElement(initialConnID))
 		for _, f := range queuedFrames {
 			nf := f.(*wire.NewConnectionIDFrame)
-			Expect(replacedWithClosed).To(HaveKeyWithValue(string(nf.ConnectionID), sess))
+			Expect(replacedWithClosed).To(ContainElement(nf.ConnectionID))
 		}
 	})
 })

--- a/conn_id_generator_test.go
+++ b/conn_id_generator_test.go
@@ -40,7 +40,11 @@ var _ = Describe("Connection ID Generator", func() {
 			connIDToToken,
 			func(c protocol.ConnectionID) { removedConnIDs = append(removedConnIDs, c) },
 			func(c protocol.ConnectionID) { retiredConnIDs = append(retiredConnIDs, c) },
-			func(c protocol.ConnectionID, h packetHandler) { replacedWithClosed[string(c)] = h },
+			func(cs []protocol.ConnectionID, h packetHandler) {
+				for _, c := range cs {
+					replacedWithClosed[string(c)] = h
+				}
+			},
 			func(f wire.Frame) { queuedFrames = append(queuedFrames, f) },
 			protocol.VersionDraft29,
 		)

--- a/connection.go
+++ b/connection.go
@@ -95,7 +95,7 @@ type connRunner interface {
 	GetStatelessResetToken(protocol.ConnectionID) protocol.StatelessResetToken
 	Retire(protocol.ConnectionID)
 	Remove(protocol.ConnectionID)
-	ReplaceWithClosed([]protocol.ConnectionID, packetHandler)
+	ReplaceWithClosed([]protocol.ConnectionID, protocol.Perspective, []byte)
 	AddResetToken(protocol.StatelessResetToken, packetHandler)
 	RemoveResetToken(protocol.StatelessResetToken)
 }
@@ -1521,7 +1521,7 @@ func (s *connection) handleCloseError(closeErr *closeError) {
 
 	// If this is a remote close we're done here
 	if closeErr.remote {
-		s.connIDGenerator.ReplaceWithClosed(newClosedRemoteConn(s.perspective))
+		s.connIDGenerator.ReplaceWithClosed(s.perspective, nil)
 		return
 	}
 	if closeErr.immediate {
@@ -1538,8 +1538,7 @@ func (s *connection) handleCloseError(closeErr *closeError) {
 	if err != nil {
 		s.logger.Debugf("Error sending CONNECTION_CLOSE: %s", err)
 	}
-	cs := newClosedLocalConn(s.conn, connClosePacket, s.perspective, s.logger)
-	s.connIDGenerator.ReplaceWithClosed(cs)
+	s.connIDGenerator.ReplaceWithClosed(s.perspective, connClosePacket)
 }
 
 func (s *connection) dropEncryptionLevel(encLevel protocol.EncryptionLevel) {

--- a/connection.go
+++ b/connection.go
@@ -95,7 +95,7 @@ type connRunner interface {
 	GetStatelessResetToken(protocol.ConnectionID) protocol.StatelessResetToken
 	Retire(protocol.ConnectionID)
 	Remove(protocol.ConnectionID)
-	ReplaceWithClosed(protocol.ConnectionID, packetHandler)
+	ReplaceWithClosed([]protocol.ConnectionID, packetHandler)
 	AddResetToken(protocol.StatelessResetToken, packetHandler)
 	RemoveResetToken(protocol.StatelessResetToken)
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -37,12 +37,6 @@ func areConnsRunning() bool {
 	return strings.Contains(b.String(), "quic-go.(*connection).run")
 }
 
-func areClosedConnsRunning() bool {
-	var b bytes.Buffer
-	pprof.Lookup("goroutine").WriteTo(&b, 1)
-	return strings.Contains(b.String(), "quic-go.(*closedLocalConn).run")
-}
-
 var _ = Describe("Connection", func() {
 	var (
 		conn          *connection
@@ -72,14 +66,11 @@ var _ = Describe("Connection", func() {
 	}
 
 	expectReplaceWithClosed := func() {
-		connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any()).Do(func(connIDs []protocol.ConnectionID, s packetHandler) {
+		connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(connIDs []protocol.ConnectionID, _ protocol.Perspective, _ []byte) {
 			Expect(connIDs).To(ContainElement(srcConnID))
 			if len(connIDs) > 1 {
 				Expect(connIDs).To(ContainElement(clientDestConnID))
 			}
-			Expect(s).To(BeAssignableToTypeOf(&closedLocalConn{}))
-			s.shutdown()
-			Eventually(areClosedConnsRunning).Should(BeFalse())
 		})
 	}
 
@@ -333,9 +324,8 @@ var _ = Describe("Connection", func() {
 				ErrorMessage: "foobar",
 			}
 			streamManager.EXPECT().CloseWithError(expectedErr)
-			connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any()).Do(func(connIDs []protocol.ConnectionID, s packetHandler) {
+			connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(connIDs []protocol.ConnectionID, _ protocol.Perspective, _ []byte) {
 				Expect(connIDs).To(ConsistOf(clientDestConnID, srcConnID))
-				Expect(s).To(BeAssignableToTypeOf(&closedRemoteConn{}))
 			})
 			cryptoSetup.EXPECT().Close()
 			gomock.InOrder(
@@ -362,9 +352,8 @@ var _ = Describe("Connection", func() {
 				ErrorMessage: "foobar",
 			}
 			streamManager.EXPECT().CloseWithError(testErr)
-			connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any()).Do(func(connIDs []protocol.ConnectionID, s packetHandler) {
+			connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(connIDs []protocol.ConnectionID, _ protocol.Perspective, _ []byte) {
 				Expect(connIDs).To(ConsistOf(clientDestConnID, srcConnID))
-				Expect(s).To(BeAssignableToTypeOf(&closedRemoteConn{}))
 			})
 			cryptoSetup.EXPECT().Close()
 			gomock.InOrder(
@@ -564,7 +553,7 @@ var _ = Describe("Connection", func() {
 			runConn()
 			cryptoSetup.EXPECT().Close()
 			streamManager.EXPECT().CloseWithError(gomock.Any())
-			connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any()).AnyTimes()
+			connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			buf := &bytes.Buffer{}
 			hdr := &wire.ExtendedHeader{
 				Header:          wire.Header{DestConnectionID: srcConnID},
@@ -2432,10 +2421,7 @@ var _ = Describe("Client Connection", func() {
 	}
 
 	expectReplaceWithClosed := func() {
-		connRunner.EXPECT().ReplaceWithClosed([]protocol.ConnectionID{srcConnID}, gomock.Any()).Do(func(_ []protocol.ConnectionID, s packetHandler) {
-			s.shutdown()
-			Eventually(areClosedConnsRunning).Should(BeFalse())
-		})
+		connRunner.EXPECT().ReplaceWithClosed([]protocol.ConnectionID{srcConnID}, gomock.Any(), gomock.Any())
 	}
 
 	BeforeEach(func() {
@@ -2766,10 +2752,7 @@ var _ = Describe("Client Connection", func() {
 
 		expectClose := func(applicationClose bool) {
 			if !closed {
-				connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any()).Do(func(_ []protocol.ConnectionID, s packetHandler) {
-					Expect(s).To(BeAssignableToTypeOf(&closedLocalConn{}))
-					s.shutdown()
-				})
+				connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any())
 				if applicationClose {
 					packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil).MaxTimes(1)
 				} else {

--- a/integrationtests/self/close_test.go
+++ b/integrationtests/self/close_test.go
@@ -1,0 +1,84 @@
+package self_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+
+	"github.com/lucas-clemente/quic-go"
+
+	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Connection ID lengths tests", func() {
+	for _, v := range protocol.SupportedVersions {
+		version := v
+
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
+			It("retransmits the CONNECTION_CLOSE packet", func() {
+				server, err := quic.ListenAddr(
+					"localhost:0",
+					getTLSConfig(),
+					getQuicConfig(&quic.Config{
+						DisablePathMTUDiscovery: true,
+					}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				var drop utils.AtomicBool
+				dropped := make(chan []byte, 100)
+				proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+					RemoteAddr: fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
+					DelayPacket: func(dir quicproxy.Direction, _ []byte) time.Duration {
+						return 5 * time.Millisecond // 10ms RTT
+					},
+					DropPacket: func(dir quicproxy.Direction, b []byte) bool {
+						if drop := drop.Get(); drop && dir == quicproxy.DirectionOutgoing {
+							dropped <- b
+							return true
+						}
+						return false
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				defer proxy.Close()
+
+				conn, err := quic.DialAddr(
+					fmt.Sprintf("localhost:%d", proxy.LocalPort()),
+					getTLSClientConfig(),
+					getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				sconn, err := server.Accept(context.Background())
+				Expect(err).ToNot(HaveOccurred())
+				time.Sleep(100 * time.Millisecond)
+				drop.Set(true)
+				sconn.CloseWithError(1337, "closing")
+
+				// send 100 packets
+				for i := 0; i < 100; i++ {
+					str, err := conn.OpenStream()
+					Expect(err).ToNot(HaveOccurred())
+					_, err = str.Write([]byte("foobar"))
+					Expect(err).ToNot(HaveOccurred())
+					time.Sleep(time.Millisecond)
+				}
+				// Expect retransmissions of the CONNECTION_CLOSE for the
+				// 1st, 2nd, 4th, 8th, 16th, 32th, 64th packet: 7 in total (+1 for the original packet)
+				Eventually(dropped).Should(HaveLen(8))
+				first := <-dropped
+				for len(dropped) > 0 {
+					Expect(<-dropped).To(Equal(first)) // these packets are all identical
+				}
+			})
+		})
+	}
+})

--- a/mock_conn_runner_test.go
+++ b/mock_conn_runner_test.go
@@ -99,15 +99,15 @@ func (mr *MockConnRunnerMockRecorder) RemoveResetToken(arg0 interface{}) *gomock
 }
 
 // ReplaceWithClosed mocks base method.
-func (m *MockConnRunner) ReplaceWithClosed(arg0 []protocol.ConnectionID, arg1 packetHandler) {
+func (m *MockConnRunner) ReplaceWithClosed(arg0 []protocol.ConnectionID, arg1 protocol.Perspective, arg2 []byte) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReplaceWithClosed", arg0, arg1)
+	m.ctrl.Call(m, "ReplaceWithClosed", arg0, arg1, arg2)
 }
 
 // ReplaceWithClosed indicates an expected call of ReplaceWithClosed.
-func (mr *MockConnRunnerMockRecorder) ReplaceWithClosed(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockConnRunnerMockRecorder) ReplaceWithClosed(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceWithClosed", reflect.TypeOf((*MockConnRunner)(nil).ReplaceWithClosed), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceWithClosed", reflect.TypeOf((*MockConnRunner)(nil).ReplaceWithClosed), arg0, arg1, arg2)
 }
 
 // Retire mocks base method.

--- a/mock_conn_runner_test.go
+++ b/mock_conn_runner_test.go
@@ -99,7 +99,7 @@ func (mr *MockConnRunnerMockRecorder) RemoveResetToken(arg0 interface{}) *gomock
 }
 
 // ReplaceWithClosed mocks base method.
-func (m *MockConnRunner) ReplaceWithClosed(arg0 protocol.ConnectionID, arg1 packetHandler) {
+func (m *MockConnRunner) ReplaceWithClosed(arg0 []protocol.ConnectionID, arg1 packetHandler) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReplaceWithClosed", arg0, arg1)
 }

--- a/mock_packet_handler_manager_test.go
+++ b/mock_packet_handler_manager_test.go
@@ -139,7 +139,7 @@ func (mr *MockPacketHandlerManagerMockRecorder) RemoveResetToken(arg0 interface{
 }
 
 // ReplaceWithClosed mocks base method.
-func (m *MockPacketHandlerManager) ReplaceWithClosed(arg0 protocol.ConnectionID, arg1 packetHandler) {
+func (m *MockPacketHandlerManager) ReplaceWithClosed(arg0 []protocol.ConnectionID, arg1 packetHandler) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReplaceWithClosed", arg0, arg1)
 }

--- a/mock_packet_handler_manager_test.go
+++ b/mock_packet_handler_manager_test.go
@@ -139,15 +139,15 @@ func (mr *MockPacketHandlerManagerMockRecorder) RemoveResetToken(arg0 interface{
 }
 
 // ReplaceWithClosed mocks base method.
-func (m *MockPacketHandlerManager) ReplaceWithClosed(arg0 []protocol.ConnectionID, arg1 packetHandler) {
+func (m *MockPacketHandlerManager) ReplaceWithClosed(arg0 []protocol.ConnectionID, arg1 protocol.Perspective, arg2 []byte) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReplaceWithClosed", arg0, arg1)
+	m.ctrl.Call(m, "ReplaceWithClosed", arg0, arg1, arg2)
 }
 
 // ReplaceWithClosed indicates an expected call of ReplaceWithClosed.
-func (mr *MockPacketHandlerManagerMockRecorder) ReplaceWithClosed(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPacketHandlerManagerMockRecorder) ReplaceWithClosed(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceWithClosed", reflect.TypeOf((*MockPacketHandlerManager)(nil).ReplaceWithClosed), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceWithClosed", reflect.TypeOf((*MockPacketHandlerManager)(nil).ReplaceWithClosed), arg0, arg1, arg2)
 }
 
 // Retire mocks base method.

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -22,33 +22,6 @@ import (
 	"github.com/lucas-clemente/quic-go/logging"
 )
 
-type zeroRTTQueue struct {
-	queue       []*receivedPacket
-	retireTimer *time.Timer
-}
-
-var _ packetHandler = &zeroRTTQueue{}
-
-func (h *zeroRTTQueue) handlePacket(p *receivedPacket) {
-	if len(h.queue) < protocol.Max0RTTQueueLen {
-		h.queue = append(h.queue, p)
-	}
-}
-func (h *zeroRTTQueue) shutdown()                            {}
-func (h *zeroRTTQueue) destroy(error)                        {}
-func (h *zeroRTTQueue) getPerspective() protocol.Perspective { return protocol.PerspectiveClient }
-func (h *zeroRTTQueue) EnqueueAll(sess packetHandler) {
-	for _, p := range h.queue {
-		sess.handlePacket(p)
-	}
-}
-
-func (h *zeroRTTQueue) Clear() {
-	for _, p := range h.queue {
-		p.buffer.Release()
-	}
-}
-
 // rawConn is a connection that allow reading of a receivedPacket.
 type rawConn interface {
 	ReadPacket() (*receivedPacket, error)

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -219,18 +219,22 @@ func (h *packetHandlerMap) Retire(id protocol.ConnectionID) {
 	})
 }
 
-func (h *packetHandlerMap) ReplaceWithClosed(id protocol.ConnectionID, handler packetHandler) {
+func (h *packetHandlerMap) ReplaceWithClosed(ids []protocol.ConnectionID, handler packetHandler) {
 	h.mutex.Lock()
-	h.handlers[string(id)] = handler
+	for _, id := range ids {
+		h.handlers[string(id)] = handler
+	}
 	h.mutex.Unlock()
-	h.logger.Debugf("Replacing connection for connection ID %s with a closed connection.", id)
+	h.logger.Debugf("Replacing connection for connection IDs %s with a closed connection.", ids)
 
 	time.AfterFunc(h.deleteRetiredConnsAfter, func() {
 		h.mutex.Lock()
 		handler.shutdown()
-		delete(h.handlers, string(id))
+		for _, id := range ids {
+			delete(h.handlers, string(id))
+		}
 		h.mutex.Unlock()
-		h.logger.Debugf("Removing connection ID %s for a closed connection after it has been retired.", id)
+		h.logger.Debugf("Removing connection IDs %s for a closed connection after it has been retired.", ids)
 	})
 }
 

--- a/zero_rtt_queue.go
+++ b/zero_rtt_queue.go
@@ -1,0 +1,34 @@
+package quic
+
+import (
+	"time"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+)
+
+type zeroRTTQueue struct {
+	queue       []*receivedPacket
+	retireTimer *time.Timer
+}
+
+var _ packetHandler = &zeroRTTQueue{}
+
+func (h *zeroRTTQueue) handlePacket(p *receivedPacket) {
+	if len(h.queue) < protocol.Max0RTTQueueLen {
+		h.queue = append(h.queue, p)
+	}
+}
+func (h *zeroRTTQueue) shutdown()                            {}
+func (h *zeroRTTQueue) destroy(error)                        {}
+func (h *zeroRTTQueue) getPerspective() protocol.Perspective { return protocol.PerspectiveClient }
+func (h *zeroRTTQueue) EnqueueAll(sess packetHandler) {
+	for _, p := range h.queue {
+		sess.handlePacket(p)
+	}
+}
+
+func (h *zeroRTTQueue) Clear() {
+	for _, p := range h.queue {
+		p.buffer.Release()
+	}
+}


### PR DESCRIPTION
Fixes #3477. The design is definitely a lot cleaner than what we had before.

This will drastically reduce the number of active Go routines, especially when handling a lot of short-lived QUIC connection. 

I'm also happy to have found a use case for the `math/bits` package.

@Stebalien, can you take a look at this PR?