### PR TITLE
http3: handle ErrAbortHandler when the handler panics

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -42,12 +42,6 @@ const (
 	streamTypeQPACKDecoderStream = 3
 )
 
-// ErrAbortHandler is a sentinel panic value to abort a handler.
-// While any panic from ServeHTTP aborts the response to the client,
-// panicking with ErrAbortHandler also suppresses logging of a stack
-// trace to the server's error log.
-var ErrAbortHandler = errors.New("net/http: abort Handler")
-
 func versionToALPN(v protocol.VersionNumber) string {
 	if v == protocol.Version1 || v == protocol.Version2 {
 		return nextProtoH3
@@ -581,7 +575,7 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	var panicked bool
 	func() {
 		defer func() {
-			if p := recover(); p != nil && err != ErrAbortHandler {
+			if p := recover(); p != nil && err != http.ErrAbortHandler {
 				// Copied from net/http/server.go
 				const size = 64 << 10
 				buf := make([]byte, size)

--- a/http3/server.go
+++ b/http3/server.go
@@ -42,6 +42,12 @@ const (
 	streamTypeQPACKDecoderStream = 3
 )
 
+// ErrAbortHandler is a sentinel panic value to abort a handler.
+// While any panic from ServeHTTP aborts the response to the client,
+// panicking with ErrAbortHandler also suppresses logging of a stack
+// trace to the server's error log.
+var ErrAbortHandler = errors.New("net/http: abort Handler")
+
 func versionToALPN(v protocol.VersionNumber) string {
 	if v == protocol.Version1 || v == protocol.Version2 {
 		return nextProtoH3
@@ -575,7 +581,7 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	var panicked bool
 	func() {
 		defer func() {
-			if p := recover(); p != nil {
+			if p := recover(); p != nil && err != ErrAbortHandler {
 				// Copied from net/http/server.go
 				const size = 64 << 10
 				buf := make([]byte, size)

--- a/http3/server.go
+++ b/http3/server.go
@@ -575,13 +575,16 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	var panicked bool
 	func() {
 		defer func() {
-			if p := recover(); p != nil && err != http.ErrAbortHandler {
+			if p := recover(); p != nil {
+				panicked = true
+				if p == http.ErrAbortHandler {
+					return
+				}
 				// Copied from net/http/server.go
 				const size = 64 << 10
 				buf := make([]byte, size)
 				buf = buf[:runtime.Stack(buf, false)]
 				s.logger.Errorf("http: panic serving: %v\n%s", p, buf)
-				panicked = true
 			}
 		}()
 		handler.ServeHTTP(r, req)

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -201,6 +201,19 @@ var _ = Describe("Server", func() {
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
 		})
 
+		It("handles aborts", func() {
+			testErr := http.ErrAbortHandler
+			done := make(chan struct{})
+			unknownStr := mockquic.NewMockStream(mockCtrl)
+			s.UniStreamHijacker = func(st StreamType, _ quic.Connection, str quic.ReceiveStream, err error) bool {
+				defer close(done)
+				Expect(st).To(BeZero())
+				Expect(str).To(Equal(unknownStr))
+				Expect(err).To(MatchError(testErr))
+				return true
+			}
+		})
+
 		It("handles a panicking handler", func() {
 			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				panic("foobar")

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -201,19 +201,6 @@ var _ = Describe("Server", func() {
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
 		})
 
-		It("handles aborts", func() {
-			testErr := http.ErrAbortHandler
-			done := make(chan struct{})
-			unknownStr := mockquic.NewMockStream(mockCtrl)
-			s.UniStreamHijacker = func(st StreamType, _ quic.Connection, str quic.ReceiveStream, err error) bool {
-				defer close(done)
-				Expect(st).To(BeZero())
-				Expect(str).To(Equal(unknownStr))
-				Expect(err).To(MatchError(testErr))
-				return true
-			}
-		})
-
 		It("handles a aborting handler", func() {
 			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				panic(http.ErrAbortHandler)


### PR DESCRIPTION
Adds in the `ErrAbortHandler` and checks for later as the stdlib does. Not sure if this is complete though.

Fixes #3572 