### PR TITLE
expose the QUIC version of a connection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -738,7 +738,7 @@ func (s *connection) ConnectionState() ConnectionState {
 	return ConnectionState{
 		TLS:               s.cryptoStreamHandler.ConnectionState(),
 		SupportsDatagrams: s.supportsDatagrams(),
-		QUICVersion:       s.version,
+		Version:           s.version,
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -738,6 +738,7 @@ func (s *connection) ConnectionState() ConnectionState {
 	return ConnectionState{
 		TLS:               s.cryptoStreamHandler.ConnectionState(),
 		SupportsDatagrams: s.supportsDatagrams(),
+		QUICVersion:       s.version,
 	}
 }
 

--- a/interface.go
+++ b/interface.go
@@ -331,7 +331,7 @@ type Config struct {
 type ConnectionState struct {
 	TLS               handshake.ConnectionState
 	SupportsDatagrams bool
-	QUICVersion       protocol.VersionNumber
+	Version       protocol.VersionNumber
 }
 
 // A Listener for incoming QUIC connections

--- a/interface.go
+++ b/interface.go
@@ -331,7 +331,7 @@ type Config struct {
 type ConnectionState struct {
 	TLS               handshake.ConnectionState
 	SupportsDatagrams bool
-	Version       protocol.VersionNumber
+	Version           protocol.VersionNumber
 }
 
 // A Listener for incoming QUIC connections

--- a/interface.go
+++ b/interface.go
@@ -331,7 +331,7 @@ type Config struct {
 type ConnectionState struct {
 	TLS               handshake.ConnectionState
 	SupportsDatagrams bool
-	Version           protocol.VersionNumber
+	Version           VersionNumber
 }
 
 // A Listener for incoming QUIC connections

--- a/interface.go
+++ b/interface.go
@@ -331,6 +331,7 @@ type Config struct {
 type ConnectionState struct {
 	TLS               handshake.ConnectionState
 	SupportsDatagrams bool
+	QUICVersion       protocol.VersionNumber
 }
 
 // A Listener for incoming QUIC connections


### PR DESCRIPTION
We already track the QUIC version in a [connection](https://github.com/lucas-clemente/quic-go/blob/master/connection.go#L2141). This simply exposes this in the public interface.