### PR TITLE
add Allow0RTT opt in the quic.Config to control 0-RTT on the server side

### DIFF
--- a/config.go
+++ b/config.go
@@ -135,6 +135,7 @@ func populateConfig(config *Config, defaultConnIDLen int) *Config {
 		EnableDatagrams:                  config.EnableDatagrams,
 		DisablePathMTUDiscovery:          config.DisablePathMTUDiscovery,
 		DisableVersionNegotiationPackets: config.DisableVersionNegotiationPackets,
+		Allow0RTT:                        config.Allow0RTT,
 		Tracer:                           config.Tracer,
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Config", func() {
 			}
 
 			switch fn := typ.Field(i).Name; fn {
-			case "RequireAddressValidation", "GetLogWriter", "AllowConnectionWindowIncrease":
+			case "RequireAddressValidation", "GetLogWriter", "AllowConnectionWindowIncrease", "Allow0RTT":
 				// Can't compare functions.
 			case "Versions":
 				f.Set(reflect.ValueOf([]VersionNumber{1, 2, 3}))

--- a/connection.go
+++ b/connection.go
@@ -241,7 +241,6 @@ var newConnection = func(
 	conf *Config,
 	tlsConf *tls.Config,
 	tokenGenerator *handshake.TokenGenerator,
-	enable0RTT bool,
 	clientAddressValidated bool,
 	tracer logging.ConnectionTracer,
 	tracingID uint64,
@@ -323,6 +322,10 @@ var newConnection = func(
 	if s.tracer != nil {
 		s.tracer.SentTransportParameters(params)
 	}
+	var allow0RTT func() bool
+	if conf.Allow0RTT != nil {
+		allow0RTT = func() bool { return conf.Allow0RTT(conn.RemoteAddr()) }
+	}
 	cs := handshake.NewCryptoSetupServer(
 		initialStream,
 		handshakeStream,
@@ -340,7 +343,7 @@ var newConnection = func(
 			},
 		},
 		tlsConf,
-		enable0RTT,
+		allow0RTT,
 		s.rttStats,
 		tracer,
 		logger,

--- a/connection_test.go
+++ b/connection_test.go
@@ -101,7 +101,6 @@ var _ = Describe("Connection", func() {
 			nil, // tls.Config
 			tokenGenerator,
 			false,
-			false,
 			tracer,
 			1234,
 			utils.DefaultLogger,

--- a/fuzzing/handshake/cmd/corpus.go
+++ b/fuzzing/handshake/cmd/corpus.go
@@ -105,7 +105,7 @@ func main() {
 		&wire.TransportParameters{},
 		runner,
 		config,
-		false,
+		nil,
 		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("server"),

--- a/fuzzing/handshake/fuzz.go
+++ b/fuzzing/handshake/fuzz.go
@@ -390,6 +390,10 @@ func runHandshake(runConfig [confLen]byte, messageConfig uint8, clientConf *tls.
 		protocol.VersionTLS,
 	)
 
+	var allow0RTT func() bool
+	if enable0RTTServer {
+		allow0RTT = func() bool { return true }
+	}
 	sChunkChan, sInitialStream, sHandshakeStream := initStreams()
 	server = handshake.NewCryptoSetupServer(
 		sInitialStream,
@@ -400,7 +404,7 @@ func runHandshake(runConfig [confLen]byte, messageConfig uint8, clientConf *tls.
 		serverTP,
 		runner,
 		serverConf,
-		enable0RTTServer,
+		allow0RTT,
 		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("server"),

--- a/interface.go
+++ b/interface.go
@@ -176,7 +176,6 @@ type Connection interface {
 	// Context returns a context that is cancelled when the connection is closed.
 	Context() context.Context
 	// ConnectionState returns basic details about the QUIC connection.
-	// It blocks until the handshake completes.
 	// Warning: This API should not be considered stable and might change soon.
 	ConnectionState() ConnectionState
 
@@ -325,6 +324,11 @@ type Config struct {
 	// This can be useful if version information is exchanged out-of-band.
 	// It has no effect for a client.
 	DisableVersionNegotiationPackets bool
+	// Allow0RTT allows the application to decide if a 0-RTT connection attempt should be accepted.
+	// When set, 0-RTT is enabled. When not set, 0-RTT is disabled.
+	// Only valid for the server.
+	// Warning: This API should not be considered stable and might change soon.
+	Allow0RTT func(net.Addr) bool
 	// Enable QUIC datagram support (RFC 9221).
 	EnableDatagrams bool
 	Tracer          logging.Tracer

--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&wire.TransportParameters{StatelessResetToken: &token},
 			runner,
 			testdata.GetTLSConfig(),
-			false,
+			nil,
 			&utils.RTTStats{},
 			nil,
 			utils.DefaultLogger.WithPrefix("server"),
@@ -177,7 +177,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&wire.TransportParameters{StatelessResetToken: &token},
 			runner,
 			testdata.GetTLSConfig(),
-			false,
+			nil,
 			&utils.RTTStats{},
 			nil,
 			utils.DefaultLogger.WithPrefix("server"),
@@ -218,7 +218,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&wire.TransportParameters{StatelessResetToken: &token},
 			runner,
 			serverConf,
-			false,
+			nil,
 			&utils.RTTStats{},
 			nil,
 			utils.DefaultLogger.WithPrefix("server"),
@@ -253,7 +253,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&wire.TransportParameters{StatelessResetToken: &token},
 			NewMockHandshakeRunner(mockCtrl),
 			serverConf,
-			false,
+			nil,
 			&utils.RTTStats{},
 			nil,
 			utils.DefaultLogger.WithPrefix("server"),
@@ -378,6 +378,10 @@ var _ = Describe("Crypto Setup TLS", func() {
 				protocol.VersionTLS,
 			)
 
+			var allow0RTT func() bool
+			if enable0RTT {
+				allow0RTT = func() bool { return true }
+			}
 			var sHandshakeComplete bool
 			sChunkChan, sInitialStream, sHandshakeStream := initStreams()
 			sErrChan := make(chan error, 1)
@@ -398,7 +402,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				serverTransportParameters,
 				sRunner,
 				serverConf,
-				enable0RTT,
+				allow0RTT,
 				serverRTTStats,
 				nil,
 				utils.DefaultLogger.WithPrefix("server"),
@@ -536,7 +540,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				sTransportParameters,
 				sRunner,
 				serverConf,
-				false,
+				nil,
 				&utils.RTTStats{},
 				nil,
 				utils.DefaultLogger.WithPrefix("server"),
@@ -591,7 +595,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&wire.TransportParameters{StatelessResetToken: &token},
 					sRunner,
 					serverConf,
-					false,
+					nil,
 					&utils.RTTStats{},
 					nil,
 					utils.DefaultLogger.WithPrefix("server"),
@@ -650,7 +654,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&wire.TransportParameters{StatelessResetToken: &token},
 					sRunner,
 					serverConf,
-					false,
+					nil,
 					&utils.RTTStats{},
 					nil,
 					utils.DefaultLogger.WithPrefix("server"),

--- a/server.go
+++ b/server.go
@@ -88,7 +88,6 @@ type baseServer struct {
 		*Config,
 		*tls.Config,
 		*handshake.TokenGenerator,
-		bool, /* enable 0-RTT */
 		bool, /* client address validated by an address validation token */
 		logging.ConnectionTracer,
 		uint64,
@@ -506,7 +505,6 @@ func (s *baseServer) handleInitialImpl(p *receivedPacket, hdr *wire.Header) erro
 			s.config,
 			s.tlsConf,
 			s.tokenGenerator,
-			s.acceptEarlyConns,
 			clientAddrIsValid,
 			tracer,
 			tracingID,

--- a/server_test.go
+++ b/server_test.go
@@ -286,14 +286,12 @@ var _ = Describe("Server", func() {
 					_ *Config,
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
-					enable0RTT bool,
 					_ bool,
 					_ logging.ConnectionTracer,
 					_ uint64,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicConn {
-					Expect(enable0RTT).To(BeFalse())
 					Expect(origDestConnID).To(Equal(protocol.ParseConnectionID([]byte{0xde, 0xad, 0xc0, 0xde})))
 					Expect(*retrySrcConnID).To(Equal(protocol.ParseConnectionID([]byte{0xde, 0xca, 0xfb, 0xad})))
 					Expect(clientDestConnID).To(Equal(hdr.DestConnectionID))
@@ -489,14 +487,12 @@ var _ = Describe("Server", func() {
 					_ *Config,
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
-					enable0RTT bool,
 					_ bool,
 					_ logging.ConnectionTracer,
 					_ uint64,
 					_ utils.Logger,
 					_ protocol.VersionNumber,
 				) quicConn {
-					Expect(enable0RTT).To(BeFalse())
 					Expect(origDestConnID).To(Equal(hdr.DestConnectionID))
 					Expect(retrySrcConnID).To(BeNil())
 					Expect(clientDestConnID).To(Equal(hdr.DestConnectionID))
@@ -549,7 +545,6 @@ var _ = Describe("Server", func() {
 					_ *Config,
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
-					_ bool,
 					_ bool,
 					_ logging.ConnectionTracer,
 					_ uint64,
@@ -604,7 +599,6 @@ var _ = Describe("Server", func() {
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
 					_ bool,
-					_ bool,
 					_ logging.ConnectionTracer,
 					_ uint64,
 					_ utils.Logger,
@@ -633,7 +627,6 @@ var _ = Describe("Server", func() {
 					_ *Config,
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
-					_ bool,
 					_ bool,
 					_ logging.ConnectionTracer,
 					_ uint64,
@@ -704,7 +697,6 @@ var _ = Describe("Server", func() {
 					_ *Config,
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
-					_ bool,
 					_ bool,
 					_ logging.ConnectionTracer,
 					_ uint64,
@@ -1011,7 +1003,6 @@ var _ = Describe("Server", func() {
 					_ *tls.Config,
 					_ *handshake.TokenGenerator,
 					_ bool,
-					_ bool,
 					_ logging.ConnectionTracer,
 					_ uint64,
 					_ utils.Logger,
@@ -1084,14 +1075,12 @@ var _ = Describe("Server", func() {
 				_ *Config,
 				_ *tls.Config,
 				_ *handshake.TokenGenerator,
-				enable0RTT bool,
 				_ bool,
 				_ logging.ConnectionTracer,
 				_ uint64,
 				_ utils.Logger,
 				_ protocol.VersionNumber,
 			) quicConn {
-				Expect(enable0RTT).To(BeTrue())
 				conn.EXPECT().handlePacket(gomock.Any())
 				conn.EXPECT().run().Do(func() {})
 				conn.EXPECT().earlyConnReady().Return(ready)
@@ -1127,7 +1116,6 @@ var _ = Describe("Server", func() {
 				_ *Config,
 				_ *tls.Config,
 				_ *handshake.TokenGenerator,
-				_ bool,
 				_ bool,
 				_ logging.ConnectionTracer,
 				_ uint64,
@@ -1190,7 +1178,6 @@ var _ = Describe("Server", func() {
 				_ *Config,
 				_ *tls.Config,
 				_ *handshake.TokenGenerator,
-				_ bool,
 				_ bool,
 				_ logging.ConnectionTracer,
 				_ uint64,


### PR DESCRIPTION
See https://github.com/lucas-clemente/quic-go/issues/3634 for the motivation and explanation of this API change.