### PR TITLE
expose function to convert byte slice to a connection ID

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -206,6 +206,12 @@ type EarlyConnection interface {
 // as they are allowed by RFC 8999.
 type ConnectionID = protocol.ConnectionID
 
+// ConnectionIDFromBytes interprets b as a Connection ID. It panics if b is
+// longer than 20 bytes.
+func ConnectionIDFromBytes(b []byte) ConnectionID {
+	return protocol.ParseConnectionID(b)
+}
+
 // A ConnectionIDGenerator is an interface that allows clients to implement their own format
 // for the Connection IDs that servers/clients use as SrcConnectionID in QUIC packets.
 //


### PR DESCRIPTION
Although `quic.Config` exposes a `ConnectionIDGenerator` option, it's not usable outside of the `quic-go` implementation because `type ConnectionID = protocol.ConnectionID` and `protocol` is an internal package not accessible from the outside.

To fix this, the `ReadConnectionID` and `ParseConnectionID` methods from `protocol` are re-exported in the toplevel package.