### PR TITLE
http3: fix double close of chan when using DontCloseRequestStream

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -301,6 +301,7 @@ func (c *client) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Respon
 			}
 			c.conn.CloseWithError(quic.ApplicationErrorCode(rerr.connErr), reason)
 		}
+		return nil, rerr.err
 	}
 	if opt.DontCloseRequestStream {
 		close(reqDone)


### PR DESCRIPTION
This should fix one of the panics discovered in https://github.com/libp2p/go-libp2p/issues/1774.