### PR TITLE
ci: run unit and integration tests on freebsd

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,3 +64,76 @@ jobs:
           name: qlogs-${{ matrix.os }}-go${{ matrix.go }}
           path: integrationtests/self/*.qlog
           retention-days: 7
+  freebsd:
+    runs-on: macos-12
+    name: Integration Tests (freebsd, Go ${{ matrix.go }})
+    env:
+      TIMESCALE_FACTOR: 3
+      DEBUG: true
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [ "1.21.x" ]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: set qlogger
+        if: env.DEBUG == 'true'
+        run: echo "QLOGFLAG= -qlog" >> $GITHUB_ENV
+      - name: pick go version
+        env:
+          GO_VERSION: ${{ matrix.go }}
+        run: |
+          GO_VERSION="$(sed "s/x/*/g" <<< $GO_VERSION)"
+          curl -s https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json | jq -r 'map(.version) | map(select(test(env.GO_VERSION))) | .[0]' | xargs -I {} echo "GO_VERSION={}" | tee -a $GITHUB_ENV
+      - uses: cross-platform-actions/action@6785ab118e0f221bdacd2e64a39253e7a1913103 # v0.19.1
+        with:
+          operating_system: 'freebsd'
+          version: '13.2'
+          environment_variables: TIMESCALE_FACTOR GO_VERSION
+          shell: bash
+          run: |
+            echo "::group::Increase the Buffer Size to prevent 'setsockopt: no buffer space available'"
+            sysctl kern.ipc.maxsockbuf
+            sudo sysctl kern.ipc.maxsockbuf=16777216
+            echo "::endgroup::"
+
+            echo "::group::Install Go"
+            curl -o go${GO_VERSION}.freebsd-amd64.tar.gz https://dl.google.com/go/go${GO_VERSION}.freebsd-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go${GO_VERSION}.freebsd-amd64.tar.gz
+            export PATH="${PATH}:/usr/local/go/bin"
+            go version
+            echo "::endgroup::"
+
+            failures=()
+
+            echo "::group::Run other tests#1"
+            go run github.com/onsi/ginkgo/v2/ginkgo -r -v -randomize-all -randomize-suites -trace -skip-package self,versionnegotiation integrationtests || failures+=("Run other tests#1")
+            echo "::endgroup::"
+
+            echo "::group::Run other tests#2"
+            go run github.com/onsi/ginkgo/v2/ginkgo -r -v -randomize-all -randomize-suites -trace integrationtests/versionnegotiation -- ${{env.QLOGFLAG}} || failures+=("Run other tests#2")
+            echo "::endgroup::"
+
+            echo "::group::Run self tests, using QUIC v1"
+            go run github.com/onsi/ginkgo/v2/ginkgo -r -v -randomize-all -randomize-suites -trace integrationtests/self -- -version=1 ${{env.QLOGFLAG}} || failures+=("Run self tests, using QUIC v1")
+            echo "::endgroup::"
+
+            echo "::group::Run self tests, using QUIC v2"
+            go run github.com/onsi/ginkgo/v2/ginkgo -r -v -randomize-all -randomize-suites -trace integrationtests/self -- -version=2 ${{env.QLOGFLAG}} || failures+=("Run self tests, using QUIC v2")
+            echo "::endgroup::"
+
+            if [ ${#failures[@]} -gt 0 ]; then
+              echo "Failures:"
+              for fail in "${failures[@]}"; do
+                echo "❌ $fail"
+              done
+              exit 1
+            fi
+      - name: save qlogs
+        if: ${{ always() && env.DEBUG == 'true' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: qlogs
+          path: integrationtests/self/*.qlog
+          retention-days: 7

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -46,3 +46,58 @@ jobs:
         with:
           files: coverage.txt,coverage-root.txt
           env_vars: OS=${{ matrix.os }}, GO=${{ matrix.go }}
+  freebsd:
+    runs-on: macos-12
+    name: Unit tests (freebsd, Go ${{ matrix.go }})
+    env:
+      TIMESCALE_FACTOR: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [ "1.20.x", "1.21.x" ]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: pick go version
+        env:
+          GO_VERSION: ${{ matrix.go }}
+        run: |
+          GO_VERSION="$(sed "s/x/*/g" <<< $GO_VERSION)"
+          curl -s https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json | jq -r 'map(.version) | map(select(test(env.GO_VERSION))) | .[0]' | xargs -I {} echo "GO_VERSION={}" | tee -a $GITHUB_ENV
+      - uses: cross-platform-actions/action@6785ab118e0f221bdacd2e64a39253e7a1913103 # v0.19.1
+        with:
+          operating_system: 'freebsd'
+          version: '13.2'
+          environment_variables: TIMESCALE_FACTOR GO_VERSION
+          shell: bash
+          run: |
+            echo "::group::Increase the Buffer Size to prevent 'setsockopt: no buffer space available'"
+            sysctl kern.ipc.maxsockbuf
+            sudo sysctl kern.ipc.maxsockbuf=16777216
+            echo "::endgroup::"
+
+            echo "::group::Install Go"
+            curl -o go${GO_VERSION}.freebsd-amd64.tar.gz https://dl.google.com/go/go${GO_VERSION}.freebsd-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go${GO_VERSION}.freebsd-amd64.tar.gz
+            export PATH="${PATH}:/usr/local/go/bin"
+            go version
+            echo "::endgroup::"
+
+            failures=()
+
+            echo "::group::Run tests"
+            go run github.com/onsi/ginkgo/v2/ginkgo -r -v -cover -randomize-all -randomize-suites -trace -skip-package integrationtests
+            echo "::endgroup::"
+
+            if [ ${#failures[@]} -gt 0 ]; then
+              echo "Failures:"
+              for fail in "${failures[@]}"; do
+                echo "❌ $fail"
+              done
+              exit 1
+            fi
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.txt,coverage-root.txt
+          env_vars: OS=freebsd, GO=${{ matrix.go }}


### PR DESCRIPTION
Follow up on https://github.com/pl-strflt/tf-aws-gh-runner/issues/24

This PR adds FreeBSD builds support (unit + integration) using https://github.com/cross-platform-actions/action (the action runs FreeBSD in a VM; using macos provides faster builds).

Providing native FreeBSD self-hosted runners would require using unofficial runner binary (https://github.com/ChristopherHX/github-act-runner). Looking through the description of the repo, that can sometimes result in irrecoverable breakage of GitHub Actions in a repo where such runner is used which we'd definitely want to avoid. That's why I decided using VM action is safer. We could still look into running VMs on self-hosted machines to speed up the builds though.

Issues I noticed when using the action:
- sometimes the builds get stuck in go download phase
- sometimes hd attachment that the action does fails on hosted runners

Testing:
- https://github.com/galargh/quic-go/actions/runs/6628996738
- https://github.com/galargh/quic-go/actions/runs/6628996737

Unit test failures:
- `[FAIL] HTTP 0.9 integration tests [It] allows setting of headers`
- `[FAIL] HTTP 0.9 integration tests [It] performs request`

Integration test failures:
- `HTTP tests [It] *` (self tests, using QUIC v1)
- `HTTP tests [It] *`(self tests, using QUIC v2)