### PR TITLE
feat: add zero-copy connection support

### DIFF
--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -26,20 +26,16 @@ type packetBufferPool struct {
 }
 
 func (p *packetBufferPool) getPacketBuffer() *packetBuffer {
-	var data []byte
-	var tag int
+	packet := packetPool.Get().(*packetBuffer)
+	packet.refCount = 1
 
 	if p == nil {
-		data = defaultPacketBufferPool.Get().([]byte)
+		packet.Data = defaultPacketBufferPool.Get().([]byte)
+		packet.Tag = -1
 	} else {
-		data, tag = p.pool.New(int(protocol.MaxPacketBufferSize))
+		packet.Data, packet.Tag = p.pool.New(int(protocol.MaxPacketBufferSize))
+		packet.pool = p.pool
 	}
-
-	packet := packetPool.Get().(*packetBuffer)
-	packet.pool = p.pool
-	packet.Tag = tag
-	packet.Data = data
-	packet.refCount = 1
 
 	return packet
 }
@@ -115,6 +111,6 @@ func init() {
 	}
 
 	defaultPacketBufferPool.New = func() interface{} {
-		return make([]byte, int(protocol.MaxPacketBufferSize))
+		return make([]byte, 0, int(protocol.MaxPacketBufferSize))
 	}
 }

--- a/buffer_pool_test.go
+++ b/buffer_pool_test.go
@@ -7,6 +7,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func getPacketBuffer() *packetBuffer {
+	var pool *packetBufferPool
+
+	return pool.getPacketBuffer()
+}
+
 var _ = Describe("Buffer Pool", func() {
 	It("returns buffers of cap", func() {
 		buf := getPacketBuffer()

--- a/client.go
+++ b/client.go
@@ -13,6 +13,8 @@ import (
 )
 
 type client struct {
+	pool *packetBufferPool
+
 	sconn sendConn
 	// If the client is created with DialAddr, we create a packet conn.
 	// If it is started with Dial, we take a packet conn as a parameter.
@@ -276,6 +278,7 @@ func (c *client) dial(ctx context.Context) error {
 	c.logger.Infof("Starting new connection to %s (%s -> %s), source connection ID %s, destination connection ID %s, version %s", c.tlsConf.ServerName, c.sconn.LocalAddr(), c.sconn.RemoteAddr(), c.srcConnID, c.destConnID, c.version)
 
 	c.conn = newClientConnection(
+		c.pool,
 		c.sconn,
 		c.packetHandlers,
 		c.destConnID,

--- a/client_test.go
+++ b/client_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Client", func() {
 		config          *Config
 
 		originalClientConnConstructor func(
+			pool *packetBufferPool,
 			conn sendConn,
 			runner connRunner,
 			destConnID protocol.ConnectionID,
@@ -113,6 +114,7 @@ var _ = Describe("Client", func() {
 
 			remoteAddrChan := make(chan string, 1)
 			newClientConnection = func(
+				_ *packetBufferPool,
 				sconn sendConn,
 				_ connRunner,
 				_ protocol.ConnectionID,
@@ -146,6 +148,7 @@ var _ = Describe("Client", func() {
 
 			hostnameChan := make(chan string, 1)
 			newClientConnection = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				_ connRunner,
 				_ protocol.ConnectionID,
@@ -179,6 +182,7 @@ var _ = Describe("Client", func() {
 
 			hostnameChan := make(chan string, 1)
 			newClientConnection = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				_ connRunner,
 				_ protocol.ConnectionID,
@@ -218,6 +222,7 @@ var _ = Describe("Client", func() {
 
 			run := make(chan struct{})
 			newClientConnection = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				runner connRunner,
 				_ protocol.ConnectionID,
@@ -261,6 +266,7 @@ var _ = Describe("Client", func() {
 			readyChan := make(chan struct{})
 			done := make(chan struct{})
 			newClientConnection = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				runner connRunner,
 				_ protocol.ConnectionID,
@@ -309,6 +315,7 @@ var _ = Describe("Client", func() {
 
 			testErr := errors.New("early handshake error")
 			newClientConnection = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				_ connRunner,
 				_ protocol.ConnectionID,
@@ -352,6 +359,7 @@ var _ = Describe("Client", func() {
 			})
 			conn.EXPECT().HandshakeComplete().Return(context.Background())
 			newClientConnection = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				_ connRunner,
 				_ protocol.ConnectionID,
@@ -404,6 +412,7 @@ var _ = Describe("Client", func() {
 			connCreated := make(chan struct{})
 			conn := NewMockQuicConn(mockCtrl)
 			newClientConnection = func(
+				_ *packetBufferPool,
 				connP sendConn,
 				_ connRunner,
 				_ protocol.ConnectionID,
@@ -438,7 +447,7 @@ var _ = Describe("Client", func() {
 			Eventually(connCreated).Should(BeClosed())
 
 			// check that the connection is not closed
-			Expect(sconn.Write([]byte("foobar"))).To(Succeed())
+			Expect(sconn.Write([]byte("foobar"), -1)).To(Succeed())
 
 			manager.EXPECT().Destroy()
 			close(run)
@@ -525,6 +534,7 @@ var _ = Describe("Client", func() {
 			var version protocol.VersionNumber
 			var conf *Config
 			newClientConnection = func(
+				_ *packetBufferPool,
 				connP sendConn,
 				_ connRunner,
 				_ protocol.ConnectionID,
@@ -565,6 +575,7 @@ var _ = Describe("Client", func() {
 
 			var counter int
 			newClientConnection = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				_ connRunner,
 				_ protocol.ConnectionID,

--- a/connection.go
+++ b/connection.go
@@ -230,6 +230,7 @@ var (
 )
 
 var newConnection = func(
+	pool *packetBufferPool,
 	conn sendConn,
 	runner connRunner,
 	origDestConnID protocol.ConnectionID,
@@ -348,6 +349,7 @@ var newConnection = func(
 	)
 	s.cryptoStreamHandler = cs
 	s.packer = newPacketPacker(
+		pool,
 		srcConnID,
 		s.connIDManager.Get,
 		initialStream,
@@ -369,6 +371,7 @@ var newConnection = func(
 
 // declare this as a variable, such that we can it mock it in the tests
 var newClientConnection = func(
+	pool *packetBufferPool,
 	conn sendConn,
 	runner connRunner,
 	destConnID protocol.ConnectionID,
@@ -476,6 +479,7 @@ var newClientConnection = func(
 	s.cryptoStreamManager = newCryptoStreamManager(cs, initialStream, handshakeStream, newCryptoStream())
 	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen, s.version)
 	s.packer = newPacketPacker(
+		pool,
 		srcConnID,
 		s.connIDManager.Get,
 		initialStream,
@@ -1955,7 +1959,7 @@ func (s *connection) sendConnectionClose(e error) ([]byte, error) {
 		return nil, err
 	}
 	s.logCoalescedPacket(packet)
-	return packet.buffer.Data, s.conn.Write(packet.buffer.Data)
+	return packet.buffer.Data, s.conn.Write(packet.buffer.Data, packet.buffer.Tag)
 }
 
 func (s *connection) logPacketContents(p *packetContents) {

--- a/mock_send_conn_test.go
+++ b/mock_send_conn_test.go
@@ -77,15 +77,15 @@ func (mr *MockSendConnMockRecorder) RemoteAddr() *gomock.Call {
 }
 
 // Write mocks base method.
-func (m *MockSendConn) Write(arg0 []byte) error {
+func (m *MockSendConn) Write(arg0 []byte, arg1 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Write", arg0)
+	ret := m.ctrl.Call(m, "Write", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockSendConnMockRecorder) Write(arg0 interface{}) *gomock.Call {
+func (mr *MockSendConnMockRecorder) Write(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockSendConn)(nil).Write), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockSendConn)(nil).Write), arg0, arg1)
 }

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -93,6 +93,7 @@ var _ = Describe("Packet packer", func() {
 		datagramQueue = newDatagramQueue(func() {}, utils.DefaultLogger)
 
 		packer = newPacketPacker(
+			nil,
 			protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
 			func() protocol.ConnectionID { return connID },
 			initialStream,

--- a/send_conn.go
+++ b/send_conn.go
@@ -6,7 +6,7 @@ import (
 
 // A sendConn allows sending using a simple Write() on a non-connected packet conn.
 type sendConn interface {
-	Write([]byte) error
+	Write([]byte, int) error
 	Close() error
 	LocalAddr() net.Addr
 	RemoteAddr() net.Addr
@@ -31,8 +31,8 @@ func newSendConn(c rawConn, remote net.Addr, info *packetInfo) sendConn {
 	}
 }
 
-func (c *sconn) Write(p []byte) error {
-	_, err := c.WritePacket(p, c.remoteAddr, c.oob)
+func (c *sconn) Write(p []byte, tag int) error {
+	_, err := c.WritePacket(p, tag, c.remoteAddr, c.oob)
 	return err
 }
 
@@ -64,7 +64,7 @@ func newSendPconn(c net.PacketConn, remote net.Addr) sendConn {
 	return &spconn{PacketConn: c, remoteAddr: remote}
 }
 
-func (c *spconn) Write(p []byte) error {
+func (c *spconn) Write(p []byte, tag int) error {
 	_, err := c.WriteTo(p, c.remoteAddr)
 	return err
 }

--- a/send_conn_test.go
+++ b/send_conn_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Connection (for sending packets)", func() {
 
 	It("writes", func() {
 		packetConn.EXPECT().WriteTo([]byte("foobar"), addr)
-		Expect(c.Write([]byte("foobar"))).To(Succeed())
+		Expect(c.Write([]byte("foobar"), -1)).To(Succeed())
 	})
 
 	It("gets the remote address", func() {

--- a/send_queue.go
+++ b/send_queue.go
@@ -70,7 +70,7 @@ func (h *sendQueue) Run() error {
 			// make sure that all queued packets are actually sent out
 			shouldClose = true
 		case p := <-h.queue:
-			if err := h.conn.Write(p.Data); err != nil {
+			if err := h.conn.Write(p.Data, p.Tag); err != nil {
 				// This additional check enables:
 				// 1. Checking for "datagram too large" message from the kernel, as such,
 				// 2. Path MTU discovery,and

--- a/send_queue_test.go
+++ b/send_queue_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Send Queue", func() {
 		q.Send(p)
 
 		written := make(chan struct{})
-		c.EXPECT().Write([]byte("foobar")).Do(func([]byte) { close(written) })
+		c.EXPECT().Write([]byte("foobar"), gomock.Any()).Do(func([]byte) { close(written) })
 		done := make(chan struct{})
 		go func() {
 			defer GinkgoRecover()
@@ -57,7 +57,7 @@ var _ = Describe("Send Queue", func() {
 		Consistently(q.Available()).ShouldNot(Receive())
 
 		// now start sending out packets. This should free up queue space.
-		c.EXPECT().Write(gomock.Any()).MinTimes(1).MaxTimes(2)
+		c.EXPECT().Write(gomock.Any(), gomock.Any()).MinTimes(1).MaxTimes(2)
 		done := make(chan struct{})
 		go func() {
 			defer GinkgoRecover()
@@ -77,7 +77,7 @@ var _ = Describe("Send Queue", func() {
 		write := make(chan struct{}, 1)
 		written := make(chan struct{}, 100)
 		// now start sending out packets. This should free up queue space.
-		c.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) error {
+		c.EXPECT().Write(gomock.Any(), gomock.Any()).DoAndReturn(func(b []byte) error {
 			<-write
 			written <- struct{}{}
 			return nil
@@ -125,7 +125,7 @@ var _ = Describe("Send Queue", func() {
 
 		// the run loop exits if there is a write error
 		testErr := errors.New("test error")
-		c.EXPECT().Write(gomock.Any()).Return(testErr)
+		c.EXPECT().Write(gomock.Any(), gomock.Any()).Return(testErr)
 		q.Send(getPacket([]byte("foobar")))
 		Eventually(done).Should(BeClosed())
 
@@ -142,7 +142,7 @@ var _ = Describe("Send Queue", func() {
 
 	It("blocks Close() until the packet has been sent out", func() {
 		written := make(chan []byte)
-		c.EXPECT().Write(gomock.Any()).Do(func(p []byte) { written <- p })
+		c.EXPECT().Write(gomock.Any(), gomock.Any()).Do(func(p []byte) { written <- p })
 		done := make(chan struct{})
 		go func() {
 			defer GinkgoRecover()

--- a/server_test.go
+++ b/server_test.go
@@ -275,6 +275,7 @@ var _ = Describe("Server", func() {
 				tracer.EXPECT().TracerForConnection(gomock.Any(), protocol.PerspectiveServer, protocol.ParseConnectionID([]byte{0xde, 0xad, 0xc0, 0xde}))
 				conn := NewMockQuicConn(mockCtrl)
 				serv.newConn = func(
+					_ *packetBufferPool,
 					_ sendConn,
 					_ connRunner,
 					origDestConnID protocol.ConnectionID,
@@ -478,6 +479,7 @@ var _ = Describe("Server", func() {
 
 				conn := NewMockQuicConn(mockCtrl)
 				serv.newConn = func(
+					_ *packetBufferPool,
 					_ sendConn,
 					_ connRunner,
 					origDestConnID protocol.ConnectionID,
@@ -538,6 +540,7 @@ var _ = Describe("Server", func() {
 				acceptConn := make(chan struct{})
 				var counter uint32 // to be used as an atomic, so we query it in Eventually
 				serv.newConn = func(
+					_ *packetBufferPool,
 					_ sendConn,
 					runner connRunner,
 					_ protocol.ConnectionID,
@@ -592,6 +595,7 @@ var _ = Describe("Server", func() {
 				var createdConn bool
 				conn := NewMockQuicConn(mockCtrl)
 				serv.newConn = func(
+					_ *packetBufferPool,
 					_ sendConn,
 					runner connRunner,
 					_ protocol.ConnectionID,
@@ -622,6 +626,7 @@ var _ = Describe("Server", func() {
 
 			It("rejects new connection attempts if the accept queue is full", func() {
 				serv.newConn = func(
+					_ *packetBufferPool,
 					_ sendConn,
 					runner connRunner,
 					_ protocol.ConnectionID,
@@ -693,6 +698,7 @@ var _ = Describe("Server", func() {
 				connCreated := make(chan struct{})
 				conn := NewMockQuicConn(mockCtrl)
 				serv.newConn = func(
+					_ *packetBufferPool,
 					_ sendConn,
 					runner connRunner,
 					_ protocol.ConnectionID,
@@ -999,6 +1005,7 @@ var _ = Describe("Server", func() {
 
 				ctx, cancel := context.WithCancel(context.Background()) // handshake context
 				serv.newConn = func(
+					_ *packetBufferPool,
 					_ sendConn,
 					runner connRunner,
 					_ protocol.ConnectionID,
@@ -1073,6 +1080,7 @@ var _ = Describe("Server", func() {
 
 			ready := make(chan struct{})
 			serv.newConn = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				runner connRunner,
 				_ protocol.ConnectionID,
@@ -1116,6 +1124,7 @@ var _ = Describe("Server", func() {
 			senderAddr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 42}
 
 			serv.newConn = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				runner connRunner,
 				_ protocol.ConnectionID,
@@ -1179,6 +1188,7 @@ var _ = Describe("Server", func() {
 			connCreated := make(chan struct{})
 			conn := NewMockQuicConn(mockCtrl)
 			serv.newConn = func(
+				_ *packetBufferPool,
 				_ sendConn,
 				runner connRunner,
 				_ protocol.ConnectionID,

--- a/sys_conn_no_oob.go
+++ b/sys_conn_no_oob.go
@@ -4,8 +4,11 @@ package quic
 
 import "net"
 
-func newConn(c net.PacketConn) (rawConn, error) {
-	return &basicConn{PacketConn: c}, nil
+func newConn(c net.PacketConn, pool *packetBufferPool) (rawConn, error) {
+	return &basicConn{
+		PacketConn: c,
+		pool:       pool,
+	}, nil
 }
 
 func inspectReadBuffer(interface{}) (int, error) {

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -24,7 +24,7 @@ var _ = Describe("OOB Conn Test", func() {
 		Expect(err).ToNot(HaveOccurred())
 		udpConn, err := net.ListenUDP(network, addr)
 		Expect(err).ToNot(HaveOccurred())
-		oobConn, err := newConn(udpConn)
+		oobConn, err := newConn(udpConn, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		packetChan := make(chan *receivedPacket)
@@ -228,7 +228,7 @@ var _ = Describe("OOB Conn Test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			udpConn, err := net.ListenUDP("udp", addr)
 			Expect(err).ToNot(HaveOccurred())
-			oobConn, err := newConn(udpConn)
+			oobConn, err := newConn(udpConn, nil)
 			Expect(err).ToNot(HaveOccurred())
 			oobConn.batchConn = batchConn
 

--- a/zero_copy_conn.go
+++ b/zero_copy_conn.go
@@ -1,0 +1,68 @@
+package quic
+
+import (
+	"net"
+	"time"
+)
+
+// ZeroCopyConn allows you to communicate with QUIC by reducing the number of
+// copies to zero. Although still a PacketConn, the ReadFrom and WriteTo
+// methods won't be invoked.
+type ZeroCopyConn interface {
+	net.PacketConn
+
+	// BufferPool returns only one buffer pool interface for the duration
+	// of the connection. This pool is used to request memory for
+	// transmitting packets. However, packets read from ReadPacket() will
+	// also be released through this pool.
+	BufferPool() BufferPool
+
+	// ReadPacket reads one packet from the underlying connection. The
+	// buffer will be released when fully processed by the stack. It's
+	// expected for this method to block until a packet becomes available.
+	// There can be many concurrent calls to this method.
+	ReadPacket() (int, []byte, int, net.Addr, error)
+
+	// WritePacket writes (or submits) the tagged buffer for writing.
+	// Expect for the buffer to be released soon after this method
+	// finishes, but take care of returning the buffer to the pool only
+	// after actual transmission has occurred.
+	WritePacket(buf []byte, tag int, addr net.Addr) (int, error)
+}
+
+type basicZeroCopyConn struct {
+	ZeroCopyConn
+
+	pool *packetBufferPool
+}
+
+func (c *basicZeroCopyConn) BufferPool() *packetBufferPool {
+	return nil
+}
+
+func (c *basicZeroCopyConn) ReadPacket() (*receivedPacket, error) {
+	n, data, tag, addr, err := c.ZeroCopyConn.ReadPacket()
+	if err != nil {
+		return nil, err
+	}
+
+	if tag == -1 {
+		panic("quic: a zero copy connection must not read packets with a -1 tag")
+	}
+
+	buffer := packetPool.Get().(*packetBuffer)
+	buffer.pool = c.ZeroCopyConn.BufferPool()
+	buffer.Data = data
+	buffer.Tag = tag
+
+	return &receivedPacket{
+		remoteAddr: addr,
+		rcvTime:    time.Now(),
+		data:       data[:n],
+		buffer:     buffer,
+	}, nil
+}
+
+func (c *basicZeroCopyConn) WritePacket(b []byte, tag int, addr net.Addr, _ []byte) (int, error) {
+	return c.ZeroCopyConn.WritePacket(b, tag, addr)
+}


### PR DESCRIPTION
Adds the ability to use zero-copy connections with QUIC. 

Internally, the package already uses a pull based model for reading packets. It first gets a byte slice from a buffer pool, then it reads into this slice using the `ReadFrom` method. This read then returns a `receivedPacket` structure which is processed accordingly.

This PR allows for the creation of `receivedPacket` structures without using copy semantics originating from `ReadFrom` and `WriteTo` methods.

It accomplishes this by allowing the use of a custom buffer pool per connection. QUIC can request a new buffer to be allocated, typically for writing. Each byte slice is accompanied by an `int` tag which uniquely identifies that buffer. When QUIC is done processing the slice, it will release the buffer from the pool. Custom buffer pools can use the tag to identify the state of such a buffer.

Similarly, byte slices originating from a zero-copy `ReadPacket()` function should also originate from the same buffer pool and be tracked with tags.

Thus, by using the byte slice tag you can coordinate zero-copy or asynchronous sends and receives. For example, you can use `io_uring` queues to send or read buffers; or eBPF urings for reading only, etc.

(This is a WIP PR and I would love a discussion over it.)