### PR TITLE
ci: cache the Go build cache for cross-compilation workflow

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -18,8 +18,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/go-build
-          key: go-${{ matrix.go }}-crosscompile-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-${{ matrix.go }}-crosscompile-
+          key: go-${{ matrix.go }}-crosscompile
+          restore-keys: go-${{ matrix.go }}-crosscompile
           # only store cache when on master
           lookup-only: ${{ github.event_name != 'push' || github.ref_name != 'master' }}
       - name: Install build utils


### PR DESCRIPTION
Inspired by https://sanitarium.se/blog/2025/07/07/working-with-gos-test-cache-on-ci/, we cache the entire go build cache folder of the expensive cross-compilation workflow. It's ~1 GB, but restoring is fast (~10s).

This job is currently running on a very powerful machine (a custom runner), but this likely won't be necessary anymore. For this PR, the build step takes just 4s. And even if we make changes to the code, update dependencies, etc., this will likely not take much longer. I will monitor progress and maybe switch back to a GitHub Actions runner.

The only time when we need to rebuild from scratch is when we add support for a new Go version (not sure about minor updates).

The cache is only saved for commits on `master`. PRs use the cache in read-only mode. The underlying assumption is that `master` is the common starting point for PRs, so will contain a lot of useful cache hits in most cases.