### PR TITLE
Add an accessor for the local EnabledDatagrams setting

### DIFF
--- a/http3/conn.go
+++ b/http3/conn.go
@@ -422,6 +422,12 @@ func (c *Conn) receiveDatagrams() error {
 	}
 }
 
+// EnabledDatagrams returns whether datagram support was enabled locally.
+// Datagrams can only be used if both peers enable them.
+func (c *Conn) EnabledDatagrams() bool {
+	return c.enableDatagrams
+}
+
 // ReceivedSettings returns a channel that is closed once the peer's SETTINGS frame was received.
 // Settings can be optained from the Settings method after the channel was closed.
 func (c *Conn) ReceivedSettings() <-chan struct{} { return c.receivedSettings }


### PR DESCRIPTION
Currently, there is no way to detect whether Datagrams are enabled on an http3.Conn or http3.ClientConn after it has been created. This means that any application that needs this information must pass this flag in parallel to any component that requires it, and risks bugs if the value is set incorrectly.

This change exposes the EnableDatagrams setting from each connection, allowing applications to determine if Datagrams can be used by inspecting the connection.