### PR TITLE
http3: expose ALPN values

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Client", func() {
 		var dialAddrCalled bool
 		dialAddr = func(_ context.Context, _ string, tlsConf *tls.Config, quicConf *quic.Config) (quic.EarlyConnection, error) {
 			Expect(quicConf).To(Equal(defaultQuicConfig))
-			Expect(tlsConf.NextProtos).To(Equal([]string{nextProtoH3}))
+			Expect(tlsConf.NextProtos).To(Equal([]string{NextProtoH3}))
 			Expect(quicConf.Versions).To(Equal([]protocol.VersionNumber{protocol.Version1}))
 			dialAddrCalled = true
 			return nil, errors.New("test done")
@@ -102,7 +102,7 @@ var _ = Describe("Client", func() {
 		dialAddr = func(_ context.Context, host string, tlsConfP *tls.Config, quicConfP *quic.Config) (quic.EarlyConnection, error) {
 			Expect(host).To(Equal("localhost:1337"))
 			Expect(tlsConfP.ServerName).To(Equal(tlsConf.ServerName))
-			Expect(tlsConfP.NextProtos).To(Equal([]string{nextProtoH3}))
+			Expect(tlsConfP.NextProtos).To(Equal([]string{NextProtoH3}))
 			Expect(quicConfP.MaxIdleTimeout).To(Equal(quicConf.MaxIdleTimeout))
 			dialAddrCalled = true
 			return nil, errors.New("test done")

--- a/http3/server.go
+++ b/http3/server.go
@@ -28,8 +28,10 @@ var (
 )
 
 const (
-	nextProtoH3Draft29 = "h3-29"
-	nextProtoH3        = "h3"
+	// NextProtoH3Draft29 is the ALPN protocol negotiated during the TLS handshake, for QUIC draft 29.
+	NextProtoH3Draft29 = "h3-29"
+	// NextProtoH3 is the ALPN protocol negotiated during the TLS handshake, for QUIC v1 and v2.
+	NextProtoH3 = "h3"
 )
 
 // StreamType is the stream type of a unidirectional stream.
@@ -44,10 +46,10 @@ const (
 
 func versionToALPN(v protocol.VersionNumber) string {
 	if v == protocol.Version1 || v == protocol.Version2 {
-		return nextProtoH3
+		return NextProtoH3
 	}
 	if v == protocol.VersionTLS || v == protocol.VersionDraft29 {
-		return nextProtoH3Draft29
+		return NextProtoH3Draft29
 	}
 	return ""
 }
@@ -62,7 +64,7 @@ func ConfigureTLSConfig(tlsConf *tls.Config) *tls.Config {
 	return &tls.Config{
 		GetConfigForClient: func(ch *tls.ClientHelloInfo) (*tls.Config, error) {
 			// determine the ALPN from the QUIC version used
-			proto := nextProtoH3
+			proto := NextProtoH3
 			if qconn, ok := ch.Conn.(handshake.ConnWithVersion); ok {
 				proto = versionToALPN(qconn.GetQUICVersion())
 			}

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -942,7 +942,7 @@ var _ = Describe("Server", func() {
 
 			config, err := tlsConf.GetConfigForClient(ch)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(config.NextProtos).To(Equal([]string{nextProtoH3}))
+			Expect(config.NextProtos).To(Equal([]string{NextProtoH3}))
 		})
 
 		It("advertises h3-29 for draft-29", func() {
@@ -952,7 +952,7 @@ var _ = Describe("Server", func() {
 			ch.Conn = newMockConn(protocol.VersionDraft29)
 			config, err := tlsConf.GetConfigForClient(ch)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(config.NextProtos).To(Equal([]string{nextProtoH3Draft29}))
+			Expect(config.NextProtos).To(Equal([]string{NextProtoH3Draft29}))
 		})
 	})
 
@@ -1146,10 +1146,10 @@ var _ = Describe("Server", func() {
 		checkGetConfigForClientVersions := func(conf *tls.Config) {
 			c, err := conf.GetConfigForClient(&tls.ClientHelloInfo{Conn: newMockConn(protocol.VersionDraft29)})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
-			ExpectWithOffset(1, c.NextProtos).To(Equal([]string{nextProtoH3Draft29}))
+			ExpectWithOffset(1, c.NextProtos).To(Equal([]string{NextProtoH3Draft29}))
 			c, err = conf.GetConfigForClient(&tls.ClientHelloInfo{Conn: newMockConn(protocol.Version1)})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
-			ExpectWithOffset(1, c.NextProtos).To(Equal([]string{nextProtoH3}))
+			ExpectWithOffset(1, c.NextProtos).To(Equal([]string{NextProtoH3}))
 		}
 
 		It("uses the quic.Config to start the QUIC server", func() {


### PR DESCRIPTION
When using a custom `quic.Listener` to accept QUIC connections, it's useful to be able to set the correct ALPN.

Constant name chosen loosely according to https://pkg.go.dev/golang.org/x/net/http2#pkg-constants.