### PR TITLE
reduce max DATAGRAM frame size, so that DATAGRAMs fit in IPv6 packets

### DIFF
--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -134,7 +134,7 @@ const MaxAckFrameSize ByteCount = 1000
 
 // MaxDatagramFrameSize is the maximum size of a DATAGRAM frame (RFC 9221).
 // The size is chosen such that a DATAGRAM frame fits into a QUIC packet.
-const MaxDatagramFrameSize ByteCount = 1220
+const MaxDatagramFrameSize ByteCount = 1200
 
 // DatagramRcvQueueLen is the length of the receive queue for DATAGRAM frames (RFC 9221)
 const DatagramRcvQueueLen = 128


### PR DESCRIPTION
Fixes #3557.