### PR TITLE
add a function to generate connection IDs for the Preferred Address

### DIFF
--- a/conn_id_generator_test.go
+++ b/conn_id_generator_test.go
@@ -67,6 +67,18 @@ var _ = Describe("Connection ID Generator", func() {
 		}
 	})
 
+	It("generates connection IDs for Server Preferred Address", func() {
+		connID, _, err := g.GetConnIDForPreferredAddress()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(addedConnIDs).To(HaveLen(1))
+		Expect(addedConnIDs[0]).To(Equal(connID))
+		Expect(queuedFrames).To(BeEmpty())
+		Expect(g.SetMaxActiveConnIDs(4)).To(Succeed())
+		Expect(queuedFrames).To(HaveLen(2))
+		Expect(queuedFrames[0].(*wire.NewConnectionIDFrame).SequenceNumber).To(BeEquivalentTo(2))
+		Expect(queuedFrames[1].(*wire.NewConnectionIDFrame).SequenceNumber).To(BeEquivalentTo(3))
+	})
+
 	It("limits the number of connection IDs that it issues", func() {
 		Expect(g.SetMaxActiveConnIDs(9999999)).To(Succeed())
 		Expect(retiredConnIDs).To(BeEmpty())


### PR DESCRIPTION
It's not used anywhere (yet), but this makes it easier to play around with SPA.