### PR TITLE
http3: use actual QUIC connection and stream in server tests

### DIFF
--- a/http3/http3_helper_test.go
+++ b/http3/http3_helper_test.go
@@ -1,11 +1,19 @@
 package http3
 
 import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/quic-go/qpack"
+	"github.com/quic-go/quic-go/integrationtests/tools"
 
 	"github.com/stretchr/testify/require"
 )
@@ -27,4 +35,71 @@ func scaleDuration(t time.Duration) time.Duration {
 		panic("TIMESCALE_FACTOR is 0")
 	}
 	return time.Duration(scaleFactor) * t
+}
+
+var tlsConfig, tlsClientConfig *tls.Config
+
+func init() {
+	ca, caPrivateKey, err := tools.GenerateCA()
+	if err != nil {
+		panic(err)
+	}
+	leafCert, leafPrivateKey, err := tools.GenerateLeafCert(ca, caPrivateKey)
+	if err != nil {
+		panic(err)
+	}
+	tlsConfig = &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{leafCert.Raw},
+			PrivateKey:  leafPrivateKey,
+		}},
+		NextProtos: []string{NextProtoH3},
+	}
+
+	root := x509.NewCertPool()
+	root.AddCert(ca)
+	tlsClientConfig = &tls.Config{
+		ServerName: "localhost",
+		RootCAs:    root,
+		NextProtos: []string{NextProtoH3},
+	}
+}
+
+func getTLSConfig() *tls.Config       { return tlsConfig.Clone() }
+func getTLSClientConfig() *tls.Config { return tlsClientConfig.Clone() }
+
+func encodeRequest(t *testing.T, req *http.Request) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	rw := newRequestWriter()
+	require.NoError(t, rw.WriteRequestHeader(&buf, req, false))
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		buf.Write((&dataFrame{Length: uint64(len(body))}).Append(nil))
+		buf.Write(body)
+	}
+	return buf.Bytes()
+}
+
+func decodeHeader(t *testing.T, r io.Reader) map[string][]string {
+	t.Helper()
+
+	fields := make(map[string][]string)
+	decoder := qpack.NewDecoder(nil)
+
+	frame, err := (&frameParser{r: r}).ParseNext()
+	require.NoError(t, err)
+	require.IsType(t, &headersFrame{}, frame)
+	headersFrame := frame.(*headersFrame)
+	data := make([]byte, headersFrame.Length)
+	_, err = io.ReadFull(r, data)
+	require.NoError(t, err)
+	hfs, err := decoder.DecodeFull(data)
+	require.NoError(t, err)
+	for _, p := range hfs {
+		fields[p.Name] = append(fields[p.Name], p.Value)
+	}
+	return fields
 }


### PR DESCRIPTION
No functional change expected.

This reduces our dependency on extensive mocking of `Connection` and `Stream`, which is needed when we convert these to structs (#5148 and #4968).