### PR TITLE
ackhandler: remove error return value from OnLossDetectionTimeout

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -593,10 +593,7 @@ runLoop:
 		if timeout := s.sentPacketHandler.GetLossDetectionTimeout(); !timeout.IsZero() && timeout.Before(now) {
 			// This could cause packets to be retransmitted.
 			// Check it before trying to send packets.
-			if err := s.sentPacketHandler.OnLossDetectionTimeout(now); err != nil {
-				s.setCloseError(&closeError{err: err})
-				break runLoop
-			}
+			s.sentPacketHandler.OnLossDetectionTimeout(now)
 		}
 
 		if keepAliveTime := s.nextKeepAliveTime(); !keepAliveTime.IsZero() && !now.Before(keepAliveTime) {

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -33,7 +33,7 @@ type SentPacketHandler interface {
 	PopPacketNumber(protocol.EncryptionLevel) protocol.PacketNumber
 
 	GetLossDetectionTimeout() time.Time
-	OnLossDetectionTimeout(now time.Time) error
+	OnLossDetectionTimeout(now time.Time)
 }
 
 type sentPacketTracker interface {

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -156,11 +156,9 @@ func (c *MockSentPacketHandlerGetLossDetectionTimeoutCall) DoAndReturn(f func() 
 }
 
 // OnLossDetectionTimeout mocks base method.
-func (m *MockSentPacketHandler) OnLossDetectionTimeout(now time.Time) error {
+func (m *MockSentPacketHandler) OnLossDetectionTimeout(now time.Time) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OnLossDetectionTimeout", now)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "OnLossDetectionTimeout", now)
 }
 
 // OnLossDetectionTimeout indicates an expected call of OnLossDetectionTimeout.
@@ -176,19 +174,19 @@ type MockSentPacketHandlerOnLossDetectionTimeoutCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) Return(arg0 error) *MockSentPacketHandlerOnLossDetectionTimeoutCall {
-	c.Call = c.Call.Return(arg0)
+func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) Return() *MockSentPacketHandlerOnLossDetectionTimeoutCall {
+	c.Call = c.Call.Return()
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) Do(f func(time.Time) error) *MockSentPacketHandlerOnLossDetectionTimeoutCall {
+func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) Do(f func(time.Time)) *MockSentPacketHandlerOnLossDetectionTimeoutCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) DoAndReturn(f func(time.Time) error) *MockSentPacketHandlerOnLossDetectionTimeoutCall {
+func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) DoAndReturn(f func(time.Time)) *MockSentPacketHandlerOnLossDetectionTimeoutCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
This removes two bug checks, one of which was completely useless, but the other one could potentially have been useful. Not sure how I feel about that.

Recreating #4918, because GitHub is just insanely stupid.