### PR TITLE
use a Peek / Pop API for the datagram queue

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -542,7 +542,7 @@ func (s *connection) preSetup() {
 	s.creationTime = now
 
 	s.windowUpdateQueue = newWindowUpdateQueue(s.streamsMap, s.connFlowController, s.framer.QueueControlFrame)
-	s.datagramQueue = newDatagramQueue(s.scheduleSending, s.logger, s.version)
+	s.datagramQueue = newDatagramQueue(s.scheduleSending, s.logger)
 }
 
 // run the connection main loop

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Packet packer", func() {
 		ackFramer = NewMockAckFrameSource(mockCtrl)
 		sealingManager = NewMockSealingManager(mockCtrl)
 		pnManager = mockackhandler.NewMockSentPacketHandler(mockCtrl)
-		datagramQueue = newDatagramQueue(func() {}, utils.DefaultLogger, version)
+		datagramQueue = newDatagramQueue(func() {}, utils.DefaultLogger)
 
 		packer = newPacketPacker(
 			protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
@@ -634,7 +634,6 @@ var _ = Describe("Packet packer", func() {
 				Expect(p.ack).ToNot(BeNil())
 				Expect(p.frames).To(BeEmpty())
 				Expect(p.buffer.Data).ToNot(BeEmpty())
-				Expect(done).ToNot(BeClosed())
 				datagramQueue.CloseWithError(nil)
 				Eventually(done).Should(BeClosed())
 			})


### PR DESCRIPTION
Fixes #3550.

This makes it easier to reason about the concurrency properties of the datagram queue. I've been unable to understand _how_ the bug described in https://github.com/lucas-clemente/quic-go/issues/3550 actually arises, but this seems change seems to fix it.

It will also allow us to pack multiple DATAGRAMs into the same QUIC packet, if we desire to do so.