### PR TITLE
Switching Windows to use `oobConn`

### DIFF
--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -12,6 +12,8 @@ type packetBuffer struct {
 	// refCount counts how many packets Data is used in.
 	// It doesn't support concurrent use.
 	// It is > 1 when used for coalesced packet.
+	// More than one packet's data can be in the same buffer?
+	// So more than one packet will reference this buffer?
 	refCount int
 }
 

--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -12,8 +12,6 @@ type packetBuffer struct {
 	// refCount counts how many packets Data is used in.
 	// It doesn't support concurrent use.
 	// It is > 1 when used for coalesced packet.
-	// More than one packet's data can be in the same buffer?
-	// So more than one packet will reference this buffer?
 	refCount int
 }
 

--- a/sys_conn_helper_nonlinux.go
+++ b/sys_conn_helper_nonlinux.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !windows
 
 package quic
 

--- a/sys_conn_helper_windows.go
+++ b/sys_conn_helper_windows.go
@@ -1,0 +1,100 @@
+//go:build windows
+
+package quic
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	GSO_SIZE          = 1500
+	UDP_SEND_MSG_SIZE = windows.UDP_SEND_MSG_SIZE
+)
+
+const batchSize = 8 // TO DO: Check if this is correct and works for windows too.
+
+// TO DO: Check what this option (SNDBUF, RCVBUF) does when I try to set something above "max".
+
+func forceSetReceiveBuffer(c syscall.RawConn, bytes int) error {
+	var serr error
+	if err := c.Control(func(fd uintptr) {
+		serr = windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_RCVBUF, bytes)
+	}); err != nil {
+		return err
+	}
+	return serr
+}
+
+func forceSetSendBuffer(c syscall.RawConn, bytes int) error {
+	var serr error
+	if err := c.Control(func(fd uintptr) {
+		serr = windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_SNDBUF, bytes)
+	}); err != nil {
+		return err
+	}
+	return serr
+}
+
+func appendUDPSegmentSizeMsg([]byte, uint16) []byte { return nil }
+
+func isGSOEnabled(conn syscall.RawConn) bool {
+	gsoSegmentSize := getMaxGSOSegments()
+	if gsoSegmentSize == 512 {
+		return true
+	}
+	return false
+}
+
+// TO DO: Implement
+func isECNEnabled() bool {
+	return false
+}
+
+// I'm unable to find windows' response upon a failure caused related to GSO. TO DO
+// Quinn just checks for GSO support using isGSOEnabled, nothing else.
+func isGSOError(error) bool {
+	return false
+}
+
+// This was written for linux, not applicable to windows.
+func isPermissionError(err error) bool { return false }
+
+// return the maximum number of GSO segments that can be sent
+// if GSO is not supported, return 1
+// if GSO is supported, return 512
+func getMaxGSOSegments() int {
+	// On Windows, GSO is supported if UDP_SEND_MSG_SIZE socket option is available
+	// We can check this by trying to set it on a dummy socket
+	dummy, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_UDP)
+	if err != nil {
+		return 1
+	}
+	defer syscall.CloseHandle(dummy)
+
+	err = syscall.SetsockoptInt(dummy, windows.IPPROTO_UDP, windows.UDP_SEND_MSG_SIZE, GSO_SIZE)
+	if err != nil {
+		return 1
+	}
+	return 512
+}
+
+// https://github.com/microsoft/win32metadata/blob/main/generation/WinSDK/RecompiledIdlHeaders/shared/ws2def.h#L726
+type Cmsghdr struct {
+	Len   uint64
+	Level int32
+	Type  int32
+}
+
+const SizeofCmsghdr = 0x10 // 16
+// TO DO: Is this okay to do?
+const CmsgAlign = 0x8 // 8
+
+func cmsgHdrAlign(len uintptr) uintptr {
+	return (len + uintptr(CmsgAlign) - 1) & ^(uintptr(CmsgAlign) - 1)
+}
+
+func cmsgDataAlign(len uintptr) uintptr {
+	return (len + uintptr(0x8) - 1) & ^(uintptr(0x8) - 1)
+}

--- a/sys_conn_helper_windows.go
+++ b/sys_conn_helper_windows.go
@@ -78,8 +78,9 @@ func isGSOEnabled(conn syscall.RawConn) bool {
 }
 
 // TO DO: Implement
+// Changing
 func isECNEnabled() bool {
-	return false
+	return true
 }
 
 // I'm unable to find windows' response upon a failure caused related to GSO. TO DO

--- a/sys_conn_windows.go
+++ b/sys_conn_windows.go
@@ -3,14 +3,142 @@
 package quic
 
 import (
+	"errors"
+	"net"
 	"net/netip"
+	"sync"
 	"syscall"
+	"time"
 
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
+
+	"golang.org/x/net/ipv4"
 	"golang.org/x/sys/windows"
 )
 
-func newConn(c OOBCapablePacketConn, supportsDF bool) (*basicConn, error) {
-	return &basicConn{PacketConn: c, supportsDF: supportsDF}, nil
+// TO DO: Check if these are correct
+const (
+	ecnMask       = 0x3
+	oobBufferSize = 128
+	IP_RECVECN    = 0x32 // https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IP_RECVECN.html
+	IPV6_RECVECN  = 0x32 // https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IPV6_RECVECN.html
+)
+
+type batchConn interface {
+	ReadBatch(ms []ipv4.Message, flags int) (int, error)
+}
+
+func newConn(c OOBCapablePacketConn, supportsDF bool) (*oobConn, error) {
+	rawConn, err := c.SyscallConn()
+	if err != nil {
+		return nil, err
+	}
+	var needsPacketInfo bool
+	if udpAddr, ok := c.LocalAddr().(*net.UDPAddr); ok && udpAddr.IP.IsUnspecified() {
+		needsPacketInfo = true
+	}
+	// rawConn may be IPv4, IPv6 or both.
+	var errECNIPv4, errECNIPv6, errPIIPv4, errPIIPv6 error
+	if err := rawConn.Control(func(fd uintptr) {
+		errECNIPv4 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, IP_RECVECN, 1)
+		errECNIPv6 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, IPV6_RECVECN, 1)
+
+		if needsPacketInfo {
+			errPIIPv4 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, windows.IP_PKTINFO, 1)
+			errPIIPv6 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, windows.IPV6_PKTINFO, 1)
+		}
+	}); err != nil {
+		return nil, err
+	}
+	switch {
+	case errECNIPv4 == nil && errECNIPv6 == nil:
+		utils.DefaultLogger.Debugf("Activating reading of ECN bits for IPv4 and IPv6.")
+	case errECNIPv4 == nil && errECNIPv6 != nil:
+		utils.DefaultLogger.Debugf("Activating reading of ECN bits for IPv4.")
+	case errECNIPv4 != nil && errECNIPv6 == nil:
+		utils.DefaultLogger.Debugf("Activating reading of ECN bits for IPv6.")
+	case errECNIPv4 != nil && errECNIPv6 != nil:
+		return nil, errors.New("activating ECN failed for both IPv4 and IPv6")
+	}
+	if needsPacketInfo {
+		switch {
+		case errPIIPv4 == nil && errPIIPv6 == nil:
+			utils.DefaultLogger.Debugf("Activating reading of packet info for IPv4 and IPv6.")
+		case errPIIPv4 == nil && errPIIPv6 != nil:
+			utils.DefaultLogger.Debugf("Activating reading of packet info bits for IPv4.")
+		case errPIIPv4 != nil && errPIIPv6 == nil:
+			utils.DefaultLogger.Debugf("Activating reading of packet info bits for IPv6.")
+		case errPIIPv4 != nil && errPIIPv6 != nil:
+			return nil, errors.New("activating packet info failed for both IPv4 and IPv6")
+		}
+	}
+
+	// Allows callers to pass in a connection that already satisfies batchConn interface
+	// to make use of the optimisation. Otherwise, ipv4.NewPacketConn would unwrap the file descriptor
+	// via SyscallConn(), and read it that way, which might not be what the caller wants.
+	var bc batchConn
+	if ibc, ok := c.(batchConn); ok {
+		bc = ibc
+	} else {
+		bc = ipv4.NewPacketConn(c)
+	}
+
+	msgs := make([]ipv4.Message, batchSize)
+	for i := range msgs {
+		// preallocate the [][]byte
+		msgs[i].Buffers = make([][]byte, 1)
+	}
+	oobConn := &oobConn{
+		OOBCapablePacketConn: c,
+		batchConn:            bc,
+		messages:             msgs,
+		readPos:              batchSize,
+		cap: connCapabilities{
+			DF:  supportsDF,
+			GSO: isGSOEnabled(rawConn),
+			ECN: isECNEnabled(),
+		},
+	}
+	for i := 0; i < batchSize; i++ {
+		oobConn.messages[i].OOB = make([]byte, oobBufferSize)
+	}
+	return oobConn, nil
+}
+
+var invalidCmsgOnceV4, invalidCmsgOnceV6 sync.Once
+
+func (c *oobConn) ReadPacket() (receivedPacket, error) {
+	if len(c.messages) == int(c.readPos) { // all messages read. Read the next batch of messages.
+		c.messages = c.messages[:batchSize] // what is happening here?
+		// replace buffers data buffers up to the packet that has been consumed during the last ReadBatch call
+		for i := uint8(0); i < c.readPos; i++ {
+			buffer := getPacketBuffer()
+			buffer.Data = buffer.Data[:protocol.MaxPacketBufferSize]
+			c.buffers[i] = buffer
+			c.messages[i].Buffers[0] = c.buffers[i].Data
+		}
+		c.readPos = 0
+
+		n, err := c.batchConn.ReadBatch(c.messages, 0)
+		if n == 0 || err != nil {
+			return receivedPacket{}, err
+		}
+		c.messages = c.messages[:n]
+	}
+
+	msg := c.messages[c.readPos]
+	buffer := c.buffers[c.readPos]
+	c.readPos++
+
+	data := msg.OOB[:msg.NN]
+	p := receivedPacket{
+		remoteAddr: msg.Addr,
+		rcvTime:    time.Now(),
+		data:       msg.Buffers[0][:msg.N],
+		buffer:     buffer,
+	}
+
 }
 
 func inspectReadBuffer(c syscall.RawConn) (int, error) {
@@ -33,6 +161,18 @@ func inspectWriteBuffer(c syscall.RawConn) (int, error) {
 		return 0, err
 	}
 	return size, serr
+}
+
+type oobConn struct {
+	OOBCapablePacketConn
+	batchConn batchConn
+
+	readPos uint8
+	// Packets received from the kernel, but not yet returned by ReadPacket().
+	messages []ipv4.Message
+	buffers  [batchSize]*packetBuffer
+
+	cap connCapabilities
 }
 
 type packetInfo struct {

--- a/sys_conn_windows.go
+++ b/sys_conn_windows.go
@@ -21,10 +21,11 @@ import (
 
 // TO DO: Check if these are correct
 const (
-	ecnMask       = 0x3
-	oobBufferSize = 128
-	IP_RECVECN    = 0x32 // https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IP_RECVECN.html
-	IPV6_RECVECN  = 0x32 // https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IPV6_RECVECN.html
+	ecnMask         = 0x3
+	oobBufferSize   = 128
+	IP_RECVECN      = 0x32 // https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IP_RECVECN.html
+	IPV6_RECVECN    = 0x32 // https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IPV6_RECVECN.html
+	IPV6_RECVTCLASS = 0x28 // https://github.com/tpn/winsdk-10/blob/master/Include/10.0.14393.0/shared/ws2ipdef.h
 )
 
 type batchConn interface {
@@ -164,7 +165,7 @@ func (c *oobConn) ReadPacket() (receivedPacket, error) {
 		}
 		if hdr.Level == windows.IPPROTO_IPV6 {
 			switch hdr.Type {
-			case windows.IPV6_RECVTCLASS:
+			case IPV6_RECVTCLASS:
 				p.ecn = protocol.ParseECNHeaderBits(body[0] & ecnMask)
 			case windows.IPV6_PKTINFO:
 				// struct in6_pktinfo {

--- a/sys_conn_windows_test.go
+++ b/sys_conn_windows_test.go
@@ -3,28 +3,94 @@
 package quic
 
 import (
+	"fmt"
 	"net"
 	"testing"
+	"time"
 
+	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/stretchr/testify/require"
 )
 
-func TestWindowsConn(t *testing.T) {
-	t.Run("IPv4", func(t *testing.T) {
-		udpConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-		require.NoError(t, err)
-		conn, err := newConn(udpConn, true)
-		require.NoError(t, err)
-		require.NoError(t, conn.Close())
-		require.True(t, conn.capabilities().DF)
-	})
+func isIPv4(ip net.IP) bool { return ip.To4() != nil }
 
-	t.Run("IPv6", func(t *testing.T) {
-		udpConn, err := net.ListenUDP("udp6", &net.UDPAddr{IP: net.IPv6loopback, Port: 0})
-		require.NoError(t, err)
-		conn, err := newConn(udpConn, false)
-		require.NoError(t, err)
-		require.NoError(t, conn.Close())
-		require.False(t, conn.capabilities().DF)
-	})
+func runSysConnServer(t *testing.T, network string, addr *net.UDPAddr) (*net.UDPAddr, <-chan receivedPacket) {
+	t.Helper()
+	udpConn, err := net.ListenUDP(network, addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { udpConn.Close() })
+
+	oobConn, err := newConn(udpConn, true)
+	require.NoError(t, err)
+	require.True(t, oobConn.capabilities().DF)
+
+	packetChan := make(chan receivedPacket, 1)
+	go func() {
+		for {
+			p, err := oobConn.ReadPacket()
+			if err != nil {
+				return
+			}
+			packetChan <- p
+		}
+	}()
+	return udpConn.LocalAddr().(*net.UDPAddr), packetChan
+}
+
+func TestSysConnPacketInfoIPv4(t *testing.T) {
+	// need to listen on 0.0.0.0, otherwise we won't get the packet info
+	addr, packetChan := runSysConnServer(t, "udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	conn, err := net.DialUDP("udp4", nil, addr)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Write([]byte("foobar"))
+	require.NoError(t, err)
+
+	select {
+	case p := <-packetChan:
+		require.WithinDuration(t, time.Now(), p.rcvTime, scaleDuration(50*time.Millisecond))
+		require.Equal(t, []byte("foobar"), p.data)
+		require.Equal(t, conn.LocalAddr(), p.remoteAddr)
+		require.True(t, p.info.addr.IsValid())
+		require.True(t, isIPv4(p.info.addr.AsSlice()))
+		require.Equal(t, net.IPv4(127, 0, 0, 1).String(), p.info.addr.String())
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for packet")
+	}
+}
+
+type oobRecordingConn struct {
+	*net.UDPConn
+	oobs [][]byte
+}
+
+func (c *oobRecordingConn) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
+	c.oobs = append(c.oobs, oob)
+	return c.UDPConn.WriteMsgUDP(b, oob, addr)
+}
+
+func TestSysConnSendGSO(t *testing.T) {
+	// if !platformSupportsGSO {
+	// 	t.Skip("GSO not supported on this platform")
+	// }
+
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	c := &oobRecordingConn{UDPConn: udpConn}
+	oobConn, err := newConn(c, true)
+	require.NoError(t, err)
+	require.True(t, oobConn.capabilities().GSO)
+
+	oob := make([]byte, 0, 123)
+	oobConn.WritePacket([]byte("foobar"), udpConn.LocalAddr(), oob, 3, protocol.ECNCE)
+	require.Len(t, c.oobs, 1)
+	oobMsg := c.oobs[0]
+
+	require.NotEmpty(t, oobMsg)
+	fmt.Println(c.oobs, oob)
+	require.Equal(t, cap(oob), cap(oobMsg)) // check that it appended to oob
+
+	expected := appendUDPSegmentSizeMsg([]byte{}, 3)
+	// Check that the first control message is the OOB control message.
+	require.Equal(t, expected, oobMsg[:len(expected)])
 }

--- a/sys_conn_windows_test.go
+++ b/sys_conn_windows_test.go
@@ -114,7 +114,7 @@ func TestAppendIPv6ECNMsg(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	for _, val := range []protocol.ECN{protocol.ECT1, protocol.ECT0, protocol.ECNCE, protocol.ECNNon} {
+	for _, val := range []protocol.ECN{protocol.ECT1, protocol.ECT0, protocol.ECNNon} {
 		oob := appendIPv6ECNMsg([]byte{}, val)
 		_, _, err = c.WriteMsgUDP([]byte("foobar"), oob, addr)
 		require.NoError(t, err)
@@ -138,6 +138,7 @@ func TestAppendIPv4ECNMsg(t *testing.T) {
 
 	for _, val := range []protocol.ECN{protocol.ECNNon, protocol.ECT1, protocol.ECT0, protocol.ECNCE} {
 		oob := appendIPv4ECNMsg([]byte{}, val)
+		fmt.Println("ecn message: ", oob)
 		_, _, err = c.WriteMsgUDP([]byte("foobar"), oob, addr)
 		require.NoError(t, err)
 		// doesn't seem to be sending the packet always times out if it reaches this point.


### PR DESCRIPTION
### Which issue does this address?
#4325

### Purpose
This draft PR showcases the current progress on implementing `oobConn` support for Windows. Since this is my first time working on something like this, I recognize that the implementation is still a work in progress. There are several open issues and uncertainties, which I have marked with `TO DO:` comments.

Most of the code is largely based on the existing Linux implementation, with minimal changes to maintain clarity for existing contributors. I would sincerely appreciate any feedback or guidance on my approach, as well as suggestions for improvements.

### Major Changes and Issues
- Implemented cmsg support from scratch, as I couldn’t find existing support in the Go libraries.
- Using a workaround for ReadBatch, as it is unsupported on Windows.
- ECN support is still in progress; I am encountering several issues getting it to function correctly.
- Unable to find a Windows equivalent for Linux’s forced receive and send buffer settings.
- No `isGSOError` function implemented yet.
- Current tests need significant improvement, both in structure and coverage.

Any feedback or guidance would be greatly appreciated!