### PR TITLE
prevent the connection timer to be reset to the same deadline

### DIFF
--- a/internal/utils/timer.go
+++ b/internal/utils/timer.go
@@ -47,6 +47,10 @@ func (t *Timer) SetRead() {
 	t.read = true
 }
 
+func (t *Timer) Deadline() time.Time {
+	return t.deadline
+}
+
 // Stop stops the timer
 func (t *Timer) Stop() {
 	t.t.Stop()

--- a/internal/utils/timer_test.go
+++ b/internal/utils/timer_test.go
@@ -21,6 +21,14 @@ var _ = Describe("Timer", func() {
 		Eventually(t.Chan()).Should(Receive())
 	})
 
+	It("returns the deadline", func() {
+		t := NewTimer()
+		deadline := time.Now().Add(d)
+		t.Reset(deadline)
+		Expect(t.Deadline()).To(Equal(deadline))
+		Eventually(t.Chan()).Should(Receive())
+	})
+
 	It("works multiple times with reading", func() {
 		t := NewTimer()
 		for i := 0; i < 10; i++ {

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,53 @@
+package quic
+
+import (
+	"time"
+
+	"github.com/lucas-clemente/quic-go/internal/utils"
+)
+
+type timerMode uint8
+
+const (
+	timerModeHandshakeIdleTimeout timerMode = 1 + iota
+	timerModeIdleTimeout
+	timerModeKeepAlive
+	timerModeAckAlarm
+	timerModeLossDetection
+	timerModePacing
+)
+
+type timer struct {
+	timer    utils.Timer
+	lastMode timerMode
+	wasRead  bool
+}
+
+func newTimer() *timer {
+	return &timer{
+		timer: *utils.NewTimer(),
+	}
+}
+
+func (t *timer) Chan() <-chan time.Time { return t.timer.Chan() }
+func (t *timer) Stop()                  { t.timer.Stop() }
+
+func (t *timer) SetRead() {
+	t.wasRead = true
+	t.timer.SetRead()
+}
+
+// MaybeReset (re-) sets the timer.
+// If the timer was already set in the same mode to the same deadline, it is not reset.
+// This prevents busy-looping when we're not able to act upon firing of the timer for any reason.
+// Possible cases where this might happen include:
+// * the send queue is backed up, which prevents us from sending any new packets
+// * we have reached the maximum number of outstanding packets that we're willing to keep track of
+func (t *timer) MaybeReset(m timerMode, d time.Time) {
+	if t.wasRead && m == t.lastMode && d != deadlineSendImmediately && t.timer.Deadline() == d {
+		return
+	}
+	t.lastMode = m
+	t.wasRead = false
+	t.timer.Reset(d)
+}

--- a/timer_test.go
+++ b/timer_test.go
@@ -1,0 +1,38 @@
+package quic
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Timer", func() {
+	It("doesn't reset the timer for the same time multiple times", func() {
+		t := newTimer()
+		d := time.Now()
+		t.MaybeReset(timerModePacing, d)
+		select {
+		case <-t.Chan():
+			return
+		case <-time.After(100 * time.Millisecond):
+			Fail("timer didn't fire")
+		}
+
+		// reset in the same mode for the same deadline, won't actually reset the timer
+		t.MaybeReset(timerModePacing, d)
+		select {
+		case <-t.Chan():
+			Fail("timer fired")
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		// reset in a different mode, this will actually reset the timer
+		t.MaybeReset(timerModeLossDetection, d)
+		select {
+		case <-t.Chan():
+			return
+		case <-time.After(100 * time.Millisecond):
+			Fail("timer didn't fire")
+		}
+	})
+})


### PR DESCRIPTION
If the timer was already set in the same mode to the same deadline, we shouldn't reset it (so that it doesn't fire again). This prevents busy-looping when we're not able to act upon firing of the timer for any reason. Possible cases where this might happen include:
* the send queue is backed up, preventing us from sending new packets
* the maximum number of outstanding packets was reached