### PR TITLE
fix client SNI handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/lucas-clemente/quic-go/internal/protocol"
 	"github.com/lucas-clemente/quic-go/internal/utils"
@@ -232,13 +231,9 @@ func newClient(
 		tlsConf = tlsConf.Clone()
 	}
 	if tlsConf.ServerName == "" {
-		sni := host
-		if strings.IndexByte(sni, ':') != -1 {
-			var err error
-			sni, _, err = net.SplitHostPort(sni)
-			if err != nil {
-				return nil, err
-			}
+		sni, _, err := net.SplitHostPort(host)
+		if err != nil {
+			sni = host
 		}
 
 		tlsConf.ServerName = sni

--- a/client.go
+++ b/client.go
@@ -233,6 +233,7 @@ func newClient(
 	if tlsConf.ServerName == "" {
 		sni, _, err := net.SplitHostPort(host)
 		if err != nil {
+			// It's ok if net.SplitHostPort returns an error - it could be a hostname/IP address without a port.
 			sni = host
 		}
 


### PR DESCRIPTION
The current code assumes that a hostname containing a colon is in the `host:port` format, but it could actually be an IPv6 address. Calling SplitHostPort in this case returns an error, and right now the Client will fail to initialize.

It is possible and not extremely rare to have a TLS cert with IPv6 SAN(s). Real-life examples include Cloudflare's https://[2606:4700:4700::1111]/ and some users of my project using self-signed CAs to issue certs for their IPv6 addresses.