### PR TITLE
remove conn from packetHandlerMap on early error

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -499,9 +499,11 @@ func (s *connection) run() error {
 	s.timer = *newTimer()
 
 	if err := s.cryptoStreamHandler.StartHandshake(s.ctx); err != nil {
+		s.connIDGenerator.RemoveAll()
 		return err
 	}
 	if err := s.handleHandshakeEvents(); err != nil {
+		s.connIDGenerator.RemoveAll()
 		return err
 	}
 	go func() {

--- a/connection_test.go
+++ b/connection_test.go
@@ -3007,6 +3007,7 @@ var _ = Describe("Client Connection", func() {
 			processed := make(chan struct{})
 			tracer.EXPECT().ReceivedTransportParameters(params).Do(func(*wire.TransportParameters) { close(processed) })
 			paramsChan <- params
+			connRunner.EXPECT().Remove(gomock.Any())
 			Eventually(processed).Should(BeClosed())
 			Eventually(errChan).Should(Receive(MatchError(&qerr.TransportError{
 				ErrorCode:    qerr.TransportParameterError,
@@ -3026,6 +3027,7 @@ var _ = Describe("Client Connection", func() {
 			processed := make(chan struct{})
 			tracer.EXPECT().ReceivedTransportParameters(params).Do(func(*wire.TransportParameters) { close(processed) })
 			paramsChan <- params
+			connRunner.EXPECT().Remove(gomock.Any())
 			Eventually(processed).Should(BeClosed())
 			Eventually(errChan).Should(Receive(MatchError(&qerr.TransportError{
 				ErrorCode:    qerr.TransportParameterError,
@@ -3047,6 +3049,7 @@ var _ = Describe("Client Connection", func() {
 			processed := make(chan struct{})
 			tracer.EXPECT().ReceivedTransportParameters(params).Do(func(*wire.TransportParameters) { close(processed) })
 			paramsChan <- params
+			connRunner.EXPECT().Remove(gomock.Any())
 			Eventually(processed).Should(BeClosed())
 			Eventually(errChan).Should(Receive(MatchError(&qerr.TransportError{
 				ErrorCode:    qerr.TransportParameterError,
@@ -3066,6 +3069,7 @@ var _ = Describe("Client Connection", func() {
 			processed := make(chan struct{})
 			tracer.EXPECT().ReceivedTransportParameters(params).Do(func(*wire.TransportParameters) { close(processed) })
 			paramsChan <- params
+			connRunner.EXPECT().Remove(gomock.Any())
 			Eventually(processed).Should(BeClosed())
 			Eventually(errChan).Should(Receive(MatchError(&qerr.TransportError{
 				ErrorCode:    qerr.TransportParameterError,
@@ -3084,6 +3088,7 @@ var _ = Describe("Client Connection", func() {
 			processed := make(chan struct{})
 			tracer.EXPECT().ReceivedTransportParameters(params).Do(func(*wire.TransportParameters) { close(processed) })
 			paramsChan <- params
+			connRunner.EXPECT().Remove(gomock.Any())
 			Eventually(processed).Should(BeClosed())
 			Eventually(errChan).Should(Receive(MatchError(&qerr.TransportError{
 				ErrorCode:    qerr.TransportParameterError,
@@ -3118,6 +3123,7 @@ var _ = Describe("Client Connection", func() {
 			tracer.EXPECT().ReceivedTransportParameters(params).Do(func(*wire.TransportParameters) { close(processed) })
 			cryptoSetup.EXPECT().ConnectionState().Return(handshake.ConnectionState{Used0RTT: true})
 			paramsChan <- params
+			connRunner.EXPECT().Remove(gomock.Any())
 			Eventually(processed).Should(BeClosed())
 			Eventually(errChan).Should(Receive(MatchError(&qerr.TransportError{
 				ErrorCode:    qerr.ProtocolViolation,


### PR DESCRIPTION
This fixes an issue where if we would return early here with an error we would never clean up our reference in the packet handler map.

but, afaict these calls never error (outside of tests with mock) because they don't actually do any IO. However, it's probably best to guard here against a leaked connection that would happen if these calls ever did return an error in the future.