### PR TITLE
delete retired connection IDs after 3 PTOs

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -1163,7 +1163,6 @@ func TestConnectionHandshakeServer(t *testing.T) {
 	require.NoError(t, err)
 
 	cs.EXPECT().DiscardInitialKeys()
-	tc.connRunner.EXPECT().Retire(gomock.Any())
 	gomock.InOrder(
 		cs.EXPECT().StartHandshake(gomock.Any()),
 		cs.EXPECT().NextEvent().Return(handshake.Event{Kind: handshake.EventNoEvent}),

--- a/connection_timer.go
+++ b/connection_timer.go
@@ -32,8 +32,11 @@ func (t *connectionTimer) Chan() <-chan time.Time {
 // It makes sure that the deadline is strictly increasing.
 // This prevents busy-looping in cases where the timer fires, but we can't actually send out a packet.
 // This doesn't apply to the pacing deadline, which can be set multiple times to deadlineSendImmediately.
-func (t *connectionTimer) SetTimer(idleTimeoutOrKeepAlive, ackAlarm, lossTime, pacing time.Time) {
+func (t *connectionTimer) SetTimer(idleTimeoutOrKeepAlive, connIDRetirement, ackAlarm, lossTime, pacing time.Time) {
 	deadline := idleTimeoutOrKeepAlive
+	if !connIDRetirement.IsZero() && connIDRetirement.Before(deadline) && connIDRetirement.After(t.last) {
+		deadline = connIDRetirement
+	}
 	if !ackAlarm.IsZero() && ackAlarm.Before(deadline) && ackAlarm.After(t.last) {
 		deadline = ackAlarm
 	}

--- a/connection_timer_test.go
+++ b/connection_timer_test.go
@@ -14,25 +14,31 @@ func TestConnectionTimerModes(t *testing.T) {
 
 	t.Run("idle timeout", func(t *testing.T) {
 		timer := newTimer()
-		timer.SetTimer(now.Add(time.Hour), time.Time{}, time.Time{}, time.Time{})
+		timer.SetTimer(now.Add(time.Hour), time.Time{}, time.Time{}, time.Time{}, time.Time{})
 		require.Equal(t, now.Add(time.Hour), timer.Deadline())
+	})
+
+	t.Run("connection ID expiry", func(t *testing.T) {
+		timer := newTimer()
+		timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), time.Time{}, time.Time{}, time.Time{})
+		require.Equal(t, now.Add(time.Minute), timer.Deadline())
 	})
 
 	t.Run("ACK timer", func(t *testing.T) {
 		timer := newTimer()
-		timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), time.Time{}, time.Time{})
+		timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), time.Time{}, time.Time{})
 		require.Equal(t, now.Add(time.Minute), timer.Deadline())
 	})
 
 	t.Run("loss timer", func(t *testing.T) {
 		timer := newTimer()
-		timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), now.Add(time.Second), time.Time{})
+		timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), now.Add(time.Second), time.Time{})
 		require.Equal(t, now.Add(time.Second), timer.Deadline())
 	})
 
 	t.Run("pacing timer", func(t *testing.T) {
 		timer := newTimer()
-		timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), now.Add(time.Second), now.Add(time.Millisecond))
+		timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), now.Add(time.Second), now.Add(time.Millisecond))
 		require.Equal(t, now.Add(time.Millisecond), timer.Deadline())
 	})
 }
@@ -40,10 +46,10 @@ func TestConnectionTimerModes(t *testing.T) {
 func TestConnectionTimerReset(t *testing.T) {
 	now := time.Now()
 	timer := newTimer()
-	timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), time.Time{}, time.Time{})
+	timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), time.Time{}, time.Time{})
 	require.Equal(t, now.Add(time.Minute), timer.Deadline())
 	timer.SetRead()
 
-	timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), time.Time{}, time.Time{})
+	timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), time.Time{}, time.Time{})
 	require.Equal(t, now.Add(time.Hour), timer.Deadline())
 }

--- a/mock_conn_runner_test.go
+++ b/mock_conn_runner_test.go
@@ -221,39 +221,3 @@ func (c *MockConnRunnerReplaceWithClosedCall) DoAndReturn(f func([]protocol.Conn
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
-
-// Retire mocks base method.
-func (m *MockConnRunner) Retire(arg0 protocol.ConnectionID) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Retire", arg0)
-}
-
-// Retire indicates an expected call of Retire.
-func (mr *MockConnRunnerMockRecorder) Retire(arg0 any) *MockConnRunnerRetireCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Retire", reflect.TypeOf((*MockConnRunner)(nil).Retire), arg0)
-	return &MockConnRunnerRetireCall{Call: call}
-}
-
-// MockConnRunnerRetireCall wrap *gomock.Call
-type MockConnRunnerRetireCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConnRunnerRetireCall) Return() *MockConnRunnerRetireCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConnRunnerRetireCall) Do(f func(protocol.ConnectionID)) *MockConnRunnerRetireCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConnRunnerRetireCall) DoAndReturn(f func(protocol.ConnectionID)) *MockConnRunnerRetireCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}

--- a/mock_packet_handler_manager_test.go
+++ b/mock_packet_handler_manager_test.go
@@ -373,39 +373,3 @@ func (c *MockPacketHandlerManagerReplaceWithClosedCall) DoAndReturn(f func([]pro
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
-
-// Retire mocks base method.
-func (m *MockPacketHandlerManager) Retire(arg0 protocol.ConnectionID) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Retire", arg0)
-}
-
-// Retire indicates an expected call of Retire.
-func (mr *MockPacketHandlerManagerMockRecorder) Retire(arg0 any) *MockPacketHandlerManagerRetireCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Retire", reflect.TypeOf((*MockPacketHandlerManager)(nil).Retire), arg0)
-	return &MockPacketHandlerManagerRetireCall{Call: call}
-}
-
-// MockPacketHandlerManagerRetireCall wrap *gomock.Call
-type MockPacketHandlerManagerRetireCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockPacketHandlerManagerRetireCall) Return() *MockPacketHandlerManagerRetireCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockPacketHandlerManagerRetireCall) Do(f func(protocol.ConnectionID)) *MockPacketHandlerManagerRetireCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPacketHandlerManagerRetireCall) DoAndReturn(f func(protocol.ConnectionID)) *MockPacketHandlerManagerRetireCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -140,16 +140,6 @@ func (h *packetHandlerMap) Remove(id protocol.ConnectionID) {
 	h.logger.Debugf("Removing connection ID %s.", id)
 }
 
-func (h *packetHandlerMap) Retire(id protocol.ConnectionID) {
-	h.logger.Debugf("Retiring connection ID %s in %s.", id, h.deleteRetiredConnsAfter)
-	time.AfterFunc(h.deleteRetiredConnsAfter, func() {
-		h.mutex.Lock()
-		delete(h.handlers, id)
-		h.mutex.Unlock()
-		h.logger.Debugf("Removing connection ID %s after it has been retired.", id)
-	})
-}
-
 // ReplaceWithClosed is called when a connection is closed.
 // Depending on which side closed the connection, we need to:
 // * remote close: absorb delayed packets

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -54,28 +54,6 @@ func TestPacketHandlerMapAddWithClientChosenConnID(t *testing.T) {
 	require.Equal(t, h, got)
 }
 
-func TestPacketHandlerMapRetire(t *testing.T) {
-	m := newPacketHandlerMap(nil, utils.DefaultLogger)
-	dur := scaleDuration(10 * time.Millisecond)
-	m.deleteRetiredConnsAfter = dur
-	connID := protocol.ParseConnectionID([]byte{1, 2, 3, 4})
-	h := &mockPacketHandler{}
-	require.True(t, m.Add(connID, h))
-	m.Retire(connID)
-
-	// immediately after retiring, the handler should still be there
-	got, ok := m.Get(connID)
-	require.True(t, ok)
-	require.Equal(t, h, got)
-
-	// after the timeout, the handler should be removed
-	time.Sleep(dur)
-	require.Eventually(t, func() bool {
-		_, ok := m.Get(connID)
-		return !ok
-	}, dur, dur/10)
-}
-
 func TestPacketHandlerMapAddGetRemoveResetTokens(t *testing.T) {
 	m := newPacketHandlerMap(nil, utils.DefaultLogger)
 	token := protocol.StatelessResetToken{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}


### PR DESCRIPTION
Fixes #4819. Also fixes #4818, since we're deleting the flaky test case :)

This means that we're getting rid of retired connection IDs earlier (in the vast majority of cases). It also means way fewer calls to `time.After` in the `packetHandlerMap`. The connection timer now takes care of this, without any additional syscalls.