### PR TITLE
http3: avoid reinitilising the frame parser on the stream

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -61,7 +61,7 @@ func encodeResponse(t *testing.T, status int) []byte {
 	buf := &bytes.Buffer{}
 	rstr := NewMockDatagramStream(mockCtrl)
 	rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-	rw := newResponseWriter(newStream(rstr, nil, func(r io.Reader, u uint64) error { return nil }), nil, false, nil)
+	rw := newResponseWriter(newStream(rstr, nil, nil, func(r io.Reader, u uint64) error { return nil }), nil, false, nil)
 	rw.WriteHeader(status)
 	rw.Flush()
 	return buf.Bytes()
@@ -326,7 +326,7 @@ func testClient1xxHandling(t *testing.T, numEarlyHints int, terminalStatus int, 
 	var rspBuf bytes.Buffer
 	rstr := NewMockDatagramStream(gomock.NewController(t))
 	rstr.EXPECT().Write(gomock.Any()).Do(rspBuf.Write).AnyTimes()
-	rw := newResponseWriter(newStream(rstr, nil, func(r io.Reader, u uint64) error { return nil }), nil, false, nil)
+	rw := newResponseWriter(newStream(rstr, nil, nil, func(r io.Reader, u uint64) error { return nil }), nil, false, nil)
 	rw.header.Add("Link", "foo")
 	rw.header.Add("Link", "bar")
 	for range numEarlyHints {
@@ -405,7 +405,7 @@ func testClientGzip(t *testing.T,
 	var rspBuf bytes.Buffer
 	rstr := NewMockDatagramStream(gomock.NewController(t))
 	rstr.EXPECT().Write(gomock.Any()).Do(rspBuf.Write).AnyTimes()
-	rw := newResponseWriter(newStream(rstr, nil, func(r io.Reader, u uint64) error { return nil }), nil, false, nil)
+	rw := newResponseWriter(newStream(rstr, nil, nil, func(r io.Reader, u uint64) error { return nil }), nil, false, nil)
 	rw.WriteHeader(http.StatusOK)
 	if responseAddContentEncoding {
 		rw.header.Add("Content-Encoding", "gzip")

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -165,7 +165,7 @@ func (c *Conn) openRequestStream(
 	rsp := &http.Response{}
 	trace := httptrace.ContextClientTrace(ctx)
 	return newRequestStream(
-		newStream(hstr, c, func(r io.Reader, l uint64) error {
+		newStream(hstr, c, trace, func(r io.Reader, l uint64) error {
 			hdr, err := c.decodeTrailers(r, l, maxHeaderBytes)
 			if err != nil {
 				return err
@@ -179,7 +179,6 @@ func (c *Conn) openRequestStream(
 		disableCompression,
 		maxHeaderBytes,
 		rsp,
-		trace,
 	), nil
 }
 

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -61,7 +61,7 @@ func newTestResponseWriter(t *testing.T) *testResponseWriter {
 	str.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
 	str.EXPECT().SetReadDeadline(gomock.Any()).Return(nil).AnyTimes()
 	str.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil).AnyTimes()
-	rw := newResponseWriter(newStream(str, nil, func(r io.Reader, u uint64) error { return nil }), nil, false, nil)
+	rw := newResponseWriter(newStream(str, nil, nil, func(r io.Reader, u uint64) error { return nil }), nil, false, nil)
 	return &testResponseWriter{responseWriter: rw, buf: buf}
 }
 

--- a/http3/server.go
+++ b/http3/server.go
@@ -610,7 +610,7 @@ func (s *Server) handleRequest(conn *Conn, str datagramStream, decoder *qpack.De
 	if _, ok := req.Header["Content-Length"]; ok && req.ContentLength >= 0 {
 		contentLength = req.ContentLength
 	}
-	hstr := newStream(str, conn, nil)
+	hstr := newStream(str, conn, nil, nil)
 	body := newRequestBody(hstr, contentLength, conn.Context(), conn.ReceivedSettings(), conn.Settings)
 	req.Body = body
 

--- a/http3/stream_test.go
+++ b/http3/stream_test.go
@@ -43,6 +43,7 @@ func TestStreamReadDataFrames(t *testing.T) {
 			nil,
 			0,
 		),
+		nil,
 		func(r io.Reader, u uint64) error { return nil },
 	)
 
@@ -91,6 +92,7 @@ func TestStreamInvalidFrame(t *testing.T) {
 	str := newStream(
 		qstr,
 		newConnection(context.Background(), clientConn, false, protocol.PerspectiveClient, nil, 0),
+		nil,
 		func(r io.Reader, u uint64) error { return nil },
 	)
 
@@ -112,7 +114,7 @@ func TestStreamWrite(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	qstr := NewMockDatagramStream(mockCtrl)
 	qstr.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
-	str := newStream(qstr, nil, func(r io.Reader, u uint64) error { return nil })
+	str := newStream(qstr, nil, nil, func(r io.Reader, u uint64) error { return nil })
 	str.Write([]byte("foo"))
 	str.Write([]byte("foobar"))
 
@@ -144,6 +146,7 @@ func TestRequestStream(t *testing.T) {
 		newStream(
 			qstr,
 			newConnection(context.Background(), clientConn, false, protocol.PerspectiveClient, nil, 0),
+			&httptrace.ClientTrace{},
 			func(r io.Reader, u uint64) error { return nil },
 		),
 		requestWriter,
@@ -152,7 +155,6 @@ func TestRequestStream(t *testing.T) {
 		true,
 		math.MaxUint64,
 		&http.Response{},
-		&httptrace.ClientTrace{},
 	)
 
 	_, err := str.Read(make([]byte, 100))


### PR DESCRIPTION
No functional change expected.