### PR TITLE
utils: use synctest to make the timer tests fully deterministic

### DIFF
--- a/internal/utils/timer_test.go
+++ b/internal/utils/timer_test.go
@@ -27,7 +27,7 @@ func TestTimerResets(t *testing.T) {
 		case <-timer.Chan():
 			require.Zero(t, time.Since(start))
 			timer.SetRead()
-		default:
+		case <-time.After(time.Hour): // this can be replaced with a default once we drop support for Go 1.24
 			t.Fatal("timer should have fired")
 		}
 


### PR DESCRIPTION
Also cleans up the tests to make them more idiomatic.