### PR TITLE
refactor header writing to append to a byte slice

### DIFF
--- a/fuzzing/header/cmd/corpus.go
+++ b/fuzzing/header/cmd/corpus.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"log"
 	"math/rand"
 
@@ -85,28 +84,28 @@ func main() {
 			PacketNumberLen: protocol.PacketNumberLen(rand.Intn(4) + 1),
 			PacketNumber:    protocol.PacketNumber(rand.Uint64()),
 		}
-		b := &bytes.Buffer{}
-		if err := extHdr.Write(b, version); err != nil {
+		b, err := extHdr.Append(nil, version)
+		if err != nil {
 			log.Fatal(err)
 		}
 		if h.Type == protocol.PacketTypeRetry {
-			b.Write([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+			b = append(b, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}...)
 		}
 		if h.Length > 0 {
-			b.Write(make([]byte, h.Length))
+			b = append(b, make([]byte, h.Length)...)
 		}
 
-		if err := helper.WriteCorpusFileWithPrefix("corpus", b.Bytes(), header.PrefixLen); err != nil {
+		if err := helper.WriteCorpusFileWithPrefix("corpus", b, header.PrefixLen); err != nil {
 			log.Fatal(err)
 		}
 	}
 
 	// short header
-	b := &bytes.Buffer{}
-	if err := wire.WriteShortHeader(b, protocol.ParseConnectionID(getRandomData(8)), 1337, protocol.PacketNumberLen2, protocol.KeyPhaseOne); err != nil {
+	b, err := wire.AppendShortHeader(nil, protocol.ParseConnectionID(getRandomData(8)), 1337, protocol.PacketNumberLen2, protocol.KeyPhaseOne)
+	if err != nil {
 		log.Fatal(err)
 	}
-	if err := helper.WriteCorpusFileWithPrefix("corpus", b.Bytes(), header.PrefixLen); err != nil {
+	if err := helper.WriteCorpusFileWithPrefix("corpus", b, header.PrefixLen); err != nil {
 		log.Fatal(err)
 	}
 

--- a/fuzzing/header/fuzz.go
+++ b/fuzzing/header/fuzz.go
@@ -64,8 +64,8 @@ func Fuzz(data []byte) int {
 	if hdr.Length > 16383 {
 		return 1
 	}
-	b := &bytes.Buffer{}
-	if err := extHdr.Write(b, version); err != nil {
+	b, err := extHdr.Append(nil, version)
+	if err != nil {
 		// We are able to parse packets with connection IDs longer than 20 bytes,
 		// but in QUIC version 1, we don't write headers with longer connection IDs.
 		if hdr.DestConnectionID.Len() <= protocol.MaxConnIDLen &&
@@ -76,8 +76,8 @@ func Fuzz(data []byte) int {
 	}
 	// GetLength is not implemented for Retry packets
 	if hdr.Type != protocol.PacketTypeRetry {
-		if expLen := extHdr.GetLength(version); expLen != protocol.ByteCount(b.Len()) {
-			panic(fmt.Sprintf("inconsistent header length: %#v. Expected %d, got %d", extHdr, expLen, b.Len()))
+		if expLen := extHdr.GetLength(version); expLen != protocol.ByteCount(len(b)) {
+			panic(fmt.Sprintf("inconsistent header length: %#v. Expected %d, got %d", extHdr, expLen, len(b)))
 		}
 	}
 	return 1

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -28,7 +28,6 @@ func isProxyRunning() bool {
 
 var _ = Describe("QUIC Proxy", func() {
 	makePacket := func(p protocol.PacketNumber, payload []byte) []byte {
-		b := &bytes.Buffer{}
 		hdr := wire.ExtendedHeader{
 			Header: wire.Header{
 				Type:             protocol.PacketTypeInitial,
@@ -40,10 +39,10 @@ var _ = Describe("QUIC Proxy", func() {
 			PacketNumber:    p,
 			PacketNumberLen: protocol.PacketNumberLen4,
 		}
-		Expect(hdr.Write(b, protocol.VersionWhatever)).To(Succeed())
-		raw := b.Bytes()
-		raw = append(raw, payload...)
-		return raw
+		b, err := hdr.Append(nil, protocol.Version1)
+		Expect(err).ToNot(HaveOccurred())
+		b = append(b, payload...)
+		return b
 	}
 
 	readPacketNumber := func(b []byte) protocol.PacketNumber {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -1,7 +1,7 @@
 package testutils
 
 import (
-	"bytes"
+	"fmt"
 
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
@@ -13,9 +13,11 @@ import (
 
 // writePacket returns a new raw packet with the specified header and payload
 func writePacket(hdr *wire.ExtendedHeader, data []byte) []byte {
-	buf := &bytes.Buffer{}
-	hdr.Write(buf, hdr.Version)
-	return append(buf.Bytes(), data...)
+	b, err := hdr.Append(nil, hdr.Version)
+	if err != nil {
+		panic(fmt.Sprintf("failed to write header: %s", err))
+	}
+	return append(b, data...)
 }
 
 // packRawPayload returns a new raw payload containing given frames

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -93,20 +94,17 @@ func (h *ExtendedHeader) readPacketNumber(b *bytes.Reader) error {
 	return nil
 }
 
-// Write writes the Header.
-func (h *ExtendedHeader) Write(b *bytes.Buffer, ver protocol.VersionNumber) error {
+// Append appends the Header.
+func (h *ExtendedHeader) Append(b []byte, v protocol.VersionNumber) ([]byte, error) {
 	if h.DestConnectionID.Len() > protocol.MaxConnIDLen {
-		return fmt.Errorf("invalid connection ID length: %d bytes", h.DestConnectionID.Len())
+		return nil, fmt.Errorf("invalid connection ID length: %d bytes", h.DestConnectionID.Len())
 	}
 	if h.SrcConnectionID.Len() > protocol.MaxConnIDLen {
-		return fmt.Errorf("invalid connection ID length: %d bytes", h.SrcConnectionID.Len())
+		return nil, fmt.Errorf("invalid connection ID length: %d bytes", h.SrcConnectionID.Len())
 	}
-	return h.writeLongHeader(b, ver)
-}
 
-func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, version protocol.VersionNumber) error {
 	var packetType uint8
-	if version == protocol.Version2 {
+	if v == protocol.Version2 {
 		//nolint:exhaustive
 		switch h.Type {
 		case protocol.PacketTypeInitial:
@@ -137,24 +135,25 @@ func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, version protocol.Versi
 		firstByte |= uint8(h.PacketNumberLen - 1)
 	}
 
-	b.WriteByte(firstByte)
-	utils.BigEndian.WriteUint32(b, uint32(h.Version))
-	b.WriteByte(uint8(h.DestConnectionID.Len()))
-	b.Write(h.DestConnectionID.Bytes())
-	b.WriteByte(uint8(h.SrcConnectionID.Len()))
-	b.Write(h.SrcConnectionID.Bytes())
+	b = append(b, firstByte)
+	b = append(b, make([]byte, 4)...)
+	binary.BigEndian.PutUint32(b[len(b)-4:], uint32(h.Version))
+	b = append(b, uint8(h.DestConnectionID.Len()))
+	b = append(b, h.DestConnectionID.Bytes()...)
+	b = append(b, uint8(h.SrcConnectionID.Len()))
+	b = append(b, h.SrcConnectionID.Bytes()...)
 
 	//nolint:exhaustive
 	switch h.Type {
 	case protocol.PacketTypeRetry:
-		b.Write(h.Token)
-		return nil
+		b = append(b, h.Token...)
+		return b, nil
 	case protocol.PacketTypeInitial:
-		quicvarint.Write(b, uint64(len(h.Token)))
-		b.Write(h.Token)
+		b = quicvarint.Append(b, uint64(len(h.Token)))
+		b = append(b, h.Token...)
 	}
-	quicvarint.WriteWithLen(b, uint64(h.Length), 2)
-	return writePacketNumber(b, h.PacketNumber, h.PacketNumberLen)
+	b = quicvarint.AppendWithLen(b, uint64(h.Length), 2)
+	return appendPacketNumber(b, h.PacketNumber, h.PacketNumberLen)
 }
 
 // ParsedLen returns the number of bytes that were consumed when parsing the header
@@ -188,18 +187,24 @@ func (h *ExtendedHeader) Log(logger utils.Logger) {
 	logger.Debugf("\tLong Header{Type: %s, DestConnectionID: %s, SrcConnectionID: %s, %sPacketNumber: %d, PacketNumberLen: %d, Length: %d, Version: %s}", h.Type, h.DestConnectionID, h.SrcConnectionID, token, h.PacketNumber, h.PacketNumberLen, h.Length, h.Version)
 }
 
-func writePacketNumber(b *bytes.Buffer, pn protocol.PacketNumber, pnLen protocol.PacketNumberLen) error {
+func appendPacketNumber(b []byte, pn protocol.PacketNumber, pnLen protocol.PacketNumberLen) ([]byte, error) {
 	switch pnLen {
 	case protocol.PacketNumberLen1:
-		b.WriteByte(uint8(pn))
+		b = append(b, uint8(pn))
 	case protocol.PacketNumberLen2:
-		utils.BigEndian.WriteUint16(b, uint16(pn))
+		buf := make([]byte, 2)
+		binary.BigEndian.PutUint16(buf, uint16(pn))
+		b = append(b, buf...)
 	case protocol.PacketNumberLen3:
-		utils.BigEndian.WriteUint24(b, uint32(pn))
+		buf := make([]byte, 4)
+		binary.BigEndian.PutUint32(buf, uint32(pn))
+		b = append(b, buf[1:]...)
 	case protocol.PacketNumberLen4:
-		utils.BigEndian.WriteUint32(b, uint32(pn))
+		buf := make([]byte, 4)
+		binary.BigEndian.PutUint32(buf, uint32(pn))
+		b = append(b, buf...)
 	default:
-		return fmt.Errorf("invalid packet number length: %d", pnLen)
+		return nil, fmt.Errorf("invalid packet number length: %d", pnLen)
 	}
-	return nil
+	return b, nil
 }

--- a/internal/wire/short_header.go
+++ b/internal/wire/short_header.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -54,15 +53,15 @@ func ParseShortHeader(data []byte, connIDLen int) (length int, _ protocol.Packet
 	return 1 + connIDLen + int(pnLen), pn, pnLen, kp, err
 }
 
-// WriteShortHeader writes a short header.
-func WriteShortHeader(b *bytes.Buffer, connID protocol.ConnectionID, pn protocol.PacketNumber, pnLen protocol.PacketNumberLen, kp protocol.KeyPhaseBit) error {
+// AppendShortHeader writes a short header.
+func AppendShortHeader(b []byte, connID protocol.ConnectionID, pn protocol.PacketNumber, pnLen protocol.PacketNumberLen, kp protocol.KeyPhaseBit) ([]byte, error) {
 	typeByte := 0x40 | uint8(pnLen-1)
 	if kp == protocol.KeyPhaseOne {
 		typeByte |= byte(1 << 2)
 	}
-	b.WriteByte(typeByte)
-	b.Write(connID.Bytes())
-	return writePacketNumber(b, pn, pnLen)
+	b = append(b, typeByte)
+	b = append(b, connID.Bytes()...)
+	return appendPacketNumber(b, pn, pnLen)
 }
 
 func ShortHeaderLen(dest protocol.ConnectionID, pnLen protocol.PacketNumberLen) protocol.ByteCount {

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -1,7 +1,6 @@
 package quic
 
 import (
-	"bytes"
 	"crypto/rand"
 	"errors"
 	"net"
@@ -14,7 +13,6 @@ import (
 	"github.com/lucas-clemente/quic-go/logging"
 
 	"github.com/golang/mock/gomock"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -37,8 +35,7 @@ var _ = Describe("Packet Handler Map", func() {
 	)
 
 	getPacketWithPacketType := func(connID protocol.ConnectionID, t protocol.PacketType, length protocol.ByteCount) []byte {
-		buf := &bytes.Buffer{}
-		Expect((&wire.ExtendedHeader{
+		b, err := (&wire.ExtendedHeader{
 			Header: wire.Header{
 				Type:             t,
 				DestConnectionID: connID,
@@ -46,8 +43,9 @@ var _ = Describe("Packet Handler Map", func() {
 				Version:          protocol.VersionTLS,
 			},
 			PacketNumberLen: protocol.PacketNumberLen2,
-		}).Write(buf, protocol.VersionWhatever)).To(Succeed())
-		return buf.Bytes()
+		}).Append(nil, protocol.VersionWhatever)
+		Expect(err).ToNot(HaveOccurred())
+		return b
 	}
 
 	getPacket := func(connID protocol.ConnectionID) []byte {

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -107,32 +107,32 @@ func Append(b []byte, i uint64) []byte {
 	panic(fmt.Sprintf("%#x doesn't fit into 62 bits", i))
 }
 
-// WriteWithLen writes i in the QUIC varint format with the desired length to w.
-func WriteWithLen(w Writer, i uint64, length protocol.ByteCount) {
+// AppendWithLen append i in the QUIC varint format with the desired length.
+func AppendWithLen(b []byte, i uint64, length protocol.ByteCount) []byte {
 	if length != 1 && length != 2 && length != 4 && length != 8 {
 		panic("invalid varint length")
 	}
 	l := Len(i)
 	if l == length {
-		Write(w, i)
-		return
+		return Append(b, i)
 	}
 	if l > length {
 		panic(fmt.Sprintf("cannot encode %d in %d bytes", i, length))
 	}
 	if length == 2 {
-		w.WriteByte(0b01000000)
+		b = append(b, 0b01000000)
 	} else if length == 4 {
-		w.WriteByte(0b10000000)
+		b = append(b, 0b10000000)
 	} else if length == 8 {
-		w.WriteByte(0b11000000)
+		b = append(b, 0b11000000)
 	}
 	for j := protocol.ByteCount(1); j < length-l; j++ {
-		w.WriteByte(0)
+		b = append(b, 0)
 	}
 	for j := protocol.ByteCount(0); j < l; j++ {
-		w.WriteByte(uint8(i >> (8 * (l - 1 - j))))
+		b = append(b, uint8(i>>(8*(l-1-j))))
 	}
+	return b
 }
 
 // Len determines the number of bytes that will be needed to write the number i.

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -142,54 +142,47 @@ var _ = Describe("Varint encoding / decoding", func() {
 
 		Context("with fixed length", func() {
 			It("panics when given an invalid length", func() {
-				Expect(func() { WriteWithLen(&bytes.Buffer{}, 25, 3) }).Should(Panic())
+				Expect(func() { AppendWithLen(nil, 25, 3) }).Should(Panic())
 			})
 
 			It("panics when given a too short length", func() {
-				Expect(func() { WriteWithLen(&bytes.Buffer{}, maxVarInt1+1, 1) }).Should(Panic())
-				Expect(func() { WriteWithLen(&bytes.Buffer{}, maxVarInt2+1, 2) }).Should(Panic())
-				Expect(func() { WriteWithLen(&bytes.Buffer{}, maxVarInt4+1, 4) }).Should(Panic())
+				Expect(func() { AppendWithLen(nil, maxVarInt1+1, 1) }).Should(Panic())
+				Expect(func() { AppendWithLen(nil, maxVarInt2+1, 2) }).Should(Panic())
+				Expect(func() { AppendWithLen(nil, maxVarInt4+1, 4) }).Should(Panic())
 			})
 
 			It("writes a 1-byte number in minimal encoding", func() {
-				b := &bytes.Buffer{}
-				WriteWithLen(b, 37, 1)
-				Expect(b.Bytes()).To(Equal([]byte{0x25}))
+				Expect(AppendWithLen(nil, 37, 1)).To(Equal([]byte{0x25}))
 			})
 
 			It("writes a 1-byte number in 2 bytes", func() {
-				b := &bytes.Buffer{}
-				WriteWithLen(b, 37, 2)
-				Expect(b.Bytes()).To(Equal([]byte{0b01000000, 0x25}))
-				Expect(Read(b)).To(BeEquivalentTo(37))
+				b := AppendWithLen(nil, 37, 2)
+				Expect(b).To(Equal([]byte{0b01000000, 0x25}))
+				Expect(Read(bytes.NewReader(b))).To(BeEquivalentTo(37))
 			})
 
 			It("writes a 1-byte number in 4 bytes", func() {
-				b := &bytes.Buffer{}
-				WriteWithLen(b, 37, 4)
-				Expect(b.Bytes()).To(Equal([]byte{0b10000000, 0, 0, 0x25}))
-				Expect(Read(b)).To(BeEquivalentTo(37))
+				b := AppendWithLen(nil, 37, 4)
+				Expect(b).To(Equal([]byte{0b10000000, 0, 0, 0x25}))
+				Expect(Read(bytes.NewReader(b))).To(BeEquivalentTo(37))
 			})
 
 			It("writes a 1-byte number in 8 bytes", func() {
-				b := &bytes.Buffer{}
-				WriteWithLen(b, 37, 8)
-				Expect(b.Bytes()).To(Equal([]byte{0b11000000, 0, 0, 0, 0, 0, 0, 0x25}))
-				Expect(Read(b)).To(BeEquivalentTo(37))
+				b := AppendWithLen(nil, 37, 8)
+				Expect(b).To(Equal([]byte{0b11000000, 0, 0, 0, 0, 0, 0, 0x25}))
+				Expect(Read(bytes.NewReader(b))).To(BeEquivalentTo(37))
 			})
 
 			It("writes a 2-byte number in 4 bytes", func() {
-				b := &bytes.Buffer{}
-				WriteWithLen(b, 15293, 4)
-				Expect(b.Bytes()).To(Equal([]byte{0b10000000, 0, 0x3b, 0xbd}))
-				Expect(Read(b)).To(BeEquivalentTo(15293))
+				b := AppendWithLen(nil, 15293, 4)
+				Expect(b).To(Equal([]byte{0b10000000, 0, 0x3b, 0xbd}))
+				Expect(Read(bytes.NewReader(b))).To(BeEquivalentTo(15293))
 			})
 
 			It("write a 4-byte number in 8 bytes", func() {
-				b := &bytes.Buffer{}
-				WriteWithLen(b, 494878333, 8)
-				Expect(b.Bytes()).To(Equal([]byte{0b11000000, 0, 0, 0, 0x1d, 0x7f, 0x3e, 0x7d}))
-				Expect(Read(b)).To(BeEquivalentTo(494878333))
+				b := AppendWithLen(nil, 494878333, 8)
+				Expect(b).To(Equal([]byte{0b11000000, 0, 0, 0, 0x1d, 0x7f, 0x3e, 0x7d}))
+				Expect(Read(bytes.NewReader(b))).To(BeEquivalentTo(494878333))
 			})
 		})
 


### PR DESCRIPTION
Depends on #3644. Part of #3526.

This avoids having to allocate a `bytes.Buffer`.