### PR TITLE
hkdf: move custom HKDF-Expand-Label implementation to a separate package

### DIFF
--- a/internal/crypto/hkdf/hkdf_expand_label.go
+++ b/internal/crypto/hkdf/hkdf_expand_label.go
@@ -1,4 +1,4 @@
-package handshake
+package hkdf
 
 import (
 	"crypto"
@@ -7,10 +7,10 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-// hkdfExpandLabel HKDF expands a label as defined in RFC 8446, section 7.1.
+// ExpandLabel HKDF expands a label as defined in RFC 8446, section 7.1.
 // Since this implementation avoids using a cryptobyte.Builder, it is about 15% faster than the
-// hkdfExpandLabel in the standard library.
-func hkdfExpandLabel(hash crypto.Hash, secret, context []byte, label string, length int) []byte {
+// ExpandLabel in the standard library.
+func ExpandLabel(hash crypto.Hash, secret, context []byte, label string, length int) []byte {
 	b := make([]byte, 3, 3+6+len(label)+1+len(context))
 	binary.BigEndian.PutUint16(b, uint16(length))
 	b[2] = uint8(6 + len(label))

--- a/internal/crypto/hkdf/hkdf_expand_label_test.go
+++ b/internal/crypto/hkdf/hkdf_expand_label_test.go
@@ -1,4 +1,4 @@
-package handshake
+package hkdf
 
 import (
 	"crypto"
@@ -41,7 +41,7 @@ var _ = Describe("HKDF", func() {
 		func(cipherSuite uint16, secret, context []byte, label string, length int) {
 			cs := cipherSuiteTLS13ByID(cipherSuite)
 			expected := expandLabel(cs, secret, label, context, length)
-			expanded := hkdfExpandLabel(cs.Hash, secret, context, label, length)
+			expanded := ExpandLabel(cs.Hash, secret, context, label, length)
 			Expect(expanded).To(Equal(expected))
 		},
 		Entry("TLS_AES_128_GCM_SHA256", tls.TLS_AES_128_GCM_SHA256, []byte("secret"), []byte("context"), "label", 42),
@@ -72,7 +72,7 @@ func benchmarkHKDFExpandLabel(b *testing.B, cipherSuite uint16, useStdLib bool) 
 		if useStdLib {
 			expandLabel(cs, secret, "label", []byte("context"), 42)
 		} else {
-			hkdfExpandLabel(cs.Hash, secret, []byte("context"), "label", 42)
+			ExpandLabel(cs.Hash, secret, []byte("context"), "label", 42)
 		}
 	}
 }

--- a/internal/crypto/hkdf/hkdf_suite_test.go
+++ b/internal/crypto/hkdf/hkdf_suite_test.go
@@ -1,0 +1,13 @@
+package hkdf_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHkdf(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HKDF Suite")
+}

--- a/internal/handshake/aead.go
+++ b/internal/handshake/aead.go
@@ -3,6 +3,7 @@ package handshake
 import (
 	"encoding/binary"
 
+	"github.com/quic-go/quic-go/internal/crypto/hkdf"
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
@@ -13,8 +14,8 @@ func createAEAD(suite *cipherSuite, trafficSecret []byte, v protocol.Version) *x
 		keyLabel = hkdfLabelKeyV2
 		ivLabel = hkdfLabelIVV2
 	}
-	key := hkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, keyLabel, suite.KeyLen)
-	iv := hkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, ivLabel, suite.IVLen())
+	key := hkdf.ExpandLabel(suite.Hash, trafficSecret, []byte{}, keyLabel, suite.KeyLen)
+	iv := hkdf.ExpandLabel(suite.Hash, trafficSecret, []byte{}, ivLabel, suite.IVLen())
 	return suite.AEAD(key, iv)
 }
 

--- a/internal/handshake/header_protector.go
+++ b/internal/handshake/header_protector.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/crypto/chacha20"
 
+	"github.com/quic-go/quic-go/internal/crypto/hkdf"
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
@@ -45,7 +46,7 @@ type aesHeaderProtector struct {
 var _ headerProtector = &aesHeaderProtector{}
 
 func newAESHeaderProtector(suite *cipherSuite, trafficSecret []byte, isLongHeader bool, hkdfLabel string) headerProtector {
-	hpKey := hkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, hkdfLabel, suite.KeyLen)
+	hpKey := hkdf.ExpandLabel(suite.Hash, trafficSecret, []byte{}, hkdfLabel, suite.KeyLen)
 	block, err := aes.NewCipher(hpKey)
 	if err != nil {
 		panic(fmt.Sprintf("error creating new AES cipher: %s", err))
@@ -89,7 +90,7 @@ type chachaHeaderProtector struct {
 var _ headerProtector = &chachaHeaderProtector{}
 
 func newChaChaHeaderProtector(suite *cipherSuite, trafficSecret []byte, isLongHeader bool, hkdfLabel string) headerProtector {
-	hpKey := hkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, hkdfLabel, suite.KeyLen)
+	hpKey := hkdf.ExpandLabel(suite.Hash, trafficSecret, []byte{}, hkdfLabel, suite.KeyLen)
 
 	p := &chachaHeaderProtector{
 		isLongHeader: isLongHeader,

--- a/internal/handshake/initial_aead.go
+++ b/internal/handshake/initial_aead.go
@@ -4,8 +4,9 @@ import (
 	"crypto"
 	"crypto/tls"
 
-	"golang.org/x/crypto/hkdf"
+	stdhkdf "golang.org/x/crypto/hkdf"
 
+	"github.com/quic-go/quic-go/internal/crypto/hkdf"
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
@@ -52,9 +53,9 @@ func NewInitialAEAD(connID protocol.ConnectionID, pers protocol.Perspective, v p
 }
 
 func computeSecrets(connID protocol.ConnectionID, v protocol.Version) (clientSecret, serverSecret []byte) {
-	initialSecret := hkdf.Extract(crypto.SHA256.New, connID.Bytes(), getSalt(v))
-	clientSecret = hkdfExpandLabel(crypto.SHA256, initialSecret, []byte{}, "client in", crypto.SHA256.Size())
-	serverSecret = hkdfExpandLabel(crypto.SHA256, initialSecret, []byte{}, "server in", crypto.SHA256.Size())
+	initialSecret := stdhkdf.Extract(crypto.SHA256.New, connID.Bytes(), getSalt(v))
+	clientSecret = hkdf.ExpandLabel(crypto.SHA256, initialSecret, []byte{}, "client in", crypto.SHA256.Size())
+	serverSecret = hkdf.ExpandLabel(crypto.SHA256, initialSecret, []byte{}, "server in", crypto.SHA256.Size())
 	return
 }
 
@@ -65,7 +66,7 @@ func computeInitialKeyAndIV(secret []byte, v protocol.Version) (key, iv []byte) 
 		keyLabel = hkdfLabelKeyV2
 		ivLabel = hkdfLabelIVV2
 	}
-	key = hkdfExpandLabel(crypto.SHA256, secret, []byte{}, keyLabel, 16)
-	iv = hkdfExpandLabel(crypto.SHA256, secret, []byte{}, ivLabel, 12)
+	key = hkdf.ExpandLabel(crypto.SHA256, secret, []byte{}, keyLabel, 16)
+	iv = hkdf.ExpandLabel(crypto.SHA256, secret, []byte{}, ivLabel, 12)
 	return
 }

--- a/internal/handshake/updatable_aead.go
+++ b/internal/handshake/updatable_aead.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/crypto/hkdf"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -114,7 +115,7 @@ func (a *updatableAEAD) startKeyDropTimer(now time.Time) {
 }
 
 func (a *updatableAEAD) getNextTrafficSecret(hash crypto.Hash, ts []byte) []byte {
-	return hkdfExpandLabel(hash, ts, []byte{}, "quic ku", hash.Size())
+	return hkdf.ExpandLabel(hash, ts, []byte{}, "quic ku", hash.Size())
 }
 
 // SetReadKey sets the read key.


### PR DESCRIPTION
The plan is to move the hkdf and hmac standard library packages here, and optimize them in terms of allocations. At some later point, we can upstream these changes into the standard library, should the Go team be interested in them.

Part of #3663.