### PR TITLE
Support BBR congestion algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 debug
 debug.test
 main
+client
 mockgen_tmp.go
 *.qtr
 *.qlog

--- a/config.go
+++ b/config.go
@@ -123,6 +123,7 @@ func populateConfig(config *Config) *Config {
 		InitialPacketSize:              initialPacketSize,
 		DisablePathMTUDiscovery:        config.DisablePathMTUDiscovery,
 		Allow0RTT:                      config.Allow0RTT,
+		CC:                             config.CC,
 		Tracer:                         config.Tracer,
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -123,6 +123,8 @@ var _ = Describe("Config", func() {
 				f.Set(reflect.ValueOf(true))
 			case "Allow0RTT":
 				f.Set(reflect.ValueOf(true))
+			case "CC":
+				f.Set(reflect.ValueOf(protocol.CcDefault))
 			default:
 				Fail(fmt.Sprintf("all fields must be accounted for, but saw unknown field %q", fn))
 			}

--- a/connection.go
+++ b/connection.go
@@ -284,6 +284,7 @@ var newConnection = func(
 		clientAddressValidated,
 		s.conn.capabilities().ECN,
 		s.perspective,
+		s.config.CC,
 		s.tracer,
 		s.logger,
 	)
@@ -394,6 +395,7 @@ var newClientConnection = func(
 		false, // has no effect
 		s.conn.capabilities().ECN,
 		s.perspective,
+		s.config.CC,
 		s.tracer,
 		s.logger,
 	)

--- a/interface.go
+++ b/interface.go
@@ -30,6 +30,18 @@ const (
 	Version2 = protocol.Version2
 )
 
+// A CongestionControlAlgorithm is a congestion control algorithm.
+type CongestionControlAlgorithm = protocol.CC
+
+const (
+	// Default
+	CcDefault = protocol.CcDefault
+	// CUBIC
+	CcCubic = protocol.CcCubic
+	// BBR
+	CcBbr = protocol.CcBbr
+)
+
 // A ClientToken is a token received by the client.
 // It can be used to skip address validation on future connection attempts.
 type ClientToken struct {
@@ -343,6 +355,9 @@ type Config struct {
 	// Enable QUIC datagram support (RFC 9221).
 	EnableDatagrams bool
 	Tracer          func(context.Context, logging.Perspective, ConnectionID) *logging.ConnectionTracer
+
+	// Congestion Control Algorithm
+	CC CongestionControlAlgorithm
 }
 
 // ClientHelloInfo contains information about an incoming connection attempt.

--- a/internal/ackhandler/ackhandler.go
+++ b/internal/ackhandler/ackhandler.go
@@ -16,9 +16,10 @@ func NewAckHandler(
 	clientAddressValidated bool,
 	enableECN bool,
 	pers protocol.Perspective,
+	cc protocol.CC,
 	tracer *logging.ConnectionTracer,
 	logger utils.Logger,
 ) (SentPacketHandler, ReceivedPacketHandler) {
-	sph := newSentPacketHandler(initialPacketNumber, initialMaxDatagramSize, rttStats, clientAddressValidated, enableECN, pers, tracer, logger)
+	sph := newSentPacketHandler(initialPacketNumber, initialMaxDatagramSize, rttStats, clientAddressValidated, enableECN, pers, cc, tracer, logger)
 	return sph, newReceivedPacketHandler(sph, logger)
 }

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -44,7 +44,7 @@ var _ = Describe("SentPacketHandler", func() {
 	JustBeforeEach(func() {
 		lostPackets = nil
 		rttStats := utils.NewRTTStats()
-		handler = newSentPacketHandler(42, protocol.InitialPacketSize, rttStats, false, false, perspective, nil, utils.DefaultLogger)
+		handler = newSentPacketHandler(42, protocol.InitialPacketSize, rttStats, false, false, perspective, protocol.CcDefault, nil, utils.DefaultLogger)
 		streamFrame = wire.StreamFrame{
 			StreamID: 5,
 			Data:     []byte{0x13, 0x37},
@@ -984,7 +984,7 @@ var _ = Describe("SentPacketHandler", func() {
 	Context("amplification limit, for the server, with validated address", func() {
 		JustBeforeEach(func() {
 			rttStats := utils.NewRTTStats()
-			handler = newSentPacketHandler(42, protocol.InitialPacketSize, rttStats, true, false, perspective, nil, utils.DefaultLogger)
+			handler = newSentPacketHandler(42, protocol.InitialPacketSize, rttStats, true, false, perspective, protocol.CcDefault, nil, utils.DefaultLogger)
 		})
 
 		It("do not limits the window", func() {
@@ -1443,7 +1443,7 @@ var _ = Describe("SentPacketHandler", func() {
 			lostPackets = nil
 			rttStats := utils.NewRTTStats()
 			rttStats.UpdateRTT(time.Hour, 0, time.Now())
-			handler = newSentPacketHandler(42, protocol.InitialPacketSize, rttStats, false, false, perspective, nil, utils.DefaultLogger)
+			handler = newSentPacketHandler(42, protocol.InitialPacketSize, rttStats, false, false, perspective, protocol.CcDefault, nil, utils.DefaultLogger)
 			handler.ecnTracker = ecnHandler
 			handler.congestion = cong
 		})

--- a/internal/congestion/bandwidth.go
+++ b/internal/congestion/bandwidth.go
@@ -7,10 +7,12 @@ import (
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
+const (
+	infBandwidth = Bandwidth(math.MaxUint64)
+)
+
 // Bandwidth of a connection
 type Bandwidth uint64
-
-const infBandwidth Bandwidth = math.MaxUint64
 
 const (
 	// BitsPerSecond is 1 bit per second

--- a/internal/congestion/bandwidth_sampler.go
+++ b/internal/congestion/bandwidth_sampler.go
@@ -1,0 +1,879 @@
+package congestion
+
+import (
+	"math"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/internal/utils/ringbuffer"
+)
+
+const (
+	infRTT                             = time.Duration(math.MaxInt64)
+	defaultConnectionStateMapQueueSize = 256
+	defaultCandidatesBufferSize        = 256
+)
+
+type roundTripCount uint64
+
+// SendTimeState is a subset of ConnectionStateOnSentPacket which is returned
+// to the caller when the packet is acked or lost.
+type sendTimeState struct {
+	// Whether other states in this object is valid.
+	isValid bool
+	// Whether the sender is app limited at the time the packet was sent.
+	// App limited bandwidth sample might be artificially low because the sender
+	// did not have enough data to send in order to saturate the link.
+	isAppLimited bool
+	// Total number of sent bytes at the time the packet was sent.
+	// Includes the packet itself.
+	totalBytesSent protocol.ByteCount
+	// Total number of acked bytes at the time the packet was sent.
+	totalBytesAcked protocol.ByteCount
+	// Total number of lost bytes at the time the packet was sent.
+	totalBytesLost protocol.ByteCount
+	// Total number of inflight bytes at the time the packet was sent.
+	// Includes the packet itself.
+	// It should be equal to |total_bytes_sent| minus the sum of
+	// |total_bytes_acked|, |total_bytes_lost| and total neutered bytes.
+	bytesInFlight protocol.ByteCount
+}
+
+func newSendTimeState(
+	isAppLimited bool,
+	totalBytesSent protocol.ByteCount,
+	totalBytesAcked protocol.ByteCount,
+	totalBytesLost protocol.ByteCount,
+	bytesInFlight protocol.ByteCount,
+) *sendTimeState {
+	return &sendTimeState{
+		isValid:         true,
+		isAppLimited:    isAppLimited,
+		totalBytesSent:  totalBytesSent,
+		totalBytesAcked: totalBytesAcked,
+		totalBytesLost:  totalBytesLost,
+		bytesInFlight:   bytesInFlight,
+	}
+}
+
+type extraAckedEvent struct {
+	// The excess bytes acknowlwedged in the time delta for this event.
+	extraAcked protocol.ByteCount
+
+	// The bytes acknowledged and time delta from the event.
+	bytesAcked protocol.ByteCount
+	timeDelta  time.Duration
+	// The round trip of the event.
+	round roundTripCount
+}
+
+func maxExtraAckedEventFunc(a, b extraAckedEvent) int {
+	if a.extraAcked > b.extraAcked {
+		return 1
+	} else if a.extraAcked < b.extraAcked {
+		return -1
+	}
+	return 0
+}
+
+// BandwidthSample
+type bandwidthSample struct {
+	// The bandwidth at that particular sample. Zero if no valid bandwidth sample
+	// is available.
+	bandwidth Bandwidth
+	// The RTT measurement at this particular sample.  Zero if no RTT sample is
+	// available.  Does not correct for delayed ack time.
+	rtt time.Duration
+	// |send_rate| is computed from the current packet being acked('P') and an
+	// earlier packet that is acked before P was sent.
+	sendRate Bandwidth
+	// States captured when the packet was sent.
+	stateAtSend sendTimeState
+}
+
+func newBandwidthSample() *bandwidthSample {
+	return &bandwidthSample{
+		sendRate: infBandwidth,
+	}
+}
+
+// MaxAckHeightTracker is part of the BandwidthSampler. It is called after every
+// ack event to keep track the degree of ack aggregation(a.k.a "ack height").
+type maxAckHeightTracker struct {
+
+	// Tracks the maximum number of bytes acked faster than the estimated
+	// bandwidth.
+	maxAckHeightFilter *utils.WindowedFilter[extraAckedEvent, roundTripCount]
+	// The time this aggregation started and the number of bytes acked during it.
+	aggregationEpochStartTime time.Time
+	aggregationEpochBytes     protocol.ByteCount
+	// The last sent packet number before the current aggregation epoch started.
+	lastSentPacketNumberBeforeEpoch protocol.PacketNumber
+	// The number of ack aggregation epochs ever started, including the ongoing
+	// one. Stats only.
+	numAckAggregationEpochs                uint64
+	ackAggregationBandwidthThreshold       float64
+	startNewAggregationEpochAfterFullRound bool
+	reduceExtraAckedOnBandwidthIncrease    bool
+}
+
+func newMaxAckHeightTracker(windowLength roundTripCount) *maxAckHeightTracker {
+	return &maxAckHeightTracker{
+		maxAckHeightFilter:               utils.NewWindowedFilter(windowLength, maxExtraAckedEventFunc),
+		lastSentPacketNumberBeforeEpoch:  protocol.InvalidPacketNumber,
+		ackAggregationBandwidthThreshold: 1.0,
+	}
+}
+
+func (m *maxAckHeightTracker) Get() protocol.ByteCount {
+	return m.maxAckHeightFilter.GetBest().extraAcked
+}
+
+func (m *maxAckHeightTracker) Update(
+	bandwidthEstimate Bandwidth,
+	isNewMaxBandwidth bool,
+	roundTripCount roundTripCount,
+	lastSentPacketNumber protocol.PacketNumber,
+	lastAckedPacketNumber protocol.PacketNumber,
+	ackTime time.Time,
+	bytesAcked protocol.ByteCount) protocol.ByteCount {
+
+	forceNewEpoch := false
+
+	if m.reduceExtraAckedOnBandwidthIncrease && isNewMaxBandwidth {
+		// Save and clear existing entries.
+		best := m.maxAckHeightFilter.GetBest()
+		secondBest := m.maxAckHeightFilter.GetSecondBest()
+		thirdBest := m.maxAckHeightFilter.GetThirdBest()
+		m.maxAckHeightFilter.Clear()
+
+		// Reinsert the heights into the filter after recalculating.
+		expectedBytesAcked := bytesFromBandwidthAndTimeDelta(bandwidthEstimate, best.timeDelta)
+		if expectedBytesAcked < best.bytesAcked {
+			best.extraAcked = best.bytesAcked - expectedBytesAcked
+			m.maxAckHeightFilter.Update(best, best.round)
+		}
+		expectedBytesAcked = bytesFromBandwidthAndTimeDelta(bandwidthEstimate, secondBest.timeDelta)
+		if expectedBytesAcked < secondBest.bytesAcked {
+			secondBest.extraAcked = secondBest.bytesAcked - expectedBytesAcked
+			m.maxAckHeightFilter.Update(secondBest, secondBest.round)
+		}
+		expectedBytesAcked = bytesFromBandwidthAndTimeDelta(bandwidthEstimate, thirdBest.timeDelta)
+		if expectedBytesAcked < thirdBest.bytesAcked {
+			thirdBest.extraAcked = thirdBest.bytesAcked - expectedBytesAcked
+			m.maxAckHeightFilter.Update(thirdBest, thirdBest.round)
+		}
+	}
+
+	// If any packet sent after the start of the epoch has been acked, start a new
+	// epoch.
+	if m.startNewAggregationEpochAfterFullRound &&
+		m.lastSentPacketNumberBeforeEpoch != protocol.InvalidPacketNumber &&
+		lastAckedPacketNumber != protocol.InvalidPacketNumber &&
+		lastAckedPacketNumber > m.lastSentPacketNumberBeforeEpoch {
+		forceNewEpoch = true
+	}
+	if m.aggregationEpochStartTime.IsZero() || forceNewEpoch {
+		m.aggregationEpochBytes = bytesAcked
+		m.aggregationEpochStartTime = ackTime
+		m.lastSentPacketNumberBeforeEpoch = lastSentPacketNumber
+		m.numAckAggregationEpochs++
+		return 0
+	}
+
+	// Compute how many bytes are expected to be delivered, assuming max bandwidth
+	// is correct.
+	aggregationDelta := ackTime.Sub(m.aggregationEpochStartTime)
+	expectedBytesAcked := bytesFromBandwidthAndTimeDelta(bandwidthEstimate, aggregationDelta)
+	// Reset the current aggregation epoch as soon as the ack arrival rate is less
+	// than or equal to the max bandwidth.
+	if m.aggregationEpochBytes <= protocol.ByteCount(m.ackAggregationBandwidthThreshold*float64(expectedBytesAcked)) {
+		// Reset to start measuring a new aggregation epoch.
+		m.aggregationEpochBytes = bytesAcked
+		m.aggregationEpochStartTime = ackTime
+		m.lastSentPacketNumberBeforeEpoch = lastSentPacketNumber
+		m.numAckAggregationEpochs++
+		return 0
+	}
+
+	m.aggregationEpochBytes += bytesAcked
+
+	// Compute how many extra bytes were delivered vs max bandwidth.
+	extraBytesAcked := m.aggregationEpochBytes - expectedBytesAcked
+	newEvent := extraAckedEvent{
+		extraAcked: expectedBytesAcked,
+		bytesAcked: m.aggregationEpochBytes,
+		timeDelta:  aggregationDelta,
+	}
+	m.maxAckHeightFilter.Update(newEvent, roundTripCount)
+	return extraBytesAcked
+}
+
+func (m *maxAckHeightTracker) SetFilterWindowLength(length roundTripCount) {
+	m.maxAckHeightFilter.SetWindowLength(length)
+}
+
+func (m *maxAckHeightTracker) Reset(newHeight protocol.ByteCount, newTime roundTripCount) {
+	newEvent := extraAckedEvent{
+		extraAcked: newHeight,
+		round:      newTime,
+	}
+	m.maxAckHeightFilter.Reset(newEvent, newTime)
+}
+
+func (m *maxAckHeightTracker) SetAckAggregationBandwidthThreshold(threshold float64) {
+	m.ackAggregationBandwidthThreshold = threshold
+}
+
+func (m *maxAckHeightTracker) SetStartNewAggregationEpochAfterFullRound(value bool) {
+	m.startNewAggregationEpochAfterFullRound = value
+}
+
+func (m *maxAckHeightTracker) SetReduceExtraAckedOnBandwidthIncrease(value bool) {
+	m.reduceExtraAckedOnBandwidthIncrease = value
+}
+
+func (m *maxAckHeightTracker) AckAggregationBandwidthThreshold() float64 {
+	return m.ackAggregationBandwidthThreshold
+}
+
+func (m *maxAckHeightTracker) NumAckAggregationEpochs() uint64 {
+	return m.numAckAggregationEpochs
+}
+
+// AckPoint represents a point on the ack line.
+type ackPoint struct {
+	ackTime         time.Time
+	totalBytesAcked protocol.ByteCount
+}
+
+// RecentAckPoints maintains the most recent 2 ack points at distinct times.
+type recentAckPoints struct {
+	ackPoints [2]ackPoint
+}
+
+func (r *recentAckPoints) Update(ackTime time.Time, totalBytesAcked protocol.ByteCount) {
+	if ackTime.Before(r.ackPoints[1].ackTime) {
+		r.ackPoints[1].ackTime = ackTime
+	} else if ackTime.After(r.ackPoints[1].ackTime) {
+		r.ackPoints[0] = r.ackPoints[1]
+		r.ackPoints[1].ackTime = ackTime
+	}
+
+	r.ackPoints[1].totalBytesAcked = totalBytesAcked
+}
+
+func (r *recentAckPoints) Clear() {
+	r.ackPoints[0] = ackPoint{}
+	r.ackPoints[1] = ackPoint{}
+}
+
+func (r *recentAckPoints) MostRecentPoint() *ackPoint {
+	return &r.ackPoints[1]
+}
+
+func (r *recentAckPoints) LessRecentPoint() *ackPoint {
+	if r.ackPoints[0].totalBytesAcked != 0 {
+		return &r.ackPoints[0]
+	}
+
+	return &r.ackPoints[1]
+}
+
+// ConnectionStateOnSentPacket represents the information about a sent packet
+// and the state of the connection at the moment the packet was sent,
+// specifically the information about the most recently acknowledged packet at
+// that moment.
+type connectionStateOnSentPacket struct {
+	// Time at which the packet is sent.
+	sentTime time.Time
+	// Size of the packet.
+	size protocol.ByteCount
+	// The value of |totalBytesSentAtLastAckedPacket| at the time the
+	// packet was sent.
+	totalBytesSentAtLastAckedPacket protocol.ByteCount
+	// The value of |lastAckedPacketSentTime| at the time the packet was
+	// sent.
+	lastAckedPacketSentTime time.Time
+	// The value of |lastAckedPacketAckTime| at the time the packet was
+	// sent.
+	lastAckedPacketAckTime time.Time
+	// Send time states that are returned to the congestion controller when the
+	// packet is acked or lost.
+	sendTimeState sendTimeState
+}
+
+// Snapshot constructor. Records the current state of the bandwidth
+// sampler.
+// |bytes_in_flight| is the bytes in flight right after the packet is sent.
+func newConnectionStateOnSentPacket(
+	sentTime time.Time,
+	size protocol.ByteCount,
+	bytesInFlight protocol.ByteCount,
+	sampler *bandwidthSampler,
+) *connectionStateOnSentPacket {
+	return &connectionStateOnSentPacket{
+		sentTime:                        sentTime,
+		size:                            size,
+		totalBytesSentAtLastAckedPacket: sampler.totalBytesSentAtLastAckedPacket,
+		lastAckedPacketSentTime:         sampler.lastAckedPacketSentTime,
+		lastAckedPacketAckTime:          sampler.lastAckedPacketAckTime,
+		sendTimeState: *newSendTimeState(
+			sampler.isAppLimited,
+			sampler.totalBytesSent,
+			sampler.totalBytesAcked,
+			sampler.totalBytesLost,
+			bytesInFlight,
+		),
+	}
+}
+
+// BandwidthSampler keeps track of sent and acknowledged packets and outputs a
+// bandwidth sample for every packet acknowledged. The samples are taken for
+// individual packets, and are not filtered; the consumer has to filter the
+// bandwidth samples itself. In certain cases, the sampler will locally severely
+// underestimate the bandwidth, hence a maximum filter with a size of at least
+// one RTT is recommended.
+//
+// This class bases its samples on the slope of two curves: the number of bytes
+// sent over time, and the number of bytes acknowledged as received over time.
+// It produces a sample of both slopes for every packet that gets acknowledged,
+// based on a slope between two points on each of the corresponding curves. Note
+// that due to the packet loss, the number of bytes on each curve might get
+// further and further away from each other, meaning that it is not feasible to
+// compare byte values coming from different curves with each other.
+//
+// The obvious points for measuring slope sample are the ones corresponding to
+// the packet that was just acknowledged. Let us denote them as S_1 (point at
+// which the current packet was sent) and A_1 (point at which the current packet
+// was acknowledged). However, taking a slope requires two points on each line,
+// so estimating bandwidth requires picking a packet in the past with respect to
+// which the slope is measured.
+//
+// For that purpose, BandwidthSampler always keeps track of the most recently
+// acknowledged packet, and records it together with every outgoing packet.
+// When a packet gets acknowledged (A_1), it has not only information about when
+// it itself was sent (S_1), but also the information about the latest
+// acknowledged packet right before it was sent (S_0 and A_0).
+//
+// Based on that data, send and ack rate are estimated as:
+//
+//	send_rate = (bytes(S_1) - bytes(S_0)) / (time(S_1) - time(S_0))
+//	ack_rate = (bytes(A_1) - bytes(A_0)) / (time(A_1) - time(A_0))
+//
+// Here, the ack rate is intuitively the rate we want to treat as bandwidth.
+// However, in certain cases (e.g. ack compression) the ack rate at a point may
+// end up higher than the rate at which the data was originally sent, which is
+// not indicative of the real bandwidth. Hence, we use the send rate as an upper
+// bound, and the sample value is
+//
+//	rate_sample = min(send_rate, ack_rate)
+//
+// An important edge case handled by the sampler is tracking the app-limited
+// samples. There are multiple meaning of "app-limited" used interchangeably,
+// hence it is important to understand and to be able to distinguish between
+// them.
+//
+// Meaning 1: connection state. The connection is said to be app-limited when
+// there is no outstanding data to send. This means that certain bandwidth
+// samples in the future would not be an accurate indication of the link
+// capacity, and it is important to inform consumer about that. Whenever
+// connection becomes app-limited, the sampler is notified via OnAppLimited()
+// method.
+//
+// Meaning 2: a phase in the bandwidth sampler. As soon as the bandwidth
+// sampler becomes notified about the connection being app-limited, it enters
+// app-limited phase. In that phase, all *sent* packets are marked as
+// app-limited. Note that the connection itself does not have to be
+// app-limited during the app-limited phase, and in fact it will not be
+// (otherwise how would it send packets?). The boolean flag below indicates
+// whether the sampler is in that phase.
+//
+// Meaning 3: a flag on the sent packet and on the sample. If a sent packet is
+// sent during the app-limited phase, the resulting sample related to the
+// packet will be marked as app-limited.
+//
+// With the terminology issue out of the way, let us consider the question of
+// what kind of situation it addresses.
+//
+// Consider a scenario where we first send packets 1 to 20 at a regular
+// bandwidth, and then immediately run out of data. After a few seconds, we send
+// packets 21 to 60, and only receive ack for 21 between sending packets 40 and
+// 41. In this case, when we sample bandwidth for packets 21 to 40, the S_0/A_0
+// we use to compute the slope is going to be packet 20, a few seconds apart
+// from the current packet, hence the resulting estimate would be extremely low
+// and not indicative of anything. Only at packet 41 the S_0/A_0 will become 21,
+// meaning that the bandwidth sample would exclude the quiescence.
+//
+// Based on the analysis of that scenario, we implement the following rule: once
+// OnAppLimited() is called, all sent packets will produce app-limited samples
+// up until an ack for a packet that was sent after OnAppLimited() was called.
+// Note that while the scenario above is not the only scenario when the
+// connection is app-limited, the approach works in other cases too.
+
+type congestionEventSample struct {
+	// The maximum bandwidth sample from all acked packets.
+	// QuicBandwidth::Zero() if no samples are available.
+	sampleMaxBandwidth Bandwidth
+	// Whether |sample_max_bandwidth| is from a app-limited sample.
+	sampleIsAppLimited bool
+	// The minimum rtt sample from all acked packets.
+	// QuicTime::Delta::Infinite() if no samples are available.
+	sampleRtt time.Duration
+	// For each packet p in acked packets, this is the max value of INFLIGHT(p),
+	// where INFLIGHT(p) is the number of bytes acked while p is inflight.
+	sampleMaxInflight protocol.ByteCount
+	// The send state of the largest packet in acked_packets, unless it is
+	// empty. If acked_packets is empty, it's the send state of the largest
+	// packet in lost_packets.
+	lastPacketSendState sendTimeState
+	// The number of extra bytes acked from this ack event, compared to what is
+	// expected from the flow's bandwidth. Larger value means more ack
+	// aggregation.
+	extraAcked protocol.ByteCount
+}
+
+func newCongestionEventSample() *congestionEventSample {
+	return &congestionEventSample{
+		sampleRtt: infRTT,
+	}
+}
+
+type bandwidthSampler struct {
+	// The total number of congestion controlled bytes sent during the connection.
+	totalBytesSent protocol.ByteCount
+
+	// The total number of congestion controlled bytes which were acknowledged.
+	totalBytesAcked protocol.ByteCount
+
+	// The total number of congestion controlled bytes which were lost.
+	totalBytesLost protocol.ByteCount
+
+	// The total number of congestion controlled bytes which have been neutered.
+	totalBytesNeutered protocol.ByteCount
+
+	// The value of |total_bytes_sent_| at the time the last acknowledged packet
+	// was sent. Valid only when |last_acked_packet_sent_time_| is valid.
+	totalBytesSentAtLastAckedPacket protocol.ByteCount
+
+	// The time at which the last acknowledged packet was sent. Set to
+	// QuicTime::Zero() if no valid timestamp is available.
+	lastAckedPacketSentTime time.Time
+
+	// The time at which the most recent packet was acknowledged.
+	lastAckedPacketAckTime time.Time
+
+	// The most recently sent packet.
+	lastSentPacket protocol.PacketNumber
+
+	// The most recently acked packet.
+	lastAckedPacket protocol.PacketNumber
+
+	// Indicates whether the bandwidth sampler is currently in an app-limited
+	// phase.
+	isAppLimited bool
+
+	// The packet that will be acknowledged after this one will cause the sampler
+	// to exit the app-limited phase.
+	endOfAppLimitedPhase protocol.PacketNumber
+
+	// Record of the connection state at the point where each packet in flight was
+	// sent, indexed by the packet number.
+	connectionStateMap *packetNumberIndexedQueue[connectionStateOnSentPacket]
+
+	recentAckPoints recentAckPoints
+	a0Candidates    ringbuffer.RingBuffer[ackPoint]
+
+	// Maximum number of tracked packets.
+	//
+	//lint:ignore U1000 Ignore unused function temporarily for debugging
+	maxTrackedPackets protocol.ByteCount
+
+	maxAckHeightTracker              *maxAckHeightTracker
+	totalBytesAckedAfterLastAckEvent protocol.ByteCount
+
+	// True if connection option 'BSAO' is set.
+	overestimateAvoidance bool
+
+	// True if connection option 'BBRB' is set.
+	limitMaxAckHeightTrackerBySendRate bool
+}
+
+func newBandwidthSampler(maxAckHeightTrackerWindowLength roundTripCount) *bandwidthSampler {
+	b := &bandwidthSampler{
+		maxAckHeightTracker:  newMaxAckHeightTracker(maxAckHeightTrackerWindowLength),
+		connectionStateMap:   newPacketNumberIndexedQueue[connectionStateOnSentPacket](defaultConnectionStateMapQueueSize),
+		lastSentPacket:       protocol.InvalidPacketNumber,
+		lastAckedPacket:      protocol.InvalidPacketNumber,
+		endOfAppLimitedPhase: protocol.InvalidPacketNumber,
+	}
+
+	b.a0Candidates.Init(defaultCandidatesBufferSize)
+
+	return b
+}
+
+func (b *bandwidthSampler) MaxAckHeight() protocol.ByteCount {
+	return b.maxAckHeightTracker.Get()
+}
+
+func (b *bandwidthSampler) NumAckAggregationEpochs() uint64 {
+	return b.maxAckHeightTracker.NumAckAggregationEpochs()
+}
+
+func (b *bandwidthSampler) SetMaxAckHeightTrackerWindowLength(length roundTripCount) {
+	b.maxAckHeightTracker.SetFilterWindowLength(length)
+}
+
+func (b *bandwidthSampler) ResetMaxAckHeightTracker(newHeight protocol.ByteCount, newTime roundTripCount) {
+	b.maxAckHeightTracker.Reset(newHeight, newTime)
+}
+
+func (b *bandwidthSampler) SetStartNewAggregationEpochAfterFullRound(value bool) {
+	b.maxAckHeightTracker.SetStartNewAggregationEpochAfterFullRound(value)
+}
+
+func (b *bandwidthSampler) SetLimitMaxAckHeightTrackerBySendRate(value bool) {
+	b.limitMaxAckHeightTrackerBySendRate = value
+}
+
+func (b *bandwidthSampler) SetReduceExtraAckedOnBandwidthIncrease(value bool) {
+	b.maxAckHeightTracker.SetReduceExtraAckedOnBandwidthIncrease(value)
+}
+
+func (b *bandwidthSampler) EnableOverestimateAvoidance() {
+	if b.overestimateAvoidance {
+		return
+	}
+
+	b.overestimateAvoidance = true
+	b.maxAckHeightTracker.SetAckAggregationBandwidthThreshold(2.0)
+}
+
+func (b *bandwidthSampler) IsOverestimateAvoidanceEnabled() bool {
+	return b.overestimateAvoidance
+}
+
+func (b *bandwidthSampler) OnPacketSent(
+	sentTime time.Time,
+	packetNumber protocol.PacketNumber,
+	bytes protocol.ByteCount,
+	bytesInFlight protocol.ByteCount,
+	isRetransmittable bool) {
+	b.lastSentPacket = packetNumber
+
+	if !isRetransmittable {
+		return
+	}
+
+	b.totalBytesSent += bytes
+
+	// If there are no packets in flight, the time at which the new transmission
+	// opens can be treated as the A_0 point for the purpose of bandwidth
+	// sampling. This underestimates bandwidth to some extent, and produces some
+	// artificially low samples for most packets in flight, but it provides with
+	// samples at important points where we would not have them otherwise, most
+	// importantly at the beginning of the connection.
+	if bytesInFlight == 0 {
+		b.lastAckedPacketAckTime = sentTime
+		if b.overestimateAvoidance {
+			b.recentAckPoints.Clear()
+			b.recentAckPoints.Update(sentTime, b.totalBytesAcked)
+			b.a0Candidates.Clear()
+			b.a0Candidates.PushBack(*b.recentAckPoints.MostRecentPoint())
+		}
+		b.totalBytesSentAtLastAckedPacket = b.totalBytesSent
+
+		// In this situation ack compression is not a concern, set send rate to
+		// effectively infinite.
+		b.lastAckedPacketSentTime = sentTime
+	}
+
+	b.connectionStateMap.Emplace(packetNumber, newConnectionStateOnSentPacket(
+		sentTime,
+		bytes,
+		bytesInFlight+bytes,
+		b,
+	))
+}
+
+func (b *bandwidthSampler) OnCongestionEvent(
+	ackTime time.Time,
+	ackedPackets []protocol.AckedPacketInfo,
+	lostPackets []protocol.LostPacketInfo,
+	maxBandwidth Bandwidth,
+	estBandwidthUpperBound Bandwidth,
+	roundTripCount roundTripCount,
+) congestionEventSample {
+	eventSample := newCongestionEventSample()
+
+	var lastLostPacketSendState sendTimeState
+
+	for _, p := range lostPackets {
+		sendState := b.OnPacketLost(p.PacketNumber, p.BytesLost)
+		if sendState.isValid {
+			lastLostPacketSendState = sendState
+		}
+	}
+
+	if len(ackedPackets) == 0 {
+		// Only populate send state for a loss-only event.
+		eventSample.lastPacketSendState = lastLostPacketSendState
+		return *eventSample
+	}
+
+	var lastAckedPacketSendState sendTimeState
+	var maxSendRate Bandwidth
+
+	for _, p := range ackedPackets {
+		sample := b.onPacketAcknowledged(ackTime, p.PacketNumber)
+		if !sample.stateAtSend.isValid {
+			continue
+		}
+
+		lastAckedPacketSendState = sample.stateAtSend
+
+		if sample.rtt != 0 {
+			eventSample.sampleRtt = utils.Min(eventSample.sampleRtt, sample.rtt)
+		}
+		if sample.bandwidth > eventSample.sampleMaxBandwidth {
+			eventSample.sampleMaxBandwidth = sample.bandwidth
+			eventSample.sampleIsAppLimited = sample.stateAtSend.isAppLimited
+		}
+		if sample.sendRate != infBandwidth {
+			maxSendRate = utils.Max(maxSendRate, sample.sendRate)
+		}
+		inflightSample := b.totalBytesAcked - lastAckedPacketSendState.totalBytesAcked
+		if inflightSample > eventSample.sampleMaxInflight {
+			eventSample.sampleMaxInflight = inflightSample
+		}
+	}
+
+	if !lastLostPacketSendState.isValid {
+		eventSample.lastPacketSendState = lastAckedPacketSendState
+	} else if !lastAckedPacketSendState.isValid {
+		eventSample.lastPacketSendState = lastLostPacketSendState
+	} else {
+		// If two packets are inflight and an alarm is armed to lose a packet and it
+		// wakes up late, then the first of two in flight packets could have been
+		// acknowledged before the wakeup, which re-evaluates loss detection, and
+		// could declare the later of the two lost.
+		if lostPackets[len(lostPackets)-1].PacketNumber > ackedPackets[len(ackedPackets)-1].PacketNumber {
+			eventSample.lastPacketSendState = lastLostPacketSendState
+		} else {
+			eventSample.lastPacketSendState = lastAckedPacketSendState
+		}
+	}
+
+	isNewMaxBandwidth := eventSample.sampleMaxBandwidth > maxBandwidth
+	maxBandwidth = utils.Max(maxBandwidth, eventSample.sampleMaxBandwidth)
+	if b.limitMaxAckHeightTrackerBySendRate {
+		maxBandwidth = utils.Max(maxBandwidth, maxSendRate)
+	}
+
+	eventSample.extraAcked = b.onAckEventEnd(utils.Min(estBandwidthUpperBound, maxBandwidth), isNewMaxBandwidth, roundTripCount)
+
+	return *eventSample
+}
+
+func (b *bandwidthSampler) OnPacketLost(packetNumber protocol.PacketNumber, bytesLost protocol.ByteCount) (s sendTimeState) {
+	b.totalBytesLost += bytesLost
+	if sentPacketPointer := b.connectionStateMap.GetEntry(packetNumber); sentPacketPointer != nil {
+		sentPacketToSendTimeState(sentPacketPointer, &s)
+	}
+	return s
+}
+
+func (b *bandwidthSampler) OnPacketNeutered(packetNumber protocol.PacketNumber) {
+	b.connectionStateMap.Remove(packetNumber, func(sentPacket connectionStateOnSentPacket) {
+		b.totalBytesNeutered += sentPacket.size
+	})
+}
+
+func (b *bandwidthSampler) OnAppLimited() {
+	b.isAppLimited = true
+	b.endOfAppLimitedPhase = b.lastSentPacket
+}
+
+func (b *bandwidthSampler) RemoveObsoletePackets(leastUnacked protocol.PacketNumber) {
+	// A packet can become obsolete when it is removed from QuicUnackedPacketMap's
+	// view of inflight before it is acked or marked as lost. For example, when
+	// QuicSentPacketManager::RetransmitCryptoPackets retransmits a crypto packet,
+	// the packet is removed from QuicUnackedPacketMap's inflight, but is not
+	// marked as acked or lost in the BandwidthSampler.
+	b.connectionStateMap.RemoveUpTo(leastUnacked)
+}
+
+func (b *bandwidthSampler) TotalBytesSent() protocol.ByteCount {
+	return b.totalBytesSent
+}
+
+func (b *bandwidthSampler) TotalBytesLost() protocol.ByteCount {
+	return b.totalBytesLost
+}
+
+func (b *bandwidthSampler) TotalBytesAcked() protocol.ByteCount {
+	return b.totalBytesAcked
+}
+
+func (b *bandwidthSampler) TotalBytesNeutered() protocol.ByteCount {
+	return b.totalBytesNeutered
+}
+
+func (b *bandwidthSampler) IsAppLimited() bool {
+	return b.isAppLimited
+}
+
+func (b *bandwidthSampler) EndOfAppLimitedPhase() protocol.PacketNumber {
+	return b.endOfAppLimitedPhase
+}
+
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+func (b *bandwidthSampler) max_ack_height() protocol.ByteCount {
+	return b.maxAckHeightTracker.Get()
+}
+
+func (b *bandwidthSampler) chooseA0Point(totalBytesAcked protocol.ByteCount, a0 *ackPoint) bool {
+	if b.a0Candidates.Empty() {
+		return false
+	}
+
+	if b.a0Candidates.Len() == 1 {
+		*a0 = *b.a0Candidates.Front()
+		return true
+	}
+
+	for i := 1; i < b.a0Candidates.Len(); i++ {
+		if b.a0Candidates.Offset(i).totalBytesAcked > totalBytesAcked {
+			*a0 = *b.a0Candidates.Offset(i - 1)
+			if i > 1 {
+				for j := 0; j < i-1; j++ {
+					b.a0Candidates.PopFront()
+				}
+			}
+			return true
+		}
+	}
+
+	*a0 = *b.a0Candidates.Back()
+	for k := 0; k < b.a0Candidates.Len()-1; k++ {
+		b.a0Candidates.PopFront()
+	}
+	return true
+}
+
+func (b *bandwidthSampler) onPacketAcknowledged(ackTime time.Time, packetNumber protocol.PacketNumber) bandwidthSample {
+	sample := newBandwidthSample()
+	b.lastAckedPacket = packetNumber
+	sentPacketPointer := b.connectionStateMap.GetEntry(packetNumber)
+	if sentPacketPointer == nil {
+		return *sample
+	}
+
+	// OnPacketAcknowledgedInner
+	b.totalBytesAcked += sentPacketPointer.size
+	b.totalBytesSentAtLastAckedPacket = sentPacketPointer.sendTimeState.totalBytesSent
+	b.lastAckedPacketSentTime = sentPacketPointer.sentTime
+	b.lastAckedPacketAckTime = ackTime
+	if b.overestimateAvoidance {
+		b.recentAckPoints.Update(ackTime, b.totalBytesAcked)
+	}
+
+	if b.isAppLimited {
+		// Exit app-limited phase in two cases:
+		// (1) end_of_app_limited_phase_ is not initialized, i.e., so far all
+		// packets are sent while there are buffered packets or pending data.
+		// (2) The current acked packet is after the sent packet marked as the end
+		// of the app limit phase.
+		if b.endOfAppLimitedPhase == protocol.InvalidPacketNumber ||
+			packetNumber > b.endOfAppLimitedPhase {
+			b.isAppLimited = false
+		}
+	}
+
+	// There might have been no packets acknowledged at the moment when the
+	// current packet was sent. In that case, there is no bandwidth sample to
+	// make.
+	if sentPacketPointer.lastAckedPacketSentTime.IsZero() {
+		return *sample
+	}
+
+	// Infinite rate indicates that the sampler is supposed to discard the
+	// current send rate sample and use only the ack rate.
+	sendRate := infBandwidth
+	if sentPacketPointer.sentTime.After(sentPacketPointer.lastAckedPacketSentTime) {
+		sendRate = BandwidthFromDelta(
+			sentPacketPointer.sendTimeState.totalBytesSent-sentPacketPointer.totalBytesSentAtLastAckedPacket,
+			sentPacketPointer.sentTime.Sub(sentPacketPointer.lastAckedPacketSentTime))
+	}
+
+	var a0 ackPoint
+	if b.overestimateAvoidance && b.chooseA0Point(sentPacketPointer.sendTimeState.totalBytesAcked, &a0) {
+	} else {
+		a0.ackTime = sentPacketPointer.lastAckedPacketAckTime
+		a0.totalBytesAcked = sentPacketPointer.sendTimeState.totalBytesAcked
+	}
+
+	// During the slope calculation, ensure that ack time of the current packet is
+	// always larger than the time of the previous packet, otherwise division by
+	// zero or integer underflow can occur.
+	if ackTime.Sub(a0.ackTime) <= 0 {
+		return *sample
+	}
+
+	ackRate := BandwidthFromDelta(b.totalBytesAcked-a0.totalBytesAcked, ackTime.Sub(a0.ackTime))
+
+	sample.bandwidth = utils.Min(sendRate, ackRate)
+	// Note: this sample does not account for delayed acknowledgement time.  This
+	// means that the RTT measurements here can be artificially high, especially
+	// on low bandwidth connections.
+	sample.rtt = ackTime.Sub(sentPacketPointer.sentTime)
+	sample.sendRate = sendRate
+	sentPacketToSendTimeState(sentPacketPointer, &sample.stateAtSend)
+
+	return *sample
+}
+
+func (b *bandwidthSampler) onAckEventEnd(
+	bandwidthEstimate Bandwidth,
+	isNewMaxBandwidth bool,
+	roundTripCount roundTripCount,
+) protocol.ByteCount {
+	newlyAckedBytes := b.totalBytesAcked - b.totalBytesAckedAfterLastAckEvent
+	if newlyAckedBytes == 0 {
+		return 0
+	}
+	b.totalBytesAckedAfterLastAckEvent = b.totalBytesAcked
+	extraAcked := b.maxAckHeightTracker.Update(
+		bandwidthEstimate,
+		isNewMaxBandwidth,
+		roundTripCount,
+		b.lastSentPacket,
+		b.lastAckedPacket,
+		b.lastAckedPacketAckTime,
+		newlyAckedBytes)
+	// If |extra_acked| is zero, i.e. this ack event marks the start of a new ack
+	// aggregation epoch, save LessRecentPoint, which is the last ack point of the
+	// previous epoch, as a A0 candidate.
+	if b.overestimateAvoidance && extraAcked == 0 {
+		b.a0Candidates.PushBack(*b.recentAckPoints.LessRecentPoint())
+	}
+	return extraAcked
+}
+
+func sentPacketToSendTimeState(sentPacket *connectionStateOnSentPacket, sendTimeState *sendTimeState) {
+	*sendTimeState = sentPacket.sendTimeState
+	sendTimeState.isValid = true
+}
+
+// BytesFromBandwidthAndTimeDelta calculates the bytes
+// from a bandwidth(bits per second) and a time delta
+func bytesFromBandwidthAndTimeDelta(bandwidth Bandwidth, delta time.Duration) protocol.ByteCount {
+	return (protocol.ByteCount(bandwidth) * protocol.ByteCount(delta)) /
+		(protocol.ByteCount(time.Second) * 8)
+}
+
+func timeDeltaFromBytesAndBandwidth(bytes protocol.ByteCount, bandwidth Bandwidth) time.Duration {
+	return time.Duration(bytes*8) * time.Second / time.Duration(bandwidth)
+}

--- a/internal/congestion/bandwidth_sampler_test.go
+++ b/internal/congestion/bandwidth_sampler_test.go
@@ -1,0 +1,886 @@
+package congestion
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
+)
+
+var _ = Describe("function", func() {
+	It("BytesFromBandwidthAndTimeDelta", func() {
+		Expect(
+			bytesFromBandwidthAndTimeDelta(
+				Bandwidth(80000),
+				100*time.Millisecond,
+			)).To(Equal(protocol.ByteCount(1000)))
+	})
+
+	It("TimeDeltaFromBytesAndBandwidth", func() {
+		Expect(timeDeltaFromBytesAndBandwidth(
+			protocol.ByteCount(50000),
+			Bandwidth(400),
+		)).To(Equal(1000 * time.Second))
+	})
+})
+
+var _ = Describe("MaxAckHeightTracker", func() {
+	var (
+		tracker               *maxAckHeightTracker
+		now                   time.Time
+		rtt                   time.Duration
+		bandwidth             Bandwidth
+		lastSentPacketNumber  protocol.PacketNumber
+		lastAckedPacketNumber protocol.PacketNumber
+
+		getRoundTripCount = func() roundTripCount {
+			return roundTripCount(now.Sub(time.Time{}) / rtt)
+		}
+
+		// Run a full aggregation episode, which is one or more aggregated acks,
+		// followed by a quiet period in which no ack happens.
+		// After this function returns, the time is set to the earliest point at which
+		// any ack event will cause tracker_.Update() to start a new aggregation.
+		aggregationEpisode = func(
+			aggregationBandwidth Bandwidth,
+			aggregationDuration time.Duration,
+			bytesPerAck protocol.ByteCount,
+			expectNewAggregationEpoch bool,
+		) {
+			Expect(aggregationBandwidth >= bandwidth).To(BeTrue())
+			startTime := now
+			aggregationBytes := bytesFromBandwidthAndTimeDelta(aggregationBandwidth, aggregationDuration)
+			numAcks := aggregationBytes / bytesPerAck
+			Expect(aggregationBytes).To(Equal(numAcks * bytesPerAck))
+			timeBetweenAcks := aggregationDuration / time.Duration(numAcks)
+			Expect(aggregationDuration).To(Equal(time.Duration(numAcks) * timeBetweenAcks))
+
+			// The total duration of aggregation time and quiet period.
+			totalDuration := timeDeltaFromBytesAndBandwidth(aggregationBytes, bandwidth)
+			Expect(aggregationBytes).To(Equal(bytesFromBandwidthAndTimeDelta(bandwidth, totalDuration)))
+
+			var lastExtraAcked protocol.ByteCount
+			for bytes := protocol.ByteCount(0); bytes < aggregationBytes; bytes += bytesPerAck {
+				extraAcked := tracker.Update(
+					bandwidth, true, getRoundTripCount(),
+					lastSentPacketNumber, lastAckedPacketNumber, now, bytesPerAck)
+				// |extra_acked| should be 0 if either
+				// [1] We are at the beginning of a aggregation epoch(bytes==0) and the
+				//     the current tracker implementation can identify it, or
+				// [2] We are not really aggregating acks.
+				if (bytes == 0 && expectNewAggregationEpoch) || (aggregationBandwidth == bandwidth) {
+					Expect(extraAcked).To(Equal(protocol.ByteCount(0)))
+				} else {
+					Expect(lastExtraAcked < extraAcked).To(BeTrue())
+				}
+				now = now.Add(timeBetweenAcks)
+				lastExtraAcked = extraAcked
+			}
+
+			// Advance past the quiet period.
+			now = startTime.Add(totalDuration)
+		}
+	)
+
+	BeforeEach(func() {
+		tracker = newMaxAckHeightTracker(10)
+		tracker.SetAckAggregationBandwidthThreshold(float64(1.8))
+		tracker.SetStartNewAggregationEpochAfterFullRound(true)
+
+		now = time.Time{}.Add(1 * time.Millisecond)
+		rtt = 60 * time.Millisecond
+		bandwidth = Bandwidth(10 * 1000 * 8)
+		lastSentPacketNumber = protocol.InvalidPacketNumber
+		lastAckedPacketNumber = protocol.InvalidPacketNumber
+	})
+
+	It("VeryAggregatedLargeAck", func() {
+		aggregationEpisode(bandwidth*20, time.Duration(6*time.Millisecond), 1200, true)
+		aggregationEpisode(bandwidth*20, time.Duration(6*time.Millisecond), 1200, true)
+		_ = now.Add(-1 * time.Millisecond)
+
+		if tracker.AckAggregationBandwidthThreshold() > float64(1.1) {
+			aggregationEpisode(bandwidth*20, time.Duration(6*time.Millisecond), 1200, true)
+			Expect(tracker.NumAckAggregationEpochs()).To(Equal(uint64(3)))
+		} else {
+			aggregationEpisode(bandwidth*20, time.Duration(6*time.Millisecond), 1200, false)
+			Expect(tracker.NumAckAggregationEpochs()).To(Equal(uint64(2)))
+		}
+	})
+
+	It("VeryAggregatedSmallAcks", func() {
+		aggregationEpisode(bandwidth*20, time.Duration(6*time.Millisecond), 300, true)
+		aggregationEpisode(bandwidth*20, time.Duration(6*time.Millisecond), 300, true)
+		_ = now.Add(-1 * time.Millisecond)
+
+		if tracker.AckAggregationBandwidthThreshold() > float64(1.1) {
+			aggregationEpisode(bandwidth*20, time.Duration(6*time.Millisecond), 300, true)
+			Expect(tracker.NumAckAggregationEpochs()).To(Equal(uint64(3)))
+		} else {
+			aggregationEpisode(bandwidth*20, time.Duration(6*time.Millisecond), 300, false)
+			Expect(tracker.NumAckAggregationEpochs()).To(Equal(uint64(2)))
+		}
+	})
+
+	It("SomewhatAggregatedLargeAck", func() {
+		aggregationEpisode(bandwidth*2, time.Duration(50*time.Millisecond), 1000, true)
+		aggregationEpisode(bandwidth*2, time.Duration(50*time.Millisecond), 1000, true)
+		_ = now.Add(-1 * time.Millisecond)
+
+		if tracker.AckAggregationBandwidthThreshold() > float64(1.1) {
+			aggregationEpisode(bandwidth*2, time.Duration(50*time.Millisecond), 1000, true)
+			Expect(tracker.NumAckAggregationEpochs()).To(Equal(uint64(3)))
+		} else {
+			aggregationEpisode(bandwidth*2, time.Duration(50*time.Millisecond), 1000, false)
+			Expect(tracker.NumAckAggregationEpochs()).To(Equal(uint64(2)))
+		}
+	})
+
+	It("SomewhatAggregatedSmallAcks", func() {
+		aggregationEpisode(bandwidth*2, time.Duration(50*time.Millisecond), 100, true)
+		aggregationEpisode(bandwidth*2, time.Duration(50*time.Millisecond), 100, true)
+		_ = now.Add(-1 * time.Millisecond)
+
+		if tracker.AckAggregationBandwidthThreshold() > float64(1.1) {
+			aggregationEpisode(bandwidth*2, time.Duration(50*time.Millisecond), 100, true)
+			Expect(tracker.NumAckAggregationEpochs()).To(Equal(uint64(3)))
+		} else {
+			aggregationEpisode(bandwidth*2, time.Duration(50*time.Millisecond), 100, false)
+			Expect(tracker.NumAckAggregationEpochs()).To(Equal(uint64(2)))
+		}
+	})
+
+	It("NotAggregated", func() {
+		aggregationEpisode(bandwidth, time.Duration(100*time.Millisecond), 100, true)
+		Expect(uint64(2) < tracker.NumAckAggregationEpochs()).To(BeTrue())
+	})
+
+	It("StartNewEpochAfterAFullRound", func() {
+		lastSentPacketNumber = protocol.PacketNumber(10)
+		aggregationEpisode(bandwidth*2, time.Duration(50*time.Millisecond), 100, true)
+
+		lastAckedPacketNumber = protocol.PacketNumber(11)
+		// Update with a tiny bandwidth causes a very low expected bytes acked, which
+		// in turn causes the current epoch to continue if the |tracker_| doesn't
+		// check the packet numbers.
+		tracker.Update(bandwidth/10, true, getRoundTripCount(), lastSentPacketNumber, lastAckedPacketNumber, now, 100)
+		Expect(tracker.NumAckAggregationEpochs()).To(Equal(uint64(2)))
+	})
+})
+
+var _ = Describe("BandwidthSampler", func() {
+	var (
+		now                      time.Time
+		sampler                  *bandwidthSampler
+		regularPacketSize        protocol.ByteCount
+		samplerAppLimitedAtStart bool
+		bytesInFlight            protocol.ByteCount
+		maxBandwidth             Bandwidth // Max observed bandwidth from acks.
+		estBandwidthUpperBound   Bandwidth
+		roundTripCount           roundTripCount // Needed to calculate extra_acked.
+
+		packetsToBytes = func(packetCount int) protocol.ByteCount {
+			return protocol.ByteCount(packetCount) * regularPacketSize
+		}
+
+		getPacketSize = func(packetNumber protocol.PacketNumber) protocol.ByteCount {
+			return sampler.connectionStateMap.GetEntry(packetNumber).size
+		}
+
+		getNumberOfTrackedPackets = func() int {
+			return sampler.connectionStateMap.NumberOfPresentEntries()
+		}
+
+		sendPacketInner = func(
+			packetNumber protocol.PacketNumber,
+			bytes protocol.ByteCount,
+			hasRetransmittableData bool,
+		) {
+			sampler.OnPacketSent(now, packetNumber, bytes, bytesInFlight, hasRetransmittableData)
+			if hasRetransmittableData {
+				bytesInFlight += bytes
+			}
+		}
+
+		sendPacket = func(packetNumber protocol.PacketNumber) {
+			sendPacketInner(packetNumber, regularPacketSize, true)
+		}
+
+		makeAckedPacket = func(packetNumber protocol.PacketNumber) protocol.AckedPacketInfo {
+			return protocol.AckedPacketInfo{
+				PacketNumber: packetNumber,
+				BytesAcked:   getPacketSize(packetNumber),
+				ReceivedTime: now,
+			}
+		}
+
+		ackPacketInner = func(packetNumber protocol.PacketNumber) bandwidthSample {
+			size := getPacketSize(packetNumber)
+			bytesInFlight -= size
+			ackedPacket := makeAckedPacket(packetNumber)
+			sample := sampler.OnCongestionEvent(now, []protocol.AckedPacketInfo{ackedPacket}, nil,
+				maxBandwidth, estBandwidthUpperBound, roundTripCount)
+			maxBandwidth = utils.Max(maxBandwidth, sample.sampleMaxBandwidth)
+			bwSample := newBandwidthSample()
+			bwSample.bandwidth = sample.sampleMaxBandwidth
+			bwSample.rtt = sample.sampleRtt
+			bwSample.stateAtSend = sample.lastPacketSendState
+			Expect(bwSample.stateAtSend.isValid).To(BeTrue())
+			return *bwSample
+		}
+
+		ackPacket = func(packetNumber protocol.PacketNumber) Bandwidth {
+			sample := ackPacketInner(packetNumber)
+			return sample.bandwidth
+		}
+
+		makeLostPacket = func(packetNumber protocol.PacketNumber) protocol.LostPacketInfo {
+			return protocol.LostPacketInfo{
+				PacketNumber: packetNumber,
+				BytesLost:    getPacketSize(packetNumber),
+			}
+		}
+
+		losePacket = func(packetNumber protocol.PacketNumber) sendTimeState {
+			size := getPacketSize(packetNumber)
+			bytesInFlight -= size
+			lostPacket := makeLostPacket(packetNumber)
+			sample := sampler.OnCongestionEvent(now, nil, []protocol.LostPacketInfo{lostPacket},
+				maxBandwidth, estBandwidthUpperBound, roundTripCount)
+
+			Expect(sample.lastPacketSendState.isValid).To(BeTrue())
+			Expect(sample.sampleMaxBandwidth).To(Equal(Bandwidth(0)))
+			Expect(sample.sampleRtt).To(Equal(infRTT))
+			return sample.lastPacketSendState
+		}
+
+		onCongestionEvent = func(ackedPacketNumbers, lostPacketNumbers []protocol.PacketNumber) congestionEventSample {
+			ackedPackets := []protocol.AckedPacketInfo{}
+			for _, packetNumber := range ackedPacketNumbers {
+				ackedPacket := makeAckedPacket(packetNumber)
+				ackedPackets = append(ackedPackets, makeAckedPacket(packetNumber))
+				bytesInFlight -= ackedPacket.BytesAcked
+			}
+			lostPackets := []protocol.LostPacketInfo{}
+			for _, packetNumber := range lostPacketNumbers {
+				lostPacket := makeLostPacket(packetNumber)
+				lostPackets = append(lostPackets, lostPacket)
+				bytesInFlight -= lostPacket.BytesLost
+			}
+
+			sample := sampler.OnCongestionEvent(now, ackedPackets, lostPackets,
+				maxBandwidth, estBandwidthUpperBound, roundTripCount)
+			maxBandwidth = utils.Max(maxBandwidth, sample.sampleMaxBandwidth)
+			return sample
+		}
+
+		// Sends one packet and acks it.  Then, send 20 packets.  Finally, send
+		// another 20 packets while acknowledging previous 20.
+		send40PacketsAndAckFirst20 = func(timeBetweenPackets time.Duration) {
+			// Send 20 packets at a constant inter-packet time.
+			for i := 1; i <= 20; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Ack packets 1 to 20, while sending new packets at the same rate as
+			// before.
+			for i := 1; i <= 20; i++ {
+				ackPacket(protocol.PacketNumber(i))
+				sendPacket(protocol.PacketNumber(i + 20))
+				now = now.Add(timeBetweenPackets)
+			}
+		}
+
+		testParameters = []struct {
+			overestimateAvoidance bool
+		}{
+			{
+				overestimateAvoidance: false,
+			},
+			{
+				overestimateAvoidance: true,
+			},
+		}
+
+		initial = func(param struct {
+			overestimateAvoidance bool
+		}) {
+			// Ensure that the clock does not start at zero.
+			now = time.Time{}.Add(1 * time.Second)
+			sampler = newBandwidthSampler(0)
+			regularPacketSize = protocol.ByteCount(1280)
+			samplerAppLimitedAtStart = false
+			bytesInFlight = protocol.ByteCount(0)
+			maxBandwidth = 0
+			estBandwidthUpperBound = infBandwidth
+			roundTripCount = 0
+
+			if param.overestimateAvoidance {
+				sampler.EnableOverestimateAvoidance()
+			}
+		}
+	)
+
+	// Test the sampler in a simple stop-and-wait sender setting.
+	It("SendAndWait", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 10 * time.Millisecond
+			expectedBandwidth := Bandwidth(regularPacketSize) * 100 * BytesPerSecond
+
+			// Send packets at the constant bandwidth.
+			for i := 1; i < 20; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				now = now.Add(timeBetweenPackets)
+				currentSample := ackPacket(protocol.PacketNumber(i))
+				Expect(expectedBandwidth).To(Equal(currentSample))
+			}
+
+			// Send packets at the exponentially decreasing bandwidth.
+			for i := 20; i < 25; i++ {
+				timeBetweenPackets *= 2
+				expectedBandwidth /= 2
+
+				sendPacket(protocol.PacketNumber(i))
+				now = now.Add(timeBetweenPackets)
+				currentSample := ackPacket(protocol.PacketNumber(i))
+				Expect(expectedBandwidth).To(Equal(currentSample))
+			}
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(25))
+
+			Expect(getNumberOfTrackedPackets()).To(Equal(int(0)))
+			Expect(bytesInFlight).To(Equal(protocol.ByteCount(0)))
+		}
+	})
+
+	It("SendTimeState", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 10 * time.Millisecond
+
+			// Send packets 1-5.
+			for i := 1; i <= 5; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				Expect(packetsToBytes(i)).To(Equal(sampler.TotalBytesSent()))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Ack packet 1.
+			sendTimeState := ackPacketInner(protocol.PacketNumber(1)).stateAtSend
+			Expect(packetsToBytes(1)).To(Equal(sendTimeState.totalBytesSent))
+			Expect(sendTimeState.totalBytesAcked).To(Equal(protocol.ByteCount(0)))
+			Expect(sendTimeState.totalBytesLost).To(Equal(protocol.ByteCount(0)))
+			Expect(packetsToBytes(1)).To(Equal(sampler.TotalBytesAcked()))
+
+			// Lose packet 2.
+			sendTimeState = losePacket(protocol.PacketNumber(2))
+			Expect(packetsToBytes(2)).To(Equal(sendTimeState.totalBytesSent))
+			Expect(sendTimeState.totalBytesAcked).To(Equal(protocol.ByteCount(0)))
+			Expect(sendTimeState.totalBytesLost).To(Equal(protocol.ByteCount(0)))
+			Expect(packetsToBytes(1)).To(Equal(sampler.TotalBytesLost()))
+
+			// Lose packet 3.
+			sendTimeState = losePacket(protocol.PacketNumber(3))
+			Expect(packetsToBytes(3)).To(Equal(sendTimeState.totalBytesSent))
+			Expect(sendTimeState.totalBytesAcked).To(Equal(protocol.ByteCount(0)))
+			Expect(sendTimeState.totalBytesLost).To(Equal(protocol.ByteCount(0)))
+			Expect(packetsToBytes(2)).To(Equal(sampler.TotalBytesLost()))
+
+			// Send packets 6-10.
+			for i := 6; i <= 10; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				Expect(packetsToBytes(i)).To(Equal(sampler.TotalBytesSent()))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Ack all inflight packets.
+			ackedPacketCount := 1
+			Expect(packetsToBytes(ackedPacketCount)).To(Equal(sampler.TotalBytesAcked()))
+			for i := 4; i <= 10; i++ {
+				sendTimeState = ackPacketInner(protocol.PacketNumber(i)).stateAtSend
+				ackedPacketCount++
+				Expect(packetsToBytes(ackedPacketCount)).To(Equal(sampler.TotalBytesAcked()))
+				Expect(packetsToBytes(i)).To(Equal(sendTimeState.totalBytesSent))
+				if i <= 5 {
+					Expect(sendTimeState.totalBytesAcked).To(Equal(protocol.ByteCount(0)))
+					Expect(sendTimeState.totalBytesLost).To(Equal(protocol.ByteCount(0)))
+				} else {
+					Expect(sendTimeState.totalBytesAcked).To(Equal(packetsToBytes(1)))
+					Expect(sendTimeState.totalBytesLost).To(Equal(packetsToBytes(2)))
+				}
+
+				// This equation works because there is no neutered bytes.
+				Expect(sendTimeState.totalBytesSent - sendTimeState.totalBytesAcked - sendTimeState.totalBytesLost).
+					To(Equal(sendTimeState.bytesInFlight))
+
+				now = now.Add(timeBetweenPackets)
+			}
+		}
+	})
+
+	// Test the sampler during regular windowed sender scenario with fixed
+	// CWND of 20.
+	It("SendPaced", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 1 * time.Millisecond
+			expectedBandwidth := Bandwidth(regularPacketSize) * 1000 * BytesPerSecond
+
+			send40PacketsAndAckFirst20(timeBetweenPackets)
+
+			// Ack the packets 21 to 40, arriving at the correct bandwidth.
+			var lastBandwidth Bandwidth
+			for i := 21; i <= 40; i++ {
+				lastBandwidth = ackPacket(protocol.PacketNumber(i))
+				Expect(expectedBandwidth).To(Equal(lastBandwidth))
+				now = now.Add(timeBetweenPackets)
+			}
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(41))
+
+			Expect(getNumberOfTrackedPackets()).To(Equal(0))
+			Expect(bytesInFlight).To(Equal(protocol.ByteCount(0)))
+		}
+	})
+
+	// Test the sampler in a scenario where 50% of packets is consistently lost.
+	It("SendWithLosses", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 1 * time.Millisecond
+			expectedBandwidth := Bandwidth(regularPacketSize) * 500 * BytesPerSecond
+
+			// Send 20 packets, each 1 ms apart.
+			for i := 1; i <= 20; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Ack packets 1 to 20, losing every even-numbered packet, while sending new
+			// packets at the same rate as before.
+			for i := 1; i <= 20; i++ {
+				if i%2 == 0 {
+					ackPacket(protocol.PacketNumber(i))
+				} else {
+					losePacket(protocol.PacketNumber(i))
+				}
+				sendPacket(protocol.PacketNumber(i + 20))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Ack the packets 21 to 40 with the same loss pattern.
+			var lastBandwidth Bandwidth
+			for i := 21; i <= 40; i++ {
+				if i%2 == 0 {
+					lastBandwidth = ackPacket(protocol.PacketNumber(i))
+					Expect(expectedBandwidth).To(Equal(lastBandwidth))
+				} else {
+					losePacket(protocol.PacketNumber(i))
+				}
+
+				now = now.Add(timeBetweenPackets)
+			}
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(41))
+
+			Expect(getNumberOfTrackedPackets()).To(Equal(0))
+			Expect(bytesInFlight).To(Equal(protocol.ByteCount(0)))
+		}
+	})
+
+	// Test the sampler in a scenario where the 50% of packets are not
+	// congestion controlled (specifically, non-retransmittable data is not
+	// congestion controlled).  Should be functionally consistent in behavior with
+	// the SendWithLosses test.
+	It("NotCongestionControlled", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 1 * time.Millisecond
+			expectedBandwidth := Bandwidth(regularPacketSize) * 500 * BytesPerSecond
+
+			// Send 20 packets, each 1 ms apart. Every even packet is not congestion
+			// controlled.
+			for i := 1; i <= 20; i++ {
+				sendPacketInner(protocol.PacketNumber(i), regularPacketSize, i%2 == 0)
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Ensure only congestion controlled packets are tracked.
+			Expect(getNumberOfTrackedPackets()).To(Equal(10))
+
+			// Ack packets 2 to 21, ignoring every even-numbered packet, while sending new
+			// packets at the same rate as before.
+			for i := 1; i <= 20; i++ {
+				if i%2 == 0 {
+					ackPacket(protocol.PacketNumber(i))
+				}
+				sendPacketInner(protocol.PacketNumber(i+20), regularPacketSize, i%2 == 0)
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Ack the packets 22 to 41 with the same congestion controlled pattern.
+			var lastBandwidth Bandwidth
+			for i := 21; i <= 40; i++ {
+				if i%2 == 0 {
+					lastBandwidth = ackPacket(protocol.PacketNumber(i))
+					Expect(expectedBandwidth).To(Equal(lastBandwidth))
+				}
+				now = now.Add(timeBetweenPackets)
+			}
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(41))
+
+			// Since only congestion controlled packets are entered into the map, it has
+			// to be empty at this point.
+			Expect(getNumberOfTrackedPackets()).To(Equal(0))
+			Expect(bytesInFlight).To(Equal(protocol.ByteCount(0)))
+		}
+	})
+
+	// Simulate a situation where ACKs arrive in burst and earlier than usual, thus
+	// producing an ACK rate which is higher than the original send rate.
+	It("CompressedAck", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 1 * time.Millisecond
+			expectedBandwidth := Bandwidth(regularPacketSize) * 1000 * BytesPerSecond
+
+			send40PacketsAndAckFirst20(timeBetweenPackets)
+
+			// Simulate an RTT somewhat lower than the one for 1-to-21 transmission.
+			now = now.Add(timeBetweenPackets * 15)
+
+			// Ack the packets 21 to 40 almost immediately at once.
+			var lastBandwidth Bandwidth
+			ridiculouslySmallTimeDelta := 20 * time.Microsecond
+			for i := 21; i <= 40; i++ {
+				lastBandwidth = ackPacket(protocol.PacketNumber(i))
+				now = now.Add(ridiculouslySmallTimeDelta)
+			}
+			Expect(expectedBandwidth).To(Equal(lastBandwidth))
+
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(41))
+
+			Expect(getNumberOfTrackedPackets()).To(Equal(0))
+			Expect(bytesInFlight).To(Equal(protocol.ByteCount(0)))
+		}
+	})
+
+	// Tests receiving ACK packets in the reverse order.
+	It("ReorderedAck", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 1 * time.Millisecond
+			expectedBandwidth := Bandwidth(regularPacketSize) * 1000 * BytesPerSecond
+
+			send40PacketsAndAckFirst20(timeBetweenPackets)
+
+			// Ack the packets 21 to 40 in the reverse order, while sending packets 41 to
+			// 60.
+			var lastBandwidth Bandwidth
+			for i := 0; i < 20; i++ {
+				lastBandwidth = ackPacket(protocol.PacketNumber(40 - i))
+				Expect(expectedBandwidth).To(Equal(lastBandwidth))
+				sendPacket(protocol.PacketNumber(41 + i))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			for i := 41; i <= 60; i++ {
+				lastBandwidth = ackPacket(protocol.PacketNumber(i))
+				Expect(expectedBandwidth).To(Equal(lastBandwidth))
+				now = now.Add(timeBetweenPackets)
+			}
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(61))
+
+			Expect(getNumberOfTrackedPackets()).To(Equal(0))
+			Expect(bytesInFlight).To(Equal(protocol.ByteCount(0)))
+		}
+	})
+
+	// Test the app-limited logic.
+	It("AppLimited", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 1 * time.Millisecond
+			expectedBandwidth := Bandwidth(regularPacketSize) * 1000 * BytesPerSecond
+
+			// Send 20 packets at a constant inter-packet time.
+			for i := 1; i <= 20; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Ack packets 1 to 20, while sending new packets at the same rate as
+			// before.
+			for i := 1; i <= 20; i++ {
+				sample := ackPacketInner(protocol.PacketNumber(i))
+				Expect(sample.stateAtSend.isAppLimited).To(Equal(samplerAppLimitedAtStart))
+				sendPacket(protocol.PacketNumber(i + 20))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// We are now app-limited. Ack 21 to 40 as usual, but do not send anything for
+			// now.
+			sampler.OnAppLimited()
+			for i := 21; i <= 40; i++ {
+				sample := ackPacketInner(protocol.PacketNumber(i))
+				Expect(sample.stateAtSend.isAppLimited).To(BeFalse())
+				Expect(expectedBandwidth).To(Equal(sample.bandwidth))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Enter quiescence.
+			now = now.Add(1 * time.Second)
+
+			// Send packets 41 to 60, all of which would be marked as app-limited.
+			for i := 41; i <= 60; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Ack packets 41 to 60, while sending packets 61 to 80.  41 to 60 should be
+			// app-limited and underestimate the bandwidth due to that.
+			for i := 41; i <= 60; i++ {
+				sample := ackPacketInner(protocol.PacketNumber(i))
+				Expect(sample.stateAtSend.isAppLimited).To(BeTrue())
+				Expect(sample.bandwidth < expectedBandwidth*7/10).To(BeTrue())
+				sendPacket(protocol.PacketNumber(i + 20))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// Run out of packets, and then ack packet 61 to 80, all of which should have
+			// correct non-app-limited samples.
+			for i := 61; i <= 80; i++ {
+				sample := ackPacketInner(protocol.PacketNumber(i))
+				Expect(sample.stateAtSend.isAppLimited).To(BeFalse())
+				Expect(expectedBandwidth).To(Equal(sample.bandwidth))
+				now = now.Add(timeBetweenPackets)
+			}
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(81))
+
+			Expect(getNumberOfTrackedPackets()).To(Equal(0))
+			Expect(bytesInFlight).To(Equal(protocol.ByteCount(0)))
+		}
+	})
+
+	// Test the samples taken at the first flight of packets sent.
+	It("FirstRoundTrip", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 1 * time.Millisecond
+			rtt := 800 * time.Millisecond
+			numPackets := 10
+			numBytes := regularPacketSize * protocol.ByteCount(numPackets)
+			realBandwidth := BandwidthFromDelta(numBytes, rtt)
+
+			for i := 1; i <= 10; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				now = now.Add(timeBetweenPackets)
+			}
+
+			now = now.Add(rtt - time.Duration(numPackets)*timeBetweenPackets)
+
+			var lastSample Bandwidth
+			for i := 1; i <= 10; i++ {
+				sample := ackPacket(protocol.PacketNumber(i))
+				Expect(sample > lastSample).To(BeTrue())
+				lastSample = sample
+				now = now.Add(timeBetweenPackets)
+			}
+
+			// The final measured sample for the first flight of sample is expected to be
+			// smaller than the real bandwidth, yet it should not lose more than 10%. The
+			// specific value of the error depends on the difference between the RTT and
+			// the time it takes to exhaust the congestion window (i.e. in the limit when
+			// all packets are sent simultaneously, last sample would indicate the real
+			// bandwidth).
+			Expect(lastSample < realBandwidth).To(BeTrue())
+			Expect(lastSample > realBandwidth*9/10).To(BeTrue())
+		}
+	})
+
+	// Test sampler's ability to remove obsolete packets.
+	It("RemoveObsoletePackets", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			for i := 1; i <= 5; i++ {
+				sendPacket(protocol.PacketNumber(i))
+			}
+
+			now = now.Add(100 * time.Millisecond)
+
+			Expect(getNumberOfTrackedPackets()).To(Equal(5))
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(4))
+			Expect(getNumberOfTrackedPackets()).To(Equal(2))
+			losePacket(protocol.PacketNumber(4))
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(5))
+
+			Expect(getNumberOfTrackedPackets()).To(Equal(1))
+			ackPacket(protocol.PacketNumber(5))
+
+			sampler.RemoveObsoletePackets(protocol.PacketNumber(6))
+
+			Expect(getNumberOfTrackedPackets()).To(Equal(0))
+		}
+	})
+
+	It("NeuterPacket", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			sendPacket(protocol.PacketNumber(1))
+			Expect(sampler.TotalBytesNeutered()).To(Equal(protocol.ByteCount(0)))
+
+			now = now.Add(10 * time.Millisecond)
+			sampler.OnPacketNeutered(protocol.PacketNumber(1))
+
+			Expect(sampler.TotalBytesNeutered() > 0).To(BeTrue())
+			Expect(sampler.TotalBytesAcked() == 0).To(BeTrue())
+
+			// If packet 1 is acked it should not produce a bandwidth sample.
+			now = now.Add(10 * time.Millisecond)
+			sample := sampler.OnCongestionEvent(now, []protocol.AckedPacketInfo{{
+				PacketNumber: protocol.PacketNumber(1),
+				BytesAcked:   regularPacketSize,
+				ReceivedTime: now,
+			}}, nil, maxBandwidth, estBandwidthUpperBound, roundTripCount)
+
+			Expect(sampler.TotalBytesAcked() == 0).To(BeTrue())
+			Expect(sample.sampleMaxBandwidth == 0).To(BeTrue())
+
+			Expect(sample.sampleIsAppLimited).To(BeFalse())
+			Expect(sample.sampleRtt == infRTT).To(BeTrue())
+			Expect(sample.sampleMaxInflight == 0).To(BeTrue())
+			Expect(sample.extraAcked == 0).To(BeTrue())
+		}
+	})
+
+	It("CongestionEventSampleDefaultValues", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			// Make sure a default constructed CongestionEventSample has the correct
+			// initial values for BandwidthSampler::OnCongestionEvent() to work.
+			sample := newCongestionEventSample()
+
+			Expect(sample.sampleMaxBandwidth == 0).To(BeTrue())
+			Expect(sample.sampleIsAppLimited).To(BeFalse())
+			Expect(sample.sampleRtt == infRTT).To(BeTrue())
+			Expect(sample.sampleMaxInflight == 0).To(BeTrue())
+			Expect(sample.extraAcked == 0).To(BeTrue())
+		}
+	})
+
+	// 1) Send 2 packets, 2) Ack both in 1 event, 3) Repeat.
+	It("TwoAckedPacketsPerEvent", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 10 * time.Millisecond
+			sendingRate := BandwidthFromDelta(regularPacketSize, timeBetweenPackets)
+
+			for i := 1; i < 21; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				now = now.Add(timeBetweenPackets)
+				if i%2 != 0 {
+					continue
+				}
+
+				sample := onCongestionEvent([]protocol.PacketNumber{
+					protocol.PacketNumber(i - 1),
+					protocol.PacketNumber(i),
+				}, []protocol.PacketNumber{})
+
+				Expect(sendingRate == sample.sampleMaxBandwidth).To(BeTrue())
+				Expect(timeBetweenPackets == sample.sampleRtt).To(BeTrue())
+				Expect(2*regularPacketSize == sample.sampleMaxInflight).To(BeTrue())
+				Expect(sample.lastPacketSendState.isValid).To(BeTrue())
+				Expect(2*regularPacketSize == sample.lastPacketSendState.bytesInFlight).To(BeTrue())
+				Expect(protocol.ByteCount(i)*regularPacketSize == sample.lastPacketSendState.totalBytesSent).To(BeTrue())
+				Expect(protocol.ByteCount(i-2)*regularPacketSize == sample.lastPacketSendState.totalBytesAcked).To(BeTrue())
+				Expect(sample.lastPacketSendState.totalBytesLost == 0).To(BeTrue())
+				sampler.RemoveObsoletePackets(protocol.PacketNumber(i - 2))
+			}
+		}
+	})
+
+	It("LoseEveryOtherPacket", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 10 * time.Millisecond
+			sendingRate := BandwidthFromDelta(regularPacketSize, timeBetweenPackets)
+
+			for i := 1; i < 21; i++ {
+				sendPacket(protocol.PacketNumber(i))
+				now = now.Add(timeBetweenPackets)
+				if i%2 != 0 {
+					continue
+				}
+
+				// Ack packet i and lose i-1.
+				sample := onCongestionEvent([]protocol.PacketNumber{
+					protocol.PacketNumber(i),
+				}, []protocol.PacketNumber{
+					protocol.PacketNumber(i - 1),
+				})
+				// Losing 50% packets means sending rate is twice the bandwidth.
+				Expect(sendingRate == sample.sampleMaxBandwidth*2).To(BeTrue())
+				Expect(timeBetweenPackets == sample.sampleRtt).To(BeTrue())
+				Expect(regularPacketSize == sample.sampleMaxInflight).To(BeTrue())
+				Expect(sample.lastPacketSendState.isValid).To(BeTrue())
+				Expect(2*regularPacketSize == sample.lastPacketSendState.bytesInFlight).To(BeTrue())
+				Expect(protocol.ByteCount(i)*regularPacketSize == sample.lastPacketSendState.totalBytesSent).To(BeTrue())
+				Expect(protocol.ByteCount(i-2)*regularPacketSize/2 == sample.lastPacketSendState.totalBytesAcked).To(BeTrue())
+				Expect(protocol.ByteCount(i-2)*regularPacketSize/2 == sample.lastPacketSendState.totalBytesLost).To(BeTrue())
+				sampler.RemoveObsoletePackets(protocol.PacketNumber(i - 2))
+			}
+		}
+	})
+
+	It("AckHeightRespectBandwidthEstimateUpperBound", func() {
+		for _, param := range testParameters {
+			initial(param)
+
+			timeBetweenPackets := 10 * time.Millisecond
+			firstPacketSendingRate := BandwidthFromDelta(regularPacketSize, timeBetweenPackets)
+
+			// Send packets 1 to 4 and ack packet 1.
+			sendPacket(protocol.PacketNumber(1))
+			now = now.Add(timeBetweenPackets)
+			sendPacket(protocol.PacketNumber(2))
+			sendPacket(protocol.PacketNumber(3))
+			sendPacket(protocol.PacketNumber(4))
+			sample := onCongestionEvent([]protocol.PacketNumber{
+				protocol.PacketNumber(1),
+			}, []protocol.PacketNumber{})
+			Expect(firstPacketSendingRate == sample.sampleMaxBandwidth).To(BeTrue())
+			Expect(firstPacketSendingRate == maxBandwidth).To(BeTrue())
+
+			// Ack packet 2, 3 and 4, all of which uses S(1) to calculate ack rate since
+			// there were no acks at the time they were sent.
+			roundTripCount++
+			estBandwidthUpperBound = firstPacketSendingRate * 3 / 10
+			now = now.Add(timeBetweenPackets)
+			sample = onCongestionEvent([]protocol.PacketNumber{
+				protocol.PacketNumber(2),
+				protocol.PacketNumber(3),
+				protocol.PacketNumber(4),
+			}, []protocol.PacketNumber{})
+			Expect(firstPacketSendingRate*2 == sample.sampleMaxBandwidth).To(BeTrue())
+			Expect(sample.sampleMaxBandwidth == maxBandwidth).To(BeTrue())
+
+			Expect(2*regularPacketSize < sample.extraAcked).To(BeTrue())
+		}
+	})
+})

--- a/internal/congestion/bbr_sender.go
+++ b/internal/congestion/bbr_sender.go
@@ -1,0 +1,947 @@
+package congestion
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/logging"
+)
+
+// BbrSender implements BBR congestion control algorithm.  BBR aims to estimate
+// the current available Bottleneck Bandwidth and RTT (hence the name), and
+// regulates the pacing rate and the size of the congestion window based on
+// those signals.
+//
+// BBR relies on pacing in order to function properly.  Do not use BBR when
+// pacing is disabled.
+//
+
+const (
+	// Constants based on TCP defaults.
+	// The minimum CWND to ensure delayed acks don't reduce bandwidth measurements.
+	// Does not inflate the pacing rate.
+	defaultMinimumCongestionWindow = 4 * protocol.ByteCount(protocol.InitialPacketSize)
+
+	// The gain used for the STARTUP, equal to 2/ln(2).
+	defaultHighGain = 2.885
+	// The newly derived gain for STARTUP, equal to 4 * ln(2)
+	//
+	//lint:ignore U1000 Ignore unused function temporarily for debugging
+	derivedHighGain = 2.773
+	// The newly derived CWND gain for STARTUP, 2.
+	derivedHighCWNDGain = 2.0
+)
+
+// The cycle of gains used during the PROBE_BW stage.
+var pacingGain = [...]float64{1.25, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}
+
+const (
+	// The length of the gain cycle.
+	gainCycleLength = len(pacingGain)
+	// The size of the bandwidth filter window, in round-trips.
+	bandwidthWindowSize = gainCycleLength + 2
+
+	// The time after which the current min_rtt value expires.
+	minRttExpiry = 10 * time.Second
+	// The minimum time the connection can spend in PROBE_RTT mode.
+	probeRttTime = 200 * time.Millisecond
+	// If the bandwidth does not increase by the factor of |kStartupGrowthTarget|
+	// within |kRoundTripsWithoutGrowthBeforeExitingStartup| rounds, the connection
+	// will exit the STARTUP mode.
+	startupGrowthTarget                         = 1.25
+	roundTripsWithoutGrowthBeforeExitingStartup = int64(3)
+
+	// Flag.
+	defaultStartupFullLossCount  = 8
+	quicBbr2DefaultLossThreshold = 0.02
+	maxBbrBurstPackets           = 3
+)
+
+type bbrMode int
+
+const (
+	// Startup phase of the connection.
+	bbrModeStartup = iota
+	// After achieving the highest possible bandwidth during the startup, lower
+	// the pacing rate in order to drain the queue.
+	bbrModeDrain
+	// Cruising mode.
+	bbrModeProbeBw
+	// Temporarily slow down sending in order to empty the buffer and measure
+	// the real minimum RTT.
+	bbrModeProbeRtt
+)
+
+// Indicates how the congestion control limits the amount of bytes in flight.
+type bbrRecoveryState int
+
+const (
+	// Do not limit.
+	bbrRecoveryStateNotInRecovery = iota
+	// Allow an extra outstanding byte for each byte acknowledged.
+	bbrRecoveryStateConservation
+	// Allow two extra outstanding bytes for each byte acknowledged (slow
+	// start).
+	bbrRecoveryStateGrowth
+)
+
+type bbrSender struct {
+	rttStats *utils.RTTStats
+	clock    Clock
+	rand     utils.Rand
+	pacer    *pacer
+
+	mode bbrMode
+
+	// Bandwidth sampler provides BBR with the bandwidth measurements at
+	// individual points.
+	sampler *bandwidthSampler
+
+	// The number of the round trips that have occurred during the connection.
+	roundTripCount roundTripCount
+
+	// The packet number of the most recently sent packet.
+	lastSentPacket protocol.PacketNumber
+	// Acknowledgement of any packet after |current_round_trip_end_| will cause
+	// the round trip counter to advance.
+	currentRoundTripEnd protocol.PacketNumber
+
+	// Number of congestion events with some losses, in the current round.
+	numLossEventsInRound uint64
+
+	// Number of total bytes lost in the current round.
+	bytesLostInRound protocol.ByteCount
+
+	// The filter that tracks the maximum bandwidth over the multiple recent
+	// round-trips.
+	maxBandwidth *utils.WindowedFilter[Bandwidth, roundTripCount]
+
+	// Minimum RTT estimate.  Automatically expires within 10 seconds (and
+	// triggers PROBE_RTT mode) if no new value is sampled during that period.
+	minRtt time.Duration
+	// The time at which the current value of |min_rtt_| was assigned.
+	minRttTimestamp time.Time
+
+	// The maximum allowed number of bytes in flight.
+	congestionWindow protocol.ByteCount
+
+	// The initial value of the |congestion_window_|.
+	initialCongestionWindow protocol.ByteCount
+
+	// The largest value the |congestion_window_| can achieve.
+	maxCongestionWindow protocol.ByteCount
+
+	// The smallest value the |congestion_window_| can achieve.
+	minCongestionWindow protocol.ByteCount
+
+	// The pacing gain applied during the STARTUP phase.
+	highGain float64
+
+	// The CWND gain applied during the STARTUP phase.
+	highCwndGain float64
+
+	// The pacing gain applied during the DRAIN phase.
+	drainGain float64
+
+	// The current pacing rate of the connection.
+	pacingRate Bandwidth
+
+	// The gain currently applied to the pacing rate.
+	pacingGain float64
+	// The gain currently applied to the congestion window.
+	congestionWindowGain float64
+
+	// The gain used for the congestion window during PROBE_BW.  Latched from
+	// quic_bbr_cwnd_gain flag.
+	congestionWindowGainConstant float64
+	// The number of RTTs to stay in STARTUP mode.  Defaults to 3.
+	numStartupRtts int64
+
+	// Number of round-trips in PROBE_BW mode, used for determining the current
+	// pacing gain cycle.
+	cycleCurrentOffset int
+	// The time at which the last pacing gain cycle was started.
+	lastCycleStart time.Time
+
+	// Indicates whether the connection has reached the full bandwidth mode.
+	isAtFullBandwidth bool
+	// Number of rounds during which there was no significant bandwidth increase.
+	roundsWithoutBandwidthGain int64
+	// The bandwidth compared to which the increase is measured.
+	bandwidthAtLastRound Bandwidth
+
+	// Set to true upon exiting quiescence.
+	exitingQuiescence bool
+
+	// Time at which PROBE_RTT has to be exited.  Setting it to zero indicates
+	// that the time is yet unknown as the number of packets in flight has not
+	// reached the required value.
+	exitProbeRttAt time.Time
+	// Indicates whether a round-trip has passed since PROBE_RTT became active.
+	probeRttRoundPassed bool
+
+	// Indicates whether the most recent bandwidth sample was marked as
+	// app-limited.
+	lastSampleIsAppLimited bool
+	// Indicates whether any non app-limited samples have been recorded.
+	hasNoAppLimitedSample bool
+
+	// Current state of recovery.
+	recoveryState bbrRecoveryState
+	// Receiving acknowledgement of a packet after |end_recovery_at_| will cause
+	// BBR to exit the recovery mode.  A value above zero indicates at least one
+	// loss has been detected, so it must not be set back to zero.
+	endRecoveryAt protocol.PacketNumber
+	// A window used to limit the number of bytes in flight during loss recovery.
+	recoveryWindow protocol.ByteCount
+	// If true, consider all samples in recovery app-limited.
+	//
+	//lint:ignore U1000 Ignore unused function temporarily for debugging
+	isAppLimitedRecovery bool // not used
+
+	// When true, pace at 1.5x and disable packet conservation in STARTUP.
+	//
+	//lint:ignore U1000 Ignore unused function temporarily for debugging
+	slowerStartup bool // not used
+	// When true, disables packet conservation in STARTUP.
+	//
+	//lint:ignore U1000 Ignore unused function temporarily for debugging
+	rateBasedStartup bool // not used
+
+	// When true, add the most recent ack aggregation measurement during STARTUP.
+	enableAckAggregationDuringStartup bool
+	// When true, expire the windowed ack aggregation values in STARTUP when
+	// bandwidth increases more than 25%.
+	expireAckAggregationInStartup bool
+
+	// If true, will not exit low gain mode until bytes_in_flight drops below BDP
+	// or it's time for high gain mode.
+	drainToTarget bool
+
+	// If true, slow down pacing rate in STARTUP when overshooting is detected.
+	detectOvershooting bool
+	// Bytes lost while detect_overshooting_ is true.
+	bytesLostWhileDetectingOvershooting protocol.ByteCount
+	// Slow down pacing rate if
+	// bytes_lost_while_detecting_overshooting_ *
+	// bytes_lost_multiplier_while_detecting_overshooting_ > IW.
+	bytesLostMultiplierWhileDetectingOvershooting uint8
+	// When overshooting is detected, do not drop pacing_rate_ below this value /
+	// min_rtt.
+	cwndToCalculateMinPacingRate protocol.ByteCount
+
+	// Max congestion window when adjusting network parameters.
+	maxCongestionWindowWithNetworkParametersAdjusted protocol.ByteCount // not used
+
+	// Params.
+	maxDatagramSize protocol.ByteCount
+	lastState       logging.CongestionState
+	tracer          *logging.ConnectionTracer
+	// Recorded on packet sent. equivalent |unacked_packets_->bytes_in_flight()|
+	bytesInFlight protocol.ByteCount
+}
+
+var (
+	_ SendAlgorithm               = &bbrSender{}
+	_ SendAlgorithmWithDebugInfos = &bbrSender{}
+	_ CongestionEventParticular   = &bbrSender{}
+)
+
+// NewCubicSender makes a new cubic sender
+func NewBbrSender(
+	clock Clock,
+	rttStats *utils.RTTStats,
+	initialMaxDatagramSize protocol.ByteCount,
+	tracer *logging.ConnectionTracer,
+) *bbrSender {
+	return newBbrSender(
+		clock,
+		rttStats,
+		initialMaxDatagramSize,
+		initialCongestionWindow*initialMaxDatagramSize,
+		protocol.MaxCongestionWindowPackets*initialMaxDatagramSize,
+		tracer,
+	)
+}
+
+func newBbrSender(
+	clock Clock,
+	rttStats *utils.RTTStats,
+	initialMaxDatagramSize,
+	initialCongestionWindow,
+	initialMaxCongestionWindow protocol.ByteCount,
+	tracer *logging.ConnectionTracer,
+) *bbrSender {
+	b := &bbrSender{
+		clock:                        clock,
+		rttStats:                     rttStats,
+		mode:                         bbrModeStartup,
+		sampler:                      newBandwidthSampler(roundTripCount(bandwidthWindowSize)),
+		lastSentPacket:               protocol.InvalidPacketNumber,
+		currentRoundTripEnd:          protocol.InvalidPacketNumber,
+		maxBandwidth:                 utils.NewWindowedFilter(roundTripCount(bandwidthWindowSize), utils.MaxFilter[Bandwidth]),
+		congestionWindow:             initialCongestionWindow,
+		initialCongestionWindow:      initialCongestionWindow,
+		maxCongestionWindow:          initialMaxCongestionWindow,
+		minCongestionWindow:          defaultMinimumCongestionWindow,
+		highGain:                     defaultHighGain,
+		highCwndGain:                 defaultHighGain,
+		drainGain:                    1.0 / defaultHighGain,
+		pacingGain:                   1.0,
+		congestionWindowGain:         1.0,
+		congestionWindowGainConstant: 2.0,
+		numStartupRtts:               roundTripsWithoutGrowthBeforeExitingStartup,
+		recoveryState:                bbrRecoveryStateNotInRecovery,
+		endRecoveryAt:                protocol.InvalidPacketNumber,
+		recoveryWindow:               initialMaxCongestionWindow,
+		bytesLostMultiplierWhileDetectingOvershooting:    2,
+		cwndToCalculateMinPacingRate:                     initialCongestionWindow,
+		maxCongestionWindowWithNetworkParametersAdjusted: initialMaxCongestionWindow,
+		maxDatagramSize: initialMaxDatagramSize,
+		tracer:          tracer,
+	}
+	b.pacer = newPacer(func() Bandwidth {
+		return Bandwidth(float64(b.bandwidthEstimate()) * b.congestionWindowGain)
+	})
+
+	if b.tracer != nil {
+		b.lastState = logging.CongestionStateStartup
+		b.tracer.UpdatedCongestionState(logging.CongestionStateStartup)
+	}
+
+	b.enterStartupMode(b.clock.Now())
+	b.setHighCwndGain(derivedHighCWNDGain)
+
+	return b
+}
+
+// TimeUntilSend implements the SendAlgorithm interface.
+func (b *bbrSender) TimeUntilSend(bytesInFlight protocol.ByteCount) time.Time {
+	return b.pacer.TimeUntilSend()
+}
+
+// HasPacingBudget implements the SendAlgorithm interface.
+func (b *bbrSender) HasPacingBudget(now time.Time) bool {
+	return b.pacer.Budget(now) >= b.maxDatagramSize
+}
+
+// OnPacketSent implements the SendAlgorithm interface.
+func (b *bbrSender) OnPacketSent(
+	sentTime time.Time,
+	bytesInFlight protocol.ByteCount,
+	packetNumber protocol.PacketNumber,
+	bytes protocol.ByteCount,
+	isRetransmittable bool) {
+
+	b.pacer.SentPacket(sentTime, bytes)
+
+	b.lastSentPacket = packetNumber
+	b.bytesInFlight = bytesInFlight
+
+	if bytesInFlight == 0 {
+		b.exitingQuiescence = true
+	}
+
+	b.sampler.OnPacketSent(sentTime, packetNumber, bytes, bytesInFlight, isRetransmittable)
+}
+
+// CanSend implements the SendAlgorithm interface.
+func (b *bbrSender) CanSend(bytesInFlight protocol.ByteCount) bool {
+	return bytesInFlight < b.GetCongestionWindow()
+}
+
+// MaybeExitSlowStart implements the SendAlgorithm interface.
+func (b *bbrSender) MaybeExitSlowStart() {
+	// Do nothing
+}
+
+// OnPacketAcked implements the SendAlgorithm interface.
+func (b *bbrSender) OnPacketAcked(number protocol.PacketNumber, ackedBytes protocol.ByteCount, priorInFlight protocol.ByteCount, eventTime time.Time) {
+	// Do nothing.
+}
+
+// OnCongestionEvent implements the SendAlgorithm interface.
+func (b *bbrSender) OnCongestionEvent(number protocol.PacketNumber, lostBytes protocol.ByteCount, priorInFlight protocol.ByteCount) {
+	// Do nothing.
+}
+
+// OnRetransmissionTimeout implements the SendAlgorithm interface.
+func (b *bbrSender) OnRetransmissionTimeout(packetsRetransmitted bool) {
+	// Do nothing.
+}
+
+// SetMaxDatagramSize implements the SendAlgorithm interface.
+func (b *bbrSender) SetMaxDatagramSize(s protocol.ByteCount) {
+	if s < b.maxDatagramSize {
+		panic(fmt.Sprintf("congestion BUG: decreased max datagram size from %d to %d", b.maxDatagramSize, s))
+	}
+	cwndIsMinCwnd := b.congestionWindow == b.minCongestionWindow
+	b.maxDatagramSize = s
+	if cwndIsMinCwnd {
+		b.congestionWindow = b.minCongestionWindow
+	}
+	b.pacer.SetMaxDatagramSize(s)
+}
+
+// InSlowStart implements the SendAlgorithmWithDebugInfos interface.
+func (b *bbrSender) InSlowStart() bool {
+	return b.mode == bbrModeStartup
+}
+
+// InRecovery implements the SendAlgorithmWithDebugInfos interface.
+func (b *bbrSender) InRecovery() bool {
+	return b.recoveryState != bbrRecoveryStateNotInRecovery
+}
+
+// GetCongestionWindow implements the SendAlgorithmWithDebugInfos interface.
+func (b *bbrSender) GetCongestionWindow() protocol.ByteCount {
+	if b.mode == bbrModeProbeRtt {
+		return b.probeRttCongestionWindow()
+	}
+
+	if b.InRecovery() && b.recoveryWindow > 0 {
+		return utils.Min(b.congestionWindow, b.recoveryWindow)
+	}
+
+	return b.congestionWindow
+}
+
+// OnCongestionEventParticular implemnets the OnCongestionEventParticular interface
+func (b *bbrSender) OnCongestionEventParticular(priorInFlight protocol.ByteCount, eventTime time.Time, ackedPackets []protocol.AckedPacketInfo, lostPackets []protocol.LostPacketInfo) {
+	totalBytesAckedBefore := b.sampler.TotalBytesAcked()
+	totalBytesLostBefore := b.sampler.TotalBytesLost()
+
+	var isRoundStart, minRttExpired bool
+	var excessAcked, bytesLost protocol.ByteCount
+
+	// The send state of the largest packet in acked_packets, unless it is
+	// empty. If acked_packets is empty, it's the send state of the largest
+	// packet in lost_packets.
+	var lastPacketSendState sendTimeState
+
+	b.maybeApplimited(priorInFlight)
+
+	// Update bytesInFlight
+	b.bytesInFlight = priorInFlight
+	for _, p := range ackedPackets {
+		b.bytesInFlight -= p.BytesAcked
+	}
+	for _, p := range lostPackets {
+		b.bytesInFlight -= p.BytesLost
+	}
+
+	if len(ackedPackets) != 0 {
+		lastAckedPacket := ackedPackets[len(ackedPackets)-1].PacketNumber
+		isRoundStart = b.updateRoundTripCounter(lastAckedPacket)
+		b.updateRecoveryState(lastAckedPacket, len(lostPackets) != 0, isRoundStart)
+	}
+
+	sample := b.sampler.OnCongestionEvent(eventTime,
+		ackedPackets, lostPackets, b.maxBandwidth.GetBest(), infBandwidth, b.roundTripCount)
+	if sample.lastPacketSendState.isValid {
+		b.lastSampleIsAppLimited = sample.lastPacketSendState.isAppLimited
+		b.hasNoAppLimitedSample = b.hasNoAppLimitedSample || !b.lastSampleIsAppLimited
+	}
+	// Avoid updating |max_bandwidth_| if a) this is a loss-only event, or b) all
+	// packets in |acked_packets| did not generate valid samples. (e.g. ack of
+	// ack-only packets). In both cases, sampler_.total_bytes_acked() will not
+	// change.
+	if totalBytesAckedBefore != b.sampler.TotalBytesAcked() {
+		if !sample.sampleIsAppLimited || sample.sampleMaxBandwidth > b.maxBandwidth.GetBest() {
+			b.maxBandwidth.Update(sample.sampleMaxBandwidth, b.roundTripCount)
+		}
+	}
+
+	if sample.sampleRtt != infRTT {
+		minRttExpired = b.maybeUpdateMinRtt(eventTime, sample.sampleRtt)
+	}
+	bytesLost = b.sampler.TotalBytesLost() - totalBytesLostBefore
+
+	excessAcked = sample.extraAcked
+	lastPacketSendState = sample.lastPacketSendState
+
+	if len(lostPackets) != 0 {
+		b.numLossEventsInRound++
+		b.bytesLostInRound += bytesLost
+	}
+
+	// Handle logic specific to PROBE_BW mode.
+	if b.mode == bbrModeProbeBw {
+		b.updateGainCyclePhase(eventTime, priorInFlight, len(lostPackets) != 0)
+	}
+
+	// Handle logic specific to STARTUP and DRAIN modes.
+	if isRoundStart && !b.isAtFullBandwidth {
+		b.checkIfFullBandwidthReached(&lastPacketSendState)
+	}
+
+	b.maybeExitStartupOrDrain(eventTime)
+
+	// Handle logic specific to PROBE_RTT.
+	b.maybeEnterOrExitProbeRtt(eventTime, isRoundStart, minRttExpired)
+
+	// Calculate number of packets acked and lost.
+	bytesAcked := b.sampler.TotalBytesAcked() - totalBytesAckedBefore
+
+	// After the model is updated, recalculate the pacing rate and congestion
+	// window.
+	b.calculatePacingRate(bytesLost)
+	b.calculateCongestionWindow(bytesAcked, excessAcked)
+	b.calculateRecoveryWindow(bytesAcked, bytesLost)
+
+	// Cleanup internal state.
+	if len(lostPackets) != 0 {
+		lastLostPacket := lostPackets[len(lostPackets)-1].PacketNumber
+		b.sampler.RemoveObsoletePackets(lastLostPacket)
+	}
+	if len(ackedPackets) != 0 {
+		bias := protocol.PacketNumber(b.calculateUselessAckBias())
+		if uselessPacketNum := ackedPackets[0].PacketNumber - bias; uselessPacketNum > 0 {
+			b.sampler.RemoveObsoletePackets(uselessPacketNum)
+		}
+	}
+	if isRoundStart {
+		b.numLossEventsInRound = 0
+		b.bytesLostInRound = 0
+	}
+}
+
+func (b *bbrSender) PacingRate() Bandwidth {
+	if b.pacingRate == 0 {
+		return Bandwidth(b.highGain * float64(
+			BandwidthFromDelta(b.initialCongestionWindow, b.getMinRtt())))
+	}
+
+	return b.pacingRate
+}
+
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+func (b *bbrSender) hasGoodBandwidthEstimateForResumption() bool {
+	return b.hasNonAppLimitedSample()
+}
+
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+func (b *bbrSender) hasNonAppLimitedSample() bool {
+	return b.hasNoAppLimitedSample
+}
+
+// Sets the pacing gain used in STARTUP.  Must be greater than 1.
+//
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+func (b *bbrSender) setHighGain(highGain float64) {
+	b.highGain = highGain
+	if b.mode == bbrModeStartup {
+		b.pacingGain = highGain
+	}
+}
+
+// Sets the CWND gain used in STARTUP.  Must be greater than 1.
+func (b *bbrSender) setHighCwndGain(highCwndGain float64) {
+
+	b.highCwndGain = highCwndGain
+	if b.mode == bbrModeStartup {
+		b.congestionWindowGain = highCwndGain
+	}
+}
+
+// Sets the gain used in DRAIN.  Must be less than 1.
+//
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+func (b *bbrSender) setDrainGain(drainGain float64) {
+	b.drainGain = drainGain
+}
+
+// What's the current estimated bandwidth in bytes per second.
+func (b *bbrSender) bandwidthEstimate() Bandwidth {
+	srtt := b.rttStats.SmoothedRTT()
+	if srtt == 0 {
+		// If we haven't measured an rtt, the bandwidth estimate is unknown.
+		return infBandwidth
+	}
+	bw := b.maxBandwidth.GetBest()
+	if bw == 0 {
+		return infBandwidth
+	}
+	return bw
+}
+
+// Returns the current estimate of the RTT of the connection.  Outside of the
+// edge cases, this is minimum RTT.
+func (b *bbrSender) getMinRtt() time.Duration {
+	if b.minRtt != 0 {
+		return b.minRtt
+	}
+	// min_rtt could be available if the handshake packet gets neutered then
+	// gets acknowledged. This could only happen for QUIC crypto where we do not
+	// drop keys.
+	return b.rttStats.MinOrInitialRtt()
+}
+
+// Computes the target congestion window using the specified gain.
+func (b *bbrSender) getTargetCongestionWindow(gain float64) protocol.ByteCount {
+	bdp := bdpFromRttAndBandwidth(b.getMinRtt(), b.bandwidthEstimate())
+	congestionWindow := protocol.ByteCount(gain * float64(bdp))
+
+	// BDP estimate will be zero if no bandwidth samples are available yet.
+	if congestionWindow == 0 {
+		congestionWindow = protocol.ByteCount(gain * float64(b.initialCongestionWindow))
+	}
+
+	return utils.Max(congestionWindow, b.minCongestionWindow)
+}
+
+// The target congestion window during PROBE_RTT.
+func (b *bbrSender) probeRttCongestionWindow() protocol.ByteCount {
+	return b.minCongestionWindow
+}
+
+func (b *bbrSender) maybeUpdateMinRtt(now time.Time, sampleMinRtt time.Duration) bool {
+	// Do not expire min_rtt if none was ever available.
+	minRttExpired := b.minRtt != 0 && now.After(b.minRttTimestamp.Add(minRttExpiry))
+	if minRttExpired || sampleMinRtt < b.minRtt || b.minRtt == 0 {
+		b.minRtt = sampleMinRtt
+		b.minRttTimestamp = now
+	}
+
+	return minRttExpired
+}
+
+// Enters the STARTUP mode.
+func (b *bbrSender) enterStartupMode(_ time.Time) {
+	b.mode = bbrModeStartup
+	b.maybeTraceStateChange(logging.CongestionStateStartup)
+	b.pacingGain = b.highGain
+	b.congestionWindowGain = b.highCwndGain
+}
+
+// Enters the PROBE_BW mode.
+func (b *bbrSender) enterProbeBandwidthMode(now time.Time) {
+	b.mode = bbrModeProbeBw
+	b.maybeTraceStateChange(logging.CongestionStateProbeBw)
+	b.congestionWindowGain = b.congestionWindowGainConstant
+
+	// Pick a random offset for the gain cycle out of {0, 2..7} range. 1 is
+	// excluded because in that case increased gain and decreased gain would not
+	// follow each other.
+	b.cycleCurrentOffset = int(b.rand.Int31n(protocol.PacketsPerConnectionID)) % (gainCycleLength - 1)
+	if b.cycleCurrentOffset >= 1 {
+		b.cycleCurrentOffset += 1
+	}
+
+	b.lastCycleStart = now
+	b.pacingGain = pacingGain[b.cycleCurrentOffset]
+}
+
+// Updates the round-trip counter if a round-trip has passed.  Returns true if
+// the counter has been advanced.
+func (b *bbrSender) updateRoundTripCounter(lastAckedPacket protocol.PacketNumber) bool {
+	if b.currentRoundTripEnd == protocol.InvalidPacketNumber || lastAckedPacket > b.currentRoundTripEnd {
+		b.roundTripCount++
+		b.currentRoundTripEnd = b.lastSentPacket
+		return true
+	}
+	return false
+}
+
+// Updates the current gain used in PROBE_BW mode.
+func (b *bbrSender) updateGainCyclePhase(now time.Time, priorInFlight protocol.ByteCount, hasLosses bool) {
+	// In most cases, the cycle is advanced after an RTT passes.
+	shouldAdvanceGainCycling := now.After(b.lastCycleStart.Add(b.getMinRtt()))
+	// If the pacing gain is above 1.0, the connection is trying to probe the
+	// bandwidth by increasing the number of bytes in flight to at least
+	// pacing_gain * BDP.  Make sure that it actually reaches the target, as long
+	// as there are no losses suggesting that the buffers are not able to hold
+	// that much.
+	if b.pacingGain > 1.0 && !hasLosses && priorInFlight < b.getTargetCongestionWindow(b.pacingGain) {
+		shouldAdvanceGainCycling = false
+	}
+
+	// If pacing gain is below 1.0, the connection is trying to drain the extra
+	// queue which could have been incurred by probing prior to it.  If the number
+	// of bytes in flight falls down to the estimated BDP value earlier, conclude
+	// that the queue has been successfully drained and exit this cycle early.
+	if b.pacingGain < 1.0 && b.bytesInFlight <= b.getTargetCongestionWindow(1) {
+		shouldAdvanceGainCycling = true
+	}
+
+	if shouldAdvanceGainCycling {
+		b.cycleCurrentOffset = (b.cycleCurrentOffset + 1) % gainCycleLength
+		b.lastCycleStart = now
+		// Stay in low gain mode until the target BDP is hit.
+		// Low gain mode will be exited immediately when the target BDP is achieved.
+		if b.drainToTarget && b.pacingGain < 1 &&
+			pacingGain[b.cycleCurrentOffset] == 1 &&
+			b.bytesInFlight > b.getTargetCongestionWindow(1) {
+			return
+		}
+		b.pacingGain = pacingGain[b.cycleCurrentOffset]
+	}
+}
+
+// Tracks for how many round-trips the bandwidth has not increased
+// significantly.
+func (b *bbrSender) checkIfFullBandwidthReached(lastPacketSendState *sendTimeState) {
+	if b.lastSampleIsAppLimited {
+		return
+	}
+
+	target := Bandwidth(float64(b.bandwidthAtLastRound) * startupGrowthTarget)
+	if b.bandwidthEstimate() >= target {
+		b.bandwidthAtLastRound = b.bandwidthEstimate()
+		b.roundsWithoutBandwidthGain = 0
+		if b.expireAckAggregationInStartup {
+			// Expire old excess delivery measurements now that bandwidth increased.
+			b.sampler.ResetMaxAckHeightTracker(0, b.roundTripCount)
+		}
+		return
+	}
+
+	b.roundsWithoutBandwidthGain++
+	if b.roundsWithoutBandwidthGain >= b.numStartupRtts ||
+		b.shouldExitStartupDueToLoss(lastPacketSendState) {
+		b.isAtFullBandwidth = true
+	}
+}
+
+func (b *bbrSender) maybeApplimited(bytesInFlight protocol.ByteCount) {
+	congestionWindow := b.GetCongestionWindow()
+	if bytesInFlight >= congestionWindow {
+		return
+	}
+	availableBytes := congestionWindow - bytesInFlight
+	drainLimited := b.mode == bbrModeDrain && bytesInFlight > congestionWindow/2
+	if !drainLimited || availableBytes > maxBbrBurstPackets*b.maxDatagramSize {
+		b.sampler.OnAppLimited()
+	}
+}
+
+// Transitions from STARTUP to DRAIN and from DRAIN to PROBE_BW if
+// appropriate.
+func (b *bbrSender) maybeExitStartupOrDrain(now time.Time) {
+	if b.mode == bbrModeStartup && b.isAtFullBandwidth {
+		b.mode = bbrModeDrain
+		b.maybeTraceStateChange(logging.CongestionStateDrain)
+		b.pacingGain = b.drainGain
+		b.congestionWindowGain = b.highCwndGain
+	}
+	if b.mode == bbrModeDrain && b.bytesInFlight <= b.getTargetCongestionWindow(1) {
+		b.enterProbeBandwidthMode(now)
+	}
+}
+
+// Decides whether to enter or exit PROBE_RTT.
+func (b *bbrSender) maybeEnterOrExitProbeRtt(now time.Time, isRoundStart, minRttExpired bool) {
+	if minRttExpired && !b.exitingQuiescence && b.mode != bbrModeProbeRtt {
+		b.mode = bbrModeProbeRtt
+		b.maybeTraceStateChange(logging.CongestionStateProbRtt)
+		b.pacingGain = 1.0
+		// Do not decide on the time to exit PROBE_RTT until the |bytes_in_flight|
+		// is at the target small value.
+		b.exitProbeRttAt = time.Time{}
+	}
+
+	if b.mode == bbrModeProbeRtt {
+		b.sampler.OnAppLimited()
+		b.maybeTraceStateChange(logging.CongestionStateApplicationLimited)
+
+		if b.exitProbeRttAt.IsZero() {
+			// If the window has reached the appropriate size, schedule exiting
+			// PROBE_RTT.  The CWND during PROBE_RTT is kMinimumCongestionWindow, but
+			// we allow an extra packet since QUIC checks CWND before sending a
+			// packet.
+			if b.bytesInFlight < b.probeRttCongestionWindow()+protocol.MaxPacketBufferSize {
+				b.exitProbeRttAt = now.Add(probeRttTime)
+				b.probeRttRoundPassed = false
+			}
+		} else {
+			if isRoundStart {
+				b.probeRttRoundPassed = true
+			}
+			if now.Sub(b.exitProbeRttAt) >= 0 && b.probeRttRoundPassed {
+				b.minRttTimestamp = now
+				if !b.isAtFullBandwidth {
+					b.enterStartupMode(now)
+				} else {
+					b.enterProbeBandwidthMode(now)
+				}
+			}
+		}
+	}
+
+	b.exitingQuiescence = false
+}
+
+// Determines whether BBR needs to enter, exit or advance state of the
+// recovery.
+func (b *bbrSender) updateRecoveryState(lastAckedPacket protocol.PacketNumber, hasLosses, isRoundStart bool) {
+	// Disable recovery in startup, if loss-based exit is enabled.
+	if !b.isAtFullBandwidth {
+		return
+	}
+
+	// Exit recovery when there are no losses for a round.
+	if hasLosses {
+		b.endRecoveryAt = b.lastSentPacket
+	}
+
+	switch b.recoveryState {
+	case bbrRecoveryStateNotInRecovery:
+		if hasLosses {
+			b.recoveryState = bbrRecoveryStateConservation
+			// This will cause the |recovery_window_| to be set to the correct
+			// value in CalculateRecoveryWindow().
+			b.recoveryWindow = 0
+			// Since the conservation phase is meant to be lasting for a whole
+			// round, extend the current round as if it were started right now.
+			b.currentRoundTripEnd = b.lastSentPacket
+		}
+	case bbrRecoveryStateConservation:
+		if isRoundStart {
+			b.recoveryState = bbrRecoveryStateGrowth
+		}
+		fallthrough
+	case bbrRecoveryStateGrowth:
+		// Exit recovery if appropriate.
+		if !hasLosses && lastAckedPacket > b.endRecoveryAt {
+			b.recoveryState = bbrRecoveryStateNotInRecovery
+		}
+	}
+}
+
+// Determines the appropriate pacing rate for the connection.
+func (b *bbrSender) calculatePacingRate(bytesLost protocol.ByteCount) {
+	if b.bandwidthEstimate() == 0 {
+		return
+	}
+
+	targetRate := Bandwidth(b.pacingGain * float64(b.bandwidthEstimate()))
+	if b.isAtFullBandwidth {
+		b.pacingRate = targetRate
+		return
+	}
+
+	// Pace at the rate of initial_window / RTT as soon as RTT measurements are
+	// available.
+	if b.pacingRate == 0 && b.rttStats.MinRTT() != 0 {
+		b.pacingRate = BandwidthFromDelta(b.initialCongestionWindow, b.rttStats.MinRTT())
+		return
+	}
+
+	if b.detectOvershooting {
+		b.bytesLostWhileDetectingOvershooting += bytesLost
+		// Check for overshooting with network parameters adjusted when pacing rate
+		// > target_rate and loss has been detected.
+		if b.pacingRate > targetRate && b.bytesLostWhileDetectingOvershooting > 0 {
+			if b.hasNoAppLimitedSample ||
+				b.bytesLostWhileDetectingOvershooting*protocol.ByteCount(b.bytesLostMultiplierWhileDetectingOvershooting) > b.initialCongestionWindow {
+				// We are fairly sure overshoot happens if 1) there is at least one
+				// non app-limited bw sample or 2) half of IW gets lost. Slow pacing
+				// rate.
+				b.pacingRate = utils.Max(targetRate, BandwidthFromDelta(b.cwndToCalculateMinPacingRate, b.rttStats.MinRTT()))
+				b.bytesLostWhileDetectingOvershooting = 0
+				b.detectOvershooting = false
+			}
+		}
+	}
+
+	// Do not decrease the pacing rate during startup.
+	b.pacingRate = utils.Max(b.pacingRate, targetRate)
+}
+
+// Determines the appropriate congestion window for the connection.
+func (b *bbrSender) calculateCongestionWindow(bytesAcked, excessAcked protocol.ByteCount) {
+	if b.mode == bbrModeProbeRtt {
+		return
+	}
+
+	targetWindow := b.getTargetCongestionWindow(b.congestionWindowGain)
+	if b.isAtFullBandwidth {
+		// Add the max recently measured ack aggregation to CWND.
+		targetWindow += b.sampler.MaxAckHeight()
+	} else if b.enableAckAggregationDuringStartup {
+		// Add the most recent excess acked.  Because CWND never decreases in
+		// STARTUP, this will automatically create a very localized max filter.
+		targetWindow += excessAcked
+	}
+
+	// Instead of immediately setting the target CWND as the new one, BBR grows
+	// the CWND towards |target_window| by only increasing it |bytes_acked| at a
+	// time.
+	if b.isAtFullBandwidth {
+		b.congestionWindow = utils.Min(targetWindow, b.congestionWindow+bytesAcked)
+	} else if b.congestionWindow < targetWindow ||
+		b.sampler.TotalBytesAcked() < b.initialCongestionWindow {
+		// If the connection is not yet out of startup phase, do not decrease the
+		// window.
+		b.congestionWindow += bytesAcked
+	}
+
+	// Enforce the limits on the congestion window.
+	b.congestionWindow = utils.Max(b.congestionWindow, b.minCongestionWindow)
+	b.congestionWindow = utils.Min(b.congestionWindow, b.maxCongestionWindow)
+}
+
+// Determines the appropriate window that constrains the in-flight during recovery.
+func (b *bbrSender) calculateRecoveryWindow(bytesAcked, bytesLost protocol.ByteCount) {
+	if b.recoveryState == bbrRecoveryStateNotInRecovery {
+		return
+	}
+
+	// Set up the initial recovery window.
+	if b.recoveryWindow == 0 {
+		b.recoveryWindow = b.bytesInFlight + bytesAcked
+		b.recoveryWindow = utils.Max(b.minCongestionWindow, b.recoveryWindow)
+		return
+	}
+
+	// Remove losses from the recovery window, while accounting for a potential
+	// integer underflow.
+	if b.recoveryWindow >= bytesLost {
+		b.recoveryWindow = b.recoveryWindow - bytesLost
+	} else {
+		b.recoveryWindow = b.maxDatagramSize
+	}
+
+	// In CONSERVATION mode, just subtracting losses is sufficient.  In GROWTH,
+	// release additional |bytes_acked| to achieve a slow-start-like behavior.
+	if b.recoveryState == bbrRecoveryStateGrowth {
+		b.recoveryWindow += bytesAcked
+	}
+
+	// Always allow sending at least |bytes_acked| in response.
+	b.recoveryWindow = utils.Max(b.recoveryWindow, b.bytesInFlight+bytesAcked)
+	b.recoveryWindow = utils.Max(b.minCongestionWindow, b.recoveryWindow)
+}
+
+// Return whether we should exit STARTUP due to excessive loss.
+func (b *bbrSender) shouldExitStartupDueToLoss(lastPacketSendState *sendTimeState) bool {
+	if b.numLossEventsInRound < defaultStartupFullLossCount || !lastPacketSendState.isValid {
+		return false
+	}
+
+	inflightAtSend := lastPacketSendState.bytesInFlight
+
+	if inflightAtSend > 0 && b.bytesLostInRound > 0 {
+		return b.bytesLostInRound > protocol.ByteCount(float64(inflightAtSend)*quicBbr2DefaultLossThreshold)
+	}
+
+	return false
+}
+
+func bdpFromRttAndBandwidth(rtt time.Duration, bandwidth Bandwidth) protocol.ByteCount {
+	return protocol.ByteCount(rtt) * protocol.ByteCount(bandwidth) / protocol.ByteCount(BytesPerSecond) / protocol.ByteCount(time.Second)
+}
+
+func (b *bbrSender) maybeTraceStateChange(new logging.CongestionState) {
+	if b.tracer == nil || new == b.lastState {
+		return
+	}
+	b.tracer.UpdatedCongestionState(new)
+	b.lastState = new
+}
+
+func (b *bbrSender) calculateUselessAckBias() int64 {
+	return int64(b.rttStats.PTO(false)) * int64(b.bandwidthEstimate()) / int64(protocol.InitialPacketSize*8) / int64(time.Second)
+}

--- a/internal/congestion/bbr_sender_test.go
+++ b/internal/congestion/bbr_sender_test.go
@@ -1,0 +1,157 @@
+package congestion
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
+)
+
+var _ = Describe("function", func() {
+	It("bdpFromRttAndBandwidth", func() {
+		Expect(bdpFromRttAndBandwidth(3*time.Millisecond, Bandwidth(8e3))).To(Equal(protocol.ByteCount(3)))
+	})
+})
+
+var _ = Describe("", func() {
+	const (
+		initialCongestionWindowPackets                    = 10
+		defaultWindowTCP                                  = protocol.ByteCount(initialCongestionWindowPackets) * maxDatagramSize
+		maxCongestionWindow            protocol.ByteCount = 200 * maxDatagramSize
+	)
+
+	var (
+		sender        *bbrSender
+		clock         mockClock
+		bytesInFlight protocol.ByteCount
+		packetNumber  protocol.PacketNumber
+		rttStats      *utils.RTTStats
+	)
+
+	SendAvailableSendWindowLen := func(packetLength protocol.ByteCount) int {
+		var packetsSent int
+		for sender.CanSend(bytesInFlight) {
+			sender.OnPacketSent(clock.Now(), bytesInFlight, packetNumber, packetLength, true)
+			packetNumber++
+			packetsSent++
+			bytesInFlight += packetLength
+		}
+		return packetsSent
+	}
+
+	AckNPacketsLen := func(packetNums []protocol.PacketNumber, packetLength protocol.ByteCount) {
+		infos := []protocol.AckedPacketInfo{}
+		for _, p := range packetNums {
+			infos = append(infos, protocol.AckedPacketInfo{
+				PacketNumber: p,
+				BytesAcked:   packetLength,
+				ReceivedTime: clock.Now(),
+			})
+		}
+		sender.OnCongestionEventParticular(bytesInFlight, clock.Now(), infos, nil)
+		bytesInFlight -= protocol.ByteCount(len(packetNums)) * packetLength
+	}
+
+	LoseNPacketsLen := func(packetNums []protocol.PacketNumber, packetLength protocol.ByteCount) {
+		infos := []protocol.LostPacketInfo{}
+		for _, p := range packetNums {
+			infos = append(infos, protocol.LostPacketInfo{
+				PacketNumber: p,
+				BytesLost:    packetLength,
+			})
+		}
+		sender.OnCongestionEventParticular(bytesInFlight, clock.Now(), nil, infos)
+		bytesInFlight -= protocol.ByteCount(len(packetNums)) * packetLength
+	}
+
+	SendAvailableSendWindow := func() int { return SendAvailableSendWindowLen(maxDatagramSize) }
+
+	AckSeqPackets := func(start, end int) {
+		Expect(start < end).To(BeTrue())
+		ackPacketNums := []protocol.PacketNumber{}
+		for i := start + 1; i <= end; i++ {
+			ackPacketNums = append(ackPacketNums, protocol.PacketNumber(i))
+		}
+		AckNPacketsLen(ackPacketNums, maxDatagramSize)
+	}
+
+	LoseSeqPackets := func(start, end int) {
+		Expect(start < end).To(BeTrue())
+		losePacketNums := []protocol.PacketNumber{}
+		for i := start + 1; i <= end; i++ {
+			losePacketNums = append(losePacketNums, protocol.PacketNumber(i))
+		}
+		LoseNPacketsLen(losePacketNums, maxDatagramSize)
+	}
+
+	BeforeEach(func() {
+		bytesInFlight = 0
+		packetNumber = 1
+		clock = mockClock{}
+		rttStats = utils.NewRTTStats()
+		sender = newBbrSender(
+			&clock,
+			rttStats,
+			protocol.InitialPacketSize,
+			initialCongestionWindowPackets*maxDatagramSize,
+			maxCongestionWindow,
+			nil,
+		)
+
+	})
+
+	It("has the right values at startup", func() {
+		// At startup make sure we are at the default.
+		Expect(sender.GetCongestionWindow()).To(Equal(defaultWindowTCP))
+		// Make sure we can send.
+		Expect(sender.TimeUntilSend(0)).To(BeZero())
+		Expect(sender.CanSend(bytesInFlight)).To(BeTrue())
+		// And that window is un-affected.
+		Expect(sender.GetCongestionWindow()).To(Equal(defaultWindowTCP))
+
+		// Fill the send window with data, then verify that we can't send.
+		SendAvailableSendWindow()
+		Expect(sender.CanSend(bytesInFlight)).To(BeFalse())
+	})
+
+	It("paces", func() {
+		rttStats.UpdateRTT(10*time.Millisecond, 0, time.Now())
+		clock.Advance(time.Hour)
+		// Fill the send window with data, then verify that we can't send.
+		SendAvailableSendWindow()
+		AckSeqPackets(0, 1)
+		delay := sender.TimeUntilSend(bytesInFlight)
+		Expect(delay).ToNot(BeZero())
+		Expect(delay).ToNot(Equal(utils.InfDuration))
+	})
+
+	It("send n packets and ack n packets", func() {
+		Expect(sender.CanSend(0)).To(BeTrue())
+		Expect(sender.TimeUntilSend(0)).To(BeZero())
+
+		sentPacketsCount := SendAvailableSendWindow()
+		Expect(sentPacketsCount).To(Equal(initialCongestionWindowPackets))
+
+		clock.Advance(60 * time.Millisecond)
+		AckSeqPackets(0, sentPacketsCount)
+
+		bytesToSend := sender.GetCongestionWindow()
+		Expect(bytesToSend).To(Equal(defaultWindowTCP + protocol.ByteCount(sentPacketsCount)*maxDatagramSize))
+	})
+
+	It("send n packets and lose n packets", func() {
+		Expect(sender.CanSend(0)).To(BeTrue())
+		Expect(sender.TimeUntilSend(0)).To(BeZero())
+
+		sentPacketsCount := SendAvailableSendWindow()
+		Expect(sentPacketsCount).To(Equal(initialCongestionWindowPackets))
+
+		clock.Advance(60 * time.Millisecond)
+		LoseSeqPackets(0, sentPacketsCount)
+
+		bytesToSend := sender.GetCongestionWindow()
+		Expect(bytesToSend).To(Equal(defaultWindowTCP))
+	})
+})

--- a/internal/congestion/interface.go
+++ b/internal/congestion/interface.go
@@ -26,3 +26,8 @@ type SendAlgorithmWithDebugInfos interface {
 	InRecovery() bool
 	GetCongestionWindow() protocol.ByteCount
 }
+
+// A CongestionEventParticular invoked when congestion event occur
+type CongestionEventParticular interface {
+	OnCongestionEventParticular(priorInFlight protocol.ByteCount, eventTime time.Time, ackedPackets []protocol.AckedPacketInfo, lostPackets []protocol.LostPacketInfo)
+}

--- a/internal/congestion/mock_clock_test.go
+++ b/internal/congestion/mock_clock_test.go
@@ -1,0 +1,13 @@
+package congestion
+
+import "time"
+
+type mockClock time.Time
+
+func (c *mockClock) Now() time.Time {
+	return time.Time(*c)
+}
+
+func (c *mockClock) Advance(d time.Duration) {
+	*c = mockClock(time.Time(*c).Add(d))
+}

--- a/internal/congestion/packet_number_indexed_queue.go
+++ b/internal/congestion/packet_number_indexed_queue.go
@@ -1,0 +1,198 @@
+package congestion
+
+import (
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils/ringbuffer"
+)
+
+// packetNumberIndexedQueue is a queue of mostly continuous numbered entries
+// which supports the following operations:
+// - adding elements to the end of the queue, or at some point past the end
+// - removing elements in any order
+// - retrieving elements
+// If all elements are inserted in order, all of the operations above are
+// amortized O(1) time.
+//
+// Internally, the data structure is a deque where each element is marked as
+// present or not.  The deque starts at the lowest present index.  Whenever an
+// element is removed, it's marked as not present, and the front of the deque is
+// cleared of elements that are not present.
+//
+// The tail of the queue is not cleared due to the assumption of entries being
+// inserted in order, though removing all elements of the queue will return it
+// to its initial state.
+//
+// Note that this data structure is inherently hazardous, since an addition of
+// just two entries will cause it to consume all of the memory available.
+// Because of that, it is not a general-purpose container and should not be used
+// as one.
+
+type entryWrapper[T any] struct {
+	present bool
+	entry   T
+}
+
+type packetNumberIndexedQueue[T any] struct {
+	entries                ringbuffer.RingBuffer[entryWrapper[T]]
+	numberOfPresentEntries int
+	firstPacket            protocol.PacketNumber
+}
+
+func newPacketNumberIndexedQueue[T any](size int) *packetNumberIndexedQueue[T] {
+	q := &packetNumberIndexedQueue[T]{
+		firstPacket: protocol.InvalidPacketNumber,
+	}
+
+	q.entries.Init(size)
+
+	return q
+}
+
+// Emplace inserts data associated |packet_number| into (or past) the end of the
+// queue, filling up the missing intermediate entries as necessary.  Returns
+// true if the element has been inserted successfully, false if it was already
+// in the queue or inserted out of order.
+func (p *packetNumberIndexedQueue[T]) Emplace(packetNumber protocol.PacketNumber, entry *T) bool {
+	if packetNumber == protocol.InvalidPacketNumber || entry == nil {
+		return false
+	}
+
+	if p.IsEmpty() {
+		p.entries.PushBack(entryWrapper[T]{
+			present: true,
+			entry:   *entry,
+		})
+		p.numberOfPresentEntries = 1
+		p.firstPacket = packetNumber
+		return true
+	}
+
+	// Do not allow insertion out-of-order.
+	if packetNumber <= p.LastPacket() {
+		return false
+	}
+
+	// Handle potentially missing elements.
+	offset := int(packetNumber - p.FirstPacket())
+	if gap := offset - p.entries.Len(); gap > 0 {
+		for i := 0; i < gap; i++ {
+			p.entries.PushBack(entryWrapper[T]{})
+		}
+	}
+
+	p.entries.PushBack(entryWrapper[T]{
+		present: true,
+		entry:   *entry,
+	})
+	p.numberOfPresentEntries++
+	return true
+}
+
+// GetEntry Retrieve the entry associated with the packet number.  Returns the pointer
+// to the entry in case of success, or nullptr if the entry does not exist.
+func (p *packetNumberIndexedQueue[T]) GetEntry(packetNumber protocol.PacketNumber) *T {
+	ew := p.getEntryWraper(packetNumber)
+	if ew == nil {
+		return nil
+	}
+
+	return &ew.entry
+}
+
+// Remove, Same as above, but if an entry is present in the queue, also call f(entry)
+// before removing it.
+func (p *packetNumberIndexedQueue[T]) Remove(packetNumber protocol.PacketNumber, f func(T)) bool {
+	ew := p.getEntryWraper(packetNumber)
+	if ew == nil {
+		return false
+	}
+	if f != nil {
+		f(ew.entry)
+	}
+	ew.present = false
+	p.numberOfPresentEntries--
+
+	if packetNumber == p.FirstPacket() {
+		p.clearup()
+	}
+
+	return true
+}
+
+// RemoveUpTo, but not including |packet_number|.
+// Unused slots in the front are also removed, which means when the function
+// returns, |first_packet()| can be larger than |packet_number|.
+func (p *packetNumberIndexedQueue[T]) RemoveUpTo(packetNumber protocol.PacketNumber) {
+	for !p.entries.Empty() &&
+		p.firstPacket != protocol.InvalidPacketNumber &&
+		p.firstPacket < packetNumber {
+		if p.entries.Front().present {
+			p.numberOfPresentEntries--
+		}
+		p.entries.PopFront()
+		p.firstPacket++
+	}
+	p.clearup()
+}
+
+// IsEmpty return if queue is empty.
+func (p *packetNumberIndexedQueue[T]) IsEmpty() bool {
+	return p.numberOfPresentEntries == 0
+}
+
+// NumberOfPresentEntries returns the number of entries in the queue.
+func (p *packetNumberIndexedQueue[T]) NumberOfPresentEntries() int {
+	return p.numberOfPresentEntries
+}
+
+// EntrySlotsUsed returns the number of entries allocated in the underlying deque.  This is
+// proportional to the memory usage of the queue.
+func (p *packetNumberIndexedQueue[T]) EntrySlotsUsed() int {
+	return p.entries.Len()
+}
+
+// LastPacket returns packet number of the first entry in the queue.
+func (p *packetNumberIndexedQueue[T]) FirstPacket() (packetNumber protocol.PacketNumber) {
+	return p.firstPacket
+}
+
+// LastPacket returns packet number of the last entry ever inserted in the queue.  Note that the
+// entry in question may have already been removed.  Zero if the queue is
+// empty.
+func (p *packetNumberIndexedQueue[T]) LastPacket() (packetNumber protocol.PacketNumber) {
+	if p.IsEmpty() {
+		return protocol.InvalidPacketNumber
+	}
+
+	return p.firstPacket + protocol.PacketNumber(p.entries.Len()-1)
+}
+
+func (p *packetNumberIndexedQueue[T]) clearup() {
+	for !p.entries.Empty() && !p.entries.Front().present {
+		p.entries.PopFront()
+		p.firstPacket++
+	}
+	if p.entries.Empty() {
+		p.firstPacket = protocol.InvalidPacketNumber
+	}
+}
+
+func (p *packetNumberIndexedQueue[T]) getEntryWraper(packetNumber protocol.PacketNumber) *entryWrapper[T] {
+	if packetNumber == protocol.InvalidPacketNumber ||
+		p.IsEmpty() ||
+		packetNumber < p.firstPacket {
+		return nil
+	}
+
+	offset := int(packetNumber - p.firstPacket)
+	if offset >= p.entries.Len() {
+		return nil
+	}
+
+	ew := p.entries.Offset(offset)
+	if ew == nil || !ew.present {
+		return nil
+	}
+
+	return ew
+}

--- a/internal/congestion/packet_number_indexed_queue_test.go
+++ b/internal/congestion/packet_number_indexed_queue_test.go
@@ -1,0 +1,194 @@
+package congestion
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+var _ = Describe("PacketNumber indexed queue", func() {
+	var (
+		queue       *packetNumberIndexedQueue[string]
+		strZero     string = "zero"
+		strOne      string = "one"
+		strOneKinda string = "one (kinda)"
+		strTwo      string = "two"
+		strThree    string = "three"
+		strFour     string = "four"
+	)
+
+	BeforeEach(func() {
+		queue = newPacketNumberIndexedQueue[string](1)
+	})
+
+	It("InitialState", func() {
+		Expect(queue.IsEmpty()).To(BeTrue())
+		Expect(queue.FirstPacket()).To(Equal(protocol.InvalidPacketNumber))
+		Expect(queue.LastPacket()).To(Equal(protocol.InvalidPacketNumber))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(0))
+		Expect(queue.EntrySlotsUsed()).To(Equal(0))
+	})
+
+	It("InsertingContinuousElements", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.GetEntry(protocol.PacketNumber(1001))).To(Equal(&strOne))
+
+		Expect(queue.Emplace(protocol.PacketNumber(1002), &strTwo)).To(BeTrue())
+		Expect(queue.GetEntry(protocol.PacketNumber(1002))).To(Equal(&strTwo))
+
+		Expect(queue.IsEmpty()).To(BeFalse())
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1001)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(1002)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(2))
+		Expect(queue.EntrySlotsUsed()).To(Equal(2))
+	})
+
+	It("InsertingOutOfOrder", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+
+		Expect(queue.Emplace(protocol.PacketNumber(1003), &strThree)).To(BeTrue())
+		Expect(queue.GetEntry(protocol.PacketNumber(1002))).To(BeNil())
+		Expect(queue.GetEntry(protocol.PacketNumber(1003))).To(Equal(&strThree))
+
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1001)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(1003)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(2))
+		Expect(queue.EntrySlotsUsed()).To(Equal(3))
+
+		Expect(queue.Emplace(protocol.PacketNumber(1002), &strTwo)).To(BeFalse())
+	})
+
+	It("InsertingIntoPast", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strZero)).To(BeFalse())
+	})
+
+	It("InsertingDuplicate", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeFalse())
+	})
+
+	It("RemoveInTheMiddle", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(1002), &strTwo)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(1003), &strThree)).To(BeTrue())
+
+		Expect(queue.Remove(protocol.PacketNumber(1002), nil)).To(BeTrue())
+		Expect(queue.GetEntry(protocol.PacketNumber(1002))).To(BeNil())
+
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1001)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(1003)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(2))
+		Expect(queue.EntrySlotsUsed()).To(Equal(3))
+	})
+
+	It("RemoveAtImmediateEdges", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(1002), &strTwo)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(1003), &strThree)).To(BeTrue())
+
+		Expect(queue.Remove(protocol.PacketNumber(1001), nil)).To(BeTrue())
+		Expect(queue.GetEntry(protocol.PacketNumber(1001))).To(BeNil())
+		Expect(queue.Remove(protocol.PacketNumber(1003), nil)).To(BeTrue())
+		Expect(queue.GetEntry(protocol.PacketNumber(1003))).To(BeNil())
+
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1002)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(1003)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(1))
+		Expect(queue.EntrySlotsUsed()).To(Equal(2))
+
+		Expect(queue.Emplace(protocol.PacketNumber(1004), &strFour)).To(BeTrue())
+	})
+
+	It("RemoveAtDistantFront", func() {
+
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(1002), &strOneKinda)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(2001), &strTwo)).To(BeTrue())
+
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1001)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(2001)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(3))
+		Expect(queue.EntrySlotsUsed()).To(Equal(1001))
+
+		Expect(queue.Remove(protocol.PacketNumber(1002), nil)).To(BeTrue())
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1001)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(2001)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(2))
+		Expect(queue.EntrySlotsUsed()).To(Equal(1001))
+
+		Expect(queue.Remove(protocol.PacketNumber(1001), nil)).To(BeTrue())
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(2001)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(2001)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(1))
+		Expect(queue.EntrySlotsUsed()).To(Equal(1))
+	})
+
+	It("RemoveAtDistantBack", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(2001), &strTwo)).To(BeTrue())
+
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1001)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(2001)))
+
+		Expect(queue.Remove(protocol.PacketNumber(2001), nil)).To(BeTrue())
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1001)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(2001)))
+	})
+
+	It("ClearAndRepopulate", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(2001), &strTwo)).To(BeTrue())
+
+		Expect(queue.Remove(protocol.PacketNumber(1001), nil)).To(BeTrue())
+		Expect(queue.Remove(protocol.PacketNumber(2001), nil)).To(BeTrue())
+		Expect(queue.IsEmpty()).To(BeTrue())
+		Expect(queue.FirstPacket()).To(Equal(protocol.InvalidPacketNumber))
+		Expect(queue.LastPacket()).To(Equal(protocol.InvalidPacketNumber))
+
+		Expect(queue.Emplace(protocol.PacketNumber(101), &strOne)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(201), &strTwo)).To(BeTrue())
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(101)))
+		Expect(queue.LastPacket()).To(Equal(protocol.PacketNumber(201)))
+	})
+
+	It("FailToRemoveElementsThatNeverExisted", func() {
+		Expect(queue.Remove(protocol.PacketNumber(1000), nil)).To(BeFalse())
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.Remove(protocol.PacketNumber(1000), nil)).To(BeFalse())
+		Expect(queue.Remove(protocol.PacketNumber(1002), nil)).To(BeFalse())
+	})
+
+	It("FailToRemoveElementsTwice", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.Remove(protocol.PacketNumber(1001), nil)).To(BeTrue())
+		Expect(queue.Remove(protocol.PacketNumber(1001), nil)).To(BeFalse())
+		Expect(queue.Remove(protocol.PacketNumber(1001), nil)).To(BeFalse())
+	})
+
+	It("RemoveUpTo", func() {
+		Expect(queue.Emplace(protocol.PacketNumber(1001), &strOne)).To(BeTrue())
+		Expect(queue.Emplace(protocol.PacketNumber(2001), &strTwo)).To(BeTrue())
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1001)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(2))
+
+		queue.RemoveUpTo(protocol.PacketNumber(1001))
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(1001)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(2))
+
+		// Remove up to 1100, since [1100, 2001) are !present, they should be cleaned
+		// up from the front.
+		queue.RemoveUpTo(protocol.PacketNumber(1100))
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(2001)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(1))
+
+		queue.RemoveUpTo(protocol.PacketNumber(2001))
+		Expect(queue.FirstPacket()).To(Equal(protocol.PacketNumber(2001)))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(1))
+
+		queue.RemoveUpTo(protocol.PacketNumber(2002))
+		Expect(queue.FirstPacket()).To(Equal(protocol.InvalidPacketNumber))
+		Expect(queue.NumberOfPresentEntries()).To(Equal(0))
+	})
+})

--- a/internal/protocol/packet_info.go
+++ b/internal/protocol/packet_info.go
@@ -1,0 +1,14 @@
+package protocol
+
+import "time"
+
+type AckedPacketInfo struct {
+	PacketNumber PacketNumber
+	BytesAcked   ByteCount
+	ReceivedTime time.Time
+}
+
+type LostPacketInfo struct {
+	PacketNumber PacketNumber
+	BytesLost    ByteCount
+}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -92,6 +92,14 @@ func (e ECN) String() string {
 	}
 }
 
+type CC int
+
+const (
+	CcDefault CC = iota
+	CcCubic
+	CcBbr
+)
+
 // A ByteCount in QUIC
 type ByteCount int64
 

--- a/internal/utils/minmax.go
+++ b/internal/utils/minmax.go
@@ -3,10 +3,26 @@ package utils
 import (
 	"math"
 	"time"
+
+	"golang.org/x/exp/constraints"
 )
 
 // InfDuration is a duration of infinite length
 const InfDuration = time.Duration(math.MaxInt64)
+
+func Max[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return b
+	}
+	return a
+}
+
+func Min[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}
 
 // MinNonZeroDuration return the minimum duration that's not zero.
 func MinNonZeroDuration(a, b time.Duration) time.Duration {
@@ -16,7 +32,7 @@ func MinNonZeroDuration(a, b time.Duration) time.Duration {
 	if b == 0 {
 		return a
 	}
-	return min(a, b)
+	return Min(a, b)
 }
 
 // MinTime returns the earlier time

--- a/internal/utils/ringbuffer/ringbuffer.go
+++ b/internal/utils/ringbuffer/ringbuffer.go
@@ -72,6 +72,38 @@ func (r *RingBuffer[T]) PeekFront() T {
 	return r.ring[r.headPos]
 }
 
+// Offset returns the offset element.
+// It must not be called when the buffer is empty, that means that
+// callers might need to check if there are elements in the buffer first
+// and check if the index larger than buffer length.
+func (r *RingBuffer[T]) Offset(index int) *T {
+	if r.Empty() || index >= r.Len() {
+		panic("github.com/quic-go/quic-go/internal/utils/ringbuffer: offset from invalid index")
+	}
+	offset := (r.headPos + index) % len(r.ring)
+	return &r.ring[offset]
+}
+
+// Front returns the front element.
+// It must not be called when the buffer is empty, that means that
+// callers might need to check if there are elements in the buffer first.
+func (r *RingBuffer[T]) Front() *T {
+	if r.Empty() {
+		panic("github.com/quic-go/quic-go/internal/utils/ringbuffer: front from an empty queue")
+	}
+	return &r.ring[r.headPos]
+}
+
+// Back returns the back element.
+// It must not be called when the buffer is empty, that means that
+// callers might need to check if there are elements in the buffer first.
+func (r *RingBuffer[T]) Back() *T {
+	if r.Empty() {
+		panic("github.com/quic-go/quic-go/internal/utils/ringbuffer: back from an empty queue")
+	}
+	return r.Offset(r.Len() - 1)
+}
+
 // Grow the maximum size of the queue.
 // This method assume the queue is full.
 func (r *RingBuffer[T]) grow() {

--- a/internal/utils/ringbuffer/ringbuffer_test.go
+++ b/internal/utils/ringbuffer/ringbuffer_test.go
@@ -47,4 +47,25 @@ var _ = Describe("RingBuffer", func() {
 		Expect(r.full).To(BeFalse())
 		Expect(r.Len()).To(Equal(0))
 	})
+	It("front, back, offset", func() {
+		r := RingBuffer[int]{}
+		r.Init(3)
+		r.PushBack(1)
+		r.PushBack(2)
+		r.PushBack(3)
+		r.PopFront()
+		r.PushBack(4)
+		Expect(r.full).To(BeTrue())
+		Expect(*r.Front()).To(Equal(2))
+		Expect(*r.Back()).To(Equal(4))
+		Expect(func() { r.Offset(4) }).To(Panic())
+		Expect(*r.Offset(0)).To(Equal(2))
+		Expect(*r.Offset(1)).To(Equal(3))
+		Expect(*r.Offset(2)).To(Equal(4))
+		*r.Front() = 4
+		*r.Back() = 2
+		Expect(*r.Offset(0)).To(Equal(4))
+		Expect(*r.Offset(1)).To(Equal(3))
+		Expect(*r.Offset(2)).To(Equal(2))
+	})
 })

--- a/internal/utils/rtt_stats.go
+++ b/internal/utils/rtt_stats.go
@@ -36,6 +36,15 @@ func NewRTTStats() *RTTStats {
 // May return Zero if no valid updates have occurred.
 func (r *RTTStats) MinRTT() time.Duration { return r.minRTT }
 
+// MinOrInitialRtt Returns the minRTT for the entire connection.
+// May return default initial RTT if no valid updates have occurred.
+func (r *RTTStats) MinOrInitialRtt() time.Duration {
+	if r.minRTT == 0 {
+		return defaultInitialRTT
+	}
+	return r.minRTT
+}
+
 // LatestRTT returns the most recent rtt measurement.
 // May return Zero if no valid updates have occurred.
 func (r *RTTStats) LatestRTT() time.Duration { return r.latestRTT }
@@ -55,7 +64,7 @@ func (r *RTTStats) PTO(includeMaxAckDelay bool) time.Duration {
 	if r.SmoothedRTT() == 0 {
 		return 2 * defaultInitialRTT
 	}
-	pto := r.SmoothedRTT() + max(4*r.MeanDeviation(), protocol.TimerGranularity)
+	pto := r.SmoothedRTT() + Max(4*r.MeanDeviation(), protocol.TimerGranularity)
 	if includeMaxAckDelay {
 		pto += r.MaxAckDelay()
 	}
@@ -126,6 +135,6 @@ func (r *RTTStats) OnConnectionMigration() {
 // is larger. The mean deviation is increased to the most recent deviation if
 // it's larger.
 func (r *RTTStats) ExpireSmoothedMetrics() {
-	r.meanDeviation = max(r.meanDeviation, (r.smoothedRTT - r.latestRTT).Abs())
-	r.smoothedRTT = max(r.smoothedRTT, r.latestRTT)
+	r.meanDeviation = Max(r.meanDeviation, (r.smoothedRTT - r.latestRTT).Abs())
+	r.smoothedRTT = Max(r.smoothedRTT, r.latestRTT)
 }

--- a/internal/utils/rtt_stats_test.go
+++ b/internal/utils/rtt_stats_test.go
@@ -19,6 +19,7 @@ var _ = Describe("RTT stats", func() {
 	It("DefaultsBeforeUpdate", func() {
 		Expect(rttStats.MinRTT()).To(Equal(time.Duration(0)))
 		Expect(rttStats.SmoothedRTT()).To(Equal(time.Duration(0)))
+		Expect(rttStats.MinOrInitialRtt()).To(BeNumerically(">", time.Duration(0)))
 	})
 
 	It("SmoothedRTT", func() {

--- a/internal/utils/windowed_filter.go
+++ b/internal/utils/windowed_filter.go
@@ -1,0 +1,162 @@
+package utils
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+// Implements Kathleen Nichols' algorithm for tracking the minimum (or maximum)
+// estimate of a stream of samples over some fixed time interval. (E.g.,
+// the minimum RTT over the past five minutes.) The algorithm keeps track of
+// the best, second best, and third best min (or max) estimates, maintaining an
+// invariant that the measurement time of the n'th best >= n-1'th best.
+
+// The algorithm works as follows. On a reset, all three estimates are set to
+// the same sample. The second best estimate is then recorded in the second
+// quarter of the window, and a third best estimate is recorded in the second
+// half of the window, bounding the worst case error when the true min is
+// monotonically increasing (or true max is monotonically decreasing) over the
+// window.
+//
+// A new best sample replaces all three estimates, since the new best is lower
+// (or higher) than everything else in the window and it is the most recent.
+// The window thus effectively gets reset on every new min. The same property
+// holds true for second best and third best estimates. Specifically, when a
+// sample arrives that is better than the second best but not better than the
+// best, it replaces the second and third best estimates but not the best
+// estimate. Similarly, a sample that is better than the third best estimate
+// but not the other estimates replaces only the third best estimate.
+//
+// Finally, when the best expires, it is replaced by the second best, which in
+// turn is replaced by the third best. The newest sample replaces the third
+// best.
+
+type WindowedFilterValue interface {
+	any
+}
+
+type WindowedFilterTime interface {
+	constraints.Integer | constraints.Float
+}
+
+type WindowedFilter[V WindowedFilterValue, T WindowedFilterTime] struct {
+	// Time length of window.
+	windowLength T
+	estimates    []entry[V, T]
+	comparator   func(V, V) int
+}
+
+type entry[V WindowedFilterValue, T WindowedFilterTime] struct {
+	sample V
+	time   T
+}
+
+// Compares two values and returns true if the first is greater than or equal
+// to the second.
+func MaxFilter[O constraints.Ordered](a, b O) int {
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+	return 0
+}
+
+// Compares two values and returns true if the first is less than or equal
+// to the second.
+func MinFilter[O constraints.Ordered](a, b O) int {
+	if a < b {
+		return 1
+	} else if a > b {
+		return -1
+	}
+	return 0
+}
+
+func NewWindowedFilter[V WindowedFilterValue, T WindowedFilterTime](windowLength T, comparator func(V, V) int) *WindowedFilter[V, T] {
+	return &WindowedFilter[V, T]{
+		windowLength: windowLength,
+		estimates:    make([]entry[V, T], 3),
+		comparator:   comparator,
+	}
+}
+
+// Changes the window length.  Does not update any current samples.
+func (f *WindowedFilter[V, T]) SetWindowLength(windowLength T) {
+	f.windowLength = windowLength
+}
+
+func (f *WindowedFilter[V, T]) GetBest() V {
+	return f.estimates[0].sample
+}
+
+func (f *WindowedFilter[V, T]) GetSecondBest() V {
+	return f.estimates[1].sample
+}
+
+func (f *WindowedFilter[V, T]) GetThirdBest() V {
+	return f.estimates[2].sample
+}
+
+// Updates best estimates with |sample|, and expires and updates best
+// estimates as necessary.
+func (f *WindowedFilter[V, T]) Update(newSample V, newTime T) {
+	// Reset all estimates if they have not yet been initialized, if new sample
+	// is a new best, or if the newest recorded estimate is too old.
+	if f.comparator(f.estimates[0].sample, *new(V)) == 0 ||
+		f.comparator(newSample, f.estimates[0].sample) >= 0 ||
+		newTime-f.estimates[2].time > f.windowLength {
+		f.Reset(newSample, newTime)
+		return
+	}
+
+	if f.comparator(newSample, f.estimates[1].sample) >= 0 {
+		f.estimates[1] = entry[V, T]{newSample, newTime}
+		f.estimates[2] = f.estimates[1]
+	} else if f.comparator(newSample, f.estimates[2].sample) >= 0 {
+		f.estimates[2] = entry[V, T]{newSample, newTime}
+	}
+
+	// Expire and update estimates as necessary.
+	if newTime-f.estimates[0].time > f.windowLength {
+		// The best estimate hasn't been updated for an entire window, so promote
+		// second and third best estimates.
+		f.estimates[0] = f.estimates[1]
+		f.estimates[1] = f.estimates[2]
+		f.estimates[2] = entry[V, T]{newSample, newTime}
+		// Need to iterate one more time. Check if the new best estimate is
+		// outside the window as well, since it may also have been recorded a
+		// long time ago. Don't need to iterate once more since we cover that
+		// case at the beginning of the method.
+		if newTime-f.estimates[0].time > f.windowLength {
+			f.estimates[0] = f.estimates[1]
+			f.estimates[1] = f.estimates[2]
+		}
+		return
+	}
+	if f.comparator(f.estimates[1].sample, f.estimates[0].sample) == 0 &&
+		newTime-f.estimates[1].time > f.windowLength/4 {
+		// A quarter of the window has passed without a better sample, so the
+		// second-best estimate is taken from the second quarter of the window.
+		f.estimates[1] = entry[V, T]{newSample, newTime}
+		f.estimates[2] = f.estimates[1]
+		return
+	}
+
+	if f.comparator(f.estimates[2].sample, f.estimates[1].sample) == 0 &&
+		newTime-f.estimates[2].time > f.windowLength/2 {
+		// We've passed a half of the window without a better estimate, so take
+		// a third-best estimate from the second half of the window.
+		f.estimates[2] = entry[V, T]{newSample, newTime}
+	}
+}
+
+// Resets all estimates to new sample.
+func (f *WindowedFilter[V, T]) Reset(newSample V, newTime T) {
+	f.estimates[2] = entry[V, T]{newSample, newTime}
+	f.estimates[1] = f.estimates[2]
+	f.estimates[0] = f.estimates[1]
+}
+
+func (f *WindowedFilter[V, T]) Clear() {
+	f.estimates = make([]entry[V, T], 3)
+}

--- a/internal/utils/windowed_filter_test.go
+++ b/internal/utils/windowed_filter_test.go
@@ -1,0 +1,290 @@
+package utils
+
+import (
+	"math"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Windowed filter", func() {
+	var (
+		// now            int64
+		windowedMinRtt *WindowedFilter[time.Duration, int64]
+		windowedMaxBw  *WindowedFilter[uint64, int64]
+
+		initializeMinFilter = func() {
+			var nowTime int64 = 0
+			var rttSample time.Duration = 10 * time.Millisecond
+			for i := 0; i < 5; i++ {
+				windowedMinRtt.Update(rttSample, nowTime)
+				nowTime += 25
+				rttSample += 10 * time.Millisecond
+			}
+		}
+
+		initializeMaxFilter = func() {
+			var nowTime int64 = 0
+			var bwSample uint64 = 1000
+			for i := 0; i < 5; i++ {
+				windowedMaxBw.Update(bwSample, nowTime)
+				nowTime += 25
+				bwSample -= 100
+			}
+		}
+
+		updateWithIrrelevantSamples = func(
+			filter *WindowedFilter[uint64, uint64],
+			maxValue, nowTime uint64) {
+			for i := uint64(0); i < 1000; i++ {
+				filter.Update(i%maxValue, nowTime)
+			}
+		}
+	)
+
+	BeforeEach(func() {
+		windowedMinRtt = NewWindowedFilter[time.Duration, int64](99, MinFilter[time.Duration])
+		windowedMaxBw = NewWindowedFilter[uint64, int64](99, MaxFilter[uint64])
+	})
+
+	It("UninitializedEstimates", func() {
+		Expect(windowedMinRtt.GetBest()).To(Equal(time.Duration(0 * time.Millisecond)))
+		Expect(windowedMinRtt.GetSecondBest()).To(Equal(time.Duration(0 * time.Millisecond)))
+		Expect(windowedMinRtt.GetThirdBest()).To(Equal(time.Duration(0 * time.Millisecond)))
+		Expect(windowedMaxBw.GetBest()).To(Equal(uint64(0)))
+		Expect(windowedMaxBw.GetSecondBest()).To(Equal(uint64(0)))
+		Expect(windowedMaxBw.GetThirdBest()).To(Equal(uint64(0)))
+	})
+
+	It("MonotonicallyIncreasingMin", func() {
+		var nowTime int64 = 0
+		var rttSample time.Duration = 10 * time.Millisecond
+		windowedMinRtt.Update(rttSample, nowTime)
+		Expect(windowedMinRtt.GetBest()).To(Equal(time.Duration(10 * time.Millisecond)))
+
+		// Gradually increase the rtt samples and ensure the windowed min rtt starts
+		// rising.
+		for i := 0; i < 6; i++ {
+			nowTime += 25
+			rttSample += 10 * time.Millisecond
+			windowedMinRtt.Update(rttSample, nowTime)
+			if i < 3 {
+				Expect(windowedMinRtt.GetBest()).To(Equal(time.Duration(10 * time.Millisecond)))
+			} else if i == 3 {
+				Expect(windowedMinRtt.GetBest()).To(Equal(time.Duration(20 * time.Millisecond)))
+			} else if i < 6 {
+				Expect(windowedMinRtt.GetBest()).To(Equal(time.Duration(40 * time.Millisecond)))
+			}
+		}
+	})
+
+	It("MonotonicallyDecreasingMax", func() {
+		var nowTime int64 = 0
+		var bwSample uint64 = 1000
+		windowedMaxBw.Update(bwSample, nowTime)
+		Expect(windowedMaxBw.GetBest()).To(Equal(uint64(1000)))
+
+		// Gradually decrease the bw samples and ensure the windowed max bw starts
+		// decreasing.
+		for i := 0; i < 6; i++ {
+			nowTime += 25
+			bwSample -= 100
+			windowedMaxBw.Update(bwSample, nowTime)
+			if i < 3 {
+				Expect(windowedMaxBw.GetBest()).To(Equal(uint64(1000)))
+			} else if i == 3 {
+				Expect(windowedMaxBw.GetBest()).To(Equal(uint64(900)))
+			} else if i < 6 {
+				Expect(windowedMaxBw.GetBest()).To(Equal(uint64(700)))
+			}
+		}
+	})
+
+	It("SampleChangesThirdBestMin", func() {
+		initializeMinFilter()
+		// RTT sample lower than the third-choice min-rtt sets that, but nothing else.
+		var rttSample = windowedMinRtt.GetThirdBest() - time.Duration(5*time.Millisecond)
+		Expect(windowedMinRtt.GetThirdBest() > time.Duration(5*time.Millisecond)).To(BeTrue())
+		// Latest sample was recorded at 100ms.
+		var nowTime int64 = 101
+		windowedMinRtt.Update(rttSample, nowTime)
+		Expect(windowedMinRtt.GetThirdBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetSecondBest()).To(Equal(time.Duration(40 * time.Millisecond)))
+		Expect(windowedMinRtt.GetBest()).To(Equal(time.Duration(20 * time.Millisecond)))
+	})
+
+	It("SampleChangesThirdBestMax", func() {
+		initializeMaxFilter()
+		// BW sample higher than the third-choice max sets that, but nothing else.
+		var bwSample = windowedMaxBw.GetThirdBest() + uint64(50)
+		// Latest sample was recorded at 100ms.
+		var nowTime int64 = 101
+		windowedMaxBw.Update(bwSample, nowTime)
+		Expect(windowedMaxBw.GetThirdBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetSecondBest()).To(Equal(uint64(700)))
+		Expect(windowedMaxBw.GetBest()).To(Equal(uint64(900)))
+	})
+
+	It("SampleChangesSecondBestMin", func() {
+		initializeMinFilter()
+		// RTT sample lower than the second-choice min sets that and also
+		// the third-choice min.
+		var rttSample = windowedMinRtt.GetSecondBest() - time.Duration(5*time.Millisecond)
+		Expect(windowedMinRtt.GetSecondBest() > time.Duration(5*time.Millisecond)).To(BeTrue())
+		// Latest sample was recorded at 100ms.
+		var nowTime int64 = 101
+		windowedMinRtt.Update(rttSample, nowTime)
+		Expect(windowedMinRtt.GetThirdBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetSecondBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetBest()).To(Equal(time.Duration(20 * time.Millisecond)))
+	})
+
+	It("SampleChangesSecondBestMax", func() {
+		initializeMaxFilter()
+		// BW sample higher than the second-choice max sets that and also
+		// the third-choice max.
+		var bwSample = windowedMaxBw.GetSecondBest() + uint64(50)
+		// Latest sample was recorded at 100ms.
+		var nowTime int64 = 101
+		windowedMaxBw.Update(bwSample, nowTime)
+		Expect(windowedMaxBw.GetThirdBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetSecondBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetBest()).To(Equal(uint64(900)))
+	})
+
+	It("SampleChangesAllMins", func() {
+		initializeMinFilter()
+		// RTT sample lower than the first-choice min-rtt sets that and also
+		// the second and third-choice mins.
+		var rttSample = windowedMinRtt.GetBest() - time.Duration(5*time.Millisecond)
+		Expect(windowedMinRtt.GetBest() > time.Duration(5*time.Millisecond)).To(BeTrue())
+		// Latest sample was recorded at 100ms.
+		var nowTime int64 = 101
+		windowedMinRtt.Update(rttSample, nowTime)
+		Expect(windowedMinRtt.GetThirdBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetSecondBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetBest()).To(Equal(rttSample))
+	})
+
+	It("SampleChangesAllMaxs", func() {
+		initializeMaxFilter()
+		// BW sample higher than the first-choice max sets that and also
+		// the second and third-choice maxs.
+		var bwSample = windowedMaxBw.GetBest() + uint64(50)
+		// Latest sample was recorded at 100ms.
+		var nowTime int64 = 101
+		windowedMaxBw.Update(bwSample, nowTime)
+		Expect(windowedMaxBw.GetThirdBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetSecondBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetBest()).To(Equal(bwSample))
+	})
+
+	It("ExpireBestMin", func() {
+		initializeMinFilter()
+		var oldThirdBest = windowedMinRtt.GetThirdBest()
+		var oldSecondBest = windowedMinRtt.GetSecondBest()
+		var rttSample = oldThirdBest + time.Duration(5*time.Millisecond)
+		// Best min sample was recorded at 25ms, so expiry time is 124ms.
+		var nowTime int64 = 125
+		windowedMinRtt.Update(rttSample, nowTime)
+		Expect(windowedMinRtt.GetThirdBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetSecondBest()).To(Equal(oldThirdBest))
+		Expect(windowedMinRtt.GetBest()).To(Equal(oldSecondBest))
+	})
+
+	It("ExpireBestMax", func() {
+		initializeMaxFilter()
+		var oldThirdBest = windowedMaxBw.GetThirdBest()
+		var oldSecondBest = windowedMaxBw.GetSecondBest()
+		var bwSample = oldThirdBest - uint64(50)
+		// Best max sample was recorded at 25ms, so expiry time is 124ms.
+		var nowTime int64 = 125
+		windowedMaxBw.Update(bwSample, nowTime)
+		Expect(windowedMaxBw.GetThirdBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetSecondBest()).To(Equal(oldThirdBest))
+		Expect(windowedMaxBw.GetBest()).To(Equal(oldSecondBest))
+	})
+
+	It("ExpireSecondBestMin", func() {
+		initializeMinFilter()
+		var oldThirdBest = windowedMinRtt.GetThirdBest()
+		var rttSample = oldThirdBest + time.Duration(5*time.Millisecond)
+		// Second best min sample was recorded at 75ms, so expiry time is 174ms.
+		var nowTime int64 = 175
+		windowedMinRtt.Update(rttSample, nowTime)
+		Expect(windowedMinRtt.GetThirdBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetSecondBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetBest()).To(Equal(oldThirdBest))
+	})
+
+	It("ExpireSecondBestMax", func() {
+		initializeMaxFilter()
+		var oldThirdBest = windowedMaxBw.GetThirdBest()
+		var bwSample = oldThirdBest - uint64(50)
+		// Second best max sample was recorded at 75ms, so expiry time is 174ms.
+		var nowTime int64 = 175
+		windowedMaxBw.Update(bwSample, nowTime)
+		Expect(windowedMaxBw.GetThirdBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetSecondBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetBest()).To(Equal(oldThirdBest))
+	})
+
+	It("ExpireAllMins", func() {
+		initializeMinFilter()
+		var rttSample = windowedMinRtt.GetThirdBest() + time.Duration(5*time.Millisecond)
+		Expect(windowedMinRtt.GetBest() < time.Duration(math.MaxInt64)-time.Duration(5*time.Millisecond)).To(BeTrue())
+		// Third best min sample was recorded at 100ms, so expiry time is 199ms.
+		var nowTime int64 = 200
+		windowedMinRtt.Update(rttSample, nowTime)
+		Expect(windowedMinRtt.GetThirdBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetSecondBest()).To(Equal(rttSample))
+		Expect(windowedMinRtt.GetBest()).To(Equal(rttSample))
+
+	})
+
+	It("ExpireAllMaxs", func() {
+		initializeMaxFilter()
+		var bwSample = windowedMaxBw.GetThirdBest() - uint64(50)
+		// Third best max sample was recorded at 100ms, so expiry time is 199ms.
+		var nowTime int64 = 200
+		windowedMaxBw.Update(bwSample, nowTime)
+		Expect(windowedMaxBw.GetThirdBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetSecondBest()).To(Equal(bwSample))
+		Expect(windowedMaxBw.GetBest()).To(Equal(bwSample))
+	})
+
+	// Test the windowed filter where the time used is an exact counter instead of a
+	// timestamp.  This is useful if, for example, the time is measured in round
+	// trips.
+	It("ExpireCounterBasedMax", func() {
+		// Create a window which starts at t = 0 and expires after two cycles.
+		var maxFilter = NewWindowedFilter[uint64, uint64](2, MaxFilter[uint64])
+		var kBest = uint64(50000)
+		// Insert 50000 at t = 1.
+		maxFilter.Update(uint64(50000), 1)
+		Expect(maxFilter.GetBest()).To(Equal(kBest))
+		updateWithIrrelevantSamples(maxFilter, 20, 1)
+		Expect(maxFilter.GetBest()).To(Equal(kBest))
+
+		// Insert 40000 at t = 2.  Nothing is expected to expire.
+		maxFilter.Update(uint64(40000), 2)
+		Expect(maxFilter.GetBest()).To(Equal(kBest))
+		updateWithIrrelevantSamples(maxFilter, 20, 2)
+		Expect(maxFilter.GetBest()).To(Equal(kBest))
+
+		// Insert 30000 at t = 3.  Nothing is expected to expire yet.
+		maxFilter.Update(uint64(30000), 3)
+		Expect(maxFilter.GetBest()).To(Equal(kBest))
+		updateWithIrrelevantSamples(maxFilter, 20, 3)
+		Expect(maxFilter.GetBest()).To(Equal(kBest))
+
+		// Insert 20000 at t = 4.  50000 at t = 1 expires, so 40000 becomes the new
+		// maximum.
+		var kNewBest = uint64(40000)
+		maxFilter.Update(uint64(20000), 4)
+		Expect(maxFilter.GetBest()).To(Equal(kNewBest))
+		updateWithIrrelevantSamples(maxFilter, 20, 4)
+		Expect(maxFilter.GetBest()).To(Equal(kNewBest))
+	})
+})

--- a/logging/types.go
+++ b/logging/types.go
@@ -91,6 +91,15 @@ const (
 	CongestionStateRecovery
 	// CongestionStateApplicationLimited means that the congestion controller is application limited
 	CongestionStateApplicationLimited
+
+	// CongestionStateStartup is the startup phase of BBR
+	CongestionStateStartup
+	// CongestionStateDrain is the drain phase of BBR
+	CongestionStateDrain
+	// CongestionStateProbeBw is the probe bandwidth phase of BBR
+	CongestionStateProbeBw
+	// CongestionStateRecovery is the probe RTT phase of BBR
+	CongestionStateProbRtt
 )
 
 // ECNState is the state of the ECN state machine (see Appendix A.4 of RFC 9000)

--- a/qlog/types.go
+++ b/qlog/types.go
@@ -308,6 +308,14 @@ func (s congestionState) String() string {
 		return "recovery"
 	case logging.CongestionStateApplicationLimited:
 		return "application_limited"
+	case logging.CongestionStateStartup:
+		return "startup"
+	case logging.CongestionStateDrain:
+		return "drain"
+	case logging.CongestionStateProbeBw:
+		return "probe_bw"
+	case logging.CongestionStateProbRtt:
+		return "probe_rtt"
 	default:
 		return "unknown congestion state"
 	}

--- a/qlog/types_test.go
+++ b/qlog/types_test.go
@@ -126,6 +126,10 @@ var _ = Describe("Types", func() {
 		Expect(congestionState(logging.CongestionStateCongestionAvoidance).String()).To(Equal("congestion_avoidance"))
 		Expect(congestionState(logging.CongestionStateApplicationLimited).String()).To(Equal("application_limited"))
 		Expect(congestionState(logging.CongestionStateRecovery).String()).To(Equal("recovery"))
+		Expect(congestionState(logging.CongestionStateStartup).String()).To(Equal("startup"))
+		Expect(congestionState(logging.CongestionStateDrain).String()).To(Equal("drain"))
+		Expect(congestionState(logging.CongestionStateProbeBw).String()).To(Equal("probe_bw"))
+		Expect(congestionState(logging.CongestionStateProbRtt).String()).To(Equal("probe_rtt"))
 	})
 
 	It("has a string representation for the ECN bits", func() {


### PR DESCRIPTION
Reference to https://github.com/quic-go/quic-go/issues/341 and https://github.com/quic-go/quic-go/pull/1888
This PR implements the BBR congestion algorithm.
For reference only. 

BBR Version:  https://github.com/google/quiche/blob/e7872fc9e12bb1d46a118949c3d4da36de58aa44/quiche/quic/core/congestion_control/bbr_sender.cc

| Source File | Performance |
|--|--|
| utils/ringbuffer.go |100% |
| utils/ringbuffer_test.go | 100% |
| utils/windowed_filter.go | 100% |
| utils/windowed_filter_test.go | 100% |
| congestion/packet_number_indexed_queue.go | 100% |
| congestion/packet_number_indexed_queue_test.go | 100% |
| congestion/bandwidth_sampler.go | 100% |
| congestion/bandwidth_sampler_test.go | 100% |
| congestion/bbr_sender.go | 100% |
| congestion/bbr_sender_test.go | 30% |
