### PR TITLE
qtls: fix cipher suite selection for ClientHellos

### DIFF
--- a/internal/qtls/go119.go
+++ b/internal/qtls/go119.go
@@ -102,11 +102,26 @@ func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
 //go:linkname cipherSuitesTLS13 github.com/quic-go/qtls-go1-19.cipherSuitesTLS13
 var cipherSuitesTLS13 []unsafe.Pointer
 
+//go:linkname defaultCipherSuitesTLS13 github.com/quic-go/qtls-go1-19.defaultCipherSuitesTLS13
+var defaultCipherSuitesTLS13 []uint16
+
+//go:linkname defaultCipherSuitesTLS13NoAES github.com/quic-go/qtls-go1-19.defaultCipherSuitesTLS13NoAES
+var defaultCipherSuitesTLS13NoAES []uint16
+
+var cipherSuitesModified bool
+
 // SetCipherSuite modifies the cipherSuiteTLS13 slice of cipher suites inside qtls
 // such that it only contains the cipher suite with the chosen id.
 // The reset function returned resets them back to the original value.
 func SetCipherSuite(id uint16) (reset func()) {
-	orig := append([]unsafe.Pointer{}, cipherSuitesTLS13...)
+	if cipherSuitesModified {
+		panic("cipher suites modified multiple times without resetting")
+	}
+	cipherSuitesModified = true
+
+	origCipherSuitesTLS13 := append([]unsafe.Pointer{}, cipherSuitesTLS13...)
+	origDefaultCipherSuitesTLS13 := append([]uint16{}, defaultCipherSuitesTLS13...)
+	origDefaultCipherSuitesTLS13NoAES := append([]uint16{}, defaultCipherSuitesTLS13NoAES...)
 	// The order is given by the order of the slice elements in cipherSuitesTLS13 in qtls.
 	switch id {
 	case tls.TLS_AES_128_GCM_SHA256:
@@ -118,5 +133,13 @@ func SetCipherSuite(id uint16) (reset func()) {
 	default:
 		panic(fmt.Sprintf("unexpected cipher suite: %d", id))
 	}
-	return func() { cipherSuitesTLS13 = orig }
+	defaultCipherSuitesTLS13 = []uint16{id}
+	defaultCipherSuitesTLS13NoAES = []uint16{id}
+
+	return func() {
+		cipherSuitesTLS13 = origCipherSuitesTLS13
+		defaultCipherSuitesTLS13 = origDefaultCipherSuitesTLS13
+		defaultCipherSuitesTLS13NoAES = origDefaultCipherSuitesTLS13NoAES
+		cipherSuitesModified = false
+	}
 }

--- a/internal/qtls/go120.go
+++ b/internal/qtls/go120.go
@@ -102,11 +102,26 @@ func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
 //go:linkname cipherSuitesTLS13 github.com/quic-go/qtls-go1-20.cipherSuitesTLS13
 var cipherSuitesTLS13 []unsafe.Pointer
 
+//go:linkname defaultCipherSuitesTLS13 github.com/quic-go/qtls-go1-20.defaultCipherSuitesTLS13
+var defaultCipherSuitesTLS13 []uint16
+
+//go:linkname defaultCipherSuitesTLS13NoAES github.com/quic-go/qtls-go1-20.defaultCipherSuitesTLS13NoAES
+var defaultCipherSuitesTLS13NoAES []uint16
+
+var cipherSuitesModified bool
+
 // SetCipherSuite modifies the cipherSuiteTLS13 slice of cipher suites inside qtls
 // such that it only contains the cipher suite with the chosen id.
 // The reset function returned resets them back to the original value.
 func SetCipherSuite(id uint16) (reset func()) {
-	orig := append([]unsafe.Pointer{}, cipherSuitesTLS13...)
+	if cipherSuitesModified {
+		panic("cipher suites modified multiple times without resetting")
+	}
+	cipherSuitesModified = true
+
+	origCipherSuitesTLS13 := append([]unsafe.Pointer{}, cipherSuitesTLS13...)
+	origDefaultCipherSuitesTLS13 := append([]uint16{}, defaultCipherSuitesTLS13...)
+	origDefaultCipherSuitesTLS13NoAES := append([]uint16{}, defaultCipherSuitesTLS13NoAES...)
 	// The order is given by the order of the slice elements in cipherSuitesTLS13 in qtls.
 	switch id {
 	case tls.TLS_AES_128_GCM_SHA256:
@@ -118,5 +133,13 @@ func SetCipherSuite(id uint16) (reset func()) {
 	default:
 		panic(fmt.Sprintf("unexpected cipher suite: %d", id))
 	}
-	return func() { cipherSuitesTLS13 = orig }
+	defaultCipherSuitesTLS13 = []uint16{id}
+	defaultCipherSuitesTLS13NoAES = []uint16{id}
+
+	return func() {
+		cipherSuitesTLS13 = origCipherSuitesTLS13
+		defaultCipherSuitesTLS13 = origDefaultCipherSuitesTLS13
+		defaultCipherSuitesTLS13NoAES = origDefaultCipherSuitesTLS13NoAES
+		cipherSuitesModified = false
+	}
 }


### PR DESCRIPTION
Looks like this is a bit more complicated than https://github.com/quic-go/quic-go/pull/3726, since we also need to modify `defaultCipherSuitesTLS13` and `defaultCipherSuitesTLS13NoAES`.

Part of the fix for #3746, but applicable more broadly.