### PR TITLE
schedule sending when writing initial or handshake crypto data

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -514,10 +514,6 @@ func (s *connection) run() error {
 		}
 	}()
 
-	if s.perspective == protocol.PerspectiveClient {
-		s.scheduleSending() // so the ClientHello actually gets sent
-	}
-
 	var sendQueueAvailable <-chan struct{}
 
 runLoop:
@@ -1406,8 +1402,10 @@ func (s *connection) handleHandshakeEvents() error {
 			err = s.dropEncryptionLevel(protocol.Encryption0RTT)
 		case handshake.EventWriteInitialData:
 			_, err = s.initialStream.Write(ev.Data)
+			s.scheduleSending()
 		case handshake.EventWriteHandshakeData:
 			_, err = s.handshakeStream.Write(ev.Data)
+			s.scheduleSending()
 		}
 		if err != nil {
 			return err

--- a/connection_test.go
+++ b/connection_test.go
@@ -2588,6 +2588,7 @@ var _ = Describe("Client Connection", func() {
 			defer GinkgoRecover()
 			cryptoSetup.EXPECT().StartHandshake().MaxTimes(1)
 			cryptoSetup.EXPECT().NextEvent().Return(handshake.Event{Kind: handshake.EventNoEvent})
+			conn.scheduleSending()
 			conn.run()
 		}()
 		Eventually(done).Should(BeClosed())


### PR DESCRIPTION
No functional change expected. We already did schedule sending for all cases but the ClientHello. Scheduling explicitly allows us to remove this corner case.