### PR TITLE
Fix data races

### DIFF
--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -75,9 +75,11 @@ var _ = Describe("Handshake tests", func() {
 			defer GinkgoRecover()
 			defer close(acceptStopped)
 			for {
-				if _, err := server.Accept(context.Background()); err != nil {
+				conn, err := server.Accept(context.Background())
+				if err != nil {
 					return
 				}
+				defer conn.CloseWithError(0, "")
 			}
 		}()
 	}
@@ -368,7 +370,8 @@ var _ = Describe("Handshake tests", func() {
 			time.Sleep(scaleDuration(200 * time.Millisecond))
 
 			// dial again, and expect that this dial succeeds
-			_, err = dial()
+			anotherConn, err := dial()
+			defer anotherConn.CloseWithError(0, "")
 			Expect(err).ToNot(HaveOccurred())
 			time.Sleep(scaleDuration(20 * time.Millisecond)) // wait a bit for the connection to be queued
 

--- a/integrationtests/self/self_suite_test.go
+++ b/integrationtests/self/self_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
+	"github.com/quic-go/quic-go/internal/testutils"
 	"log"
 	"os"
 	"runtime/pprof"
@@ -207,6 +208,10 @@ var _ = BeforeEach(func() {
 		utils.DefaultLogger.SetLogLevel(utils.LogLevelDebug)
 		log.SetOutput(logBuf)
 	}
+})
+
+var _ = AfterEach(func() {
+	Eventually(testutils.AreConnsRunning).Should(BeFalse())
 })
 
 func areHandshakesRunning() bool {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -1,7 +1,10 @@
 package testutils
 
 import (
+	"bytes"
 	"fmt"
+	"runtime/pprof"
+	"strings"
 
 	"github.com/quic-go/quic-go/internal/handshake"
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -98,4 +101,10 @@ func ComposeRetryPacket(
 	}
 	data := writePacket(hdr, nil)
 	return append(data, handshake.GetRetryIntegrityTag(data, origDestConnID, version)[:]...)
+}
+
+func AreConnsRunning() bool {
+	var b bytes.Buffer
+	pprof.Lookup("goroutine").WriteTo(&b, 1)
+	return strings.Contains(b.String(), "quic-go.(*connection).run")
 }

--- a/server_test.go
+++ b/server_test.go
@@ -660,6 +660,7 @@ var _ = Describe("Server", func() {
 					c := make(chan struct{})
 					close(c)
 					conn.EXPECT().HandshakeComplete().Return(c)
+					conn.EXPECT().destroy(gomock.Any())
 					return conn
 				}
 
@@ -1276,6 +1277,7 @@ var _ = Describe("Server", func() {
 				conn.EXPECT().run()
 				conn.EXPECT().earlyConnReady().Return(ready)
 				conn.EXPECT().Context().Return(context.Background())
+				conn.EXPECT().destroy(gomock.Any())
 				return conn
 			}
 


### PR DESCRIPTION
Test that modify global variables should not run simultaneously with other tests.