### PR TITLE
Respect zero-length connection id when adding a path to a connection with a single use transport

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2104,7 +2104,7 @@ func (s *connection) sendPackets(now time.Time) error {
 				if err != nil {
 					return err
 				}
-				s.logger.Debugf("sending path probe packet from %s", s.LocalAddr())
+				s.logger.Debugf("sending path probe packet from %s", tr.conn.LocalAddr())
 				s.logShortHeaderPacket(probe.DestConnID, probe.Ack, probe.Frames, probe.StreamFrames, probe.PacketNumber, probe.PacketNumberLen, probe.KeyPhase, protocol.ECNNon, buf.Len(), false)
 				s.registerPackedShortHeaderPacket(probe, protocol.ECNNon, now)
 				tr.WriteTo(buf.Data, s.conn.RemoteAddr())
@@ -2639,7 +2639,7 @@ func (s *connection) AddPath(t *Transport) (*Path, error) {
 	if s.peerParams.DisableActiveMigration {
 		return nil, errors.New("server disabled connection migration")
 	}
-	if err := t.init(false); err != nil {
+	if err := t.init(s.srcConnIDLen == 0); err != nil {
 		return nil, err
 	}
 	return s.getPathManager().NewPath(


### PR DESCRIPTION
The quic.Dial*() functions create connections with single use transports which use zero-length connection IDs. 

Attempting to add a new path to these connections initializes the new transport with a non-zero connection id length causing path response packets from the server to be dropped because the transport defaults to 4-byte connection ids and tries to parse that from the received packets.

This PR is one suggestion for reducing the friction of using connection migration with client connections started using quic.Dial*() by allowing zero connection ids on the new transport when the connection is already using a zero-length connection id.

The PR adds a simple probe attempt to the echo example which fails without the change. This can be removed before merging.
The PR also has a minor logging fix that logs the correct local address when sending probe packets.