### PR TITLE
http3: tighten checks for incorrect use of RequestStream

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -318,7 +318,7 @@ func (c *ClientConn) sendRequestBody(str *RequestStream, body io.ReadCloser, con
 
 func (c *ClientConn) doRequest(req *http.Request, str *RequestStream) (*http.Response, error) {
 	trace := httptrace.ContextClientTrace(req.Context())
-	if err := str.SendRequestHeader(req); err != nil {
+	if err := str.sendRequestHeader(req); err != nil {
 		traceWroteRequest(trace, err)
 		return nil, err
 	}


### PR DESCRIPTION
The `RequestStream` is a low-level API that’s used by WebTransport, CONNECT-UDP and CONNECT-IP. Methods on the `RequestStream` must be called in a certain order, and we should detect misuse of the API.