### PR TITLE
ackhandler: immediately clear ackedPacket slice after processing ACK

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -435,6 +435,9 @@ func (h *sentPacketHandler) GetLowestPacketNotConfirmedAcked() protocol.PacketNu
 func (h *sentPacketHandler) detectAndRemoveAckedPackets(ack *wire.AckFrame, encLevel protocol.EncryptionLevel) ([]*packet, error) {
 	pnSpace := h.getPacketNumberSpace(encLevel)
 	ackRangeIndex := 0
+	if len(h.ackedPackets) > 0 {
+		return nil, errors.New("ackhandler BUG: ackedPackets slice not empty")
+	}
 	lowestAcked := ack.LowestAcked()
 	largestAcked := ack.LargestAcked()
 	for p := range pnSpace.history.Packets() {


### PR DESCRIPTION
I don't think the current code was wrong or racy, but it's weird to put a buffer back into the pool, and still hold a pointer to it (even if it's just in a slice that won't be accessed anymore). Clearing and immediately re-slicing seems like the safer way to go, and it probably allows the GC to clean up elements from the `sync.Pool` earlier as well.