### PR TITLE
allow connection timer resets to earlier times

### DIFF
--- a/connection_timer_test.go
+++ b/connection_timer_test.go
@@ -51,6 +51,6 @@ func TestConnectionTimerReset(t *testing.T) {
 	require.Equal(t, now.Add(time.Minute), timer.Deadline())
 	timer.SetRead()
 
-	timer.SetTimer(now.Add(time.Hour), 0, now.Add(time.Minute), 0, 0)
-	require.Equal(t, now.Add(time.Hour), timer.Deadline())
+	timer.SetTimer(now.Add(time.Hour), 0, now.Add(2*time.Minute), 0, 0)
+	require.Equal(t, now.Add(2*time.Minute), timer.Deadline())
 }


### PR DESCRIPTION
This can happen when a connection starts sending after being idle. In the idle state, the timer is set for the idle timeout, e.g. 30s into the future. Once we start sending packets again, we need to be able to set the loss recovery timer to timestamps before that old idle timeout value.

I hope that this doesn't re-introduce the issues we had with busy-looping earlier, e.g. in https://github.com/quic-go/quic-go/issues/3567 and https://github.com/quic-go/quic-go/pull/4943.