### PR TITLE
limit concurrency when closing all connections handled by a Transport

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -247,12 +247,15 @@ func (h *packetHandlerMap) Close(e error) {
 
 	close(h.closeChan)
 
+	sem := make(chan struct{}, 4)
 	var wg sync.WaitGroup
 	for _, handler := range h.handlers {
 		wg.Add(1)
+		sem <- struct{}{}
 		go func(handler packetHandler) {
 			handler.destroy(e)
 			wg.Done()
+			<-sem
 		}(handler)
 	}
 	h.closed = true


### PR DESCRIPTION
I'm not 100% sure we not a Go routine here in the first place, but limiting the concurrency definitely seems reasonable.