### PR TITLE
ackhandler: avoid storing packet number in packet struct

### DIFF
--- a/internal/ackhandler/ecn.go
+++ b/internal/ackhandler/ecn.go
@@ -24,7 +24,7 @@ const numECNTestingPackets = 10
 type ecnHandler interface {
 	SentPacket(protocol.PacketNumber, protocol.ECN)
 	Mode() protocol.ECN
-	HandleNewlyAcked(packets []*packetWithPacketNumber, ect0, ect1, ecnce int64) (congested bool)
+	HandleNewlyAcked(packets []packetWithPacketNumber, ect0, ect1, ecnce int64) (congested bool)
 	LostPacket(protocol.PacketNumber)
 }
 
@@ -144,7 +144,7 @@ func (e *ecnTracker) LostPacket(pn protocol.PacketNumber) {
 // HandleNewlyAcked handles the ECN counts on an ACK frame.
 // It must only be called for ACK frames that increase the largest acknowledged packet number,
 // see section 13.4.2.1 of RFC 9000.
-func (e *ecnTracker) HandleNewlyAcked(packets []*packetWithPacketNumber, ect0, ect1, ecnce int64) (congested bool) {
+func (e *ecnTracker) HandleNewlyAcked(packets []packetWithPacketNumber, ect0, ect1, ecnce int64) (congested bool) {
 	if e.state == ecnStateFailed {
 		return false
 	}

--- a/internal/ackhandler/ecn_test.go
+++ b/internal/ackhandler/ecn_test.go
@@ -12,10 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func getAckedPackets(pns ...protocol.PacketNumber) []*packetWithPacketNumber {
-	var packets []*packetWithPacketNumber
+func getAckedPackets(pns ...protocol.PacketNumber) []packetWithPacketNumber {
+	var packets []packetWithPacketNumber
 	for _, p := range pns {
-		packets = append(packets, &packetWithPacketNumber{PacketNumber: p})
+		packets = append(packets, packetWithPacketNumber{PacketNumber: p})
 	}
 	return packets
 }
@@ -131,7 +131,7 @@ func TestECNValidationFailures(t *testing.T) {
 
 func testECNValidationFailure(
 	t *testing.T,
-	ackedPackets []*packetWithPacketNumber,
+	ackedPackets []packetWithPacketNumber,
 	ect0, ect1, ecnce int64,
 	expectedTrigger logging.ECNStateTrigger,
 ) {

--- a/internal/ackhandler/mock_ecn_handler_test.go
+++ b/internal/ackhandler/mock_ecn_handler_test.go
@@ -41,7 +41,7 @@ func (m *MockECNHandler) EXPECT() *MockECNHandlerMockRecorder {
 }
 
 // HandleNewlyAcked mocks base method.
-func (m *MockECNHandler) HandleNewlyAcked(packets []*packetWithPacketNumber, ect0, ect1, ecnce int64) bool {
+func (m *MockECNHandler) HandleNewlyAcked(packets []packetWithPacketNumber, ect0, ect1, ecnce int64) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleNewlyAcked", packets, ect0, ect1, ecnce)
 	ret0, _ := ret[0].(bool)
@@ -67,13 +67,13 @@ func (c *MockECNHandlerHandleNewlyAckedCall) Return(congested bool) *MockECNHand
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockECNHandlerHandleNewlyAckedCall) Do(f func([]*packetWithPacketNumber, int64, int64, int64) bool) *MockECNHandlerHandleNewlyAckedCall {
+func (c *MockECNHandlerHandleNewlyAckedCall) Do(f func([]packetWithPacketNumber, int64, int64, int64) bool) *MockECNHandlerHandleNewlyAckedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockECNHandlerHandleNewlyAckedCall) DoAndReturn(f func([]*packetWithPacketNumber, int64, int64, int64) bool) *MockECNHandlerHandleNewlyAckedCall {
+func (c *MockECNHandlerHandleNewlyAckedCall) DoAndReturn(f func([]packetWithPacketNumber, int64, int64, int64) bool) *MockECNHandlerHandleNewlyAckedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -9,7 +9,7 @@ import (
 
 type packetWithPacketNumber struct {
 	PacketNumber protocol.PacketNumber
-	packet
+	*packet
 }
 
 // A Packet is a packet

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -1058,7 +1058,7 @@ func TestSentPacketHandlerECN(t *testing.T) {
 	// Receive an ACK with a short RTT, such that the first packet is lost.
 	cong.EXPECT().OnCongestionEvent(gomock.Any(), gomock.Any(), gomock.Any())
 	ecnHandler.EXPECT().LostPacket(pns[0])
-	ecnHandler.EXPECT().HandleNewlyAcked(gomock.Any(), int64(10), int64(11), int64(12)).DoAndReturn(func(packets []*packetWithPacketNumber, _, _, _ int64) bool {
+	ecnHandler.EXPECT().HandleNewlyAcked(gomock.Any(), int64(10), int64(11), int64(12)).DoAndReturn(func(packets []packetWithPacketNumber, _, _, _ int64) bool {
 		require.Len(t, packets, 2)
 		require.Equal(t, pns[2], packets[0].PacketNumber)
 		require.Equal(t, pns[3], packets[1].PacketNumber)
@@ -1089,7 +1089,7 @@ func TestSentPacketHandlerECN(t *testing.T) {
 	pns[0] = sendPacket(now, protocol.ECT1)
 	pns[1] = sendPacket(now, protocol.ECT1)
 	ecnHandler.EXPECT().HandleNewlyAcked(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(packets []*packetWithPacketNumber, _, _, _ int64) bool {
+		func(packets []packetWithPacketNumber, _, _, _ int64) bool {
 			require.Len(t, packets, 1)
 			require.Equal(t, pns[1], packets[0].PacketNumber)
 			return false


### PR DESCRIPTION
Part of #3846.

The packet number can be derived from the position that this packet is stored at in the packets slice in the sent packet history. There is no need to store the packet number, saving 8 bytes per packet. This slice contains all in-flight packets, and therefore can consume significant amounts of memory on high-BDP connection. 

By going from an `iter.Seq[*packet]` to an `iter.Seq2[protocol.PacketNumber, *packet]`, the changes to the logic calling into the packet history are fairly minimal (although they're somewhat verbose).

cc @MarcoPolo, since we talked about this a long time ago