### PR TITLE
remove version parameter from constructors where they are not needed

### DIFF
--- a/conn_id_generator.go
+++ b/conn_id_generator.go
@@ -22,8 +22,6 @@ type connIDGenerator struct {
 	retireConnectionID     func(protocol.ConnectionID)
 	replaceWithClosed      func([]protocol.ConnectionID, protocol.Perspective, []byte)
 	queueControlFrame      func(wire.Frame)
-
-	version protocol.VersionNumber
 }
 
 func newConnIDGenerator(
@@ -36,7 +34,6 @@ func newConnIDGenerator(
 	replaceWithClosed func([]protocol.ConnectionID, protocol.Perspective, []byte),
 	queueControlFrame func(wire.Frame),
 	generator ConnectionIDGenerator,
-	version protocol.VersionNumber,
 ) *connIDGenerator {
 	m := &connIDGenerator{
 		generator:              generator,
@@ -47,7 +44,6 @@ func newConnIDGenerator(
 		retireConnectionID:     retireConnectionID,
 		replaceWithClosed:      replaceWithClosed,
 		queueControlFrame:      queueControlFrame,
-		version:                version,
 	}
 	m.activeSrcConnIDs[0] = initialConnectionID
 	m.initialClientDestConnID = initialClientDestConnID

--- a/conn_id_generator_test.go
+++ b/conn_id_generator_test.go
@@ -46,7 +46,6 @@ var _ = Describe("Connection ID Generator", func() {
 			},
 			func(f wire.Frame) { queuedFrames = append(queuedFrames, f) },
 			&protocol.DefaultConnectionIDGenerator{ConnLen: initialConnID.Len()},
-			protocol.VersionDraft29,
 		)
 	})
 

--- a/connection.go
+++ b/connection.go
@@ -296,7 +296,6 @@ var newConnection = func(
 		s.perspective,
 		s.tracer,
 		s.logger,
-		s.version,
 	)
 	initialStream := newCryptoStream()
 	handshakeStream := newCryptoStream()
@@ -431,7 +430,6 @@ var newClientConnection = func(
 		s.perspective,
 		s.tracer,
 		s.logger,
-		s.version,
 	)
 	initialStream := newCryptoStream()
 	handshakeStream := newCryptoStream()

--- a/connection.go
+++ b/connection.go
@@ -508,7 +508,7 @@ var newClientConnection = func(
 func (s *connection) preSetup() {
 	s.sendQueue = newSendQueue(s.conn)
 	s.retransmissionQueue = newRetransmissionQueue()
-	s.frameParser = wire.NewFrameParser(s.config.EnableDatagrams, s.version)
+	s.frameParser = wire.NewFrameParser(s.config.EnableDatagrams)
 	s.rttStats = &utils.RTTStats{}
 	s.connFlowController = flowcontrol.NewConnectionFlowController(
 		protocol.ByteCount(s.config.InitialConnectionReceiveWindow),
@@ -1284,7 +1284,7 @@ func (s *connection) handleFrames(
 	// If we're not tracing, this slice will always remain empty.
 	var frames []wire.Frame
 	for len(data) > 0 {
-		l, frame, err := s.frameParser.ParseNext(data, encLevel)
+		l, frame, err := s.frameParser.ParseNext(data, encLevel, s.version)
 		if err != nil {
 			return false, err
 		}

--- a/connection.go
+++ b/connection.go
@@ -507,7 +507,7 @@ var newClientConnection = func(
 
 func (s *connection) preSetup() {
 	s.sendQueue = newSendQueue(s.conn)
-	s.retransmissionQueue = newRetransmissionQueue(s.version)
+	s.retransmissionQueue = newRetransmissionQueue()
 	s.frameParser = wire.NewFrameParser(s.config.EnableDatagrams, s.version)
 	s.rttStats = &utils.RTTStats{}
 	s.connFlowController = flowcontrol.NewConnectionFlowController(

--- a/connection.go
+++ b/connection.go
@@ -503,7 +503,7 @@ func (s *connection) preSetup() {
 		uint64(s.config.MaxIncomingUniStreams),
 		s.perspective,
 	)
-	s.framer = newFramer(s.streamsMap, s.version)
+	s.framer = newFramer(s.streamsMap)
 	s.receivedPackets = make(chan *receivedPacket, protocol.MaxConnUnprocessedPackets)
 	s.closeChan = make(chan closeError, 1)
 	s.sendingScheduled = make(chan struct{}, 1)

--- a/connection.go
+++ b/connection.go
@@ -284,7 +284,6 @@ var newConnection = func(
 		runner.ReplaceWithClosed,
 		s.queueControlFrame,
 		s.config.ConnectionIDGenerator,
-		s.version,
 	)
 	s.preSetup()
 	s.ctx, s.ctxCancel = context.WithCancel(context.WithValue(context.Background(), ConnectionTracingKey, tracingID))
@@ -418,7 +417,6 @@ var newClientConnection = func(
 		runner.ReplaceWithClosed,
 		s.queueControlFrame,
 		s.config.ConnectionIDGenerator,
-		s.version,
 	)
 	s.preSetup()
 	s.ctx, s.ctxCancel = context.WithCancel(context.WithValue(context.Background(), ConnectionTracingKey, tracingID))

--- a/connection.go
+++ b/connection.go
@@ -530,7 +530,6 @@ func (s *connection) preSetup() {
 		uint64(s.config.MaxIncomingStreams),
 		uint64(s.config.MaxIncomingUniStreams),
 		s.perspective,
-		s.version,
 	)
 	s.framer = newFramer(s.streamsMap, s.version)
 	s.receivedPackets = make(chan *receivedPacket, protocol.MaxConnUnprocessedPackets)

--- a/connection_test.go
+++ b/connection_test.go
@@ -441,7 +441,7 @@ var _ = Describe("Connection", func() {
 			cryptoSetup.EXPECT().Close()
 			buffer := getPacketBuffer()
 			buffer.Data = append(buffer.Data, []byte("connection close")...)
-			packer.EXPECT().PackApplicationClose(gomock.Any()).DoAndReturn(func(e *qerr.ApplicationError) (*coalescedPacket, error) {
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).DoAndReturn(func(e *qerr.ApplicationError, _ protocol.VersionNumber) (*coalescedPacket, error) {
 				Expect(e.ErrorCode).To(BeEquivalentTo(qerr.NoError))
 				Expect(e.ErrorMessage).To(BeEmpty())
 				return &coalescedPacket{buffer: buffer}, nil
@@ -466,7 +466,7 @@ var _ = Describe("Connection", func() {
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			mconn.EXPECT().Write(gomock.Any())
 			tracer.EXPECT().ClosedConnection(gomock.Any())
 			tracer.EXPECT().Close()
@@ -485,7 +485,7 @@ var _ = Describe("Connection", func() {
 			streamManager.EXPECT().CloseWithError(expectedErr)
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackApplicationClose(expectedErr).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackApplicationClose(expectedErr, conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			mconn.EXPECT().Write(gomock.Any())
 			gomock.InOrder(
 				tracer.EXPECT().ClosedConnection(expectedErr),
@@ -506,7 +506,7 @@ var _ = Describe("Connection", func() {
 			streamManager.EXPECT().CloseWithError(expectedErr)
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackConnectionClose(expectedErr).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackConnectionClose(expectedErr, conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			mconn.EXPECT().Write(gomock.Any())
 			gomock.InOrder(
 				tracer.EXPECT().ClosedConnection(expectedErr),
@@ -546,7 +546,7 @@ var _ = Describe("Connection", func() {
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			returned := make(chan struct{})
 			go func() {
 				defer GinkgoRecover()
@@ -614,8 +614,8 @@ var _ = Describe("Connection", func() {
 			cryptoSetup.EXPECT().Close()
 			conn.sentPacketHandler = sph
 			p, buffer := getShortHeaderPacket(1)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
 			runConn()
 			conn.queueControlFrame(&wire.PingFrame{})
 			conn.scheduleSending()
@@ -804,7 +804,7 @@ var _ = Describe("Connection", func() {
 			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(nil, handshake.ErrDecryptionFailed)
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackConnectionClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			go func() {
 				defer GinkgoRecover()
 				cryptoSetup.EXPECT().RunHandshake().MaxTimes(1)
@@ -841,7 +841,7 @@ var _ = Describe("Connection", func() {
 			}).Times(3)
 			tracer.EXPECT().ReceivedShortHeaderPacket(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(hdr *logging.ShortHeader, _ protocol.ByteCount, _ []logging.Frame) {
 			}).Times(3)
-			packer.EXPECT().PackCoalescedPacket(false) // only expect a single call
+			packer.EXPECT().PackCoalescedPacket(false, conn.version) // only expect a single call
 
 			for i := 0; i < 3; i++ {
 				conn.handlePacket(getShortHeaderPacket(srcConnID, 0x1337+protocol.PacketNumber(i), []byte("foobar")))
@@ -857,7 +857,7 @@ var _ = Describe("Connection", func() {
 			// make the go routine return
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackConnectionClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			expectReplaceWithClosed()
 			tracer.EXPECT().ClosedConnection(gomock.Any())
 			tracer.EXPECT().Close()
@@ -876,7 +876,7 @@ var _ = Describe("Connection", func() {
 			}).Times(3)
 			tracer.EXPECT().ReceivedShortHeaderPacket(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(hdr *logging.ShortHeader, _ protocol.ByteCount, _ []logging.Frame) {
 			}).Times(3)
-			packer.EXPECT().PackCoalescedPacket(false).Times(3) // only expect a single call
+			packer.EXPECT().PackCoalescedPacket(false, conn.version).Times(3) // only expect a single call
 
 			for i := 0; i < 3; i++ {
 				conn.handlePacket(getShortHeaderPacket(srcConnID, 0x1337+protocol.PacketNumber(i), []byte("foobar")))
@@ -892,7 +892,7 @@ var _ = Describe("Connection", func() {
 			// make the go routine return
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackConnectionClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			expectReplaceWithClosed()
 			tracer.EXPECT().ClosedConnection(gomock.Any())
 			tracer.EXPECT().Close()
@@ -905,7 +905,7 @@ var _ = Describe("Connection", func() {
 			unpacker.EXPECT().UnpackShortHeader(gomock.Any(), gomock.Any()).Return(protocol.PacketNumber(0), protocol.PacketNumberLen(0), protocol.KeyPhaseBit(0), nil, wire.ErrInvalidReservedBits)
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackConnectionClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			done := make(chan struct{})
 			go func() {
 				defer GinkgoRecover()
@@ -941,7 +941,7 @@ var _ = Describe("Connection", func() {
 			conn.handlePacket(getShortHeaderPacket(srcConnID, 0x42, nil))
 			Consistently(runErr).ShouldNot(Receive())
 			// make the go routine return
-			packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			tracer.EXPECT().ClosedConnection(gomock.Any())
 			tracer.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
@@ -953,7 +953,7 @@ var _ = Describe("Connection", func() {
 			unpacker.EXPECT().UnpackShortHeader(gomock.Any(), gomock.Any()).Return(protocol.PacketNumber(0), protocol.PacketNumberLen(0), protocol.KeyPhaseBit(0), nil, &qerr.TransportError{ErrorCode: qerr.ConnectionIDLimitError})
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			cryptoSetup.EXPECT().Close()
-			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackConnectionClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			done := make(chan struct{})
 			go func() {
 				defer GinkgoRecover()
@@ -1178,7 +1178,7 @@ var _ = Describe("Connection", func() {
 
 		AfterEach(func() {
 			streamManager.EXPECT().CloseWithError(gomock.Any())
-			packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
@@ -1210,8 +1210,8 @@ var _ = Describe("Connection", func() {
 			conn.sentPacketHandler = sph
 			runConn()
 			p, buffer := getShortHeaderPacket(1)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
 			sent := make(chan struct{})
 			sender.EXPECT().WouldBlock().AnyTimes()
 			sender.EXPECT().Send(gomock.Any()).Do(func(packet *packetBuffer) { close(sent) })
@@ -1228,7 +1228,7 @@ var _ = Describe("Connection", func() {
 		It("doesn't send packets if there's nothing to send", func() {
 			conn.handshakeConfirmed = true
 			runConn()
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
 			conn.receivedPacketHandler.ReceivedPacket(0x035e, protocol.ECNNon, protocol.Encryption1RTT, time.Now(), true)
 			conn.scheduleSending()
 			time.Sleep(50 * time.Millisecond) // make sure there are no calls to mconn.Write()
@@ -1240,7 +1240,7 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAck)
 			done := make(chan struct{})
-			packer.EXPECT().PackCoalescedPacket(true).Do(func(bool) { close(done) })
+			packer.EXPECT().PackCoalescedPacket(true, conn.version).Do(func(bool, protocol.VersionNumber) { close(done) })
 			conn.sentPacketHandler = sph
 			runConn()
 			conn.scheduleSending()
@@ -1260,8 +1260,8 @@ var _ = Describe("Connection", func() {
 			fc.EXPECT().IsNewlyBlocked().Return(true, protocol.ByteCount(1337))
 			fc.EXPECT().IsNewlyBlocked()
 			p, buffer := getShortHeaderPacket(1)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
 			conn.connFlowController = fc
 			runConn()
 			sent := make(chan struct{})
@@ -1314,7 +1314,7 @@ var _ = Describe("Connection", func() {
 					sph.EXPECT().SendMode().Return(ackhandler.SendNone)
 					sph.EXPECT().QueueProbePacket(encLevel)
 					p := getCoalescedPacket(123, enc != protocol.Encryption1RTT)
-					packer.EXPECT().MaybePackProbePacket(encLevel).Return(p, nil)
+					packer.EXPECT().MaybePackProbePacket(encLevel, conn.version).Return(p, nil)
 					sph.EXPECT().SentPacket(gomock.Any()).Do(func(packet *ackhandler.Packet) {
 						Expect(packet.PacketNumber).To(Equal(protocol.PacketNumber(123)))
 					})
@@ -1339,7 +1339,7 @@ var _ = Describe("Connection", func() {
 					sph.EXPECT().SendMode().Return(ackhandler.SendNone)
 					sph.EXPECT().QueueProbePacket(encLevel).Return(false)
 					p := getCoalescedPacket(123, enc != protocol.Encryption1RTT)
-					packer.EXPECT().MaybePackProbePacket(encLevel).Return(p, nil)
+					packer.EXPECT().MaybePackProbePacket(encLevel, conn.version).Return(p, nil)
 					sph.EXPECT().SentPacket(gomock.Any()).Do(func(packet *ackhandler.Packet) {
 						Expect(packet.PacketNumber).To(Equal(protocol.PacketNumber(123)))
 					})
@@ -1383,7 +1383,7 @@ var _ = Describe("Connection", func() {
 
 		AfterEach(func() {
 			// make the go routine return
-			packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
@@ -1401,9 +1401,9 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(3)
 			p, buffer := getShortHeaderPacket(10)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
 			p, buffer = getShortHeaderPacket(11)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
 			sender.EXPECT().WouldBlock().AnyTimes()
 			sender.EXPECT().Send(gomock.Any()).Times(2)
 			go func() {
@@ -1420,8 +1420,8 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().HasPacingBudget().Return(true).AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(2)
 			p, buffer := getShortHeaderPacket(10)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack)
 			sender.EXPECT().WouldBlock().AnyTimes()
 			sender.EXPECT().Send(gomock.Any())
 			go func() {
@@ -1439,7 +1439,7 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
 			p, buffer := getShortHeaderPacket(10)
-			packer.EXPECT().PackPacket(true, gomock.Any()).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(true, gomock.Any(), conn.version).Return(p, buffer, nil)
 
 			sender.EXPECT().WouldBlock().AnyTimes()
 			sender.EXPECT().Send(gomock.Any())
@@ -1460,7 +1460,7 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
 			sph.EXPECT().SendMode().Return(ackhandler.SendAck)
 			p, buffer := getShortHeaderPacket(100)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
 			sender.EXPECT().WouldBlock().AnyTimes()
 			sender.EXPECT().Send(gomock.Any())
 			go func() {
@@ -1479,12 +1479,12 @@ var _ = Describe("Connection", func() {
 			p2, buffer2 := getShortHeaderPacket(101)
 			gomock.InOrder(
 				sph.EXPECT().HasPacingBudget().Return(true),
-				packer.EXPECT().PackPacket(false, gomock.Any()).Return(p1, buffer1, nil),
+				packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p1, buffer1, nil),
 				sph.EXPECT().SentPacket(gomock.Any()),
 				sph.EXPECT().HasPacingBudget(),
 				sph.EXPECT().TimeUntilSend().Return(time.Now().Add(pacingDelay)),
 				sph.EXPECT().HasPacingBudget().Return(true),
-				packer.EXPECT().PackPacket(false, gomock.Any()).Return(p2, buffer2, nil),
+				packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p2, buffer2, nil),
 				sph.EXPECT().SentPacket(gomock.Any()),
 				sph.EXPECT().HasPacingBudget(),
 				sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour)),
@@ -1511,7 +1511,7 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(4)
 			for pn := protocol.PacketNumber(1000); pn < 1003; pn++ {
 				p, buffer := getShortHeaderPacket(pn)
-				packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
+				packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
 			}
 			written := make(chan struct{}, 3)
 			sender.EXPECT().WouldBlock().AnyTimes()
@@ -1543,8 +1543,8 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().HasPacingBudget().Return(true).AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
 			p, buffer := getShortHeaderPacket(1000)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack)
 			sender.EXPECT().Send(gomock.Any()).DoAndReturn(func(p *packetBuffer) { close(written) })
 			available <- struct{}{}
 			Eventually(written).Should(BeClosed())
@@ -1567,8 +1567,8 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().HasPacingBudget().Return(true).AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
 			p, buffer := getShortHeaderPacket(1000)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack)
 			sender.EXPECT().Send(gomock.Any()).DoAndReturn(func(p *packetBuffer) { close(written) })
 
 			conn.scheduleSending()
@@ -1582,7 +1582,7 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().HasPacingBudget().Return(true).AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
 			p, buffer := getShortHeaderPacket(1000)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
 			written := make(chan struct{}, 1)
 			sender.EXPECT().WouldBlock()
 			sender.EXPECT().WouldBlock().Return(true).Times(2)
@@ -1604,8 +1604,8 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
 			sender.EXPECT().WouldBlock().AnyTimes()
 			p, buffer = getShortHeaderPacket(1001)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack)
 			sender.EXPECT().Send(gomock.Any()).DoAndReturn(func(p *packetBuffer) { written <- struct{}{} })
 			available <- struct{}{}
 			Eventually(written).Should(Receive())
@@ -1619,7 +1619,7 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().HasPacingBudget().Return(true)
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
 			sender.EXPECT().WouldBlock().AnyTimes()
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack)
 			// don't EXPECT any calls to mconn.Write()
 			go func() {
 				defer GinkgoRecover()
@@ -1645,7 +1645,7 @@ var _ = Describe("Connection", func() {
 			ping := ackhandler.Frame{Frame: &wire.PingFrame{}}
 			mtuDiscoverer.EXPECT().GetPing().Return(ping, protocol.ByteCount(1234))
 			p, buffer := getShortHeaderPacket(1)
-			packer.EXPECT().PackMTUProbePacket(ping, protocol.ByteCount(1234), gomock.Any()).Return(p, buffer, nil)
+			packer.EXPECT().PackMTUProbePacket(ping, protocol.ByteCount(1234), gomock.Any(), conn.version).Return(p, buffer, nil)
 			go func() {
 				defer GinkgoRecover()
 				cryptoSetup.EXPECT().RunHandshake().MaxTimes(1)
@@ -1671,7 +1671,7 @@ var _ = Describe("Connection", func() {
 			// make the go routine return
 			expectReplaceWithClosed()
 			streamManager.EXPECT().CloseWithError(gomock.Any())
-			packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
 			sender.EXPECT().Close()
@@ -1690,8 +1690,8 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
 			conn.sentPacketHandler = sph
 			p, buffer := getShortHeaderPacket(1)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack)
 
 			go func() {
 				defer GinkgoRecover()
@@ -1710,8 +1710,8 @@ var _ = Describe("Connection", func() {
 
 		It("sets the timer to the ack timer", func() {
 			p, buffer := getShortHeaderPacket(1234)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(p, buffer, nil)
-			packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(p, buffer, nil)
+			packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack)
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
@@ -1745,7 +1745,7 @@ var _ = Describe("Connection", func() {
 		conn.sentPacketHandler = sph
 		buffer := getPacketBuffer()
 		buffer.Data = append(buffer.Data, []byte("foobar")...)
-		packer.EXPECT().PackCoalescedPacket(false).Return(&coalescedPacket{
+		packer.EXPECT().PackCoalescedPacket(false, conn.version).Return(&coalescedPacket{
 			buffer: buffer,
 			longHdrPackets: []*longHeaderPacket{
 				{
@@ -1764,7 +1764,7 @@ var _ = Describe("Connection", func() {
 				},
 			},
 		}, nil)
-		packer.EXPECT().PackCoalescedPacket(false).AnyTimes()
+		packer.EXPECT().PackCoalescedPacket(false, conn.version).AnyTimes()
 
 		sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 		sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
@@ -1805,7 +1805,7 @@ var _ = Describe("Connection", func() {
 		// make sure the go routine returns
 		streamManager.EXPECT().CloseWithError(gomock.Any())
 		expectReplaceWithClosed()
-		packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+		packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
 		tracer.EXPECT().ClosedConnection(gomock.Any())
@@ -1815,7 +1815,7 @@ var _ = Describe("Connection", func() {
 	})
 
 	It("cancels the HandshakeComplete context when the handshake completes", func() {
-		packer.EXPECT().PackCoalescedPacket(false).AnyTimes()
+		packer.EXPECT().PackCoalescedPacket(false, conn.version).AnyTimes()
 		finishHandshake := make(chan struct{})
 		sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 		conn.sentPacketHandler = sph
@@ -1840,7 +1840,7 @@ var _ = Describe("Connection", func() {
 		// make sure the go routine returns
 		streamManager.EXPECT().CloseWithError(gomock.Any())
 		expectReplaceWithClosed()
-		packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+		packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
 		tracer.EXPECT().ClosedConnection(gomock.Any())
@@ -1851,7 +1851,7 @@ var _ = Describe("Connection", func() {
 
 	It("sends a connection ticket when the handshake completes", func() {
 		const size = protocol.MaxPostHandshakeCryptoFrameSize * 3 / 2
-		packer.EXPECT().PackCoalescedPacket(false).AnyTimes()
+		packer.EXPECT().PackCoalescedPacket(false, conn.version).AnyTimes()
 		finishHandshake := make(chan struct{})
 		connRunner.EXPECT().Retire(clientDestConnID)
 		go func() {
@@ -1885,7 +1885,7 @@ var _ = Describe("Connection", func() {
 		// make sure the go routine returns
 		streamManager.EXPECT().CloseWithError(gomock.Any())
 		expectReplaceWithClosed()
-		packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+		packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
 		tracer.EXPECT().ClosedConnection(gomock.Any())
@@ -1895,10 +1895,10 @@ var _ = Describe("Connection", func() {
 	})
 
 	It("doesn't cancel the HandshakeComplete context when the handshake fails", func() {
-		packer.EXPECT().PackCoalescedPacket(false).AnyTimes()
+		packer.EXPECT().PackCoalescedPacket(false, conn.version).AnyTimes()
 		streamManager.EXPECT().CloseWithError(gomock.Any())
 		expectReplaceWithClosed()
-		packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+		packer.EXPECT().PackConnectionClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 		cryptoSetup.EXPECT().Close()
 		tracer.EXPECT().ClosedConnection(gomock.Any())
 		tracer.EXPECT().Close()
@@ -1928,14 +1928,14 @@ var _ = Describe("Connection", func() {
 		conn.sentPacketHandler = sph
 		done := make(chan struct{})
 		connRunner.EXPECT().Retire(clientDestConnID)
-		packer.EXPECT().PackPacket(false, gomock.Any()).DoAndReturn(func(bool, time.Time) (shortHeaderPacket, *packetBuffer, error) {
+		packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).DoAndReturn(func(bool, time.Time, protocol.VersionNumber) (shortHeaderPacket, *packetBuffer, error) {
 			frames, _ := conn.framer.AppendControlFrames(nil, protocol.MaxByteCount)
 			Expect(frames).ToNot(BeEmpty())
 			Expect(frames[0].Frame).To(BeEquivalentTo(&wire.HandshakeDoneFrame{}))
 			defer close(done)
 			return shortHeaderPacket{Packet: &ackhandler.Packet{}}, getPacketBuffer(), nil
 		})
-		packer.EXPECT().PackPacket(false, gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
+		packer.EXPECT().PackPacket(false, gomock.Any(), conn.version).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
 		go func() {
 			defer GinkgoRecover()
 			cryptoSetup.EXPECT().RunHandshake()
@@ -1949,7 +1949,7 @@ var _ = Describe("Connection", func() {
 		// make sure the go routine returns
 		streamManager.EXPECT().CloseWithError(gomock.Any())
 		expectReplaceWithClosed()
-		packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+		packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 		cryptoSetup.EXPECT().Close()
 		tracer.EXPECT().ClosedConnection(gomock.Any())
 		tracer.EXPECT().Close()
@@ -1967,7 +1967,7 @@ var _ = Describe("Connection", func() {
 		}()
 		streamManager.EXPECT().CloseWithError(gomock.Any())
 		expectReplaceWithClosed()
-		packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+		packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
 		tracer.EXPECT().ClosedConnection(gomock.Any())
@@ -1991,7 +1991,7 @@ var _ = Describe("Connection", func() {
 		}()
 		streamManager.EXPECT().CloseWithError(gomock.Any())
 		expectReplaceWithClosed()
-		packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+		packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
 		tracer.EXPECT().ClosedConnection(gomock.Any())
@@ -2013,7 +2013,7 @@ var _ = Describe("Connection", func() {
 			}
 			streamManager.EXPECT().UpdateLimits(params)
 			packer.EXPECT().HandleTransportParameters(params)
-			packer.EXPECT().PackCoalescedPacket(false).MaxTimes(3)
+			packer.EXPECT().PackCoalescedPacket(false, conn.version).MaxTimes(3)
 			Expect(conn.earlyConnReady()).ToNot(BeClosed())
 			connRunner.EXPECT().GetStatelessResetToken(gomock.Any()).Times(2)
 			connRunner.EXPECT().Add(gomock.Any(), conn).Times(2)
@@ -2052,7 +2052,7 @@ var _ = Describe("Connection", func() {
 			// make the go routine return
 			expectReplaceWithClosed()
 			streamManager.EXPECT().CloseWithError(gomock.Any())
-			packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
 			tracer.EXPECT().ClosedConnection(gomock.Any())
@@ -2065,7 +2065,7 @@ var _ = Describe("Connection", func() {
 			setRemoteIdleTimeout(5 * time.Second)
 			conn.lastPacketReceivedTime = time.Now().Add(-5 * time.Second / 2)
 			sent := make(chan struct{})
-			packer.EXPECT().PackCoalescedPacket(false).Do(func(bool) (*coalescedPacket, error) {
+			packer.EXPECT().PackCoalescedPacket(false, conn.version).Do(func(bool, protocol.VersionNumber) (*coalescedPacket, error) {
 				close(sent)
 				return nil, nil
 			})
@@ -2078,7 +2078,7 @@ var _ = Describe("Connection", func() {
 			setRemoteIdleTimeout(time.Hour)
 			conn.lastPacketReceivedTime = time.Now().Add(-protocol.MaxKeepAliveInterval).Add(-time.Millisecond)
 			sent := make(chan struct{})
-			packer.EXPECT().PackCoalescedPacket(false).Do(func(bool) (*coalescedPacket, error) {
+			packer.EXPECT().PackCoalescedPacket(false, conn.version).Do(func(bool, protocol.VersionNumber) (*coalescedPacket, error) {
 				close(sent)
 				return nil, nil
 			})
@@ -2166,7 +2166,7 @@ var _ = Describe("Connection", func() {
 			conn.config.HandshakeIdleTimeout = 9999 * time.Second
 			conn.config.MaxIdleTimeout = 9999 * time.Second
 			conn.lastPacketReceivedTime = time.Now().Add(-time.Minute)
-			packer.EXPECT().PackApplicationClose(gomock.Any()).DoAndReturn(func(e *qerr.ApplicationError) (*coalescedPacket, error) {
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).DoAndReturn(func(e *qerr.ApplicationError, _ protocol.VersionNumber) (*coalescedPacket, error) {
 				Expect(e.ErrorCode).To(BeZero())
 				return &coalescedPacket{buffer: getPacketBuffer()}, nil
 			})
@@ -2197,7 +2197,7 @@ var _ = Describe("Connection", func() {
 
 		It("closes the connection due to the idle timeout before handshake", func() {
 			conn.config.HandshakeIdleTimeout = 0
-			packer.EXPECT().PackCoalescedPacket(false).AnyTimes()
+			packer.EXPECT().PackCoalescedPacket(false, conn.version).AnyTimes()
 			connRunner.EXPECT().Remove(gomock.Any()).AnyTimes()
 			cryptoSetup.EXPECT().Close()
 			gomock.InOrder(
@@ -2223,7 +2223,7 @@ var _ = Describe("Connection", func() {
 		})
 
 		It("closes the connection due to the idle timeout after handshake", func() {
-			packer.EXPECT().PackCoalescedPacket(false).AnyTimes()
+			packer.EXPECT().PackCoalescedPacket(false, conn.version).AnyTimes()
 			gomock.InOrder(
 				connRunner.EXPECT().Retire(clientDestConnID),
 				connRunner.EXPECT().Remove(gomock.Any()),
@@ -2264,7 +2264,7 @@ var _ = Describe("Connection", func() {
 			}()
 			Consistently(conn.Context().Done()).ShouldNot(BeClosed())
 			// make the go routine return
-			packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+			packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 			expectReplaceWithClosed()
 			cryptoSetup.EXPECT().Close()
 			mconn.EXPECT().Write(gomock.Any())
@@ -2448,7 +2448,7 @@ var _ = Describe("Client Connection", func() {
 		tracer.EXPECT().ReceivedLongHeaderPacket(gomock.Any(), p.Size(), []logging.Frame{})
 		Expect(conn.handlePacketImpl(p)).To(BeTrue())
 		// make sure the go routine returns
-		packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
+		packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
 		expectReplaceWithClosed()
 		cryptoSetup.EXPECT().Close()
 		mconn.EXPECT().Write(gomock.Any())
@@ -2707,9 +2707,9 @@ var _ = Describe("Client Connection", func() {
 			if !closed {
 				connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any())
 				if applicationClose {
-					packer.EXPECT().PackApplicationClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil).MaxTimes(1)
+					packer.EXPECT().PackApplicationClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil).MaxTimes(1)
 				} else {
-					packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil).MaxTimes(1)
+					packer.EXPECT().PackConnectionClose(gomock.Any(), conn.version).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil).MaxTimes(1)
 				}
 				cryptoSetup.EXPECT().Close()
 				mconn.EXPECT().Write(gomock.Any())
@@ -2739,7 +2739,7 @@ var _ = Describe("Client Connection", func() {
 				},
 			}
 			packer.EXPECT().HandleTransportParameters(gomock.Any())
-			packer.EXPECT().PackCoalescedPacket(false).MaxTimes(1)
+			packer.EXPECT().PackCoalescedPacket(false, conn.version).MaxTimes(1)
 			tracer.EXPECT().ReceivedTransportParameters(params)
 			conn.handleTransportParameters(params)
 			conn.handleHandshakeComplete()

--- a/connection_test.go
+++ b/connection_test.go
@@ -1289,7 +1289,7 @@ var _ = Describe("Connection", func() {
 
 			Context(fmt.Sprintf("sending %s probe packets", encLevel), func() {
 				var sendMode ackhandler.SendMode
-				var getFrame func(protocol.ByteCount) wire.Frame
+				var getFrame func(protocol.ByteCount, protocol.VersionNumber) wire.Frame
 
 				BeforeEach(func() {
 					//nolint:exhaustive
@@ -1356,7 +1356,7 @@ var _ = Describe("Connection", func() {
 					Eventually(sent).Should(BeClosed())
 					// We're using a mock packet packer in this test.
 					// We therefore need to test separately that the PING was actually queued.
-					Expect(getFrame(1000)).To(BeAssignableToTypeOf(&wire.PingFrame{}))
+					Expect(getFrame(1000, protocol.Version1)).To(BeAssignableToTypeOf(&wire.PingFrame{}))
 				})
 			})
 		}

--- a/connection_test.go
+++ b/connection_test.go
@@ -755,7 +755,7 @@ var _ = Describe("Connection", func() {
 			packet := getLongHeaderPacket(hdr, nil)
 			packet.ecn = protocol.ECNCE
 			rcvTime := time.Now().Add(-10 * time.Second)
-			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), rcvTime, gomock.Any()).Return(&unpackedPacket{
+			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), rcvTime, gomock.Any(), conn.version).Return(&unpackedPacket{
 				encryptionLevel: protocol.EncryptionInitial,
 				hdr:             &unpackedHdr,
 				data:            []byte{0}, // one PADDING frame
@@ -801,7 +801,7 @@ var _ = Describe("Connection", func() {
 		})
 
 		It("drops a packet when unpacking fails", func() {
-			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, handshake.ErrDecryptionFailed)
+			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(nil, handshake.ErrDecryptionFailed)
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			cryptoSetup.EXPECT().Close()
 			packer.EXPECT().PackConnectionClose(gomock.Any()).Return(&coalescedPacket{buffer: getPacketBuffer()}, nil)
@@ -998,7 +998,7 @@ var _ = Describe("Connection", func() {
 			Expect(srcConnID).ToNot(Equal(hdr2.SrcConnectionID))
 			// Send one packet, which might change the connection ID.
 			// only EXPECT one call to the unpacker
-			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).Return(&unpackedPacket{
+			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(&unpackedPacket{
 				encryptionLevel: protocol.Encryption1RTT,
 				hdr:             hdr1,
 				data:            []byte{0}, // one PADDING frame
@@ -1026,7 +1026,7 @@ var _ = Describe("Connection", func() {
 				PacketNumberLen: protocol.PacketNumberLen1,
 				PacketNumber:    1,
 			}
-			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, handshake.ErrKeysNotYetAvailable)
+			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(nil, handshake.ErrKeysNotYetAvailable)
 			packet := getLongHeaderPacket(hdr, nil)
 			tracer.EXPECT().BufferedPacket(logging.PacketTypeHandshake, packet.Size())
 			Expect(conn.handlePacketImpl(packet)).To(BeFalse())
@@ -1067,7 +1067,7 @@ var _ = Describe("Connection", func() {
 
 			It("cuts packets to the right length", func() {
 				hdrLen, packet := getPacketWithLength(srcConnID, 456)
-				unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte) (*unpackedPacket, error) {
+				unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte, _ protocol.VersionNumber) (*unpackedPacket, error) {
 					Expect(data).To(HaveLen(hdrLen + 456 - 3))
 					return &unpackedPacket{
 						encryptionLevel: protocol.EncryptionHandshake,
@@ -1081,7 +1081,7 @@ var _ = Describe("Connection", func() {
 
 			It("handles coalesced packets", func() {
 				hdrLen1, packet1 := getPacketWithLength(srcConnID, 456)
-				unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte) (*unpackedPacket, error) {
+				unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte, _ protocol.VersionNumber) (*unpackedPacket, error) {
 					Expect(data).To(HaveLen(hdrLen1 + 456 - 3))
 					return &unpackedPacket{
 						encryptionLevel: protocol.EncryptionHandshake,
@@ -1093,7 +1093,7 @@ var _ = Describe("Connection", func() {
 					}, nil
 				})
 				hdrLen2, packet2 := getPacketWithLength(srcConnID, 123)
-				unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte) (*unpackedPacket, error) {
+				unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte, _ protocol.VersionNumber) (*unpackedPacket, error) {
 					Expect(data).To(HaveLen(hdrLen2 + 123 - 3))
 					return &unpackedPacket{
 						encryptionLevel: protocol.EncryptionHandshake,
@@ -1117,8 +1117,8 @@ var _ = Describe("Connection", func() {
 				hdrLen1, packet1 := getPacketWithLength(srcConnID, 456)
 				hdrLen2, packet2 := getPacketWithLength(srcConnID, 123)
 				gomock.InOrder(
-					unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, handshake.ErrKeysNotYetAvailable),
-					unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte) (*unpackedPacket, error) {
+					unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(nil, handshake.ErrKeysNotYetAvailable),
+					unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte, _ protocol.VersionNumber) (*unpackedPacket, error) {
 						Expect(data).To(HaveLen(hdrLen2 + 123 - 3))
 						return &unpackedPacket{
 							encryptionLevel: protocol.EncryptionHandshake,
@@ -1142,7 +1142,7 @@ var _ = Describe("Connection", func() {
 				wrongConnID := protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef})
 				Expect(srcConnID).ToNot(Equal(wrongConnID))
 				hdrLen1, packet1 := getPacketWithLength(srcConnID, 456)
-				unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte) (*unpackedPacket, error) {
+				unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).DoAndReturn(func(_ *wire.Header, _ time.Time, data []byte, _ protocol.VersionNumber) (*unpackedPacket, error) {
 					Expect(data).To(HaveLen(hdrLen1 + 456 - 3))
 					return &unpackedPacket{
 						encryptionLevel: protocol.EncryptionHandshake,
@@ -2421,7 +2421,7 @@ var _ = Describe("Client Connection", func() {
 
 	It("changes the connection ID when receiving the first packet from the server", func() {
 		unpacker := NewMockUnpacker(mockCtrl)
-		unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(hdr *wire.Header, _ time.Time, data []byte) (*unpackedPacket, error) {
+		unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).DoAndReturn(func(hdr *wire.Header, _ time.Time, data []byte, _ protocol.VersionNumber) (*unpackedPacket, error) {
 			return &unpackedPacket{
 				encryptionLevel: protocol.Encryption1RTT,
 				hdr:             &wire.ExtendedHeader{Header: *hdr},
@@ -2469,7 +2469,7 @@ var _ = Describe("Client Connection", func() {
 		})
 		Expect(conn.connIDManager.Get()).To(Equal(protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5})))
 		// now receive a packet with the original source connection ID
-		unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(hdr *wire.Header, _ time.Time, _ []byte) (*unpackedPacket, error) {
+		unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).DoAndReturn(func(hdr *wire.Header, _ time.Time, _ []byte, _ protocol.VersionNumber) (*unpackedPacket, error) {
 			return &unpackedPacket{
 				hdr:             &wire.ExtendedHeader{Header: *hdr},
 				data:            []byte{0},
@@ -2906,7 +2906,7 @@ var _ = Describe("Client Connection", func() {
 			Expect(hdr2.SrcConnectionID).ToNot(Equal(srcConnID))
 			// Send one packet, which might change the connection ID.
 			// only EXPECT one call to the unpacker
-			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any()).Return(&unpackedPacket{
+			unpacker.EXPECT().UnpackLongHeader(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(&unpackedPacket{
 				encryptionLevel: protocol.EncryptionInitial,
 				hdr:             hdr1,
 				data:            []byte{0}, // one PADDING frame

--- a/framer.go
+++ b/framer.go
@@ -14,10 +14,10 @@ type framer interface {
 	HasData() bool
 
 	QueueControlFrame(wire.Frame)
-	AppendControlFrames([]*ackhandler.Frame, protocol.ByteCount) ([]*ackhandler.Frame, protocol.ByteCount)
+	AppendControlFrames([]*ackhandler.Frame, protocol.ByteCount, protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount)
 
 	AddActiveStream(protocol.StreamID)
-	AppendStreamFrames([]*ackhandler.Frame, protocol.ByteCount) ([]*ackhandler.Frame, protocol.ByteCount)
+	AppendStreamFrames([]*ackhandler.Frame, protocol.ByteCount, protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount)
 
 	Handle0RTTRejection() error
 }
@@ -26,7 +26,6 @@ type framerI struct {
 	mutex sync.Mutex
 
 	streamGetter streamGetter
-	version      protocol.VersionNumber
 
 	activeStreams map[protocol.StreamID]struct{}
 	streamQueue   []protocol.StreamID
@@ -37,14 +36,10 @@ type framerI struct {
 
 var _ framer = &framerI{}
 
-func newFramer(
-	streamGetter streamGetter,
-	v protocol.VersionNumber,
-) framer {
+func newFramer(streamGetter streamGetter) framer {
 	return &framerI{
 		streamGetter:  streamGetter,
 		activeStreams: make(map[protocol.StreamID]struct{}),
-		version:       v,
 	}
 }
 
@@ -67,12 +62,12 @@ func (f *framerI) QueueControlFrame(frame wire.Frame) {
 	f.controlFrameMutex.Unlock()
 }
 
-func (f *framerI) AppendControlFrames(frames []*ackhandler.Frame, maxLen protocol.ByteCount) ([]*ackhandler.Frame, protocol.ByteCount) {
+func (f *framerI) AppendControlFrames(frames []*ackhandler.Frame, maxLen protocol.ByteCount, v protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount) {
 	var length protocol.ByteCount
 	f.controlFrameMutex.Lock()
 	for len(f.controlFrames) > 0 {
 		frame := f.controlFrames[len(f.controlFrames)-1]
-		frameLen := frame.Length(f.version)
+		frameLen := frame.Length(v)
 		if length+frameLen > maxLen {
 			break
 		}
@@ -95,7 +90,7 @@ func (f *framerI) AddActiveStream(id protocol.StreamID) {
 	f.mutex.Unlock()
 }
 
-func (f *framerI) AppendStreamFrames(frames []*ackhandler.Frame, maxLen protocol.ByteCount) ([]*ackhandler.Frame, protocol.ByteCount) {
+func (f *framerI) AppendStreamFrames(frames []*ackhandler.Frame, maxLen protocol.ByteCount, v protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount) {
 	var length protocol.ByteCount
 	var lastFrame *ackhandler.Frame
 	f.mutex.Lock()
@@ -120,7 +115,7 @@ func (f *framerI) AppendStreamFrames(frames []*ackhandler.Frame, maxLen protocol
 		// Therefore, we can pretend to have more bytes available when popping
 		// the STREAM frame (which will always have the DataLen set).
 		remainingLen += quicvarint.Len(uint64(remainingLen))
-		frame, hasMoreData := str.popStreamFrame(remainingLen, f.version)
+		frame, hasMoreData := str.popStreamFrame(remainingLen, v)
 		if hasMoreData { // put the stream back in the queue (at the end)
 			f.streamQueue = append(f.streamQueue, id)
 		} else { // no more data to send. Stream is not active any more
@@ -133,15 +128,15 @@ func (f *framerI) AppendStreamFrames(frames []*ackhandler.Frame, maxLen protocol
 			continue
 		}
 		frames = append(frames, frame)
-		length += frame.Length(f.version)
+		length += frame.Length(v)
 		lastFrame = frame
 	}
 	f.mutex.Unlock()
 	if lastFrame != nil {
-		lastFrameLen := lastFrame.Length(f.version)
+		lastFrameLen := lastFrame.Length(v)
 		// account for the smaller size of the last STREAM frame
 		lastFrame.Frame.(*wire.StreamFrame).DataLenPresent = false
-		length += lastFrame.Length(f.version) - lastFrameLen
+		length += lastFrame.Length(v) - lastFrameLen
 	}
 	return frames, length
 }

--- a/framer.go
+++ b/framer.go
@@ -120,7 +120,7 @@ func (f *framerI) AppendStreamFrames(frames []*ackhandler.Frame, maxLen protocol
 		// Therefore, we can pretend to have more bytes available when popping
 		// the STREAM frame (which will always have the DataLen set).
 		remainingLen += quicvarint.Len(uint64(remainingLen))
-		frame, hasMoreData := str.popStreamFrame(remainingLen)
+		frame, hasMoreData := str.popStreamFrame(remainingLen, f.version)
 		if hasMoreData { // put the stream back in the queue (at the end)
 			f.streamQueue = append(f.streamQueue, id)
 		} else { // no more data to send. Stream is not active any more

--- a/framer_test.go
+++ b/framer_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Framer", func() {
 		stream1.EXPECT().StreamID().Return(protocol.StreamID(5)).AnyTimes()
 		stream2 = NewMockSendStreamI(mockCtrl)
 		stream2.EXPECT().StreamID().Return(protocol.StreamID(6)).AnyTimes()
-		framer = newFramer(streamGetter, protocol.Version1)
+		framer = newFramer(streamGetter)
 	})
 
 	Context("handling control frames", func() {
@@ -42,7 +42,7 @@ var _ = Describe("Framer", func() {
 			msf := &wire.MaxStreamsFrame{MaxStreamNum: 0x1337}
 			framer.QueueControlFrame(mdf)
 			framer.QueueControlFrame(msf)
-			frames, length := framer.AppendControlFrames(nil, 1000)
+			frames, length := framer.AppendControlFrames(nil, 1000, protocol.Version1)
 			Expect(frames).To(HaveLen(2))
 			fs := []wire.Frame{frames[0].Frame, frames[1].Frame}
 			Expect(fs).To(ContainElement(mdf))
@@ -55,7 +55,7 @@ var _ = Describe("Framer", func() {
 			f := &wire.MaxDataFrame{MaximumData: 0x42}
 			framer.QueueControlFrame(f)
 			Expect(framer.HasData()).To(BeTrue())
-			frames, _ := framer.AppendControlFrames(nil, 1000)
+			frames, _ := framer.AppendControlFrames(nil, 1000, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(framer.HasData()).To(BeFalse())
 		})
@@ -64,7 +64,7 @@ var _ = Describe("Framer", func() {
 			ping := &wire.PingFrame{}
 			mdf := &wire.MaxDataFrame{MaximumData: 0x42}
 			framer.QueueControlFrame(mdf)
-			frames, length := framer.AppendControlFrames([]*ackhandler.Frame{{Frame: ping}}, 1000)
+			frames, length := framer.AppendControlFrames([]*ackhandler.Frame{{Frame: ping}}, 1000, protocol.Version1)
 			Expect(frames).To(HaveLen(2))
 			Expect(frames[0].Frame).To(Equal(ping))
 			Expect(frames[1].Frame).To(Equal(mdf))
@@ -79,10 +79,10 @@ var _ = Describe("Framer", func() {
 			for i := 0; i < numFrames+1; i++ {
 				framer.QueueControlFrame(bf)
 			}
-			frames, length := framer.AppendControlFrames(nil, maxSize)
+			frames, length := framer.AppendControlFrames(nil, maxSize, protocol.Version1)
 			Expect(frames).To(HaveLen(numFrames))
 			Expect(length).To(BeNumerically(">", maxSize-bfLen))
-			frames, length = framer.AppendControlFrames(nil, maxSize)
+			frames, length = framer.AppendControlFrames(nil, maxSize, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(length).To(Equal(bfLen))
 		})
@@ -105,7 +105,7 @@ var _ = Describe("Framer", func() {
 				framer.QueueControlFrame(f)
 			}
 			Expect(framer.Handle0RTTRejection()).To(Succeed())
-			fs, length := framer.AppendControlFrames(nil, protocol.MaxByteCount)
+			fs, length := framer.AppendControlFrames(nil, protocol.MaxByteCount, protocol.Version1)
 			Expect(fs).To(HaveLen(2))
 			Expect(length).To(Equal(ping.Length(version) + ncid.Length(version)))
 		})
@@ -113,7 +113,7 @@ var _ = Describe("Framer", func() {
 
 	Context("popping STREAM frames", func() {
 		It("returns nil when popping an empty framer", func() {
-			Expect(framer.AppendStreamFrames(nil, 1000)).To(BeEmpty())
+			Expect(framer.AppendStreamFrames(nil, 1000, protocol.Version1)).To(BeEmpty())
 		})
 
 		It("returns STREAM frames", func() {
@@ -126,7 +126,7 @@ var _ = Describe("Framer", func() {
 			}
 			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
-			fs, length := framer.AppendStreamFrames(nil, 1000)
+			fs, length := framer.AppendStreamFrames(nil, 1000, protocol.Version1)
 			Expect(fs).To(HaveLen(1))
 			Expect(fs[0].Frame.(*wire.StreamFrame).DataLenPresent).To(BeFalse())
 			Expect(length).To(Equal(f.Length(version)))
@@ -141,11 +141,11 @@ var _ = Describe("Framer", func() {
 			f2 := &wire.StreamFrame{StreamID: id1, Data: []byte("bar")}
 			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f1}, true)
 			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f2}, false)
-			frames, _ := framer.AppendStreamFrames(nil, protocol.MaxByteCount)
+			frames, _ := framer.AppendStreamFrames(nil, protocol.MaxByteCount, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f1))
 			Expect(framer.HasData()).To(BeTrue())
-			frames, _ = framer.AppendStreamFrames(nil, protocol.MaxByteCount)
+			frames, _ = framer.AppendStreamFrames(nil, protocol.MaxByteCount, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f2))
 			Expect(framer.HasData()).To(BeFalse())
@@ -162,7 +162,7 @@ var _ = Describe("Framer", func() {
 			framer.AddActiveStream(id1)
 			mdf := &wire.MaxDataFrame{MaximumData: 1337}
 			frames := []*ackhandler.Frame{{Frame: mdf}}
-			fs, length := framer.AppendStreamFrames(frames, 1000)
+			fs, length := framer.AppendStreamFrames(frames, 1000, protocol.Version1)
 			Expect(fs).To(HaveLen(2))
 			Expect(fs[0].Frame).To(Equal(mdf))
 			Expect(fs[1].Frame.(*wire.StreamFrame).Data).To(Equal([]byte("foobar")))
@@ -181,7 +181,7 @@ var _ = Describe("Framer", func() {
 			stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
 			framer.AddActiveStream(id2)
-			frames, _ := framer.AppendStreamFrames(nil, 1000)
+			frames, _ := framer.AppendStreamFrames(nil, 1000, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f))
 		})
@@ -198,7 +198,7 @@ var _ = Describe("Framer", func() {
 			stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
 			framer.AddActiveStream(id2)
-			frames, _ := framer.AppendStreamFrames(nil, 1000)
+			frames, _ := framer.AppendStreamFrames(nil, 1000, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f))
 		})
@@ -210,14 +210,14 @@ var _ = Describe("Framer", func() {
 			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f1}, true)
 			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f2}, false)
 			framer.AddActiveStream(id1) // only add it once
-			frames, _ := framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize)
+			frames, _ := framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f1))
-			frames, _ = framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize)
+			frames, _ = framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f2))
 			// no further calls to popStreamFrame, after popStreamFrame said there's no more data
-			frames, _ = framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize)
+			frames, _ = framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize, protocol.Version1)
 			Expect(frames).To(BeNil())
 		})
 
@@ -233,15 +233,15 @@ var _ = Describe("Framer", func() {
 			framer.AddActiveStream(id1) // only add it once
 			framer.AddActiveStream(id2)
 			// first a frame from stream 1
-			frames, _ := framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize)
+			frames, _ := framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f11))
 			// then a frame from stream 2
-			frames, _ = framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize)
+			frames, _ = framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f2))
 			// then another frame from stream 1
-			frames, _ = framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize)
+			frames, _ = framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f12))
 		})
@@ -256,7 +256,7 @@ var _ = Describe("Framer", func() {
 			stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f2}, true)
 			framer.AddActiveStream(id1)
 			framer.AddActiveStream(id2)
-			frames, length := framer.AppendStreamFrames(nil, 1000)
+			frames, length := framer.AppendStreamFrames(nil, 1000, protocol.Version1)
 			Expect(frames).To(HaveLen(2))
 			Expect(frames[0].Frame).To(Equal(f1))
 			Expect(frames[1].Frame).To(Equal(f2))
@@ -272,7 +272,7 @@ var _ = Describe("Framer", func() {
 			stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f2}, false)
 			framer.AddActiveStream(id2)
 			framer.AddActiveStream(id1)
-			frames, _ := framer.AppendStreamFrames(nil, 1000)
+			frames, _ := framer.AppendStreamFrames(nil, 1000, protocol.Version1)
 			Expect(frames).To(HaveLen(2))
 			Expect(frames[0].Frame).To(Equal(f2))
 			Expect(frames[1].Frame).To(Equal(f1))
@@ -284,12 +284,12 @@ var _ = Describe("Framer", func() {
 			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false) // only one call to this function
 			framer.AddActiveStream(id1)
 			framer.AddActiveStream(id1)
-			frames, _ := framer.AppendStreamFrames(nil, 1000)
+			frames, _ := framer.AppendStreamFrames(nil, 1000, protocol.Version1)
 			Expect(frames).To(HaveLen(1))
 		})
 
 		It("does not pop empty frames", func() {
-			fs, length := framer.AppendStreamFrames(nil, 500)
+			fs, length := framer.AppendStreamFrames(nil, 500, protocol.Version1)
 			Expect(fs).To(BeEmpty())
 			Expect(length).To(BeZero())
 		})
@@ -307,7 +307,7 @@ var _ = Describe("Framer", func() {
 					return &ackhandler.Frame{Frame: f}, false
 				})
 				framer.AddActiveStream(id1)
-				frames, _ := framer.AppendStreamFrames(nil, i)
+				frames, _ := framer.AppendStreamFrames(nil, i, protocol.Version1)
 				Expect(frames).To(HaveLen(1))
 				f := frames[0].Frame.(*wire.StreamFrame)
 				Expect(f.DataLenPresent).To(BeFalse())
@@ -338,7 +338,7 @@ var _ = Describe("Framer", func() {
 				})
 				framer.AddActiveStream(id1)
 				framer.AddActiveStream(id2)
-				frames, _ := framer.AppendStreamFrames(nil, i)
+				frames, _ := framer.AppendStreamFrames(nil, i, protocol.Version1)
 				Expect(frames).To(HaveLen(2))
 				f1 := frames[0].Frame.(*wire.StreamFrame)
 				f2 := frames[1].Frame.(*wire.StreamFrame)
@@ -353,12 +353,12 @@ var _ = Describe("Framer", func() {
 			f := &wire.StreamFrame{Data: []byte("foobar")}
 			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
-			framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize)
+			framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize, protocol.Version1)
 		})
 
 		It("does not pop frames smaller than the minimum size", func() {
 			// don't expect a call to PopStreamFrame()
-			framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize-1)
+			framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize-1, protocol.Version1)
 		})
 
 		It("stops iterating when the remaining size is smaller than the minimum STREAM frame size", func() {
@@ -371,7 +371,7 @@ var _ = Describe("Framer", func() {
 			}
 			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
-			fs, length := framer.AppendStreamFrames(nil, 500)
+			fs, length := framer.AppendStreamFrames(nil, 500, protocol.Version1)
 			Expect(fs).To(HaveLen(1))
 			Expect(fs[0].Frame).To(Equal(f))
 			Expect(length).To(Equal(f.Length(version)))
@@ -380,7 +380,7 @@ var _ = Describe("Framer", func() {
 		It("drops all STREAM frames when 0-RTT is rejected", func() {
 			framer.AddActiveStream(id1)
 			Expect(framer.Handle0RTTRejection()).To(Succeed())
-			fs, length := framer.AppendStreamFrames(nil, protocol.MaxByteCount)
+			fs, length := framer.AppendStreamFrames(nil, protocol.MaxByteCount, protocol.Version1)
 			Expect(fs).To(BeEmpty())
 			Expect(length).To(BeZero())
 		})

--- a/framer_test.go
+++ b/framer_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Framer", func() {
 		stream1.EXPECT().StreamID().Return(protocol.StreamID(5)).AnyTimes()
 		stream2 = NewMockSendStreamI(mockCtrl)
 		stream2.EXPECT().StreamID().Return(protocol.StreamID(6)).AnyTimes()
-		framer = newFramer(streamGetter, version)
+		framer = newFramer(streamGetter, protocol.Version1)
 	})
 
 	Context("handling control frames", func() {
@@ -124,7 +124,7 @@ var _ = Describe("Framer", func() {
 				Offset:         42,
 				DataLenPresent: true,
 			}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f}, false)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
 			fs, length := framer.AppendStreamFrames(nil, 1000)
 			Expect(fs).To(HaveLen(1))
@@ -139,8 +139,8 @@ var _ = Describe("Framer", func() {
 			Expect(framer.HasData()).To(BeTrue())
 			f1 := &wire.StreamFrame{StreamID: id1, Data: []byte("foo")}
 			f2 := &wire.StreamFrame{StreamID: id1, Data: []byte("bar")}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f1}, true)
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f2}, false)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f1}, true)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f2}, false)
 			frames, _ := framer.AppendStreamFrames(nil, protocol.MaxByteCount)
 			Expect(frames).To(HaveLen(1))
 			Expect(frames[0].Frame).To(Equal(f1))
@@ -158,7 +158,7 @@ var _ = Describe("Framer", func() {
 				Data:           []byte("foobar"),
 				DataLenPresent: true,
 			}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f}, false)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
 			mdf := &wire.MaxDataFrame{MaximumData: 1337}
 			frames := []*ackhandler.Frame{{Frame: mdf}}
@@ -178,7 +178,7 @@ var _ = Describe("Framer", func() {
 				Data:           []byte("foobar"),
 				DataLenPresent: true,
 			}
-			stream2.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f}, false)
+			stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
 			framer.AddActiveStream(id2)
 			frames, _ := framer.AppendStreamFrames(nil, 1000)
@@ -194,8 +194,8 @@ var _ = Describe("Framer", func() {
 				Data:           []byte("foobar"),
 				DataLenPresent: true,
 			}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(nil, false)
-			stream2.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f}, false)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(nil, false)
+			stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
 			framer.AddActiveStream(id2)
 			frames, _ := framer.AppendStreamFrames(nil, 1000)
@@ -207,8 +207,8 @@ var _ = Describe("Framer", func() {
 			streamGetter.EXPECT().GetOrOpenSendStream(id1).Return(stream1, nil).Times(2)
 			f1 := &wire.StreamFrame{StreamID: id1, Data: []byte("foobar")}
 			f2 := &wire.StreamFrame{StreamID: id1, Data: []byte("foobaz")}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f1}, true)
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f2}, false)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f1}, true)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f2}, false)
 			framer.AddActiveStream(id1) // only add it once
 			frames, _ := framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize)
 			Expect(frames).To(HaveLen(1))
@@ -227,9 +227,9 @@ var _ = Describe("Framer", func() {
 			f11 := &wire.StreamFrame{StreamID: id1, Data: []byte("foobar")}
 			f12 := &wire.StreamFrame{StreamID: id1, Data: []byte("foobaz")}
 			f2 := &wire.StreamFrame{StreamID: id2, Data: []byte("raboof")}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f11}, true)
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f12}, false)
-			stream2.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f2}, false)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f11}, true)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f12}, false)
+			stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f2}, false)
 			framer.AddActiveStream(id1) // only add it once
 			framer.AddActiveStream(id2)
 			// first a frame from stream 1
@@ -252,8 +252,8 @@ var _ = Describe("Framer", func() {
 			f1 := &wire.StreamFrame{StreamID: id1, Data: []byte("foobar")}
 			f2 := &wire.StreamFrame{StreamID: id2, Data: []byte("raboof")}
 			// both streams have more data, and will be re-queued
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f1}, true)
-			stream2.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f2}, true)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f1}, true)
+			stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f2}, true)
 			framer.AddActiveStream(id1)
 			framer.AddActiveStream(id2)
 			frames, length := framer.AppendStreamFrames(nil, 1000)
@@ -268,8 +268,8 @@ var _ = Describe("Framer", func() {
 			streamGetter.EXPECT().GetOrOpenSendStream(id2).Return(stream2, nil)
 			f1 := &wire.StreamFrame{Data: []byte("foobar")}
 			f2 := &wire.StreamFrame{Data: []byte("foobaz")}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f1}, false)
-			stream2.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f2}, false)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f1}, false)
+			stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f2}, false)
 			framer.AddActiveStream(id2)
 			framer.AddActiveStream(id1)
 			frames, _ := framer.AppendStreamFrames(nil, 1000)
@@ -281,7 +281,7 @@ var _ = Describe("Framer", func() {
 		It("only asks a stream for data once, even if it was reported active multiple times", func() {
 			streamGetter.EXPECT().GetOrOpenSendStream(id1).Return(stream1, nil)
 			f := &wire.StreamFrame{Data: []byte("foobar")}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f}, false) // only one call to this function
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false) // only one call to this function
 			framer.AddActiveStream(id1)
 			framer.AddActiveStream(id1)
 			frames, _ := framer.AppendStreamFrames(nil, 1000)
@@ -297,12 +297,12 @@ var _ = Describe("Framer", func() {
 		It("pops maximum size STREAM frames", func() {
 			for i := protocol.MinStreamFrameSize; i < 2000; i++ {
 				streamGetter.EXPECT().GetOrOpenSendStream(id1).Return(stream1, nil)
-				stream1.EXPECT().popStreamFrame(gomock.Any()).DoAndReturn(func(size protocol.ByteCount) (*ackhandler.Frame, bool) {
+				stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(func(size protocol.ByteCount, v protocol.VersionNumber) (*ackhandler.Frame, bool) {
 					f := &wire.StreamFrame{
 						StreamID:       id1,
 						DataLenPresent: true,
 					}
-					f.Data = make([]byte, f.MaxDataLen(size, version))
+					f.Data = make([]byte, f.MaxDataLen(size, v))
 					Expect(f.Length(version)).To(Equal(size))
 					return &ackhandler.Frame{Frame: f}, false
 				})
@@ -319,20 +319,20 @@ var _ = Describe("Framer", func() {
 			for i := 2 * protocol.MinStreamFrameSize; i < 2000; i++ {
 				streamGetter.EXPECT().GetOrOpenSendStream(id1).Return(stream1, nil)
 				streamGetter.EXPECT().GetOrOpenSendStream(id2).Return(stream2, nil)
-				stream1.EXPECT().popStreamFrame(gomock.Any()).DoAndReturn(func(size protocol.ByteCount) (*ackhandler.Frame, bool) {
+				stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(func(size protocol.ByteCount, v protocol.VersionNumber) (*ackhandler.Frame, bool) {
 					f := &wire.StreamFrame{
 						StreamID:       id2,
 						DataLenPresent: true,
 					}
-					f.Data = make([]byte, f.MaxDataLen(protocol.MinStreamFrameSize, version))
+					f.Data = make([]byte, f.MaxDataLen(protocol.MinStreamFrameSize, v))
 					return &ackhandler.Frame{Frame: f}, false
 				})
-				stream2.EXPECT().popStreamFrame(gomock.Any()).DoAndReturn(func(size protocol.ByteCount) (*ackhandler.Frame, bool) {
+				stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(func(size protocol.ByteCount, v protocol.VersionNumber) (*ackhandler.Frame, bool) {
 					f := &wire.StreamFrame{
 						StreamID:       id2,
 						DataLenPresent: true,
 					}
-					f.Data = make([]byte, f.MaxDataLen(size, version))
+					f.Data = make([]byte, f.MaxDataLen(size, v))
 					Expect(f.Length(version)).To(Equal(size))
 					return &ackhandler.Frame{Frame: f}, false
 				})
@@ -351,7 +351,7 @@ var _ = Describe("Framer", func() {
 		It("pops frames that when asked for the the minimum STREAM frame size", func() {
 			streamGetter.EXPECT().GetOrOpenSendStream(id1).Return(stream1, nil)
 			f := &wire.StreamFrame{Data: []byte("foobar")}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f}, false)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
 			framer.AppendStreamFrames(nil, protocol.MinStreamFrameSize)
 		})
@@ -369,7 +369,7 @@ var _ = Describe("Framer", func() {
 				Data:           bytes.Repeat([]byte("f"), int(500-protocol.MinStreamFrameSize)),
 				DataLenPresent: true,
 			}
-			stream1.EXPECT().popStreamFrame(gomock.Any()).Return(&ackhandler.Frame{Frame: f}, false)
+			stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(&ackhandler.Frame{Frame: f}, false)
 			framer.AddActiveStream(id1)
 			fs, length := framer.AppendStreamFrames(nil, 500)
 			Expect(fs).To(HaveLen(1))

--- a/fuzzing/frames/fuzz.go
+++ b/fuzzing/frames/fuzz.go
@@ -33,7 +33,7 @@ func Fuzz(data []byte) int {
 	encLevel := toEncLevel(data[0])
 	data = data[PrefixLen:]
 
-	parser := wire.NewFrameParser(true, version)
+	parser := wire.NewFrameParser(true)
 	parser.SetAckDelayExponent(protocol.DefaultAckDelayExponent)
 
 	initialLen := len(data)
@@ -41,7 +41,7 @@ func Fuzz(data []byte) int {
 	var frames []wire.Frame
 
 	for len(data) > 0 {
-		l, f, err := parser.ParseNext(data, encLevel)
+		l, f, err := parser.ParseNext(data, encLevel, version)
 		if err != nil {
 			break
 		}

--- a/internal/ackhandler/ackhandler.go
+++ b/internal/ackhandler/ackhandler.go
@@ -17,8 +17,7 @@ func NewAckHandler(
 	pers protocol.Perspective,
 	tracer logging.ConnectionTracer,
 	logger utils.Logger,
-	version protocol.VersionNumber,
 ) (SentPacketHandler, ReceivedPacketHandler) {
 	sph := newSentPacketHandler(initialPacketNumber, initialMaxDatagramSize, rttStats, clientAddressValidated, pers, tracer, logger)
-	return sph, newReceivedPacketHandler(sph, rttStats, logger, version)
+	return sph, newReceivedPacketHandler(sph, rttStats, logger)
 }

--- a/internal/ackhandler/received_packet_handler.go
+++ b/internal/ackhandler/received_packet_handler.go
@@ -25,13 +25,12 @@ func newReceivedPacketHandler(
 	sentPackets sentPacketTracker,
 	rttStats *utils.RTTStats,
 	logger utils.Logger,
-	version protocol.VersionNumber,
 ) ReceivedPacketHandler {
 	return &receivedPacketHandler{
 		sentPackets:      sentPackets,
-		initialPackets:   newReceivedPacketTracker(rttStats, logger, version),
-		handshakePackets: newReceivedPacketTracker(rttStats, logger, version),
-		appDataPackets:   newReceivedPacketTracker(rttStats, logger, version),
+		initialPackets:   newReceivedPacketTracker(rttStats, logger),
+		handshakePackets: newReceivedPacketTracker(rttStats, logger),
+		appDataPackets:   newReceivedPacketTracker(rttStats, logger),
 		lowest1RTTPacket: protocol.InvalidPacketNumber,
 	}
 }

--- a/internal/ackhandler/received_packet_handler_test.go
+++ b/internal/ackhandler/received_packet_handler_test.go
@@ -23,7 +23,6 @@ var _ = Describe("Received Packet Handler", func() {
 			sentPackets,
 			&utils.RTTStats{},
 			utils.DefaultLogger,
-			protocol.VersionWhatever,
 		)
 	})
 

--- a/internal/ackhandler/received_packet_tracker.go
+++ b/internal/ackhandler/received_packet_tracker.go
@@ -31,21 +31,17 @@ type receivedPacketTracker struct {
 	lastAck                                 *wire.AckFrame
 
 	logger utils.Logger
-
-	version protocol.VersionNumber
 }
 
 func newReceivedPacketTracker(
 	rttStats *utils.RTTStats,
 	logger utils.Logger,
-	version protocol.VersionNumber,
 ) *receivedPacketTracker {
 	return &receivedPacketTracker{
 		packetHistory: newReceivedPacketHistory(),
 		maxAckDelay:   protocol.MaxAckDelay,
 		rttStats:      rttStats,
 		logger:        logger,
-		version:       version,
 	}
 }
 

--- a/internal/ackhandler/received_packet_tracker_test.go
+++ b/internal/ackhandler/received_packet_tracker_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Received Packet Tracker", func() {
 
 	BeforeEach(func() {
 		rttStats = &utils.RTTStats{}
-		tracker = newReceivedPacketTracker(rttStats, utils.DefaultLogger, protocol.VersionWhatever)
+		tracker = newReceivedPacketTracker(rttStats, utils.DefaultLogger)
 	})
 
 	Context("accepting packets", func() {

--- a/internal/wire/frame_parser.go
+++ b/internal/wire/frame_parser.go
@@ -16,31 +16,30 @@ type frameParser struct {
 	ackDelayExponent uint8
 
 	supportsDatagrams bool
-
-	version protocol.VersionNumber
 }
 
+var _ FrameParser = &frameParser{}
+
 // NewFrameParser creates a new frame parser.
-func NewFrameParser(supportsDatagrams bool, v protocol.VersionNumber) FrameParser {
+func NewFrameParser(supportsDatagrams bool) *frameParser {
 	return &frameParser{
 		r:                 *bytes.NewReader(nil),
 		supportsDatagrams: supportsDatagrams,
-		version:           v,
 	}
 }
 
 // ParseNext parses the next frame.
 // It skips PADDING frames.
-func (p *frameParser) ParseNext(data []byte, encLevel protocol.EncryptionLevel) (int, Frame, error) {
+func (p *frameParser) ParseNext(data []byte, encLevel protocol.EncryptionLevel, v protocol.VersionNumber) (int, Frame, error) {
 	startLen := len(data)
 	p.r.Reset(data)
-	frame, err := p.parseNext(&p.r, encLevel)
+	frame, err := p.parseNext(&p.r, encLevel, v)
 	n := startLen - p.r.Len()
 	p.r.Reset(nil)
 	return n, frame, err
 }
 
-func (p *frameParser) parseNext(r *bytes.Reader, encLevel protocol.EncryptionLevel) (Frame, error) {
+func (p *frameParser) parseNext(r *bytes.Reader, encLevel protocol.EncryptionLevel, v protocol.VersionNumber) (Frame, error) {
 	for r.Len() != 0 {
 		typeByte, _ := p.r.ReadByte()
 		if typeByte == 0x0 { // PADDING frame
@@ -48,7 +47,7 @@ func (p *frameParser) parseNext(r *bytes.Reader, encLevel protocol.EncryptionLev
 		}
 		r.UnreadByte()
 
-		f, err := p.parseFrame(r, typeByte, encLevel)
+		f, err := p.parseFrame(r, typeByte, encLevel, v)
 		if err != nil {
 			return nil, &qerr.TransportError{
 				FrameType:    uint64(typeByte),
@@ -61,56 +60,56 @@ func (p *frameParser) parseNext(r *bytes.Reader, encLevel protocol.EncryptionLev
 	return nil, nil
 }
 
-func (p *frameParser) parseFrame(r *bytes.Reader, typeByte byte, encLevel protocol.EncryptionLevel) (Frame, error) {
+func (p *frameParser) parseFrame(r *bytes.Reader, typeByte byte, encLevel protocol.EncryptionLevel, v protocol.VersionNumber) (Frame, error) {
 	var frame Frame
 	var err error
 	if typeByte&0xf8 == 0x8 {
-		frame, err = parseStreamFrame(r, p.version)
+		frame, err = parseStreamFrame(r, v)
 	} else {
 		switch typeByte {
 		case 0x1:
-			frame, err = parsePingFrame(r, p.version)
+			frame, err = parsePingFrame(r, v)
 		case 0x2, 0x3:
 			ackDelayExponent := p.ackDelayExponent
 			if encLevel != protocol.Encryption1RTT {
 				ackDelayExponent = protocol.DefaultAckDelayExponent
 			}
-			frame, err = parseAckFrame(r, ackDelayExponent, p.version)
+			frame, err = parseAckFrame(r, ackDelayExponent, v)
 		case 0x4:
-			frame, err = parseResetStreamFrame(r, p.version)
+			frame, err = parseResetStreamFrame(r, v)
 		case 0x5:
-			frame, err = parseStopSendingFrame(r, p.version)
+			frame, err = parseStopSendingFrame(r, v)
 		case 0x6:
-			frame, err = parseCryptoFrame(r, p.version)
+			frame, err = parseCryptoFrame(r, v)
 		case 0x7:
-			frame, err = parseNewTokenFrame(r, p.version)
+			frame, err = parseNewTokenFrame(r, v)
 		case 0x10:
-			frame, err = parseMaxDataFrame(r, p.version)
+			frame, err = parseMaxDataFrame(r, v)
 		case 0x11:
-			frame, err = parseMaxStreamDataFrame(r, p.version)
+			frame, err = parseMaxStreamDataFrame(r, v)
 		case 0x12, 0x13:
-			frame, err = parseMaxStreamsFrame(r, p.version)
+			frame, err = parseMaxStreamsFrame(r, v)
 		case 0x14:
-			frame, err = parseDataBlockedFrame(r, p.version)
+			frame, err = parseDataBlockedFrame(r, v)
 		case 0x15:
-			frame, err = parseStreamDataBlockedFrame(r, p.version)
+			frame, err = parseStreamDataBlockedFrame(r, v)
 		case 0x16, 0x17:
-			frame, err = parseStreamsBlockedFrame(r, p.version)
+			frame, err = parseStreamsBlockedFrame(r, v)
 		case 0x18:
-			frame, err = parseNewConnectionIDFrame(r, p.version)
+			frame, err = parseNewConnectionIDFrame(r, v)
 		case 0x19:
-			frame, err = parseRetireConnectionIDFrame(r, p.version)
+			frame, err = parseRetireConnectionIDFrame(r, v)
 		case 0x1a:
-			frame, err = parsePathChallengeFrame(r, p.version)
+			frame, err = parsePathChallengeFrame(r, v)
 		case 0x1b:
-			frame, err = parsePathResponseFrame(r, p.version)
+			frame, err = parsePathResponseFrame(r, v)
 		case 0x1c, 0x1d:
-			frame, err = parseConnectionCloseFrame(r, p.version)
+			frame, err = parseConnectionCloseFrame(r, v)
 		case 0x1e:
-			frame, err = parseHandshakeDoneFrame(r, p.version)
+			frame, err = parseHandshakeDoneFrame(r, v)
 		case 0x30, 0x31:
 			if p.supportsDatagrams {
-				frame, err = parseDatagramFrame(r, p.version)
+				frame, err = parseDatagramFrame(r, v)
 				break
 			}
 			fallthrough

--- a/internal/wire/frame_parser_test.go
+++ b/internal/wire/frame_parser_test.go
@@ -13,11 +13,11 @@ var _ = Describe("Frame parsing", func() {
 	var parser FrameParser
 
 	BeforeEach(func() {
-		parser = NewFrameParser(true, protocol.Version1)
+		parser = NewFrameParser(true)
 	})
 
 	It("returns nil if there's nothing more to read", func() {
-		l, f, err := parser.ParseNext(nil, protocol.Encryption1RTT)
+		l, f, err := parser.ParseNext(nil, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(l).To(BeZero())
 		Expect(f).To(BeNil())
@@ -27,14 +27,14 @@ var _ = Describe("Frame parsing", func() {
 		b := []byte{0, 0} // 2 PADDING frames
 		b, err := (&PingFrame{}).Append(b, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, f, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, f, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(f).To(Equal(&PingFrame{}))
 		Expect(l).To(Equal(2 + 1))
 	})
 
 	It("handles PADDING at the end", func() {
-		l, f, err := parser.ParseNext([]byte{0, 0, 0}, protocol.Encryption1RTT)
+		l, f, err := parser.ParseNext([]byte{0, 0, 0}, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(f).To(BeNil())
 		Expect(l).To(Equal(3))
@@ -47,7 +47,7 @@ var _ = Describe("Frame parsing", func() {
 			b, err = (&PingFrame{}).Append(b, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 		}
-		l, f, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, f, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(f).To(BeAssignableToTypeOf(&PingFrame{}))
 		Expect(l).To(Equal(1))
@@ -57,7 +57,7 @@ var _ = Describe("Frame parsing", func() {
 		f := &AckFrame{AckRanges: []AckRange{{Smallest: 1, Largest: 0x13}}}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).ToNot(BeNil())
 		Expect(frame).To(BeAssignableToTypeOf(f))
@@ -73,7 +73,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		_, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		_, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		// The ACK frame is always written using the protocol.AckDelayExponent.
 		// That's why we expect a different value when parsing.
@@ -88,7 +88,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		_, frame, err := parser.ParseNext(b, protocol.EncryptionHandshake)
+		_, frame, err := parser.ParseNext(b, protocol.EncryptionHandshake, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame.(*AckFrame).DelayTime).To(Equal(time.Second))
 	})
@@ -101,7 +101,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -111,7 +111,7 @@ var _ = Describe("Frame parsing", func() {
 		f := &StopSendingFrame{StreamID: 0x42}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -124,7 +124,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).ToNot(BeNil())
 		Expect(frame).To(Equal(f))
@@ -135,7 +135,7 @@ var _ = Describe("Frame parsing", func() {
 		f := &NewTokenFrame{Token: []byte("foobar")}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).ToNot(BeNil())
 		Expect(frame).To(Equal(f))
@@ -151,7 +151,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).ToNot(BeNil())
 		Expect(frame).To(Equal(f))
@@ -164,7 +164,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -177,7 +177,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -190,7 +190,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -200,7 +200,7 @@ var _ = Describe("Frame parsing", func() {
 		f := &DataBlockedFrame{MaximumData: 0x1234}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -213,7 +213,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -226,7 +226,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -240,7 +240,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -250,7 +250,7 @@ var _ = Describe("Frame parsing", func() {
 		f := &RetireConnectionIDFrame{SequenceNumber: 0x1337}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -260,7 +260,7 @@ var _ = Describe("Frame parsing", func() {
 		f := &PathChallengeFrame{Data: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).ToNot(BeNil())
 		Expect(frame).To(BeAssignableToTypeOf(f))
@@ -272,7 +272,7 @@ var _ = Describe("Frame parsing", func() {
 		f := &PathResponseFrame{Data: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).ToNot(BeNil())
 		Expect(frame).To(BeAssignableToTypeOf(f))
@@ -287,7 +287,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -297,7 +297,7 @@ var _ = Describe("Frame parsing", func() {
 		f := &HandshakeDoneFrame{}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
@@ -307,18 +307,18 @@ var _ = Describe("Frame parsing", func() {
 		f := &DatagramFrame{Data: []byte("foobar")}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT)
+		l, frame, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(frame).To(Equal(f))
 		Expect(l).To(Equal(len(b)))
 	})
 
 	It("errors when DATAGRAM frames are not supported", func() {
-		parser = NewFrameParser(false, protocol.Version1)
+		parser = NewFrameParser(false)
 		f := &DatagramFrame{Data: []byte("foobar")}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		_, _, err = parser.ParseNext(b, protocol.Encryption1RTT)
+		_, _, err = parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).To(MatchError(&qerr.TransportError{
 			ErrorCode:    qerr.FrameEncodingError,
 			FrameType:    0x30,
@@ -327,7 +327,7 @@ var _ = Describe("Frame parsing", func() {
 	})
 
 	It("errors on invalid type", func() {
-		_, _, err := parser.ParseNext([]byte{0x42}, protocol.Encryption1RTT)
+		_, _, err := parser.ParseNext([]byte{0x42}, protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).To(MatchError(&qerr.TransportError{
 			ErrorCode:    qerr.FrameEncodingError,
 			FrameType:    0x42,
@@ -342,7 +342,7 @@ var _ = Describe("Frame parsing", func() {
 		}
 		b, err := f.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
-		_, _, err = parser.ParseNext(b[:len(b)-2], protocol.Encryption1RTT)
+		_, _, err = parser.ParseNext(b[:len(b)-2], protocol.Encryption1RTT, protocol.Version1)
 		Expect(err).To(HaveOccurred())
 		Expect(err.(*qerr.TransportError).ErrorCode).To(Equal(qerr.FrameEncodingError))
 	})
@@ -384,7 +384,7 @@ var _ = Describe("Frame parsing", func() {
 
 		It("rejects all frames but ACK, CRYPTO, PING and CONNECTION_CLOSE in Initial packets", func() {
 			for i, b := range framesSerialized {
-				_, _, err := parser.ParseNext(b, protocol.EncryptionInitial)
+				_, _, err := parser.ParseNext(b, protocol.EncryptionInitial, protocol.Version1)
 				switch frames[i].(type) {
 				case *AckFrame, *ConnectionCloseFrame, *CryptoFrame, *PingFrame:
 					Expect(err).ToNot(HaveOccurred())
@@ -398,7 +398,7 @@ var _ = Describe("Frame parsing", func() {
 
 		It("rejects all frames but ACK, CRYPTO, PING and CONNECTION_CLOSE in Handshake packets", func() {
 			for i, b := range framesSerialized {
-				_, _, err := parser.ParseNext(b, protocol.EncryptionHandshake)
+				_, _, err := parser.ParseNext(b, protocol.EncryptionHandshake, protocol.Version1)
 				switch frames[i].(type) {
 				case *AckFrame, *ConnectionCloseFrame, *CryptoFrame, *PingFrame:
 					Expect(err).ToNot(HaveOccurred())
@@ -412,7 +412,7 @@ var _ = Describe("Frame parsing", func() {
 
 		It("rejects all frames but ACK, CRYPTO, CONNECTION_CLOSE, NEW_TOKEN, PATH_RESPONSE and RETIRE_CONNECTION_ID in 0-RTT packets", func() {
 			for i, b := range framesSerialized {
-				_, _, err := parser.ParseNext(b, protocol.Encryption0RTT)
+				_, _, err := parser.ParseNext(b, protocol.Encryption0RTT, protocol.Version1)
 				switch frames[i].(type) {
 				case *AckFrame, *ConnectionCloseFrame, *CryptoFrame, *NewTokenFrame, *PathResponseFrame, *RetireConnectionIDFrame:
 					Expect(err).To(BeAssignableToTypeOf(&qerr.TransportError{}))
@@ -426,7 +426,7 @@ var _ = Describe("Frame parsing", func() {
 
 		It("accepts all frame types in 1-RTT packets", func() {
 			for _, b := range framesSerialized {
-				_, _, err := parser.ParseNext(b, protocol.Encryption1RTT)
+				_, _, err := parser.ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})

--- a/internal/wire/interface.go
+++ b/internal/wire/interface.go
@@ -12,6 +12,6 @@ type Frame interface {
 
 // A FrameParser parses QUIC frames, one by one.
 type FrameParser interface {
-	ParseNext([]byte, protocol.EncryptionLevel) (int, Frame, error)
+	ParseNext([]byte, protocol.EncryptionLevel, protocol.VersionNumber) (int, Frame, error)
 	SetAckDelayExponent(uint8)
 }

--- a/mock_frame_source_test.go
+++ b/mock_frame_source_test.go
@@ -36,33 +36,33 @@ func (m *MockFrameSource) EXPECT() *MockFrameSourceMockRecorder {
 }
 
 // AppendControlFrames mocks base method.
-func (m *MockFrameSource) AppendControlFrames(arg0 []*ackhandler.Frame, arg1 protocol.ByteCount) ([]*ackhandler.Frame, protocol.ByteCount) {
+func (m *MockFrameSource) AppendControlFrames(arg0 []*ackhandler.Frame, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendControlFrames", arg0, arg1)
+	ret := m.ctrl.Call(m, "AppendControlFrames", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*ackhandler.Frame)
 	ret1, _ := ret[1].(protocol.ByteCount)
 	return ret0, ret1
 }
 
 // AppendControlFrames indicates an expected call of AppendControlFrames.
-func (mr *MockFrameSourceMockRecorder) AppendControlFrames(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockFrameSourceMockRecorder) AppendControlFrames(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendControlFrames", reflect.TypeOf((*MockFrameSource)(nil).AppendControlFrames), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendControlFrames", reflect.TypeOf((*MockFrameSource)(nil).AppendControlFrames), arg0, arg1, arg2)
 }
 
 // AppendStreamFrames mocks base method.
-func (m *MockFrameSource) AppendStreamFrames(arg0 []*ackhandler.Frame, arg1 protocol.ByteCount) ([]*ackhandler.Frame, protocol.ByteCount) {
+func (m *MockFrameSource) AppendStreamFrames(arg0 []*ackhandler.Frame, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendStreamFrames", arg0, arg1)
+	ret := m.ctrl.Call(m, "AppendStreamFrames", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*ackhandler.Frame)
 	ret1, _ := ret[1].(protocol.ByteCount)
 	return ret0, ret1
 }
 
 // AppendStreamFrames indicates an expected call of AppendStreamFrames.
-func (mr *MockFrameSourceMockRecorder) AppendStreamFrames(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockFrameSourceMockRecorder) AppendStreamFrames(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendStreamFrames", reflect.TypeOf((*MockFrameSource)(nil).AppendStreamFrames), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendStreamFrames", reflect.TypeOf((*MockFrameSource)(nil).AppendStreamFrames), arg0, arg1, arg2)
 }
 
 // HasData mocks base method.

--- a/mock_packer_test.go
+++ b/mock_packer_test.go
@@ -51,69 +51,69 @@ func (mr *MockPackerMockRecorder) HandleTransportParameters(arg0 interface{}) *g
 }
 
 // MaybePackProbePacket mocks base method.
-func (m *MockPacker) MaybePackProbePacket(arg0 protocol.EncryptionLevel) (*coalescedPacket, error) {
+func (m *MockPacker) MaybePackProbePacket(arg0 protocol.EncryptionLevel, arg1 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MaybePackProbePacket", arg0)
+	ret := m.ctrl.Call(m, "MaybePackProbePacket", arg0, arg1)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MaybePackProbePacket indicates an expected call of MaybePackProbePacket.
-func (mr *MockPackerMockRecorder) MaybePackProbePacket(arg0 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) MaybePackProbePacket(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybePackProbePacket", reflect.TypeOf((*MockPacker)(nil).MaybePackProbePacket), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybePackProbePacket", reflect.TypeOf((*MockPacker)(nil).MaybePackProbePacket), arg0, arg1)
 }
 
 // PackApplicationClose mocks base method.
-func (m *MockPacker) PackApplicationClose(arg0 *qerr.ApplicationError) (*coalescedPacket, error) {
+func (m *MockPacker) PackApplicationClose(arg0 *qerr.ApplicationError, arg1 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackApplicationClose", arg0)
+	ret := m.ctrl.Call(m, "PackApplicationClose", arg0, arg1)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackApplicationClose indicates an expected call of PackApplicationClose.
-func (mr *MockPackerMockRecorder) PackApplicationClose(arg0 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackApplicationClose(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackApplicationClose", reflect.TypeOf((*MockPacker)(nil).PackApplicationClose), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackApplicationClose", reflect.TypeOf((*MockPacker)(nil).PackApplicationClose), arg0, arg1)
 }
 
 // PackCoalescedPacket mocks base method.
-func (m *MockPacker) PackCoalescedPacket(onlyAck bool) (*coalescedPacket, error) {
+func (m *MockPacker) PackCoalescedPacket(onlyAck bool, v protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackCoalescedPacket", onlyAck)
+	ret := m.ctrl.Call(m, "PackCoalescedPacket", onlyAck, v)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackCoalescedPacket indicates an expected call of PackCoalescedPacket.
-func (mr *MockPackerMockRecorder) PackCoalescedPacket(onlyAck interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackCoalescedPacket(onlyAck, v interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackCoalescedPacket", reflect.TypeOf((*MockPacker)(nil).PackCoalescedPacket), onlyAck)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackCoalescedPacket", reflect.TypeOf((*MockPacker)(nil).PackCoalescedPacket), onlyAck, v)
 }
 
 // PackConnectionClose mocks base method.
-func (m *MockPacker) PackConnectionClose(arg0 *qerr.TransportError) (*coalescedPacket, error) {
+func (m *MockPacker) PackConnectionClose(arg0 *qerr.TransportError, arg1 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackConnectionClose", arg0)
+	ret := m.ctrl.Call(m, "PackConnectionClose", arg0, arg1)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackConnectionClose indicates an expected call of PackConnectionClose.
-func (mr *MockPackerMockRecorder) PackConnectionClose(arg0 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackConnectionClose(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackConnectionClose", reflect.TypeOf((*MockPacker)(nil).PackConnectionClose), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackConnectionClose", reflect.TypeOf((*MockPacker)(nil).PackConnectionClose), arg0, arg1)
 }
 
 // PackMTUProbePacket mocks base method.
-func (m *MockPacker) PackMTUProbePacket(ping ackhandler.Frame, size protocol.ByteCount, now time.Time) (shortHeaderPacket, *packetBuffer, error) {
+func (m *MockPacker) PackMTUProbePacket(ping ackhandler.Frame, size protocol.ByteCount, now time.Time, v protocol.VersionNumber) (shortHeaderPacket, *packetBuffer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackMTUProbePacket", ping, size, now)
+	ret := m.ctrl.Call(m, "PackMTUProbePacket", ping, size, now, v)
 	ret0, _ := ret[0].(shortHeaderPacket)
 	ret1, _ := ret[1].(*packetBuffer)
 	ret2, _ := ret[2].(error)
@@ -121,15 +121,15 @@ func (m *MockPacker) PackMTUProbePacket(ping ackhandler.Frame, size protocol.Byt
 }
 
 // PackMTUProbePacket indicates an expected call of PackMTUProbePacket.
-func (mr *MockPackerMockRecorder) PackMTUProbePacket(ping, size, now interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackMTUProbePacket(ping, size, now, v interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackMTUProbePacket", reflect.TypeOf((*MockPacker)(nil).PackMTUProbePacket), ping, size, now)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackMTUProbePacket", reflect.TypeOf((*MockPacker)(nil).PackMTUProbePacket), ping, size, now, v)
 }
 
 // PackPacket mocks base method.
-func (m *MockPacker) PackPacket(onlyAck bool, now time.Time) (shortHeaderPacket, *packetBuffer, error) {
+func (m *MockPacker) PackPacket(onlyAck bool, now time.Time, v protocol.VersionNumber) (shortHeaderPacket, *packetBuffer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackPacket", onlyAck, now)
+	ret := m.ctrl.Call(m, "PackPacket", onlyAck, now, v)
 	ret0, _ := ret[0].(shortHeaderPacket)
 	ret1, _ := ret[1].(*packetBuffer)
 	ret2, _ := ret[2].(error)
@@ -137,9 +137,9 @@ func (m *MockPacker) PackPacket(onlyAck bool, now time.Time) (shortHeaderPacket,
 }
 
 // PackPacket indicates an expected call of PackPacket.
-func (mr *MockPackerMockRecorder) PackPacket(onlyAck, now interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackPacket(onlyAck, now, v interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackPacket", reflect.TypeOf((*MockPacker)(nil).PackPacket), onlyAck, now)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackPacket", reflect.TypeOf((*MockPacker)(nil).PackPacket), onlyAck, now, v)
 }
 
 // SetMaxPacketSize mocks base method.

--- a/mock_send_stream_internal_test.go
+++ b/mock_send_stream_internal_test.go
@@ -160,18 +160,18 @@ func (mr *MockSendStreamIMockRecorder) hasData() *gomock.Call {
 }
 
 // popStreamFrame mocks base method.
-func (m *MockSendStreamI) popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Frame, bool) {
+func (m *MockSendStreamI) popStreamFrame(maxBytes protocol.ByteCount, v protocol.VersionNumber) (*ackhandler.Frame, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "popStreamFrame", maxBytes)
+	ret := m.ctrl.Call(m, "popStreamFrame", maxBytes, v)
 	ret0, _ := ret[0].(*ackhandler.Frame)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // popStreamFrame indicates an expected call of popStreamFrame.
-func (mr *MockSendStreamIMockRecorder) popStreamFrame(maxBytes interface{}) *gomock.Call {
+func (mr *MockSendStreamIMockRecorder) popStreamFrame(maxBytes, v interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockSendStreamI)(nil).popStreamFrame), maxBytes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockSendStreamI)(nil).popStreamFrame), maxBytes, v)
 }
 
 // updateSendWindow mocks base method.

--- a/mock_stream_internal_test.go
+++ b/mock_stream_internal_test.go
@@ -257,18 +257,18 @@ func (mr *MockStreamIMockRecorder) hasData() *gomock.Call {
 }
 
 // popStreamFrame mocks base method.
-func (m *MockStreamI) popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Frame, bool) {
+func (m *MockStreamI) popStreamFrame(maxBytes protocol.ByteCount, v protocol.VersionNumber) (*ackhandler.Frame, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "popStreamFrame", maxBytes)
+	ret := m.ctrl.Call(m, "popStreamFrame", maxBytes, v)
 	ret0, _ := ret[0].(*ackhandler.Frame)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // popStreamFrame indicates an expected call of popStreamFrame.
-func (mr *MockStreamIMockRecorder) popStreamFrame(maxBytes interface{}) *gomock.Call {
+func (mr *MockStreamIMockRecorder) popStreamFrame(maxBytes, v interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockStreamI)(nil).popStreamFrame), maxBytes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockStreamI)(nil).popStreamFrame), maxBytes, v)
 }
 
 // updateSendWindow mocks base method.

--- a/mock_unpacker_test.go
+++ b/mock_unpacker_test.go
@@ -37,18 +37,18 @@ func (m *MockUnpacker) EXPECT() *MockUnpackerMockRecorder {
 }
 
 // UnpackLongHeader mocks base method.
-func (m *MockUnpacker) UnpackLongHeader(hdr *wire.Header, rcvTime time.Time, data []byte) (*unpackedPacket, error) {
+func (m *MockUnpacker) UnpackLongHeader(hdr *wire.Header, rcvTime time.Time, data []byte, v protocol.VersionNumber) (*unpackedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnpackLongHeader", hdr, rcvTime, data)
+	ret := m.ctrl.Call(m, "UnpackLongHeader", hdr, rcvTime, data, v)
 	ret0, _ := ret[0].(*unpackedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnpackLongHeader indicates an expected call of UnpackLongHeader.
-func (mr *MockUnpackerMockRecorder) UnpackLongHeader(hdr, rcvTime, data interface{}) *gomock.Call {
+func (mr *MockUnpackerMockRecorder) UnpackLongHeader(hdr, rcvTime, data, v interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpackLongHeader", reflect.TypeOf((*MockUnpacker)(nil).UnpackLongHeader), hdr, rcvTime, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpackLongHeader", reflect.TypeOf((*MockUnpacker)(nil).UnpackLongHeader), hdr, rcvTime, data, v)
 }
 
 // UnpackShortHeader mocks base method.

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -569,9 +569,9 @@ func (p *packetPacker) maybeGetCryptoPacket(maxPacketSize protocol.ByteCount, en
 			//nolint:exhaustive // 0-RTT packets can't contain any retransmission.s
 			switch encLevel {
 			case protocol.EncryptionInitial:
-				f = p.retransmissionQueue.GetInitialFrame(maxPacketSize)
+				f = p.retransmissionQueue.GetInitialFrame(maxPacketSize, p.version)
 			case protocol.EncryptionHandshake:
-				f = p.retransmissionQueue.GetHandshakeFrame(maxPacketSize)
+				f = p.retransmissionQueue.GetHandshakeFrame(maxPacketSize, p.version)
 			}
 			if f == nil {
 				break
@@ -683,7 +683,7 @@ func (p *packetPacker) composeNextPacket(maxFrameSize protocol.ByteCount, onlyAc
 			if remainingLen < protocol.MinStreamFrameSize {
 				break
 			}
-			f := p.retransmissionQueue.GetAppDataFrame(remainingLen)
+			f := p.retransmissionQueue.GetAppDataFrame(remainingLen, p.version)
 			if f == nil {
 				break
 			}

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -143,8 +143,8 @@ type sealingManager interface {
 
 type frameSource interface {
 	HasData() bool
-	AppendStreamFrames([]*ackhandler.Frame, protocol.ByteCount) ([]*ackhandler.Frame, protocol.ByteCount)
-	AppendControlFrames([]*ackhandler.Frame, protocol.ByteCount) ([]*ackhandler.Frame, protocol.ByteCount)
+	AppendStreamFrames([]*ackhandler.Frame, protocol.ByteCount, protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount)
+	AppendControlFrames([]*ackhandler.Frame, protocol.ByteCount, protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount)
 }
 
 type ackFrameSource interface {
@@ -681,10 +681,10 @@ func (p *packetPacker) composeNextPacket(maxFrameSize protocol.ByteCount, onlyAc
 
 	if hasData {
 		var lengthAdded protocol.ByteCount
-		pl.frames, lengthAdded = p.framer.AppendControlFrames(pl.frames, maxFrameSize-pl.length)
+		pl.frames, lengthAdded = p.framer.AppendControlFrames(pl.frames, maxFrameSize-pl.length, v)
 		pl.length += lengthAdded
 
-		pl.frames, lengthAdded = p.framer.AppendStreamFrames(pl.frames, maxFrameSize-pl.length)
+		pl.frames, lengthAdded = p.framer.AppendStreamFrames(pl.frames, maxFrameSize-pl.length, v)
 		pl.length += lengthAdded
 	}
 	return pl

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -672,8 +672,8 @@ var _ = Describe("Packet packer", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(secondPayloadByte).To(Equal(byte(0)))
 				// ... followed by the PING
-				frameParser := wire.NewFrameParser(false, packer.version)
-				l, frame, err := frameParser.ParseNext(data[len(data)-r.Len():], protocol.Encryption1RTT)
+				frameParser := wire.NewFrameParser(false)
+				l, frame, err := frameParser.ParseNext(data[len(data)-r.Len():], protocol.Encryption1RTT, packer.version)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(frame).To(BeAssignableToTypeOf(&wire.PingFrame{}))
 				Expect(r.Len() - l).To(Equal(sealer.Overhead()))
@@ -708,8 +708,8 @@ var _ = Describe("Packet packer", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(firstPayloadByte).To(Equal(byte(0)))
 				// ... followed by the STREAM frame
-				frameParser := wire.NewFrameParser(true, packer.version)
-				l, frame, err := frameParser.ParseNext(buffer.Data[len(data)-r.Len():], protocol.Encryption1RTT)
+				frameParser := wire.NewFrameParser(true)
+				l, frame, err := frameParser.ParseNext(buffer.Data[len(data)-r.Len():], protocol.Encryption1RTT, packer.version)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(frame).To(BeAssignableToTypeOf(&wire.StreamFrame{}))
 				sf := frame.(*wire.StreamFrame)
@@ -1268,8 +1268,8 @@ var _ = Describe("Packet packer", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(secondPayloadByte).To(Equal(byte(0)))
 				// ... followed by the PING
-				frameParser := wire.NewFrameParser(false, packer.version)
-				l, frame, err := frameParser.ParseNext(data[len(data)-r.Len():], protocol.Encryption1RTT)
+				frameParser := wire.NewFrameParser(false)
+				l, frame, err := frameParser.ParseNext(data[len(data)-r.Len():], protocol.Encryption1RTT, packer.version)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(frame).To(BeAssignableToTypeOf(&wire.PingFrame{}))
 				Expect(r.Len() - l).To(Equal(sealer.Overhead()))

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Packet packer", func() {
 
 	BeforeEach(func() {
 		rand.Seed(GinkgoRandomSeed())
-		retransmissionQueue = newRetransmissionQueue(version)
+		retransmissionQueue = newRetransmissionQueue()
 		mockSender := NewMockStreamSender(mockCtrl)
 		mockSender.EXPECT().onHasStreamData(gomock.Any()).AnyTimes()
 		initialStream = NewMockCryptoStream(mockCtrl)
@@ -1593,7 +1593,7 @@ var _ = Describe("Converting to ackhandler.Packet", func() {
 					{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) { pingLost = true }},
 				},
 			}
-			p := packet.ToAckHandlerPacket(time.Now(), newRetransmissionQueue(protocol.VersionTLS))
+			p := packet.ToAckHandlerPacket(time.Now(), newRetransmissionQueue())
 			Expect(p.Frames).To(HaveLen(2))
 			Expect(p.Frames[0].OnLost).ToNot(BeNil())
 			p.Frames[1].OnLost(nil)

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 var _ = Describe("Packet Unpacker", func() {
-	const version = protocol.VersionTLS
-
 	var (
 		unpacker *packetUnpacker
 		cs       *mocks.MockCryptoSetup
@@ -26,7 +24,7 @@ var _ = Describe("Packet Unpacker", func() {
 	)
 
 	getLongHeader := func(extHdr *wire.ExtendedHeader) (*wire.Header, []byte) {
-		b, err := extHdr.Append(nil, version)
+		b, err := extHdr.Append(nil, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		hdrLen := len(b)
@@ -46,7 +44,7 @@ var _ = Describe("Packet Unpacker", func() {
 
 	BeforeEach(func() {
 		cs = mocks.NewMockCryptoSetup(mockCtrl)
-		unpacker = newPacketUnpacker(cs, 4, version).(*packetUnpacker)
+		unpacker = newPacketUnpacker(cs, 4)
 	})
 
 	It("errors when the packet is too small to obtain the header decryption sample, for long headers", func() {
@@ -54,7 +52,7 @@ var _ = Describe("Packet Unpacker", func() {
 			Header: wire.Header{
 				Type:             protocol.PacketTypeHandshake,
 				DestConnectionID: connID,
-				Version:          version,
+				Version:          protocol.Version1,
 			},
 			PacketNumber:    1337,
 			PacketNumberLen: protocol.PacketNumberLen2,
@@ -63,7 +61,7 @@ var _ = Describe("Packet Unpacker", func() {
 		data := append(hdrRaw, make([]byte, 2 /* fill up packet number */ +15 /* need 16 bytes */)...)
 		opener := mocks.NewMockLongHeaderOpener(mockCtrl)
 		cs.EXPECT().GetHandshakeOpener().Return(opener, nil)
-		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), data)
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), data, protocol.Version1)
 		Expect(err).To(BeAssignableToTypeOf(&headerParseError{}))
 		var headerErr *headerParseError
 		Expect(errors.As(err, &headerErr)).To(BeTrue())
@@ -87,7 +85,7 @@ var _ = Describe("Packet Unpacker", func() {
 				Type:             protocol.PacketTypeInitial,
 				Length:           3 + 6, // packet number len + payload
 				DestConnectionID: connID,
-				Version:          version,
+				Version:          protocol.Version1,
 			},
 			PacketNumber:    2,
 			PacketNumberLen: 3,
@@ -100,7 +98,7 @@ var _ = Describe("Packet Unpacker", func() {
 			opener.EXPECT().DecodePacketNumber(protocol.PacketNumber(2), protocol.PacketNumberLen3).Return(protocol.PacketNumber(1234)),
 			opener.EXPECT().Open(gomock.Any(), payload, protocol.PacketNumber(1234), hdrRaw).Return([]byte("decrypted"), nil),
 		)
-		packet, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
+		packet, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...), protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(packet.encryptionLevel).To(Equal(protocol.EncryptionInitial))
 		Expect(packet.data).To(Equal([]byte("decrypted")))
@@ -112,7 +110,7 @@ var _ = Describe("Packet Unpacker", func() {
 				Type:             protocol.PacketType0RTT,
 				Length:           3 + 6, // packet number len + payload
 				DestConnectionID: connID,
-				Version:          version,
+				Version:          protocol.Version1,
 			},
 			PacketNumber:    20,
 			PacketNumberLen: 2,
@@ -125,7 +123,7 @@ var _ = Describe("Packet Unpacker", func() {
 			opener.EXPECT().DecodePacketNumber(protocol.PacketNumber(20), protocol.PacketNumberLen2).Return(protocol.PacketNumber(321)),
 			opener.EXPECT().Open(gomock.Any(), payload, protocol.PacketNumber(321), hdrRaw).Return([]byte("decrypted"), nil),
 		)
-		packet, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
+		packet, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...), protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(packet.encryptionLevel).To(Equal(protocol.Encryption0RTT))
 		Expect(packet.data).To(Equal([]byte("decrypted")))
@@ -174,7 +172,7 @@ var _ = Describe("Packet Unpacker", func() {
 			opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any()).Return(protocol.PacketNumber(321)),
 			opener.EXPECT().Open(gomock.Any(), payload, protocol.PacketNumber(321), hdrRaw).Return([]byte(""), nil),
 		)
-		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...), protocol.Version1)
 		Expect(err).To(MatchError(&qerr.TransportError{
 			ErrorCode:    qerr.ProtocolViolation,
 			ErrorMessage: "empty packet",
@@ -204,7 +202,7 @@ var _ = Describe("Packet Unpacker", func() {
 				Type:             protocol.PacketTypeHandshake,
 				Length:           3, // packet number len
 				DestConnectionID: connID,
-				Version:          version,
+				Version:          protocol.Version1,
 			},
 			PacketNumber:    2,
 			PacketNumberLen: 3,
@@ -216,7 +214,7 @@ var _ = Describe("Packet Unpacker", func() {
 		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any())
 		unpackErr := &qerr.TransportError{ErrorCode: qerr.CryptoBufferExceeded}
 		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, unpackErr)
-		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...), protocol.Version1)
 		Expect(err).To(MatchError(unpackErr))
 	})
 
@@ -225,7 +223,7 @@ var _ = Describe("Packet Unpacker", func() {
 			Header: wire.Header{
 				Type:             protocol.PacketTypeHandshake,
 				DestConnectionID: connID,
-				Version:          version,
+				Version:          protocol.Version1,
 			},
 			PacketNumber:    0x1337,
 			PacketNumberLen: 2,
@@ -237,7 +235,7 @@ var _ = Describe("Packet Unpacker", func() {
 		cs.EXPECT().GetHandshakeOpener().Return(opener, nil)
 		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any())
 		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte("payload"), nil)
-		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...), protocol.Version1)
 		Expect(err).To(MatchError(wire.ErrInvalidReservedBits))
 	})
 
@@ -258,7 +256,7 @@ var _ = Describe("Packet Unpacker", func() {
 			Header: wire.Header{
 				Type:             protocol.PacketTypeHandshake,
 				DestConnectionID: connID,
-				Version:          version,
+				Version:          protocol.Version1,
 			},
 			PacketNumber:    0x1337,
 			PacketNumberLen: 2,
@@ -270,7 +268,7 @@ var _ = Describe("Packet Unpacker", func() {
 		cs.EXPECT().GetHandshakeOpener().Return(opener, nil)
 		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any())
 		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, handshake.ErrDecryptionFailed)
-		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...))
+		_, err := unpacker.UnpackLongHeader(hdr, time.Now(), append(hdrRaw, payload...), protocol.Version1)
 		Expect(err).To(MatchError(handshake.ErrDecryptionFailed))
 	})
 
@@ -292,7 +290,7 @@ var _ = Describe("Packet Unpacker", func() {
 				Type:             protocol.PacketTypeHandshake,
 				Length:           3, // packet number len
 				DestConnectionID: connID,
-				Version:          version,
+				Version:          protocol.Version1,
 			},
 			PacketNumber:    0x1337,
 			PacketNumberLen: 2,
@@ -324,7 +322,7 @@ var _ = Describe("Packet Unpacker", func() {
 		for i := 1; i <= 100; i++ {
 			data = append(data, uint8(i))
 		}
-		packet, err := unpacker.UnpackLongHeader(hdr, time.Now(), data)
+		packet, err := unpacker.UnpackLongHeader(hdr, time.Now(), data, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(packet.hdr.PacketNumber).To(Equal(protocol.PacketNumber(0x7331)))
 	})

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -51,7 +51,6 @@ type receiveStream struct {
 	deadline time.Time
 
 	flowController flowcontrol.StreamFlowController
-	version        protocol.VersionNumber
 }
 
 var (
@@ -63,7 +62,6 @@ func newReceiveStream(
 	streamID protocol.StreamID,
 	sender streamSender,
 	flowController flowcontrol.StreamFlowController,
-	version protocol.VersionNumber,
 ) *receiveStream {
 	return &receiveStream{
 		streamID:       streamID,
@@ -73,7 +71,6 @@ func newReceiveStream(
 		readChan:       make(chan struct{}, 1),
 		readOnce:       make(chan struct{}, 1),
 		finalOffset:    protocol.MaxByteCount,
-		version:        version,
 	}
 }
 

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Receive Stream", func() {
 	BeforeEach(func() {
 		mockSender = NewMockStreamSender(mockCtrl)
 		mockFC = mocks.NewMockStreamFlowController(mockCtrl)
-		str = newReceiveStream(streamID, mockSender, mockFC, protocol.VersionWhatever)
+		str = newReceiveStream(streamID, mockSender, mockFC)
 
 		timeout := scaleDuration(250 * time.Millisecond)
 		strWithTimeout = gbytes.TimeoutReader(str, timeout)

--- a/send_stream.go
+++ b/send_stream.go
@@ -18,7 +18,7 @@ type sendStreamI interface {
 	SendStream
 	handleStopSendingFrame(*wire.StopSendingFrame)
 	hasData() bool
-	popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Frame, bool)
+	popStreamFrame(maxBytes protocol.ByteCount, v protocol.VersionNumber) (*ackhandler.Frame, bool)
 	closeForShutdown(error)
 	updateSendWindow(protocol.ByteCount)
 }
@@ -54,8 +54,6 @@ type sendStream struct {
 	deadline  time.Time
 
 	flowController flowcontrol.StreamFlowController
-
-	version protocol.VersionNumber
 }
 
 var (
@@ -67,7 +65,6 @@ func newSendStream(
 	streamID protocol.StreamID,
 	sender streamSender,
 	flowController flowcontrol.StreamFlowController,
-	version protocol.VersionNumber,
 ) *sendStream {
 	s := &sendStream{
 		streamID:       streamID,
@@ -75,7 +72,6 @@ func newSendStream(
 		flowController: flowController,
 		writeChan:      make(chan struct{}, 1),
 		writeOnce:      make(chan struct{}, 1), // cap: 1, to protect against concurrent use of Write
-		version:        version,
 	}
 	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
 	return s
@@ -204,9 +200,9 @@ func (s *sendStream) canBufferStreamFrame() bool {
 
 // popStreamFrame returns the next STREAM frame that is supposed to be sent on this stream
 // maxBytes is the maximum length this frame (including frame header) will have.
-func (s *sendStream) popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Frame, bool /* has more data to send */) {
+func (s *sendStream) popStreamFrame(maxBytes protocol.ByteCount, v protocol.VersionNumber) (*ackhandler.Frame, bool /* has more data to send */) {
 	s.mutex.Lock()
-	f, hasMoreData := s.popNewOrRetransmittedStreamFrame(maxBytes)
+	f, hasMoreData := s.popNewOrRetransmittedStreamFrame(maxBytes, v)
 	if f != nil {
 		s.numOutstandingFrames++
 	}
@@ -222,13 +218,13 @@ func (s *sendStream) popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Fr
 	return af, hasMoreData
 }
 
-func (s *sendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCount) (*wire.StreamFrame, bool /* has more data to send */) {
+func (s *sendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCount, v protocol.VersionNumber) (*wire.StreamFrame, bool /* has more data to send */) {
 	if s.canceledWrite || s.closeForShutdownErr != nil {
 		return nil, false
 	}
 
 	if len(s.retransmissionQueue) > 0 {
-		f, hasMoreRetransmissions := s.maybeGetRetransmission(maxBytes)
+		f, hasMoreRetransmissions := s.maybeGetRetransmission(maxBytes, v)
 		if f != nil || hasMoreRetransmissions {
 			if f == nil {
 				return nil, true
@@ -264,7 +260,7 @@ func (s *sendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 		return nil, true
 	}
 
-	f, hasMoreData := s.popNewStreamFrame(maxBytes, sendWindow)
+	f, hasMoreData := s.popNewStreamFrame(maxBytes, sendWindow, v)
 	if dataLen := f.DataLen(); dataLen > 0 {
 		s.writeOffset += f.DataLen()
 		s.flowController.AddBytesSent(f.DataLen())
@@ -276,12 +272,12 @@ func (s *sendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 	return f, hasMoreData
 }
 
-func (s *sendStream) popNewStreamFrame(maxBytes, sendWindow protocol.ByteCount) (*wire.StreamFrame, bool) {
+func (s *sendStream) popNewStreamFrame(maxBytes, sendWindow protocol.ByteCount, v protocol.VersionNumber) (*wire.StreamFrame, bool) {
 	if s.nextFrame != nil {
 		nextFrame := s.nextFrame
 		s.nextFrame = nil
 
-		maxDataLen := utils.Min(sendWindow, nextFrame.MaxDataLen(maxBytes, s.version))
+		maxDataLen := utils.Min(sendWindow, nextFrame.MaxDataLen(maxBytes, v))
 		if nextFrame.DataLen() > maxDataLen {
 			s.nextFrame = wire.GetStreamFrame()
 			s.nextFrame.StreamID = s.streamID
@@ -303,7 +299,7 @@ func (s *sendStream) popNewStreamFrame(maxBytes, sendWindow protocol.ByteCount) 
 	f.DataLenPresent = true
 	f.Data = f.Data[:0]
 
-	hasMoreData := s.popNewStreamFrameWithoutBuffer(f, maxBytes, sendWindow)
+	hasMoreData := s.popNewStreamFrameWithoutBuffer(f, maxBytes, sendWindow, v)
 	if len(f.Data) == 0 && !f.Fin {
 		f.PutBack()
 		return nil, hasMoreData
@@ -311,8 +307,8 @@ func (s *sendStream) popNewStreamFrame(maxBytes, sendWindow protocol.ByteCount) 
 	return f, hasMoreData
 }
 
-func (s *sendStream) popNewStreamFrameWithoutBuffer(f *wire.StreamFrame, maxBytes, sendWindow protocol.ByteCount) bool {
-	maxDataLen := f.MaxDataLen(maxBytes, s.version)
+func (s *sendStream) popNewStreamFrameWithoutBuffer(f *wire.StreamFrame, maxBytes, sendWindow protocol.ByteCount, v protocol.VersionNumber) bool {
+	maxDataLen := f.MaxDataLen(maxBytes, v)
 	if maxDataLen == 0 { // a STREAM frame must have at least one byte of data
 		return s.dataForWriting != nil || s.nextFrame != nil || s.finishedWriting
 	}
@@ -321,9 +317,9 @@ func (s *sendStream) popNewStreamFrameWithoutBuffer(f *wire.StreamFrame, maxByte
 	return s.dataForWriting != nil || s.nextFrame != nil || s.finishedWriting
 }
 
-func (s *sendStream) maybeGetRetransmission(maxBytes protocol.ByteCount) (*wire.StreamFrame, bool /* has more retransmissions */) {
+func (s *sendStream) maybeGetRetransmission(maxBytes protocol.ByteCount, v protocol.VersionNumber) (*wire.StreamFrame, bool /* has more retransmissions */) {
 	f := s.retransmissionQueue[0]
-	newFrame, needsSplit := f.MaybeSplitOffFrame(maxBytes, s.version)
+	newFrame, needsSplit := f.MaybeSplitOffFrame(maxBytes, v)
 	if needsSplit {
 		return newFrame, true
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -743,7 +743,7 @@ var _ = Describe("Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				data, err := opener.Open(nil, b[extHdr.ParsedLen():], extHdr.PacketNumber, b[:extHdr.ParsedLen()])
 				Expect(err).ToNot(HaveOccurred())
-				_, f, err := wire.NewFrameParser(false, origHdr.Version).ParseNext(data, protocol.EncryptionInitial)
+				_, f, err := wire.NewFrameParser(false).ParseNext(data, protocol.EncryptionInitial, origHdr.Version)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(f).To(BeAssignableToTypeOf(&wire.ConnectionCloseFrame{}))
 				ccf := f.(*wire.ConnectionCloseFrame)

--- a/stream.go
+++ b/stream.go
@@ -60,7 +60,7 @@ type streamI interface {
 	// for sending
 	hasData() bool
 	handleStopSendingFrame(*wire.StopSendingFrame)
-	popStreamFrame(maxBytes protocol.ByteCount) (*ackhandler.Frame, bool)
+	popStreamFrame(maxBytes protocol.ByteCount, v protocol.VersionNumber) (*ackhandler.Frame, bool)
 	updateSendWindow(protocol.ByteCount)
 }
 
@@ -102,7 +102,7 @@ func newStream(streamID protocol.StreamID,
 			s.completedMutex.Unlock()
 		},
 	}
-	s.sendStream = *newSendStream(streamID, senderForSendStream, flowController, version)
+	s.sendStream = *newSendStream(streamID, senderForSendStream, flowController)
 	senderForReceiveStream := &uniStreamSender{
 		streamSender: sender,
 		onStreamCompletedImpl: func() {

--- a/stream.go
+++ b/stream.go
@@ -112,7 +112,7 @@ func newStream(streamID protocol.StreamID,
 			s.completedMutex.Unlock()
 		},
 	}
-	s.receiveStream = *newReceiveStream(streamID, senderForReceiveStream, flowController, version)
+	s.receiveStream = *newReceiveStream(streamID, senderForReceiveStream, flowController)
 	return s
 }
 

--- a/stream.go
+++ b/stream.go
@@ -80,8 +80,6 @@ type stream struct {
 	sender                 streamSender
 	receiveStreamCompleted bool
 	sendStreamCompleted    bool
-
-	version protocol.VersionNumber
 }
 
 var _ Stream = &stream{}
@@ -90,9 +88,8 @@ var _ Stream = &stream{}
 func newStream(streamID protocol.StreamID,
 	sender streamSender,
 	flowController flowcontrol.StreamFlowController,
-	version protocol.VersionNumber,
 ) *stream {
-	s := &stream{sender: sender, version: version}
+	s := &stream{sender: sender}
 	senderForSendStream := &uniStreamSender{
 		streamSender: sender,
 		onStreamCompletedImpl: func() {

--- a/stream_test.go
+++ b/stream_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Stream", func() {
 	BeforeEach(func() {
 		mockSender = NewMockStreamSender(mockCtrl)
 		mockFC = mocks.NewMockStreamFlowController(mockCtrl)
-		str = newStream(streamID, mockSender, mockFC, protocol.VersionWhatever)
+		str = newStream(streamID, mockSender, mockFC)
 
 		timeout := scaleDuration(250 * time.Millisecond)
 		strWithTimeout = struct {

--- a/streams_map.go
+++ b/streams_map.go
@@ -89,7 +89,7 @@ func (m *streamsMap) initMaps() {
 		protocol.StreamTypeBidi,
 		func(num protocol.StreamNum) streamI {
 			id := num.StreamID(protocol.StreamTypeBidi, m.perspective)
-			return newStream(id, m.sender, m.newFlowController(id), m.version)
+			return newStream(id, m.sender, m.newFlowController(id))
 		},
 		m.sender.queueControlFrame,
 	)
@@ -97,7 +97,7 @@ func (m *streamsMap) initMaps() {
 		protocol.StreamTypeBidi,
 		func(num protocol.StreamNum) streamI {
 			id := num.StreamID(protocol.StreamTypeBidi, m.perspective.Opposite())
-			return newStream(id, m.sender, m.newFlowController(id), m.version)
+			return newStream(id, m.sender, m.newFlowController(id))
 		},
 		m.maxIncomingBidiStreams,
 		m.sender.queueControlFrame,

--- a/streams_map.go
+++ b/streams_map.go
@@ -106,7 +106,7 @@ func (m *streamsMap) initMaps() {
 		protocol.StreamTypeUni,
 		func(num protocol.StreamNum) sendStreamI {
 			id := num.StreamID(protocol.StreamTypeUni, m.perspective)
-			return newSendStream(id, m.sender, m.newFlowController(id), m.version)
+			return newSendStream(id, m.sender, m.newFlowController(id))
 		},
 		m.sender.queueControlFrame,
 	)

--- a/streams_map.go
+++ b/streams_map.go
@@ -46,7 +46,6 @@ var errTooManyOpenStreams = errors.New("too many open streams")
 
 type streamsMap struct {
 	perspective protocol.Perspective
-	version     protocol.VersionNumber
 
 	maxIncomingBidiStreams uint64
 	maxIncomingUniStreams  uint64
@@ -70,7 +69,6 @@ func newStreamsMap(
 	maxIncomingBidiStreams uint64,
 	maxIncomingUniStreams uint64,
 	perspective protocol.Perspective,
-	version protocol.VersionNumber,
 ) streamManager {
 	m := &streamsMap{
 		perspective:            perspective,
@@ -78,7 +76,6 @@ func newStreamsMap(
 		maxIncomingBidiStreams: maxIncomingBidiStreams,
 		maxIncomingUniStreams:  maxIncomingUniStreams,
 		sender:                 sender,
-		version:                version,
 	}
 	m.initMaps()
 	return m

--- a/streams_map.go
+++ b/streams_map.go
@@ -114,7 +114,7 @@ func (m *streamsMap) initMaps() {
 		protocol.StreamTypeUni,
 		func(num protocol.StreamNum) receiveStreamI {
 			id := num.StreamID(protocol.StreamTypeUni, m.perspective.Opposite())
-			return newReceiveStream(id, m.sender, m.newFlowController(id), m.version)
+			return newReceiveStream(id, m.sender, m.newFlowController(id))
 		},
 		m.maxIncomingUniStreams,
 		m.sender.queueControlFrame,

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -42,9 +42,9 @@ var _ = Describe("Streams Map (incoming)", func() {
 
 	// check that the frame can be serialized and deserialized
 	checkFrameSerialization := func(f wire.Frame) {
-		b, err := f.Append(nil, protocol.VersionTLS)
+		b, err := f.Append(nil, protocol.Version1)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		_, frame, err := wire.NewFrameParser(false, protocol.VersionTLS).ParseNext(b, protocol.Encryption1RTT)
+		_, frame, err := wire.NewFrameParser(false).ParseNext(b, protocol.Encryption1RTT, protocol.Version1)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		Expect(f).To(Equal(frame))
 	}

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Streams Map", func() {
 
 			BeforeEach(func() {
 				mockSender = NewMockStreamSender(mockCtrl)
-				m = newStreamsMap(mockSender, newFlowController, MaxBidiStreamNum, MaxUniStreamNum, perspective, protocol.VersionWhatever).(*streamsMap)
+				m = newStreamsMap(mockSender, newFlowController, MaxBidiStreamNum, MaxUniStreamNum, perspective).(*streamsMap)
 			})
 
 			Context("opening", func() {


### PR DESCRIPTION
When doing a compatible version upgrade (see #3640), the version of the connection will change during the handshake. It's cleaner if we don't save the version with every helper struct, but pass it as a function arguments.

This is also expected to be slightly faster, since arguments are passed on the stack. It definitely reduces the memory size of a bunch of structs.

The only place where we can't simply do this is the crypto setup, as the AEADs are version dependent. The crypto setup will most likely gain a new method `UpdateVersion` or so.