### PR TITLE
fuzzing: fix timeout in frame parser

### DIFF
--- a/fuzzing/frames/fuzz.go
+++ b/fuzzing/frames/fuzz.go
@@ -45,7 +45,7 @@ func Fuzz(data []byte) int {
 		frameType, l, err := parser.ParseType(data, encLevel)
 		if err != nil {
 			if err == io.EOF { // the last frame was a PADDING frame
-				continue
+				break
 			}
 			break
 		}


### PR DESCRIPTION
The fuzzing had triggered a timeout, because in some cases, we continued without advancing the buffer. This created an infinite loop. 

This only affected the fuzzing, as in the connection, we already perform this break. So this fixes the fuzzing issues. 