### PR TITLE
[POC] QUIC on Streams

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,6 +53,9 @@ func validateConfig(config *Config) error {
 	}
 	return nil
 }
+func PopulateConfigWithDefaults(config *Config) *Config {
+	return populateConfig(config)
+}
 
 // populateConfig populates fields in the quic.Config with their default values, if none are set
 // it may be called with nil

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -108,7 +108,9 @@ type StatelessResetToken [16]byte
 // ethernet's max size, minus the IP and UDP headers. IPv6 has a 40 byte header,
 // UDP adds an additional 8 bytes.  This is a total overhead of 48 bytes.
 // Ethernet's max packet size is 1500 bytes,  1500 - 48 = 1452.
-const MaxPacketBufferSize = 1452
+// const MaxPacketBufferSize = 1452
+// Temporary to allow max frame size of 16k. We'd need to plumb this
+const MaxPacketBufferSize = 16 << 10
 
 // MaxLargePacketBufferSize is used when using GSO
 const MaxLargePacketBufferSize = 20 * 1024

--- a/internal/wire/qs_ping_frame.go
+++ b/internal/wire/qs_ping_frame.go
@@ -1,0 +1,26 @@
+package wire
+
+import (
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+// A QoSPing is a PING frame
+type QoSPing struct {
+	SeqNo int
+}
+
+// this number is TBD
+const qosPingFrameType = 0x3f5153300d0a1d0a
+
+func (f *QoSPing) Append(b []byte, _ protocol.Version) ([]byte, error) {
+	b = quicvarint.Append(b, qosPingFrameType)
+	b = quicvarint.Append(b, uint64(f.SeqNo))
+	return b, nil
+}
+
+// Length of a written frame
+func (f *QoSPing) Length(_ protocol.Version) protocol.ByteCount {
+	return (protocol.ByteCount(quicvarint.Len(qosPingFrameType)) +
+		protocol.ByteCount(quicvarint.Len(uint64(f.SeqNo))))
+}

--- a/internal/wire/qs_transport_parameters_frame.go
+++ b/internal/wire/qs_transport_parameters_frame.go
@@ -1,6 +1,9 @@
 package wire
 
 import (
+	"errors"
+	"io"
+
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 )
@@ -8,22 +11,50 @@ import (
 // A QoSTransportParameters is a PING frame
 type QoSTransportParameters struct {
 	Perspective protocol.Perspective
-	Params      TransportParameters
+	Params      *TransportParameters
 }
 
 const qosTransportParametersFrameType = 0x3f5153300d0a0d0a
 
 func (f *QoSTransportParameters) Append(b []byte, _ protocol.Version) ([]byte, error) {
 	b = quicvarint.Append(b, qosTransportParametersFrameType)
-	paramsB := f.Params.Marshal(f.Perspective)
+	paramsB := f.Params.MarshalQoS(f.Perspective)
 	b = quicvarint.Append(b, uint64(len(paramsB)))
 	b = append(b, paramsB...)
 	return b, nil
 }
 
+func ReadQoSTransportParametersFrame(frame *QoSTransportParameters, rdr io.Reader, pers protocol.Perspective, _ protocol.Version) error {
+	r := quicvarint.NewReader(rdr)
+	fTyp, err := quicvarint.Read(r)
+	if err != nil {
+		return err
+	}
+	if fTyp != qosTransportParametersFrameType {
+		return errors.New("invalid QoS transport parameters frame")
+	}
+	paramLen, err := quicvarint.Read(r)
+	if err != nil {
+		return err
+	}
+	if paramLen > 1024 {
+		return errors.New("QoS transport parameters too long")
+	}
+	b := make([]byte, paramLen)
+	io.ReadFull(r, b)
+	t := TransportParameters{}
+	err = t.Unmarshal(b, pers)
+	if err != nil {
+		return err
+	}
+	frame.Params = &t
+	frame.Perspective = pers
+	return nil
+}
+
 // Length of a written frame
 func (f *QoSTransportParameters) Length(_ protocol.Version) protocol.ByteCount {
-	params := f.Params.Marshal(f.Perspective)
+	params := f.Params.MarshalQoS(f.Perspective)
 	return (protocol.ByteCount(quicvarint.Len(qosTransportParametersFrameType)) +
 		protocol.ByteCount(quicvarint.Len(uint64(len(params)))) +
 		protocol.ByteCount(len(params)))

--- a/internal/wire/qs_transport_parameters_frame.go
+++ b/internal/wire/qs_transport_parameters_frame.go
@@ -1,0 +1,30 @@
+package wire
+
+import (
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+// A QoSTransportParameters is a PING frame
+type QoSTransportParameters struct {
+	Perspective protocol.Perspective
+	Params      TransportParameters
+}
+
+const qosTransportParametersFrameType = 0x3f5153300d0a0d0a
+
+func (f *QoSTransportParameters) Append(b []byte, _ protocol.Version) ([]byte, error) {
+	b = quicvarint.Append(b, qosTransportParametersFrameType)
+	paramsB := f.Params.Marshal(f.Perspective)
+	b = quicvarint.Append(b, uint64(len(paramsB)))
+	b = append(b, paramsB...)
+	return b, nil
+}
+
+// Length of a written frame
+func (f *QoSTransportParameters) Length(_ protocol.Version) protocol.ByteCount {
+	params := f.Params.Marshal(f.Perspective)
+	return (protocol.ByteCount(quicvarint.Len(qosTransportParametersFrameType)) +
+		protocol.ByteCount(quicvarint.Len(uint64(len(params)))) +
+		protocol.ByteCount(len(params)))
+}

--- a/qos.go
+++ b/qos.go
@@ -1,0 +1,425 @@
+package quic
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/handshake"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/logging"
+)
+
+func exchangeTptParamsQos(logger utils.Logger, conf *Config, conn io.ReadWriter, myPers protocol.Perspective) (*wire.TransportParameters, error) {
+	go func() {
+		myParams := &wire.TransportParameters{
+			InitialMaxStreamDataBidiLocal:  protocol.ByteCount(conf.InitialStreamReceiveWindow),
+			InitialMaxStreamDataBidiRemote: protocol.ByteCount(conf.InitialStreamReceiveWindow),
+			InitialMaxStreamDataUni:        protocol.ByteCount(conf.InitialStreamReceiveWindow),
+			InitialMaxData:                 protocol.ByteCount(conf.InitialConnectionReceiveWindow),
+			MaxBidiStreamNum:               protocol.StreamNum(conf.MaxIncomingStreams),
+			MaxUniStreamNum:                protocol.StreamNum(conf.MaxIncomingUniStreams),
+		}
+
+		// max_idle_timeout
+		// initial_max_data
+		// initial_max_stream_data_bidi_local
+		// initial_max_stream_data_bidi_remote
+		// initial_max_stream_data_uni
+		// initial_max_streams_bidi
+		// initial_max_streams_uni
+
+		f := &wire.QoSTransportParameters{
+			Perspective: myPers,
+			Params:      myParams,
+		}
+		buf := make([]byte, 0, f.Length(Version1))
+		buf, err := f.Append(buf, Version1)
+		if err != nil {
+			logger.Errorf("error appending QoSTransportParameters: %s", err)
+		}
+		conn.Write(buf)
+	}()
+
+	f := wire.QoSTransportParameters{}
+	err := wire.ReadQoSTransportParametersFrame(&f, conn, myPers.Opposite(), protocol.Version1)
+	if err != nil {
+		return nil, err
+	}
+	return f.Params, nil
+}
+
+type qosSendConn struct {
+	stream io.ReadWriteCloser
+}
+
+// Close implements sendConn.
+func (q *qosSendConn) Close() error {
+	return q.stream.Close()
+}
+
+type streamBackedAddr struct {
+	addr string
+}
+
+// Network implements net.Addr.
+func (s *streamBackedAddr) Network() string {
+	return "qos"
+}
+
+// String implements net.Addr.
+func (s *streamBackedAddr) String() string {
+	return s.addr
+}
+
+var _ net.Addr = &streamBackedAddr{}
+
+// LocalAddr implements sendConn.
+func (q *qosSendConn) LocalAddr() net.Addr {
+	return &streamBackedAddr{
+		addr: "stream",
+	}
+}
+
+// RemoteAddr implements sendConn.
+func (q *qosSendConn) RemoteAddr() net.Addr {
+	return &streamBackedAddr{
+		addr: "stream",
+	}
+}
+
+// Write implements sendConn.
+func (q *qosSendConn) Write(b []byte, gsoSize uint16, ecn protocol.ECN) error {
+	_, err := q.stream.Write(b)
+	fmt.Println("Wrote packet of size", len(b))
+	return err
+}
+
+// capabilities implements sendConn.
+func (q *qosSendConn) capabilities() connCapabilities {
+	return connCapabilities{}
+}
+
+var _ sendConn = &qosSendConn{}
+
+type qosRunner struct {
+	label   string
+	logger  utils.Logger
+	stream  io.ReadWriteCloser
+	readBuf []byte
+	conn    *connection
+	// If we've read a partial frame, where does it end?
+	partialFrameBufIdx int
+	// For sending
+	ctlFrames    []ackhandler.Frame
+	streamFrames []ackhandler.StreamFrame
+	writer       *bufio.Writer
+}
+
+func (q *qosRunner) init(label string, logger utils.Logger) error {
+	q.readBuf = make([]byte, 4*16<<10)
+	q.label = label
+	q.logger = logger
+	return nil
+}
+func (q *qosRunner) setConn(conn *connection) {
+	q.conn = conn
+}
+
+func (q *qosRunner) run(ctx context.Context) error {
+	// Read loop
+	for {
+		n, err := q.stream.Read(q.readBuf[q.partialFrameBufIdx:])
+		if err != nil {
+			return err
+		}
+		frameData := q.readBuf[:q.partialFrameBufIdx+n]
+		q.logger.Debugf("[%s] Received %d bytes", q.label, len(frameData))
+		// q.logger.Debugf("[%s] [dump] %x", q.label, frameData)
+		_, restData, err := q.conn.handleFrames(frameData, protocol.ConnectionID{}, protocol.Encryption1RTT, nil)
+		parsedByteCount := len(frameData) - len(restData)
+		if parsedByteCount == 0 && len(frameData) > 20<<10 {
+			q.logger.Debugf("[%s] [dump] %x", q.label, frameData)
+			q.logger.Debugf("[%s] no bytes parsed, %v", q.label, err)
+			panic("todo")
+		}
+		q.logger.Debugf("[%s] parsed %d bytes", q.label, parsedByteCount)
+		copy(q.readBuf, restData)
+		q.partialFrameBufIdx = len(restData)
+		if err == io.EOF {
+			continue
+		}
+		if err != nil {
+			q.logger.Errorf("[%s] handle frames err %v", q.label, err)
+			q.logger.Errorf("[%s] [dump] %x", q.label, q.readBuf[:q.partialFrameBufIdx])
+			return err
+		}
+	}
+}
+
+func (q *qosRunner) send(f framer) error {
+	buf := make([]byte, 0, 16<<10)
+	q.ctlFrames, _ = f.AppendControlFrames(q.ctlFrames, 16<<10, Version1)
+	var wroteData bool
+	var err error
+	for _, f := range q.ctlFrames {
+		wire.LogFrame(q.logger, f.Frame, true)
+		buf, err = f.Frame.Append(buf, Version1)
+		if err != nil {
+			return err
+		}
+		_, err = q.writer.Write(buf)
+		if err != nil {
+			return err
+		}
+		wroteData = true
+		buf = buf[:0]
+	}
+	q.ctlFrames = q.ctlFrames[:0]
+	var l protocol.ByteCount
+	q.streamFrames, l = f.AppendStreamFrames(q.streamFrames, 16<<10, Version1)
+	q.logger.Debugf("[%s] I have %d bytes to write", q.label, l)
+	for _, f := range q.streamFrames {
+		q.logger.Debugf("[%s] has len: %v", q.label, f.Frame.DataLenPresent)
+		f.Frame.DataLenPresent = true
+		wire.LogFrame(q.logger, f.Frame, true)
+		buf, err = f.Frame.Append(buf, Version1)
+		if err != nil {
+			return err
+		}
+		q.logger.Debugf("[%s] dump", q.label, buf)
+		_, err = q.writer.Write(buf)
+		if err != nil {
+			return err
+		}
+		wroteData = true
+		q.logger.Debugf("[%s] wrote %d bytes", q.label, len(buf))
+		buf = buf[:0]
+	}
+	q.streamFrames = q.streamFrames[:0]
+
+	if wroteData {
+		return q.writer.Flush()
+	}
+	return nil
+}
+
+type qosConnGenerator struct{}
+
+// ConnectionIDLen implements ConnectionIDGenerator.
+func (q *qosConnGenerator) ConnectionIDLen() int {
+	return 4
+}
+
+// GenerateConnectionID implements ConnectionIDGenerator.
+func (q *qosConnGenerator) GenerateConnectionID() (protocol.ConnectionID, error) {
+	return protocol.ConnectionID{}, nil
+}
+
+var _ ConnectionIDGenerator = &qosConnGenerator{}
+
+func NewQoSConn(stream io.ReadWriteCloser, tlsConf *tls.Config, conf *Config, perspective protocol.Perspective) (EarlyConnection, error) {
+	logger := utils.DefaultLogger
+	peerParams, err := exchangeTptParamsQos(logger, conf, stream, perspective)
+	if err != nil {
+		return nil, err
+	}
+	logger.Debugf("Client Received QoSTransportParameters: %s", peerParams)
+
+	runner := &qosRunner{
+		stream: stream,
+		writer: bufio.NewWriter(stream),
+	}
+	err = runner.init(perspective.String(), logger)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	conn := newQoSConnection(
+		ctx,
+		cancel,
+		perspective,
+		&qosSendConn{stream: stream},
+		nil,
+		protocol.ConnectionID{},
+		&protocol.ConnectionID{},
+		protocol.ConnectionID{},
+		protocol.ConnectionID{},
+		protocol.ConnectionID{},
+		&qosConnGenerator{},
+		protocol.StatelessResetToken{},
+		conf,
+		tlsConf,
+		&handshake.TokenGenerator{},
+		true,
+		nil,
+		logger,
+		Version1,
+	)
+	c := conn.(*connection)
+
+	runner.setConn(c)
+
+	go func() {
+		err := runner.run(context.Background())
+		if err != nil {
+			logger.Debugf("QoS runner failed: %s", err)
+		}
+	}()
+
+	peerParams.RetrySourceConnectionID = nil
+	c.quicOnStream = runner
+	c.isQuicOnStream = true
+	c.peerParams = peerParams
+	c.streamsMap.UpdateLimits(peerParams)
+	err = c.handleTransportParameters(peerParams)
+	if err != nil {
+		return nil, err
+	}
+	if perspective == protocol.PerspectiveClient {
+		c.applyTransportParameters()
+	}
+
+	c.sentPacketHandler.DropPackets(protocol.EncryptionInitial)
+	c.sentPacketHandler.DropPackets(protocol.EncryptionHandshake)
+	c.sentPacketHandler.SetHandshakeConfirmed()
+	c.handshakeComplete = true
+	close(c.handshakeCompleteChan)
+
+	go func() {
+		err := c.run()
+		logger.Debugf("Connection run done: %s", err)
+	}()
+	c.scheduleSending()
+
+	return conn, nil
+
+}
+
+var newQoSConnection = func(
+	ctx context.Context,
+	ctxCancel context.CancelCauseFunc,
+	perspective protocol.Perspective,
+	conn sendConn,
+	runner connRunner,
+	origDestConnID protocol.ConnectionID,
+	retrySrcConnID *protocol.ConnectionID,
+	clientDestConnID protocol.ConnectionID,
+	destConnID protocol.ConnectionID,
+	srcConnID protocol.ConnectionID,
+	connIDGenerator ConnectionIDGenerator,
+	statelessResetToken protocol.StatelessResetToken,
+	conf *Config,
+	tlsConf *tls.Config,
+	tokenGenerator *handshake.TokenGenerator,
+	clientAddressValidated bool,
+	tracer *logging.ConnectionTracer,
+	logger utils.Logger,
+	v protocol.Version,
+) quicConn {
+	s := &connection{
+		isQuicOnStream:      true,
+		ctx:                 ctx,
+		ctxCancel:           ctxCancel,
+		conn:                conn,
+		config:              conf,
+		handshakeDestConnID: destConnID,
+		srcConnIDLen:        srcConnID.Len(),
+		tokenGenerator:      tokenGenerator,
+		oneRTTStream:        newCryptoStream(),
+		perspective:         perspective,
+		tracer:              tracer,
+		logger:              logger,
+		version:             v,
+	}
+	if origDestConnID.Len() > 0 {
+		s.logID = origDestConnID.String()
+	} else {
+		s.logID = destConnID.String()
+	}
+	if runner != nil {
+		s.connIDManager = newConnIDManager(
+			destConnID,
+			func(token protocol.StatelessResetToken) { runner.AddResetToken(token, s) },
+			runner.RemoveResetToken,
+			s.queueControlFrame,
+		)
+		s.connIDGenerator = newConnIDGenerator(
+			srcConnID,
+			&clientDestConnID,
+			func(connID protocol.ConnectionID) { runner.Add(connID, s) },
+			runner.GetStatelessResetToken,
+			runner.Remove,
+			runner.Retire,
+			runner.ReplaceWithClosed,
+			s.queueControlFrame,
+			connIDGenerator,
+		)
+	}
+	s.preSetup()
+	s.sentPacketHandler, s.receivedPacketHandler = ackhandler.NewAckHandler(
+		0,
+		protocol.ByteCount(s.config.InitialPacketSize),
+		s.rttStats,
+		clientAddressValidated,
+		s.conn.capabilities().ECN,
+		s.perspective,
+		s.tracer,
+		s.logger,
+	)
+	s.maxPayloadSizeEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
+	params := &wire.TransportParameters{
+		InitialMaxStreamDataBidiLocal:   protocol.ByteCount(s.config.InitialStreamReceiveWindow),
+		InitialMaxStreamDataBidiRemote:  protocol.ByteCount(s.config.InitialStreamReceiveWindow),
+		InitialMaxStreamDataUni:         protocol.ByteCount(s.config.InitialStreamReceiveWindow),
+		InitialMaxData:                  protocol.ByteCount(s.config.InitialConnectionReceiveWindow),
+		MaxIdleTimeout:                  s.config.MaxIdleTimeout,
+		MaxBidiStreamNum:                protocol.StreamNum(s.config.MaxIncomingStreams),
+		MaxUniStreamNum:                 protocol.StreamNum(s.config.MaxIncomingUniStreams),
+		MaxAckDelay:                     protocol.MaxAckDelayInclGranularity,
+		AckDelayExponent:                protocol.AckDelayExponent,
+		MaxUDPPayloadSize:               protocol.MaxPacketBufferSize,
+		DisableActiveMigration:          true,
+		StatelessResetToken:             &statelessResetToken,
+		OriginalDestinationConnectionID: origDestConnID,
+		// For interoperability with quic-go versions before May 2023, this value must be set to a value
+		// different from protocol.DefaultActiveConnectionIDLimit.
+		// If set to the default value, it will be omitted from the transport parameters, which will make
+		// old quic-go versions interpret it as 0, instead of the default value of 2.
+		// See https://github.com/quic-go/quic-go/pull/3806.
+		ActiveConnectionIDLimit:   protocol.MaxActiveConnectionIDs,
+		InitialSourceConnectionID: srcConnID,
+		RetrySourceConnectionID:   retrySrcConnID,
+	}
+	if s.config.EnableDatagrams {
+		params.MaxDatagramFrameSize = wire.MaxDatagramSize
+	} else {
+		params.MaxDatagramFrameSize = protocol.InvalidByteCount
+	}
+	if s.tracer != nil && s.tracer.SentTransportParameters != nil {
+		s.tracer.SentTransportParameters(params)
+	}
+	cs := handshake.NewCryptoSetupServer(
+		clientDestConnID,
+		conn.LocalAddr(),
+		conn.RemoteAddr(),
+		params,
+		tlsConf,
+		conf.Allow0RTT,
+		s.rttStats,
+		tracer,
+		logger,
+		s.version,
+	)
+	s.cryptoStreamHandler = cs
+	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, s.receivedPacketHandler, s.datagramQueue, s.perspective)
+	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen)
+	s.cryptoStreamManager = newCryptoStreamManager(cs, s.initialStream, s.handshakeStream, s.oneRTTStream)
+	return s
+}

--- a/qos_sep_test.go
+++ b/qos_sep_test.go
@@ -1,0 +1,177 @@
+package quic_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+type chanBackedStream struct {
+	toRemote   chan<- []byte
+	fromRemote <-chan []byte
+	buf        []byte
+}
+
+// Read implements io.ReadWriter.
+func (c *chanBackedStream) Read(p []byte) (n int, err error) {
+	var b []byte
+	if c.buf != nil {
+		b = c.buf
+		c.buf = nil
+	} else {
+		var ok bool
+		b, ok = <-c.fromRemote
+		if !ok {
+			return 0, io.EOF
+		}
+	}
+	if len(b) < len(p) {
+		copy(p, b)
+		return len(b), nil
+	}
+
+	copy(p, b[:len(p)])
+	c.buf = b[len(p):]
+	return len(p), nil
+}
+
+// Write implements io.ReadWriter.
+func (c *chanBackedStream) Write(p []byte) (n int, err error) {
+	cloned := make([]byte, len(p))
+	copy(cloned, p)
+	c.toRemote <- cloned
+	return len(p), nil
+}
+
+func (c *chanBackedStream) Close() error {
+	return nil
+}
+
+func newPair() (*chanBackedStream, *chanBackedStream) {
+	atob := make(chan []byte, 1024)
+	btoa := make(chan []byte, 1024)
+	a := &chanBackedStream{
+		toRemote:   atob,
+		fromRemote: btoa,
+	}
+	b := &chanBackedStream{
+		toRemote:   btoa,
+		fromRemote: atob,
+	}
+	return a, b
+}
+
+func TestQoSH3(t *testing.T) {
+	atob, btoa := newPair()
+
+	server := http3.Server{}
+	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println("server got request")
+		w.Write([]byte("hello"))
+	})
+	waitForServer := make(chan struct{})
+	go func() {
+		close(waitForServer)
+		c, err := quic.NewQoSConn(btoa, &tls.Config{InsecureSkipVerify: true}, quic.PopulateConfigWithDefaults(nil), protocol.PerspectiveServer)
+		if err != nil {
+			fmt.Println("server err", err)
+			t.Fail()
+			return
+		}
+		err = server.ServeQUICConn(c)
+		if err != nil {
+			fmt.Println("server serve err", err)
+			t.Fail()
+		}
+	}()
+
+	clientRT := &http3.RoundTripper{
+		TLSClientConfig: &tls.Config{}, // set a TLS client config, if desired
+		Dial: func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
+			clientConn, err := quic.NewQoSConn(atob, &tls.Config{InsecureSkipVerify: true}, quic.PopulateConfigWithDefaults(nil), protocol.PerspectiveClient)
+			if err != nil {
+				return nil, err
+			}
+			return clientConn, nil
+		},
+	}
+	client := &http.Client{
+		Transport: clientRT,
+	}
+	resp, err := client.Get("https://www.example.com/")
+	if err != nil {
+		fmt.Println("client get err", err)
+		t.Fail()
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("client get err", err)
+		t.Fail()
+	}
+
+	if string(respBody) != "hello" {
+		fmt.Println("client get err", err)
+		t.Fail()
+	}
+
+	<-waitForServer
+}
+
+func TestQoSH3h2o(t *testing.T) {
+	t.Skip("Requires h2o to be running")
+	h2oEndpoint := "31.133.134.206:8443"
+
+	f, err := os.OpenFile("/tmp/keys", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true, // Don't verify server certificate (not recommended for production)
+		NextProtos:         []string{"h3"},
+		KeyLogWriter:       f,
+	}
+
+	conn, err := tls.Dial("tcp", h2oEndpoint, tlsConfig)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	c, err := quic.NewQoSConn(conn, tlsConfig, quic.PopulateConfigWithDefaults(nil), protocol.PerspectiveClient)
+	if err != nil {
+		t.Fatalf("Failed to create QoS connection: %v", err)
+	}
+
+	clientRT := &http3.RoundTripper{
+		TLSClientConfig: &tls.Config{}, // set a TLS client config, if desired
+		Dial: func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
+			return c, nil
+		},
+	}
+	client := &http.Client{
+		Transport: clientRT,
+	}
+	resp, err := client.Get("https://www.example.com/file/src/main.c")
+	if err != nil {
+		fmt.Println("client get err", err)
+		t.Fail()
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("client get err", err)
+		t.Fail()
+	}
+	fmt.Println("Status code", resp.StatusCode)
+	fmt.Println("Body", string(respBody))
+
+}

--- a/qos_test.go
+++ b/qos_test.go
@@ -1,0 +1,151 @@
+package quic
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+type chanBackedStream struct {
+	toRemote   chan<- []byte
+	fromRemote <-chan []byte
+	buf        []byte
+}
+
+// Read implements io.ReadWriter.
+func (c *chanBackedStream) Read(p []byte) (n int, err error) {
+	var b []byte
+	if c.buf != nil {
+		b = c.buf
+		c.buf = nil
+	} else {
+		var ok bool
+		b, ok = <-c.fromRemote
+		if !ok {
+			return 0, io.EOF
+		}
+	}
+	if len(b) < len(p) {
+		copy(p, b)
+		return len(b), nil
+	}
+
+	copy(p, b[:len(p)])
+	c.buf = b[len(p):]
+	return len(p), nil
+}
+
+// Write implements io.ReadWriter.
+func (c *chanBackedStream) Write(p []byte) (n int, err error) {
+	cloned := make([]byte, len(p))
+	copy(cloned, p)
+	c.toRemote <- cloned
+	return len(p), nil
+}
+
+func (c *chanBackedStream) Close() error {
+	return nil
+}
+
+func newPair() (*chanBackedStream, *chanBackedStream) {
+	atob := make(chan []byte, 1024)
+	btoa := make(chan []byte, 1024)
+	a := &chanBackedStream{
+		toRemote:   atob,
+		fromRemote: btoa,
+	}
+	b := &chanBackedStream{
+		toRemote:   btoa,
+		fromRemote: atob,
+	}
+	return a, b
+}
+
+var _ io.ReadWriter = &chanBackedStream{}
+
+func TestPair(t *testing.T) {
+	atob, btoa := newPair()
+
+	go func() {
+		atob.Write([]byte("hello"))
+	}()
+	out := make([]byte, 1024)
+	n, err := btoa.Read(out)
+	if !(err == nil && n == 5 && string(out[:n]) == "hello") {
+		t.Fatal("failed")
+	}
+}
+
+func TestQoS(t *testing.T) {
+	atob, btoa := newPair()
+
+	waitForServer := make(chan struct{})
+	go func() {
+		defer close(waitForServer)
+		conn, err := NewQoSConn(btoa, &tls.Config{InsecureSkipVerify: true}, populateConfig(nil), protocol.PerspectiveServer)
+		if err != nil {
+			fmt.Println("server err", err)
+			t.Fail()
+			return
+		}
+
+		s, err := conn.AcceptStream(context.Background())
+		if err != nil {
+			fmt.Println("server stream err", err)
+			t.Fail()
+		}
+		defer s.Close()
+		buf := make([]byte, 1024)
+		n, err := s.Read(buf)
+		if err != nil && err != io.EOF {
+			fmt.Println("server read err", err)
+			t.Fail()
+		}
+
+		res := buf[:n]
+		if string(res) != "hello" {
+			fmt.Println("server read wrong data", string(res))
+			t.Fail()
+		}
+
+		_, err = s.Write(res)
+		if err != nil {
+			fmt.Println("server write err", err)
+			t.Fail()
+		}
+	}()
+
+	clientConn, err := NewQoSConn(atob, &tls.Config{InsecureSkipVerify: true}, populateConfig(nil), protocol.PerspectiveClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := clientConn.OpenStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = s.Write([]byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1024)
+	n, err := s.Read(buf)
+	res := buf[:n]
+	if err != nil && err != io.EOF {
+		t.Fatalf("client read err: %v", err)
+	}
+	if string(res) != "hello" {
+		t.Fatalf("client read wrong data: %s", string(res))
+	}
+
+	err = s.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-waitForServer
+}


### PR DESCRIPTION
This implements [QUIC on Streams](https://datatracker.ietf.org/doc/html/draft-kazuho-quic-quic-on-streams) which lets one run parts of the QUIC stack on a reliable stream like TCP+TLS.

The changes are about ~600 LoC (not including ~300 LOC for tests). The code is hacky, but is intended to be a proof of concept.

**Zero** changes to h3 code were required to get h3 on QUIC on Streams. This code interoperates with [h2o](https://github.com/h2o/h2o/pull/3373). Specifically we successfully made an HTTP/3 GET requests for a file hosted by h2o over a TCP+TLS connection.