### PR TITLE
introduce a separate code paths for Short Header packet handling

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1199,7 +1199,16 @@ func (s *connection) handleUnpackedPacket(
 		for i, frame := range frames {
 			fs[i] = logutils.ConvertFrame(frame)
 		}
-		s.tracer.ReceivedPacket(packet.hdr, packetSize, fs)
+		if packet.hdr.IsLongHeader {
+			s.tracer.ReceivedLongHeaderPacket(packet.hdr, packetSize, fs)
+		} else {
+			s.tracer.ReceivedShortHeaderPacket(&wire.ShortHeader{
+				DestConnectionID: packet.hdr.DestConnectionID,
+				PacketNumber:     packet.hdr.PacketNumber,
+				PacketNumberLen:  packet.hdr.PacketNumberLen,
+				KeyPhase:         packet.hdr.KeyPhase,
+			}, packetSize, fs)
+		}
 		for _, frame := range frames {
 			if err := s.handleFrame(frame, packet.encryptionLevel, packet.hdr.DestConnectionID); err != nil {
 				return err

--- a/connection.go
+++ b/connection.go
@@ -1123,13 +1123,6 @@ func (s *connection) handleUnpackedPacket(
 	rcvTime time.Time,
 	packetSize protocol.ByteCount, // only for logging
 ) error {
-	if len(packet.data) == 0 {
-		return &qerr.TransportError{
-			ErrorCode:    qerr.ProtocolViolation,
-			ErrorMessage: "empty packet",
-		}
-	}
-
 	if !s.receivedFirstPacket {
 		s.receivedFirstPacket = true
 		if !s.versionNegotiated && s.tracer != nil {

--- a/connection.go
+++ b/connection.go
@@ -982,11 +982,11 @@ func (s *connection) handleSinglePacket(p *receivedPacket, hdr *wire.Header) boo
 	}
 
 	if s.logger.Debug() {
-		s.logger.Debugf("<- Reading packet %d (%d bytes) for connection %s, %s", packet.packetNumber, p.Size(), hdr.DestConnectionID, packet.encryptionLevel)
+		s.logger.Debugf("<- Reading packet %d (%d bytes) for connection %s, %s", packet.hdr.PacketNumber, p.Size(), hdr.DestConnectionID, packet.encryptionLevel)
 		packet.hdr.Log(s.logger)
 	}
 
-	if s.receivedPacketHandler.IsPotentiallyDuplicate(packet.packetNumber, packet.encryptionLevel) {
+	if s.receivedPacketHandler.IsPotentiallyDuplicate(packet.hdr.PacketNumber, packet.encryptionLevel) {
 		s.logger.Debugf("Dropping (potentially) duplicate packet.")
 		if s.tracer != nil {
 			s.tracer.DroppedPacket(logging.PacketTypeFromHeader(hdr), p.Size(), logging.PacketDropDuplicate)
@@ -1214,7 +1214,7 @@ func (s *connection) handleUnpackedPacket(
 		}
 	}
 
-	return s.receivedPacketHandler.ReceivedPacket(packet.packetNumber, ecn, packet.encryptionLevel, rcvTime, isAckEliciting)
+	return s.receivedPacketHandler.ReceivedPacket(packet.hdr.PacketNumber, ecn, packet.encryptionLevel, rcvTime, isAckEliciting)
 }
 
 func (s *connection) handleFrame(f wire.Frame, encLevel protocol.EncryptionLevel, destConnID protocol.ConnectionID) error {

--- a/integrationtests/self/key_update_test.go
+++ b/integrationtests/self/key_update_test.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	sentHeaders     []*logging.ExtendedHeader
-	receivedHeaders []*logging.ExtendedHeader
+	receivedHeaders []*logging.ShortHeader
 )
 
 func countKeyPhases() (sent, received int) {
@@ -33,9 +33,6 @@ func countKeyPhases() (sent, received int) {
 	}
 	lastKeyPhase = protocol.KeyPhaseOne
 	for _, hdr := range receivedHeaders {
-		if hdr.IsLongHeader {
-			continue
-		}
 		if hdr.KeyPhase != lastKeyPhase {
 			received++
 			lastKeyPhase = hdr.KeyPhase
@@ -52,7 +49,7 @@ func (t *keyUpdateConnTracer) SentPacket(hdr *logging.ExtendedHeader, size loggi
 	sentHeaders = append(sentHeaders, hdr)
 }
 
-func (t *keyUpdateConnTracer) ReceivedPacket(hdr *logging.ExtendedHeader, size logging.ByteCount, frames []logging.Frame) {
+func (t *keyUpdateConnTracer) ReceivedShortHeaderPacket(hdr *logging.ShortHeader, size logging.ByteCount, frames []logging.Frame) {
 	receivedHeaders = append(receivedHeaders, hdr)
 }
 

--- a/integrationtests/self/packetization_test.go
+++ b/integrationtests/self/packetization_test.go
@@ -84,11 +84,8 @@ var _ = Describe("Packetization", func() {
 		}
 		Expect(conn.CloseWithError(0, "")).To(Succeed())
 
-		countBundledPackets := func(packets []packet) (numBundled int) {
+		countBundledPackets := func(packets []shortHeaderPacket) (numBundled int) {
 			for _, p := range packets {
-				if p.hdr.IsLongHeader {
-					continue
-				}
 				var hasAck, hasStreamFrame bool
 				for _, f := range p.frames {
 					switch f.(type) {
@@ -105,8 +102,8 @@ var _ = Describe("Packetization", func() {
 			return
 		}
 
-		numBundledIncoming := countBundledPackets(clientTracer.getRcvdPackets())
-		numBundledOutgoing := countBundledPackets(serverTracer.getRcvdPackets())
+		numBundledIncoming := countBundledPackets(clientTracer.getRcvdShortHeaderPackets())
+		numBundledOutgoing := countBundledPackets(serverTracer.getRcvdShortHeaderPackets())
 		fmt.Fprintf(GinkgoWriter, "bundled incoming packets: %d / %d\n", numBundledIncoming, numMsg)
 		fmt.Fprintf(GinkgoWriter, "bundled outgoing packets: %d / %d\n", numBundledOutgoing, numMsg)
 		Expect(numBundledIncoming).To(And(

--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Timeout tests", func() {
 					lastAckElicitingPacketSentAt = p.time
 				}
 			}
-			rcvdPackets := tr.getRcvdPackets()
+			rcvdPackets := tr.getRcvdShortHeaderPackets()
 			lastPacketRcvdAt := rcvdPackets[len(rcvdPackets)-1].time
 			// We're ignoring here that only the first ack-eliciting packet sent resets the idle timeout.
 			// This is ok since we're dealing with a lossless connection here,

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -217,7 +217,7 @@ var _ = Describe("0-RTT", func() {
 					)
 
 					var numNewConnIDs int
-					for _, p := range tracer.getRcvdPackets() {
+					for _, p := range tracer.getRcvdLongHeaderPackets() {
 						for _, f := range p.frames {
 							if _, ok := f.(*logging.NewConnectionIDFrame); ok {
 								numNewConnIDs++
@@ -233,7 +233,7 @@ var _ = Describe("0-RTT", func() {
 					num0RTT := atomic.LoadUint32(num0RTTPackets)
 					fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
 					Expect(num0RTT).ToNot(BeZero())
-					zeroRTTPackets := get0RTTPackets(tracer.getRcvdPackets())
+					zeroRTTPackets := get0RTTPackets(tracer.getRcvdLongHeaderPackets())
 					Expect(len(zeroRTTPackets)).To(BeNumerically(">", 10))
 					sort.Slice(zeroRTTPackets, func(i, j int) bool { return zeroRTTPackets[i] < zeroRTTPackets[j] })
 					Expect(zeroRTTPackets[0]).To(Equal(protocol.PacketNumber(0)))
@@ -310,7 +310,7 @@ var _ = Describe("0-RTT", func() {
 				num0RTT := atomic.LoadUint32(num0RTTPackets)
 				fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
 				Expect(num0RTT).To(Or(BeEquivalentTo(2), BeEquivalentTo(3))) // the FIN might be sent in a separate packet
-				Expect(get0RTTPackets(tracer.getRcvdPackets())).To(HaveLen(int(num0RTT)))
+				Expect(get0RTTPackets(tracer.getRcvdLongHeaderPackets())).To(HaveLen(int(num0RTT)))
 			})
 
 			It("transfers 0-RTT data, when 0-RTT packets are lost", func() {
@@ -367,7 +367,7 @@ var _ = Describe("0-RTT", func() {
 				fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets. Dropped %d of those.", num0RTT, numDropped)
 				Expect(numDropped).ToNot(BeZero())
 				Expect(num0RTT).ToNot(BeZero())
-				Expect(get0RTTPackets(tracer.getRcvdPackets())).ToNot(BeEmpty())
+				Expect(get0RTTPackets(tracer.getRcvdLongHeaderPackets())).ToNot(BeEmpty())
 			})
 
 			It("retransmits all 0-RTT data when the server performs a Retry", func() {
@@ -441,7 +441,7 @@ var _ = Describe("0-RTT", func() {
 				defer mutex.Unlock()
 				Expect(firstCounter).To(BeNumerically("~", 5000+100 /* framing overhead */, 100)) // the FIN bit might be sent extra
 				Expect(secondCounter).To(BeNumerically("~", firstCounter, 20))
-				zeroRTTPackets := get0RTTPackets(tracer.getRcvdPackets())
+				zeroRTTPackets := get0RTTPackets(tracer.getRcvdLongHeaderPackets())
 				Expect(len(zeroRTTPackets)).To(BeNumerically(">=", 5))
 				Expect(zeroRTTPackets[0]).To(BeNumerically(">=", protocol.PacketNumber(5)))
 			})
@@ -516,7 +516,7 @@ var _ = Describe("0-RTT", func() {
 				num0RTT := atomic.LoadUint32(num0RTTPackets)
 				fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
 				Expect(num0RTT).ToNot(BeZero())
-				Expect(get0RTTPackets(tracer.getRcvdPackets())).To(BeEmpty())
+				Expect(get0RTTPackets(tracer.getRcvdLongHeaderPackets())).To(BeEmpty())
 			})
 
 			It("rejects 0-RTT when the ALPN changed", func() {
@@ -545,7 +545,7 @@ var _ = Describe("0-RTT", func() {
 				num0RTT := atomic.LoadUint32(num0RTTPackets)
 				fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
 				Expect(num0RTT).ToNot(BeZero())
-				Expect(get0RTTPackets(tracer.getRcvdPackets())).To(BeEmpty())
+				Expect(get0RTTPackets(tracer.getRcvdLongHeaderPackets())).To(BeEmpty())
 			})
 
 			DescribeTable("flow control limits",
@@ -603,7 +603,7 @@ var _ = Describe("0-RTT", func() {
 					Eventually(conn.Context().Done()).Should(BeClosed())
 
 					var processedFirst bool
-					for _, p := range tracer.getRcvdPackets() {
+					for _, p := range tracer.getRcvdLongHeaderPackets() {
 						for _, f := range p.frames {
 							if sf, ok := f.(*logging.StreamFrame); ok {
 								if !processedFirst {
@@ -613,9 +613,7 @@ var _ = Describe("0-RTT", func() {
 									Expect(sf.Length).To(BeEquivalentTo(3))
 									processedFirst = true
 								} else {
-									// All other STREAM frames can only be sent after handshake completion.
-									Expect(p.hdr.IsLongHeader).To(BeFalse())
-									Expect(sf.Offset).ToNot(BeZero())
+									Fail("STREAM was shouldn't have been sent in 0-RTT")
 								}
 							}
 						}
@@ -700,7 +698,7 @@ var _ = Describe("0-RTT", func() {
 					num0RTT := atomic.LoadUint32(num0RTTPackets)
 					fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
 					Expect(num0RTT).ToNot(BeZero())
-					Expect(get0RTTPackets(tracer.getRcvdPackets())).To(BeEmpty())
+					Expect(get0RTTPackets(tracer.getRcvdLongHeaderPackets())).To(BeEmpty())
 				})
 			}
 
@@ -732,8 +730,8 @@ var _ = Describe("0-RTT", func() {
 
 				transfer0RTTData(ln, proxy.LocalPort(), clientConf, nil, PRData)
 
-				Expect(tracer.getRcvdPackets()[0].hdr.Type).To(Equal(protocol.PacketTypeInitial))
-				zeroRTTPackets := get0RTTPackets(tracer.getRcvdPackets())
+				Expect(tracer.getRcvdLongHeaderPackets()[0].hdr.Type).To(Equal(protocol.PacketTypeInitial))
+				zeroRTTPackets := get0RTTPackets(tracer.getRcvdLongHeaderPackets())
 				Expect(len(zeroRTTPackets)).To(BeNumerically(">", 10))
 				Expect(zeroRTTPackets[0]).To(Equal(protocol.PacketNumber(0)))
 			})

--- a/internal/mocks/logging/connection_tracer.go
+++ b/internal/mocks/logging/connection_tracer.go
@@ -183,16 +183,16 @@ func (mr *MockConnectionTracerMockRecorder) NegotiatedVersion(arg0, arg1, arg2 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NegotiatedVersion", reflect.TypeOf((*MockConnectionTracer)(nil).NegotiatedVersion), arg0, arg1, arg2)
 }
 
-// ReceivedPacket mocks base method.
-func (m *MockConnectionTracer) ReceivedPacket(arg0 *wire.ExtendedHeader, arg1 protocol.ByteCount, arg2 []logging.Frame) {
+// ReceivedLongHeaderPacket mocks base method.
+func (m *MockConnectionTracer) ReceivedLongHeaderPacket(arg0 *wire.ExtendedHeader, arg1 protocol.ByteCount, arg2 []logging.Frame) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReceivedPacket", arg0, arg1, arg2)
+	m.ctrl.Call(m, "ReceivedLongHeaderPacket", arg0, arg1, arg2)
 }
 
-// ReceivedPacket indicates an expected call of ReceivedPacket.
-func (mr *MockConnectionTracerMockRecorder) ReceivedPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ReceivedLongHeaderPacket indicates an expected call of ReceivedLongHeaderPacket.
+func (mr *MockConnectionTracerMockRecorder) ReceivedLongHeaderPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedPacket", reflect.TypeOf((*MockConnectionTracer)(nil).ReceivedPacket), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedLongHeaderPacket", reflect.TypeOf((*MockConnectionTracer)(nil).ReceivedLongHeaderPacket), arg0, arg1, arg2)
 }
 
 // ReceivedRetry mocks base method.
@@ -205,6 +205,18 @@ func (m *MockConnectionTracer) ReceivedRetry(arg0 *wire.Header) {
 func (mr *MockConnectionTracerMockRecorder) ReceivedRetry(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedRetry", reflect.TypeOf((*MockConnectionTracer)(nil).ReceivedRetry), arg0)
+}
+
+// ReceivedShortHeaderPacket mocks base method.
+func (m *MockConnectionTracer) ReceivedShortHeaderPacket(arg0 *wire.ShortHeader, arg1 protocol.ByteCount, arg2 []logging.Frame) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ReceivedShortHeaderPacket", arg0, arg1, arg2)
+}
+
+// ReceivedShortHeaderPacket indicates an expected call of ReceivedShortHeaderPacket.
+func (mr *MockConnectionTracerMockRecorder) ReceivedShortHeaderPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedShortHeaderPacket", reflect.TypeOf((*MockConnectionTracer)(nil).ReceivedShortHeaderPacket), arg0, arg1, arg2)
 }
 
 // ReceivedTransportParameters mocks base method.

--- a/internal/utils/byteoder_big_endian_test.go
+++ b/internal/utils/byteoder_big_endian_test.go
@@ -9,6 +9,23 @@ import (
 )
 
 var _ = Describe("Big Endian encoding / decoding", func() {
+	Context("converting", func() {
+		It("Uint16", func() {
+			b := []byte{0x13, 0x37}
+			Expect(BigEndian.Uint16(b)).To(Equal(uint16(0x1337)))
+		})
+
+		It("Uint24", func() {
+			b := []byte{0x13, 0x99, 0x37}
+			Expect(BigEndian.Uint24(b)).To(Equal(uint32(0x139937)))
+		})
+
+		It("Uint32", func() {
+			b := []byte{0xde, 0xad, 0xbe, 0xef}
+			Expect(BigEndian.Uint32(b)).To(Equal(uint32(0xdeadbeef)))
+		})
+	})
+
 	Context("ReadUint16", func() {
 		It("reads a big endian", func() {
 			b := []byte{0x13, 0xEF}

--- a/internal/utils/byteorder.go
+++ b/internal/utils/byteorder.go
@@ -7,6 +7,10 @@ import (
 
 // A ByteOrder specifies how to convert byte sequences into 16-, 32-, or 64-bit unsigned integers.
 type ByteOrder interface {
+	Uint32([]byte) uint32
+	Uint24([]byte) uint32
+	Uint16([]byte) uint16
+
 	ReadUint32(io.ByteReader) (uint32, error)
 	ReadUint24(io.ByteReader) (uint32, error)
 	ReadUint16(io.ByteReader) (uint16, error)

--- a/internal/utils/byteorder_big_endian.go
+++ b/internal/utils/byteorder_big_endian.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 )
 
@@ -71,6 +72,19 @@ func (bigEndian) ReadUint16(b io.ByteReader) (uint16, error) {
 		return 0, err
 	}
 	return uint16(b1) + uint16(b2)<<8, nil
+}
+
+func (bigEndian) Uint32(b []byte) uint32 {
+	return binary.BigEndian.Uint32(b)
+}
+
+func (bigEndian) Uint24(b []byte) uint32 {
+	_ = b[2] // bounds check hint to compiler; see golang.org/issue/14808
+	return uint32(b[2]) | uint32(b[1])<<8 | uint32(b[0])<<16
+}
+
+func (bigEndian) Uint16(b []byte) uint16 {
+	return binary.BigEndian.Uint16(b)
 }
 
 // WriteUint32 writes a uint32

--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -29,6 +29,9 @@ func ParseConnectionID(data []byte, shortHeaderConnIDLen int) (protocol.Connecti
 		return protocol.ConnectionID{}, io.EOF
 	}
 	destConnIDLen := int(data[5])
+	if destConnIDLen > protocol.MaxConnIDLen {
+		return protocol.ConnectionID{}, protocol.ErrInvalidConnectionIDLen
+	}
 	if len(data) < 6+destConnIDLen {
 		return protocol.ConnectionID{}, io.EOF
 	}

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -86,6 +86,15 @@ var _ = Describe("Header Parsing", func() {
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})
+
+		It("errors when encountering a too long connection ID", func() {
+			b := []byte{0x80, 0, 0, 0, 0}
+			binary.BigEndian.PutUint32(b[1:], uint32(protocol.Version1))
+			b = append(b, 21) // dest conn id len
+			b = append(b, make([]byte, 21)...)
+			_, err := ParseConnectionID(b, 4)
+			Expect(err).To(MatchError(protocol.ErrInvalidConnectionIDLen))
+		})
 	})
 
 	Context("identifying 0-RTT packets", func() {

--- a/internal/wire/short_header.go
+++ b/internal/wire/short_header.go
@@ -1,0 +1,73 @@
+package wire
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+)
+
+type ShortHeader struct {
+	DestConnectionID protocol.ConnectionID
+	PacketNumber     protocol.PacketNumber
+	PacketNumberLen  protocol.PacketNumberLen
+	KeyPhase         protocol.KeyPhaseBit
+}
+
+func ParseShortHeader(data []byte, connIDLen int) (*ShortHeader, error) {
+	if len(data) == 0 {
+		return nil, io.EOF
+	}
+	if data[0]&0x80 > 0 {
+		return nil, errors.New("not a short header packet")
+	}
+	if data[0]&0x40 == 0 {
+		return nil, errors.New("not a QUIC packet")
+	}
+	pnLen := protocol.PacketNumberLen(data[0]&0b11) + 1
+	if len(data) < 1+int(pnLen)+connIDLen {
+		return nil, io.EOF
+	}
+	destConnID := protocol.ParseConnectionID(data[1 : 1+connIDLen])
+
+	pos := 1 + connIDLen
+	var pn protocol.PacketNumber
+	switch pnLen {
+	case protocol.PacketNumberLen1:
+		pn = protocol.PacketNumber(data[pos])
+	case protocol.PacketNumberLen2:
+		pn = protocol.PacketNumber(utils.BigEndian.Uint16(data[pos : pos+2]))
+	case protocol.PacketNumberLen3:
+		pn = protocol.PacketNumber(utils.BigEndian.Uint24(data[pos : pos+3]))
+	case protocol.PacketNumberLen4:
+		pn = protocol.PacketNumber(utils.BigEndian.Uint32(data[pos : pos+4]))
+	default:
+		return nil, fmt.Errorf("invalid packet number length: %d", pnLen)
+	}
+	kp := protocol.KeyPhaseZero
+	if data[0]&0b100 > 0 {
+		kp = protocol.KeyPhaseOne
+	}
+
+	var err error
+	if data[0]&0x18 != 0 {
+		err = ErrInvalidReservedBits
+	}
+	return &ShortHeader{
+		DestConnectionID: destConnID,
+		PacketNumber:     pn,
+		PacketNumberLen:  pnLen,
+		KeyPhase:         kp,
+	}, err
+}
+
+func (h *ShortHeader) Len() protocol.ByteCount {
+	return 1 + protocol.ByteCount(h.DestConnectionID.Len()) + protocol.ByteCount(h.PacketNumberLen)
+}
+
+// Log logs the Header
+func (h *ShortHeader) Log(logger utils.Logger) {
+	logger.Debugf("\tShort Header{DestConnectionID: %s, PacketNumber: %d, PacketNumberLen: %d, KeyPhase: %s}", h.DestConnectionID, h.PacketNumber, h.PacketNumberLen, h.KeyPhase)
+}

--- a/internal/wire/short_header_test.go
+++ b/internal/wire/short_header_test.go
@@ -1,0 +1,110 @@
+package wire
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Short Header", func() {
+	Context("Parsing", func() {
+		It("parses", func() {
+			data := []byte{
+				0b01000110,
+				0xde, 0xad, 0xbe, 0xef,
+				0x13, 0x37, 0x99,
+			}
+			hdr, err := ParseShortHeader(data, 4)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hdr.DestConnectionID).To(Equal(protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef})))
+			Expect(hdr.KeyPhase).To(Equal(protocol.KeyPhaseOne))
+			Expect(hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x133799)))
+			Expect(hdr.PacketNumberLen).To(Equal(protocol.PacketNumberLen3))
+		})
+
+		It("errors when the QUIC bit is not set", func() {
+			data := []byte{
+				0b00000101,
+				0xde, 0xad, 0xbe, 0xef,
+				0x13, 0x37,
+			}
+			_, err := ParseShortHeader(data, 4)
+			Expect(err).To(MatchError("not a QUIC packet"))
+		})
+
+		It("errors, but returns the header, when the reserved bits are set", func() {
+			data := []byte{
+				0b01010101,
+				0xde, 0xad, 0xbe, 0xef,
+				0x13, 0x37,
+			}
+			hdr, err := ParseShortHeader(data, 4)
+			Expect(err).To(MatchError(ErrInvalidReservedBits))
+			Expect(hdr).ToNot(BeNil())
+			Expect(hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x1337)))
+		})
+
+		It("errors when passed a long header packet", func() {
+			_, err := ParseShortHeader([]byte{0x80}, 4)
+			Expect(err).To(MatchError("not a short header packet"))
+		})
+
+		It("errors on EOF", func() {
+			data := []byte{
+				0b01000110,
+				0xde, 0xad, 0xbe, 0xef,
+				0x13, 0x37, 0x99,
+			}
+			_, err := ParseShortHeader(data, 4)
+			Expect(err).ToNot(HaveOccurred())
+			for i := range data {
+				_, err := ParseShortHeader(data[:i], 4)
+				Expect(err).To(MatchError(io.EOF))
+			}
+		})
+	})
+
+	Context("logging", func() {
+		var (
+			buf    *bytes.Buffer
+			logger utils.Logger
+		)
+
+		BeforeEach(func() {
+			buf = &bytes.Buffer{}
+			logger = utils.DefaultLogger
+			logger.SetLogLevel(utils.LogLevelDebug)
+			log.SetOutput(buf)
+		})
+
+		AfterEach(func() {
+			log.SetOutput(os.Stdout)
+		})
+
+		It("logs Short Headers containing a connection ID", func() {
+			(&ShortHeader{
+				DestConnectionID: protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37}),
+				KeyPhase:         protocol.KeyPhaseOne,
+				PacketNumber:     1337,
+				PacketNumberLen:  4,
+			}).Log(logger)
+			Expect(buf.String()).To(ContainSubstring("Short Header{DestConnectionID: deadbeefcafe1337, PacketNumber: 1337, PacketNumberLen: 4, KeyPhase: 1}"))
+		})
+	})
+
+	It("determines the length", func() {
+		Expect((&ShortHeader{
+			DestConnectionID: protocol.ParseConnectionID([]byte{0xde, 0xaf}),
+			PacketNumber:     0x1337,
+			PacketNumberLen:  protocol.PacketNumberLen3,
+			KeyPhase:         protocol.KeyPhaseOne,
+		}).Len()).To(Equal(protocol.ByteCount(1 + 2 + 3)))
+	})
+})

--- a/logging/interface.go
+++ b/logging/interface.go
@@ -44,8 +44,10 @@ type (
 
 	// The Header is the QUIC packet header, before removing header protection.
 	Header = wire.Header
-	// The ExtendedHeader is the QUIC packet header, after removing header protection.
+	// The ExtendedHeader is the QUIC Long Header packet header, after removing header protection.
 	ExtendedHeader = wire.ExtendedHeader
+	// The ShortHeader is the QUIC Short Header packet header, after removing header protection.
+	ShortHeader = wire.ShortHeader
 	// The TransportParameters are QUIC transport parameters.
 	TransportParameters = wire.TransportParameters
 	// The PreferredAddress is the preferred address sent in the transport parameters.
@@ -116,7 +118,8 @@ type ConnectionTracer interface {
 	SentPacket(hdr *ExtendedHeader, size ByteCount, ack *AckFrame, frames []Frame)
 	ReceivedVersionNegotiationPacket(dest, src ArbitraryLenConnectionID, _ []VersionNumber)
 	ReceivedRetry(*Header)
-	ReceivedPacket(hdr *ExtendedHeader, size ByteCount, frames []Frame)
+	ReceivedLongHeaderPacket(hdr *ExtendedHeader, size ByteCount, frames []Frame)
+	ReceivedShortHeaderPacket(hdr *ShortHeader, size ByteCount, frames []Frame)
 	BufferedPacket(PacketType)
 	DroppedPacket(PacketType, ByteCount, PacketDropReason)
 	UpdatedMetrics(rttStats *RTTStats, cwnd, bytesInFlight ByteCount, packetsInFlight int)

--- a/logging/mock_connection_tracer_test.go
+++ b/logging/mock_connection_tracer_test.go
@@ -182,16 +182,16 @@ func (mr *MockConnectionTracerMockRecorder) NegotiatedVersion(arg0, arg1, arg2 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NegotiatedVersion", reflect.TypeOf((*MockConnectionTracer)(nil).NegotiatedVersion), arg0, arg1, arg2)
 }
 
-// ReceivedPacket mocks base method.
-func (m *MockConnectionTracer) ReceivedPacket(arg0 *wire.ExtendedHeader, arg1 protocol.ByteCount, arg2 []Frame) {
+// ReceivedLongHeaderPacket mocks base method.
+func (m *MockConnectionTracer) ReceivedLongHeaderPacket(arg0 *wire.ExtendedHeader, arg1 protocol.ByteCount, arg2 []Frame) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReceivedPacket", arg0, arg1, arg2)
+	m.ctrl.Call(m, "ReceivedLongHeaderPacket", arg0, arg1, arg2)
 }
 
-// ReceivedPacket indicates an expected call of ReceivedPacket.
-func (mr *MockConnectionTracerMockRecorder) ReceivedPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ReceivedLongHeaderPacket indicates an expected call of ReceivedLongHeaderPacket.
+func (mr *MockConnectionTracerMockRecorder) ReceivedLongHeaderPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedPacket", reflect.TypeOf((*MockConnectionTracer)(nil).ReceivedPacket), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedLongHeaderPacket", reflect.TypeOf((*MockConnectionTracer)(nil).ReceivedLongHeaderPacket), arg0, arg1, arg2)
 }
 
 // ReceivedRetry mocks base method.
@@ -204,6 +204,18 @@ func (m *MockConnectionTracer) ReceivedRetry(arg0 *wire.Header) {
 func (mr *MockConnectionTracerMockRecorder) ReceivedRetry(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedRetry", reflect.TypeOf((*MockConnectionTracer)(nil).ReceivedRetry), arg0)
+}
+
+// ReceivedShortHeaderPacket mocks base method.
+func (m *MockConnectionTracer) ReceivedShortHeaderPacket(arg0 *wire.ShortHeader, arg1 protocol.ByteCount, arg2 []Frame) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ReceivedShortHeaderPacket", arg0, arg1, arg2)
+}
+
+// ReceivedShortHeaderPacket indicates an expected call of ReceivedShortHeaderPacket.
+func (mr *MockConnectionTracerMockRecorder) ReceivedShortHeaderPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceivedShortHeaderPacket", reflect.TypeOf((*MockConnectionTracer)(nil).ReceivedShortHeaderPacket), arg0, arg1, arg2)
 }
 
 // ReceivedTransportParameters mocks base method.

--- a/logging/multiplex.go
+++ b/logging/multiplex.go
@@ -122,9 +122,15 @@ func (m *connTracerMultiplexer) ReceivedRetry(hdr *Header) {
 	}
 }
 
-func (m *connTracerMultiplexer) ReceivedPacket(hdr *ExtendedHeader, size ByteCount, frames []Frame) {
+func (m *connTracerMultiplexer) ReceivedLongHeaderPacket(hdr *ExtendedHeader, size ByteCount, frames []Frame) {
 	for _, t := range m.tracers {
-		t.ReceivedPacket(hdr, size, frames)
+		t.ReceivedLongHeaderPacket(hdr, size, frames)
+	}
+}
+
+func (m *connTracerMultiplexer) ReceivedShortHeaderPacket(hdr *ShortHeader, size ByteCount, frames []Frame) {
+	for _, t := range m.tracers {
+		t.ReceivedShortHeaderPacket(hdr, size, frames)
 	}
 }
 

--- a/logging/multiplex_test.go
+++ b/logging/multiplex_test.go
@@ -181,12 +181,20 @@ var _ = Describe("Tracing", func() {
 			tracer.ReceivedRetry(hdr)
 		})
 
-		It("traces the ReceivedPacket event", func() {
+		It("traces the ReceivedLongHeaderPacket event", func() {
 			hdr := &ExtendedHeader{Header: Header{DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3})}}
 			ping := &PingFrame{}
-			tr1.EXPECT().ReceivedPacket(hdr, ByteCount(1337), []Frame{ping})
-			tr2.EXPECT().ReceivedPacket(hdr, ByteCount(1337), []Frame{ping})
-			tracer.ReceivedPacket(hdr, 1337, []Frame{ping})
+			tr1.EXPECT().ReceivedLongHeaderPacket(hdr, ByteCount(1337), []Frame{ping})
+			tr2.EXPECT().ReceivedLongHeaderPacket(hdr, ByteCount(1337), []Frame{ping})
+			tracer.ReceivedLongHeaderPacket(hdr, 1337, []Frame{ping})
+		})
+
+		It("traces the ReceivedShortHeaderPacket event", func() {
+			hdr := &ShortHeader{DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3})}
+			ping := &PingFrame{}
+			tr1.EXPECT().ReceivedShortHeaderPacket(hdr, ByteCount(1337), []Frame{ping})
+			tr2.EXPECT().ReceivedShortHeaderPacket(hdr, ByteCount(1337), []Frame{ping})
+			tracer.ReceivedShortHeaderPacket(hdr, 1337, []Frame{ping})
 		})
 
 		It("traces the BufferedPacket event", func() {

--- a/logging/null_tracer.go
+++ b/logging/null_tracer.go
@@ -38,10 +38,12 @@ func (n NullConnectionTracer) RestoredTransportParameters(*TransportParameters) 
 func (n NullConnectionTracer) SentPacket(*ExtendedHeader, ByteCount, *AckFrame, []Frame) {}
 func (n NullConnectionTracer) ReceivedVersionNegotiationPacket(dest, src ArbitraryLenConnectionID, _ []VersionNumber) {
 }
-func (n NullConnectionTracer) ReceivedRetry(*Header)                                              {}
-func (n NullConnectionTracer) ReceivedPacket(hdr *ExtendedHeader, size ByteCount, frames []Frame) {}
-func (n NullConnectionTracer) BufferedPacket(PacketType)                                          {}
-func (n NullConnectionTracer) DroppedPacket(PacketType, ByteCount, PacketDropReason)              {}
+func (n NullConnectionTracer) ReceivedRetry(*Header)                                        {}
+func (n NullConnectionTracer) ReceivedLongHeaderPacket(*ExtendedHeader, ByteCount, []Frame) {}
+func (n NullConnectionTracer) ReceivedShortHeaderPacket(*ShortHeader, ByteCount, []Frame)   {}
+func (n NullConnectionTracer) BufferedPacket(PacketType)                                    {}
+func (n NullConnectionTracer) DroppedPacket(PacketType, ByteCount, PacketDropReason)        {}
+
 func (n NullConnectionTracer) UpdatedMetrics(rttStats *RTTStats, cwnd, bytesInFlight ByteCount, packetsInFlight int) {
 }
 func (n NullConnectionTracer) AcknowledgedPacket(EncryptionLevel, PacketNumber)            {}

--- a/mock_unpacker_test.go
+++ b/mock_unpacker_test.go
@@ -35,17 +35,33 @@ func (m *MockUnpacker) EXPECT() *MockUnpackerMockRecorder {
 	return m.recorder
 }
 
-// Unpack mocks base method.
-func (m *MockUnpacker) Unpack(hdr *wire.Header, rcvTime time.Time, data []byte) (*unpackedPacket, error) {
+// UnpackLongHeader mocks base method.
+func (m *MockUnpacker) UnpackLongHeader(hdr *wire.Header, rcvTime time.Time, data []byte) (*unpackedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unpack", hdr, rcvTime, data)
+	ret := m.ctrl.Call(m, "UnpackLongHeader", hdr, rcvTime, data)
 	ret0, _ := ret[0].(*unpackedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Unpack indicates an expected call of Unpack.
-func (mr *MockUnpackerMockRecorder) Unpack(hdr, rcvTime, data interface{}) *gomock.Call {
+// UnpackLongHeader indicates an expected call of UnpackLongHeader.
+func (mr *MockUnpackerMockRecorder) UnpackLongHeader(hdr, rcvTime, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unpack", reflect.TypeOf((*MockUnpacker)(nil).Unpack), hdr, rcvTime, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpackLongHeader", reflect.TypeOf((*MockUnpacker)(nil).UnpackLongHeader), hdr, rcvTime, data)
+}
+
+// UnpackShortHeader mocks base method.
+func (m *MockUnpacker) UnpackShortHeader(rcvTime time.Time, data []byte) (*wire.ShortHeader, []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnpackShortHeader", rcvTime, data)
+	ret0, _ := ret[0].(*wire.ShortHeader)
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// UnpackShortHeader indicates an expected call of UnpackShortHeader.
+func (mr *MockUnpackerMockRecorder) UnpackShortHeader(rcvTime, data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpackShortHeader", reflect.TypeOf((*MockUnpacker)(nil).UnpackShortHeader), rcvTime, data)
 }

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -37,22 +37,25 @@ type unpackedPacket struct {
 type packetUnpacker struct {
 	cs handshake.CryptoSetup
 
-	version protocol.VersionNumber
+	shortHdrConnIDLen int
+	version           protocol.VersionNumber
 }
 
 var _ unpacker = &packetUnpacker{}
 
-func newPacketUnpacker(cs handshake.CryptoSetup, version protocol.VersionNumber) unpacker {
+func newPacketUnpacker(cs handshake.CryptoSetup, shortHdrConnIDLen int, version protocol.VersionNumber) unpacker {
 	return &packetUnpacker{
-		cs:      cs,
-		version: version,
+		cs:                cs,
+		shortHdrConnIDLen: shortHdrConnIDLen,
+		version:           version,
 	}
 }
 
+// UnpackLongHeader unpacks a Long Header packet.
 // If the reserved bits are invalid, the error is wire.ErrInvalidReservedBits.
 // If any other error occurred when parsing the header, the error is of type headerParseError.
 // If decrypting the payload fails for any reason, the error is the error returned by the AEAD.
-func (u *packetUnpacker) Unpack(hdr *wire.Header, rcvTime time.Time, data []byte) (*unpackedPacket, error) {
+func (u *packetUnpacker) UnpackLongHeader(hdr *wire.Header, rcvTime time.Time, data []byte) (*unpackedPacket, error) {
 	var encLevel protocol.EncryptionLevel
 	var extHdr *wire.ExtendedHeader
 	var decrypted []byte
@@ -89,18 +92,7 @@ func (u *packetUnpacker) Unpack(hdr *wire.Header, rcvTime time.Time, data []byte
 			return nil, err
 		}
 	default:
-		if hdr.IsLongHeader {
-			return nil, fmt.Errorf("unknown packet type: %s", hdr.Type)
-		}
-		encLevel = protocol.Encryption1RTT
-		opener, err := u.cs.Get1RTTOpener()
-		if err != nil {
-			return nil, err
-		}
-		extHdr, decrypted, err = u.unpackShortHeaderPacket(opener, hdr, rcvTime, data)
-		if err != nil {
-			return nil, err
-		}
+		return nil, fmt.Errorf("unknown packet type: %s", hdr.Type)
 	}
 
 	if len(decrypted) == 0 {
@@ -117,8 +109,26 @@ func (u *packetUnpacker) Unpack(hdr *wire.Header, rcvTime time.Time, data []byte
 	}, nil
 }
 
+func (u *packetUnpacker) UnpackShortHeader(rcvTime time.Time, data []byte) (*wire.ShortHeader, []byte, error) {
+	opener, err := u.cs.Get1RTTOpener()
+	if err != nil {
+		return nil, nil, err
+	}
+	hdr, decrypted, err := u.unpackShortHeaderPacket(opener, rcvTime, data)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(decrypted) == 0 {
+		return nil, nil, &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "empty packet",
+		}
+	}
+	return hdr, decrypted, nil
+}
+
 func (u *packetUnpacker) unpackLongHeaderPacket(opener handshake.LongHeaderOpener, hdr *wire.Header, data []byte) (*wire.ExtendedHeader, []byte, error) {
-	extHdr, parseErr := u.unpackHeader(opener, hdr, data)
+	extHdr, parseErr := u.unpackLongHeader(opener, hdr, data)
 	// If the reserved bits are set incorrectly, we still need to continue unpacking.
 	// This avoids a timing side-channel, which otherwise might allow an attacker
 	// to gain information about the header encryption.
@@ -137,41 +147,58 @@ func (u *packetUnpacker) unpackLongHeaderPacket(opener handshake.LongHeaderOpene
 	return extHdr, decrypted, nil
 }
 
-func (u *packetUnpacker) unpackShortHeaderPacket(
-	opener handshake.ShortHeaderOpener,
-	hdr *wire.Header,
-	rcvTime time.Time,
-	data []byte,
-) (*wire.ExtendedHeader, []byte, error) {
-	extHdr, parseErr := u.unpackHeader(opener, hdr, data)
+func (u *packetUnpacker) unpackShortHeaderPacket(opener handshake.ShortHeaderOpener, rcvTime time.Time, data []byte) (*wire.ShortHeader, []byte, error) {
+	hdr, parseErr := u.unpackShortHeader(opener, data)
 	// If the reserved bits are set incorrectly, we still need to continue unpacking.
 	// This avoids a timing side-channel, which otherwise might allow an attacker
 	// to gain information about the header encryption.
 	if parseErr != nil && parseErr != wire.ErrInvalidReservedBits {
-		return nil, nil, parseErr
+		return nil, nil, &headerParseError{parseErr}
 	}
-	extHdr.PacketNumber = opener.DecodePacketNumber(extHdr.PacketNumber, extHdr.PacketNumberLen)
-	extHdrLen := extHdr.ParsedLen()
-	decrypted, err := opener.Open(data[extHdrLen:extHdrLen], data[extHdrLen:], rcvTime, extHdr.PacketNumber, extHdr.KeyPhase, data[:extHdrLen])
+	hdr.PacketNumber = opener.DecodePacketNumber(hdr.PacketNumber, hdr.PacketNumberLen)
+	l := hdr.Len()
+	decrypted, err := opener.Open(data[l:l], data[l:], rcvTime, hdr.PacketNumber, hdr.KeyPhase, data[:l])
 	if err != nil {
 		return nil, nil, err
 	}
-	if parseErr != nil {
-		return nil, nil, parseErr
+	return hdr, decrypted, parseErr
+}
+
+func (u *packetUnpacker) unpackShortHeader(hd headerDecryptor, data []byte) (*wire.ShortHeader, error) {
+	hdrLen := 1 /* first header byte */ + u.shortHdrConnIDLen
+	if len(data) < hdrLen+4+16 {
+		return nil, fmt.Errorf("packet too small, expected at least 20 bytes after the header, got %d", len(data)-hdrLen)
 	}
-	return extHdr, decrypted, nil
+	origPNBytes := make([]byte, 4)
+	copy(origPNBytes, data[hdrLen:hdrLen+4])
+	// 2. decrypt the header, assuming a 4 byte packet number
+	hd.DecryptHeader(
+		data[hdrLen+4:hdrLen+4+16],
+		&data[0],
+		data[hdrLen:hdrLen+4],
+	)
+	// 3. parse the header (and learn the actual length of the packet number)
+	hdr, parseErr := wire.ParseShortHeader(data, u.shortHdrConnIDLen)
+	if parseErr != nil && parseErr != wire.ErrInvalidReservedBits {
+		return nil, parseErr
+	}
+	// 4. if the packet number is shorter than 4 bytes, replace the remaining bytes with the copy we saved earlier
+	if hdr.PacketNumberLen != protocol.PacketNumberLen4 {
+		copy(data[hdrLen+int(hdr.PacketNumberLen):hdrLen+4], origPNBytes[int(hdr.PacketNumberLen):])
+	}
+	return hdr, parseErr
 }
 
 // The error is either nil, a wire.ErrInvalidReservedBits or of type headerParseError.
-func (u *packetUnpacker) unpackHeader(hd headerDecryptor, hdr *wire.Header, data []byte) (*wire.ExtendedHeader, error) {
-	extHdr, err := unpackHeader(hd, hdr, data, u.version)
+func (u *packetUnpacker) unpackLongHeader(hd headerDecryptor, hdr *wire.Header, data []byte) (*wire.ExtendedHeader, error) {
+	extHdr, err := unpackLongHeader(hd, hdr, data, u.version)
 	if err != nil && err != wire.ErrInvalidReservedBits {
 		return nil, &headerParseError{err: err}
 	}
 	return extHdr, err
 }
 
-func unpackHeader(hd headerDecryptor, hdr *wire.Header, data []byte, version protocol.VersionNumber) (*wire.ExtendedHeader, error) {
+func unpackLongHeader(hd headerDecryptor, hdr *wire.Header, data []byte, version protocol.VersionNumber) (*wire.ExtendedHeader, error) {
 	r := bytes.NewReader(data)
 
 	hdrLen := hdr.ParsedLen()

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -27,7 +27,6 @@ func (e *headerParseError) Error() string {
 }
 
 type unpackedPacket struct {
-	packetNumber    protocol.PacketNumber // the decoded packet number
 	hdr             *wire.ExtendedHeader
 	encryptionLevel protocol.EncryptionLevel
 	data            []byte
@@ -105,7 +104,6 @@ func (u *packetUnpacker) Unpack(hdr *wire.Header, rcvTime time.Time, data []byte
 
 	return &unpackedPacket{
 		hdr:             extHdr,
-		packetNumber:    extHdr.PacketNumber,
 		encryptionLevel: encLevel,
 		data:            decrypted,
 	}, nil

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qerr"
 	"github.com/lucas-clemente/quic-go/internal/wire"
 )
 
@@ -99,6 +100,13 @@ func (u *packetUnpacker) Unpack(hdr *wire.Header, rcvTime time.Time, data []byte
 		extHdr, decrypted, err = u.unpackShortHeaderPacket(opener, hdr, rcvTime, data)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	if len(decrypted) == 0 {
+		return nil, &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "empty packet",
 		}
 	}
 

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -287,6 +287,6 @@ var _ = Describe("Packet Unpacker", func() {
 		}
 		packet, err := unpacker.Unpack(hdr, time.Now(), data)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.packetNumber).To(Equal(protocol.PacketNumber(0x7331)))
+		Expect(packet.hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x7331)))
 	})
 })

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Packet Unpacker", func() {
 
 	BeforeEach(func() {
 		cs = mocks.NewMockCryptoSetup(mockCtrl)
-		unpacker = newPacketUnpacker(cs, version).(*packetUnpacker)
+		unpacker = newPacketUnpacker(cs, 4, version).(*packetUnpacker)
 	})
 
 	It("errors when the packet is too small to obtain the header decryption sample, for long headers", func() {
@@ -59,7 +59,7 @@ var _ = Describe("Packet Unpacker", func() {
 		data := append(hdrRaw, make([]byte, 2 /* fill up packet number */ +15 /* need 16 bytes */)...)
 		opener := mocks.NewMockLongHeaderOpener(mockCtrl)
 		cs.EXPECT().GetHandshakeOpener().Return(opener, nil)
-		_, err := unpacker.Unpack(hdr, time.Now(), data)
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), data)
 		Expect(err).To(BeAssignableToTypeOf(&headerParseError{}))
 		var headerErr *headerParseError
 		Expect(errors.As(err, &headerErr)).To(BeTrue())
@@ -67,18 +67,17 @@ var _ = Describe("Packet Unpacker", func() {
 	})
 
 	It("errors when the packet is too small to obtain the header decryption sample, for short headers", func() {
-		extHdr := &wire.ExtendedHeader{
+		_, hdrRaw := getHeader(&wire.ExtendedHeader{
 			Header:          wire.Header{DestConnectionID: connID},
 			PacketNumber:    1337,
 			PacketNumberLen: protocol.PacketNumberLen2,
-		}
-		hdr, hdrRaw := getHeader(extHdr)
+		})
 		data := append(hdrRaw, make([]byte, 2 /* fill up packet number */ +15 /* need 16 bytes */)...)
 		opener := mocks.NewMockShortHeaderOpener(mockCtrl)
 		cs.EXPECT().Get1RTTOpener().Return(opener, nil)
-		_, err := unpacker.Unpack(hdr, time.Now(), data)
+		_, _, err := unpacker.UnpackShortHeader(time.Now(), data)
 		Expect(err).To(BeAssignableToTypeOf(&headerParseError{}))
-		Expect(err).To(MatchError("Packet too small. Expected at least 20 bytes after the header, got 19"))
+		Expect(err).To(MatchError("packet too small, expected at least 20 bytes after the header, got 19"))
 	})
 
 	It("opens Initial packets", func() {
@@ -101,7 +100,7 @@ var _ = Describe("Packet Unpacker", func() {
 			opener.EXPECT().DecodePacketNumber(protocol.PacketNumber(2), protocol.PacketNumberLen3).Return(protocol.PacketNumber(1234)),
 			opener.EXPECT().Open(gomock.Any(), payload, protocol.PacketNumber(1234), hdrRaw).Return([]byte("decrypted"), nil),
 		)
-		packet, err := unpacker.Unpack(hdr, time.Now(), append(hdrRaw, payload...))
+		packet, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(packet.encryptionLevel).To(Equal(protocol.EncryptionInitial))
 		Expect(packet.data).To(Equal([]byte("decrypted")))
@@ -127,7 +126,7 @@ var _ = Describe("Packet Unpacker", func() {
 			opener.EXPECT().DecodePacketNumber(protocol.PacketNumber(20), protocol.PacketNumberLen2).Return(protocol.PacketNumber(321)),
 			opener.EXPECT().Open(gomock.Any(), payload, protocol.PacketNumber(321), hdrRaw).Return([]byte("decrypted"), nil),
 		)
-		packet, err := unpacker.Unpack(hdr, time.Now(), append(hdrRaw, payload...))
+		packet, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(packet.encryptionLevel).To(Equal(protocol.Encryption0RTT))
 		Expect(packet.data).To(Equal([]byte("decrypted")))
@@ -140,7 +139,7 @@ var _ = Describe("Packet Unpacker", func() {
 			PacketNumber:    99,
 			PacketNumberLen: protocol.PacketNumberLen4,
 		}
-		hdr, hdrRaw := getHeader(extHdr)
+		_, hdrRaw := getHeader(extHdr)
 		opener := mocks.NewMockShortHeaderOpener(mockCtrl)
 		now := time.Now()
 		gomock.InOrder(
@@ -149,10 +148,11 @@ var _ = Describe("Packet Unpacker", func() {
 			opener.EXPECT().DecodePacketNumber(protocol.PacketNumber(99), protocol.PacketNumberLen4).Return(protocol.PacketNumber(321)),
 			opener.EXPECT().Open(gomock.Any(), payload, now, protocol.PacketNumber(321), protocol.KeyPhaseOne, hdrRaw).Return([]byte("decrypted"), nil),
 		)
-		packet, err := unpacker.Unpack(hdr, now, append(hdrRaw, payload...))
+		hdr, data, err := unpacker.UnpackShortHeader(now, append(hdrRaw, payload...))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(packet.encryptionLevel).To(Equal(protocol.Encryption1RTT))
-		Expect(packet.data).To(Equal([]byte("decrypted")))
+		Expect(hdr.PacketNumber).To(Equal(protocol.PacketNumber(321)))
+		Expect(hdr.PacketNumberLen).To(Equal(protocol.PacketNumberLen4))
+		Expect(data).To(Equal([]byte("decrypted")))
 	})
 
 	It("returns the error when getting the opener fails", func() {
@@ -161,19 +161,45 @@ var _ = Describe("Packet Unpacker", func() {
 			PacketNumber:    0x1337,
 			PacketNumberLen: 2,
 		}
-		hdr, hdrRaw := getHeader(extHdr)
+		_, hdrRaw := getHeader(extHdr)
 		cs.EXPECT().Get1RTTOpener().Return(nil, handshake.ErrKeysNotYetAvailable)
-		_, err := unpacker.Unpack(hdr, time.Now(), append(hdrRaw, payload...))
+		_, _, err := unpacker.UnpackShortHeader(time.Now(), append(hdrRaw, payload...))
 		Expect(err).To(MatchError(handshake.ErrKeysNotYetAvailable))
 	})
 
-	It("errors on empty packets", func() {
+	It("errors on empty packets, for long header packets", func() {
+		extHdr := &wire.ExtendedHeader{
+			Header: wire.Header{
+				IsLongHeader:     true,
+				Type:             protocol.PacketTypeHandshake,
+				DestConnectionID: connID,
+				Version:          Version1,
+			},
+			KeyPhase:        protocol.KeyPhaseOne,
+			PacketNumberLen: protocol.PacketNumberLen4,
+		}
+		hdr, hdrRaw := getHeader(extHdr)
+		opener := mocks.NewMockLongHeaderOpener(mockCtrl)
+		gomock.InOrder(
+			cs.EXPECT().GetHandshakeOpener().Return(opener, nil),
+			opener.EXPECT().DecryptHeader(gomock.Any(), gomock.Any(), gomock.Any()),
+			opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any()).Return(protocol.PacketNumber(321)),
+			opener.EXPECT().Open(gomock.Any(), payload, protocol.PacketNumber(321), hdrRaw).Return([]byte(""), nil),
+		)
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
+		Expect(err).To(MatchError(&qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "empty packet",
+		}))
+	})
+
+	It("errors on empty packets, for short header packets", func() {
 		extHdr := &wire.ExtendedHeader{
 			Header:          wire.Header{DestConnectionID: connID},
 			KeyPhase:        protocol.KeyPhaseOne,
 			PacketNumberLen: protocol.PacketNumberLen4,
 		}
-		hdr, hdrRaw := getHeader(extHdr)
+		_, hdrRaw := getHeader(extHdr)
 		opener := mocks.NewMockShortHeaderOpener(mockCtrl)
 		now := time.Now()
 		gomock.InOrder(
@@ -182,7 +208,7 @@ var _ = Describe("Packet Unpacker", func() {
 			opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any()).Return(protocol.PacketNumber(321)),
 			opener.EXPECT().Open(gomock.Any(), payload, now, protocol.PacketNumber(321), protocol.KeyPhaseOne, hdrRaw).Return([]byte(""), nil),
 		)
-		_, err := unpacker.Unpack(hdr, now, append(hdrRaw, payload...))
+		_, _, err := unpacker.UnpackShortHeader(now, append(hdrRaw, payload...))
 		Expect(err).To(MatchError(&qerr.TransportError{
 			ErrorCode:    qerr.ProtocolViolation,
 			ErrorMessage: "empty packet",
@@ -208,7 +234,7 @@ var _ = Describe("Packet Unpacker", func() {
 		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any())
 		unpackErr := &qerr.TransportError{ErrorCode: qerr.CryptoBufferExceeded}
 		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, unpackErr)
-		_, err := unpacker.Unpack(hdr, time.Now(), append(hdrRaw, payload...))
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
 		Expect(err).To(MatchError(unpackErr))
 	})
 
@@ -230,7 +256,7 @@ var _ = Describe("Packet Unpacker", func() {
 		cs.EXPECT().GetHandshakeOpener().Return(opener, nil)
 		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any())
 		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte("payload"), nil)
-		_, err := unpacker.Unpack(hdr, time.Now(), append(hdrRaw, payload...))
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
 		Expect(err).To(MatchError(wire.ErrInvalidReservedBits))
 	})
 
@@ -240,31 +266,53 @@ var _ = Describe("Packet Unpacker", func() {
 			PacketNumber:    0x1337,
 			PacketNumberLen: 2,
 		}
-		hdr, hdrRaw := getHeader(extHdr)
+		_, hdrRaw := getHeader(extHdr)
 		hdrRaw[0] |= 0x18
 		opener := mocks.NewMockShortHeaderOpener(mockCtrl)
 		opener.EXPECT().DecryptHeader(gomock.Any(), gomock.Any(), gomock.Any())
 		cs.EXPECT().Get1RTTOpener().Return(opener, nil)
 		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any())
 		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte("payload"), nil)
-		_, err := unpacker.Unpack(hdr, time.Now(), append(hdrRaw, payload...))
+		_, _, err := unpacker.UnpackShortHeader(time.Now(), append(hdrRaw, payload...))
 		Expect(err).To(MatchError(wire.ErrInvalidReservedBits))
 	})
 
-	It("returns the decryption error, when unpacking a packet with wrong reserved bits fails", func() {
+	It("returns the decryption error, when unpacking a packet with wrong reserved bits fails, for long headers", func() {
+		extHdr := &wire.ExtendedHeader{
+			Header: wire.Header{
+				IsLongHeader:     true,
+				Type:             protocol.PacketTypeHandshake,
+				DestConnectionID: connID,
+				Version:          version,
+			},
+			PacketNumber:    0x1337,
+			PacketNumberLen: 2,
+		}
+		hdr, hdrRaw := getHeader(extHdr)
+		hdrRaw[0] |= 0x18
+		opener := mocks.NewMockLongHeaderOpener(mockCtrl)
+		opener.EXPECT().DecryptHeader(gomock.Any(), gomock.Any(), gomock.Any())
+		cs.EXPECT().GetHandshakeOpener().Return(opener, nil)
+		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any())
+		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, handshake.ErrDecryptionFailed)
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
+		Expect(err).To(MatchError(handshake.ErrDecryptionFailed))
+	})
+
+	It("returns the decryption error, when unpacking a packet with wrong reserved bits fails, for short headers", func() {
 		extHdr := &wire.ExtendedHeader{
 			Header:          wire.Header{DestConnectionID: connID},
 			PacketNumber:    0x1337,
 			PacketNumberLen: 2,
 		}
-		hdr, hdrRaw := getHeader(extHdr)
+		_, hdrRaw := getHeader(extHdr)
 		hdrRaw[0] |= 0x18
 		opener := mocks.NewMockShortHeaderOpener(mockCtrl)
 		opener.EXPECT().DecryptHeader(gomock.Any(), gomock.Any(), gomock.Any())
 		cs.EXPECT().Get1RTTOpener().Return(opener, nil)
 		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any())
 		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, handshake.ErrDecryptionFailed)
-		_, err := unpacker.Unpack(hdr, time.Now(), append(hdrRaw, payload...))
+		_, _, err := unpacker.UnpackShortHeader(time.Now(), append(hdrRaw, payload...))
 		Expect(err).To(MatchError(handshake.ErrDecryptionFailed))
 	})
 
@@ -307,7 +355,7 @@ var _ = Describe("Packet Unpacker", func() {
 		for i := 1; i <= 100; i++ {
 			data = append(data, uint8(i))
 		}
-		packet, err := unpacker.Unpack(hdr, time.Now(), data)
+		packet, err := unpacker.UnpackLongHeader(hdr, time.Now(), data)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(packet.hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x7331)))
 	})

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -177,7 +177,7 @@ func (e eventPacketSent) MarshalJSONObject(enc *gojay.Encoder) {
 }
 
 type eventPacketReceived struct {
-	Header        packetHeader
+	Header        gojay.MarshalerJSONObject // either a shortHeader or a packetHeader
 	Length        logging.ByteCount
 	PayloadLength logging.ByteCount
 	Frames        frames

--- a/qlog/packet_header_test.go
+++ b/qlog/packet_header_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Packet Header", func() {
 		check := func(hdr *wire.ExtendedHeader, expected map[string]interface{}) {
 			buf := &bytes.Buffer{}
 			enc := gojay.NewEncoder(buf)
-			ExpectWithOffset(1, enc.Encode(transformExtendedHeader(hdr))).To(Succeed())
+			ExpectWithOffset(1, enc.Encode(transformLongHeader(hdr))).To(Succeed())
 			data := buf.Bytes()
 			ExpectWithOffset(1, json.Valid(data)).To(BeTrue())
 			checkEncoding(data, expected)

--- a/server.go
+++ b/server.go
@@ -601,7 +601,7 @@ func (s *baseServer) maybeSendInvalidToken(p *receivedPacket, hdr *wire.Header) 
 	// This makes sure that we won't send it for packets that were corrupted.
 	sealer, opener := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveServer, hdr.Version)
 	data := p.data[:hdr.ParsedLen()+hdr.Length]
-	extHdr, err := unpackHeader(opener, hdr, data, hdr.Version)
+	extHdr, err := unpackLongHeader(opener, hdr, data, hdr.Version)
 	if err != nil {
 		if s.config.Tracer != nil {
 			s.config.Tracer.DroppedPacket(p.remoteAddr, logging.PacketTypeInitial, p.Size(), logging.PacketDropHeaderParseError)

--- a/server_test.go
+++ b/server_test.go
@@ -758,7 +758,7 @@ var _ = Describe("Server", func() {
 				Expect(replyHdr.SrcConnectionID).To(Equal(origHdr.DestConnectionID))
 				Expect(replyHdr.DestConnectionID).To(Equal(origHdr.SrcConnectionID))
 				_, opener := handshake.NewInitialAEAD(origHdr.DestConnectionID, protocol.PerspectiveClient, replyHdr.Version)
-				extHdr, err := unpackHeader(opener, replyHdr, b, origHdr.Version)
+				extHdr, err := unpackLongHeader(opener, replyHdr, b, origHdr.Version)
 				Expect(err).ToNot(HaveOccurred())
 				data, err := opener.Open(nil, b[extHdr.ParsedLen():], extHdr.PacketNumber, b[:extHdr.ParsedLen()])
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Part of #3526.

This allows us to avoid the expensive code path of first parsing a `wire.Header`, then converting it into a `wire.ExtendedHeader`, which then has most of its field unset, since it can represent the entire complexity of a Long Header.

This change brings down the allocations for receiving data significantly.
In follow-up PRs, I'm planning to:
* get rid of the `wire.ShortHeader` struct. The 4 fields could be return values, making sure that all allocations happen on the stack
* improve the code path for sending short header packets