### PR TITLE
http3: add http3.Server.ServeQUICConn to serve a single QUIC connection

### DIFF
--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -351,6 +351,29 @@ var _ = Describe("HTTP tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(repl).To(Equal(data))
 			})
+
+			if version != protocol.VersionDraft29 {
+				It("serves other QUIC connections", func() {
+					tlsConf := testdata.GetTLSConfig()
+					tlsConf.NextProtos = []string{"h3"}
+					ln, err := quic.ListenAddr("localhost:0", tlsConf, nil)
+					Expect(err).ToNot(HaveOccurred())
+					done := make(chan struct{})
+					go func() {
+						defer GinkgoRecover()
+						defer close(done)
+						conn, err := ln.Accept(context.Background())
+						Expect(err).ToNot(HaveOccurred())
+						Expect(server.ServeQUICConn(conn)).To(Succeed())
+					}()
+
+					resp, err := client.Get(fmt.Sprintf("https://localhost:%d/hello", ln.Addr().(*net.UDPAddr).Port))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+					client.Transport.(io.Closer).Close()
+					Eventually(done).Should(BeClosed())
+				})
+			}
 		})
 	}
 })


### PR DESCRIPTION
Recreating #3579, which was merged and which I had to force-revert from `master`, since there was a merge conflict after merging #3580.