### PR TITLE
ci: enable the usetesting linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - usetesting
   settings:
     depguard:
       rules:
@@ -47,6 +48,10 @@ linters:
     misspell:
       ignore-rules:
         - ect
+    # see https://github.com/ldez/usetesting/issues/10
+    usetesting:
+      context-background: false
+      context-todo: false
   exclusions:
     generated: lax
     presets:

--- a/fuzzing/internal/helper/helper_test.go
+++ b/fuzzing/internal/helper/helper_test.go
@@ -8,19 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createTempDir(t *testing.T) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("", "fuzzing-helper")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	return dir
-}
-
 func TestWriteCorpusFile(t *testing.T) {
 	const data = "lorem ipsum"
 	const expectedShaSum = "bfb7759a67daeb65410490b4d98bb9da7d1ea2ce"
 
-	dir := createTempDir(t)
+	dir := t.TempDir()
 	require.NoError(t, WriteCorpusFile(dir, []byte(data)))
 
 	path := filepath.Join(dir, expectedShaSum)
@@ -36,7 +28,7 @@ func TestWriteCorpusFileWithPrefix(t *testing.T) {
 	const expectedShaSum = "523f5cab80fab0c7889dbf50dd310ab8c8879f9c"
 	const prefixLen = 7
 
-	dir := createTempDir(t)
+	dir := t.TempDir()
 	require.NoError(t, WriteCorpusFileWithPrefix(dir, []byte(data), prefixLen))
 
 	path := filepath.Join(dir, expectedShaSum)
@@ -49,7 +41,7 @@ func TestWriteCorpusFileWithPrefix(t *testing.T) {
 }
 
 func TestCreateDirectoryIfNotExists(t *testing.T) {
-	dir := createTempDir(t)
+	dir := t.TempDir()
 	subdir := filepath.Join(dir, "corpus")
 	require.NoDirExists(t, subdir)
 

--- a/internal/utils/log_test.go
+++ b/internal/utils/log_test.go
@@ -123,8 +123,6 @@ func TestLogAddPrefixes(t *testing.T) {
 }
 
 func TestLogLevelFromEnv(t *testing.T) {
-	defer os.Unsetenv(logEnv)
-
 	testCases := []struct {
 		envValue string
 		expected LogLevel
@@ -136,13 +134,13 @@ func TestLogLevelFromEnv(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		os.Setenv(logEnv, tc.envValue)
+		t.Setenv(logEnv, tc.envValue)
 		require.Equal(t, tc.expected, readLoggingEnv())
 	}
 
 	// invalid values
-	os.Setenv(logEnv, "")
+	t.Setenv(logEnv, "")
 	require.Equal(t, LogLevelNothing, readLoggingEnv())
-	os.Setenv(logEnv, "asdf")
+	t.Setenv(logEnv, "asdf")
 	require.Equal(t, LogLevelNothing, readLoggingEnv())
 }


### PR DESCRIPTION
This linter is useful to detect the creation of temporary directories and the setting of environment variables in tests.

See https://github.com/ldez/usetesting/issues/10 for a discussion of the context-related linters.