### PR TITLE
speed up marshaling of transport parameters

### DIFF
--- a/fuzzing/transportparameters/cmd/corpus.go
+++ b/fuzzing/transportparameters/cmd/corpus.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"log"
 	"math"
 	"math/rand"
@@ -78,9 +77,7 @@ func main() {
 			}
 			data = tp.Marshal(pers)
 		} else {
-			b := &bytes.Buffer{}
-			tp.MarshalForSessionTicket(b)
-			data = b.Bytes()
+			data = tp.MarshalForSessionTicket(nil)
 		}
 		if err := helper.WriteCorpusFileWithPrefix("corpus", data, transportparameters.PrefixLen); err != nil {
 			log.Fatal(err)

--- a/fuzzing/transportparameters/fuzz.go
+++ b/fuzzing/transportparameters/fuzz.go
@@ -51,10 +51,9 @@ func fuzzTransportParametersForSessionTicket(data []byte) int {
 	if err := tp.UnmarshalFromSessionTicket(bytes.NewReader(data)); err != nil {
 		return 0
 	}
-	buf := &bytes.Buffer{}
-	tp.MarshalForSessionTicket(buf)
+	b := tp.MarshalForSessionTicket(nil)
 	tp2 := &wire.TransportParameters{}
-	if err := tp2.UnmarshalFromSessionTicket(bytes.NewReader(buf.Bytes())); err != nil {
+	if err := tp2.UnmarshalFromSessionTicket(bytes.NewReader(b)); err != nil {
 		panic(err)
 	}
 	return 1

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -432,11 +432,10 @@ func (h *cryptoSetup) handleTransportParameters(data []byte) {
 
 // must be called after receiving the transport parameters
 func (h *cryptoSetup) marshalDataForSessionState() []byte {
-	buf := &bytes.Buffer{}
-	quicvarint.Write(buf, clientSessionStateRevision)
-	quicvarint.Write(buf, uint64(h.rttStats.SmoothedRTT().Microseconds()))
-	h.peerParams.MarshalForSessionTicket(buf)
-	return buf.Bytes()
+	b := make([]byte, 0, 256)
+	b = quicvarint.Append(b, clientSessionStateRevision)
+	b = quicvarint.Append(b, uint64(h.rttStats.SmoothedRTT().Microseconds()))
+	return h.peerParams.MarshalForSessionTicket(b)
 }
 
 func (h *cryptoSetup) handleDataFromSessionState(data []byte) {

--- a/internal/handshake/session_ticket.go
+++ b/internal/handshake/session_ticket.go
@@ -18,11 +18,10 @@ type sessionTicket struct {
 }
 
 func (t *sessionTicket) Marshal() []byte {
-	b := &bytes.Buffer{}
-	quicvarint.Write(b, sessionTicketRevision)
-	quicvarint.Write(b, uint64(t.RTT.Microseconds()))
-	t.Parameters.MarshalForSessionTicket(b)
-	return b.Bytes()
+	b := make([]byte, 0, 256)
+	b = quicvarint.Append(b, sessionTicketRevision)
+	b = quicvarint.Append(b, uint64(t.RTT.Microseconds()))
+	return t.Parameters.MarshalForSessionTicket(b)
 }
 
 func (t *sessionTicket) Unmarshal(b []byte) error {

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -486,10 +486,9 @@ var _ = Describe("Transport Parameters", func() {
 				ActiveConnectionIDLimit:        getRandomValue(),
 			}
 			Expect(params.ValidFor0RTT(params)).To(BeTrue())
-			b := &bytes.Buffer{}
-			params.MarshalForSessionTicket(b)
+			b := params.MarshalForSessionTicket(nil)
 			var tp TransportParameters
-			Expect(tp.UnmarshalFromSessionTicket(bytes.NewReader(b.Bytes()))).To(Succeed())
+			Expect(tp.UnmarshalFromSessionTicket(bytes.NewReader(b))).To(Succeed())
 			Expect(tp.InitialMaxStreamDataBidiLocal).To(Equal(params.InitialMaxStreamDataBidiLocal))
 			Expect(tp.InitialMaxStreamDataBidiRemote).To(Equal(params.InitialMaxStreamDataBidiRemote))
 			Expect(tp.InitialMaxStreamDataUni).To(Equal(params.InitialMaxStreamDataUni))
@@ -506,9 +505,7 @@ var _ = Describe("Transport Parameters", func() {
 
 		It("rejects the parameters if the version changed", func() {
 			var p TransportParameters
-			buf := &bytes.Buffer{}
-			p.MarshalForSessionTicket(buf)
-			data := buf.Bytes()
+			data := p.MarshalForSessionTicket(nil)
 			b := &bytes.Buffer{}
 			quicvarint.Write(b, transportParameterMarshalingVersion+1)
 			b.Write(data[quicvarint.Len(transportParameterMarshalingVersion):])


### PR DESCRIPTION
This is not in the critical path, so technically this is not a part of #3526. It's fun to see how much we can gain anyway, and such an easy and self-contained change that it's definitely worth doing.

The speedup comes from multiple sources:
1. We now preallocate a byte slice, instead of appending multiple times.
2. Marshaling into a byte slice is faster than using a bytes.Buffer.
3. quicvarint.Write allocates, while quicvarint.Append doesn't.

```
benchmark                                  old ns/op     new ns/op     delta
BenchmarkTransportParametersMarshal-10     368           196           -46.80%

benchmark                                  old allocs     new allocs     delta
BenchmarkTransportParametersMarshal-10     14             1              -92.86%

benchmark                                  old bytes     new bytes     delta
BenchmarkTransportParametersMarshal-10     273           256           -6.23%
```