### PR TITLE
qlog: privatize Encode functions of non-Event structs

### DIFF
--- a/qlog/event.go
+++ b/qlog/event.go
@@ -28,7 +28,7 @@ func (h *encoderHelper) WriteToken(t jsontext.Token) {
 
 type versions []Version
 
-func (v versions) Encode(enc *jsontext.Encoder) error {
+func (v versions) encode(enc *jsontext.Encoder) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginArray)
 	for _, e := range v {
@@ -43,7 +43,7 @@ type RawInfo struct {
 	PayloadLength int // length of the packet payload, excluding AEAD tag
 }
 
-func (i RawInfo) Encode(enc *jsontext.Encoder) error {
+func (i RawInfo) encode(enc *jsontext.Encoder) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("length"))
@@ -103,13 +103,13 @@ func (e VersionInformation) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	h.WriteToken(jsontext.BeginObject)
 	if len(e.ClientVersions) > 0 {
 		h.WriteToken(jsontext.String("client_versions"))
-		if err := versions(e.ClientVersions).Encode(enc); err != nil {
+		if err := versions(e.ClientVersions).encode(enc); err != nil {
 			return err
 		}
 	}
 	if len(e.ServerVersions) > 0 {
 		h.WriteToken(jsontext.String("server_versions"))
-		if err := versions(e.ServerVersions).Encode(enc); err != nil {
+		if err := versions(e.ServerVersions).encode(enc); err != nil {
 			return err
 		}
 	}
@@ -198,16 +198,16 @@ func (e PacketSent) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("header"))
-	if err := e.Header.Encode(enc); err != nil {
+	if err := e.Header.encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.String("raw"))
-	if err := e.Raw.Encode(enc); err != nil {
+	if err := e.Raw.encode(enc); err != nil {
 		return err
 	}
 	if len(e.Frames) > 0 {
 		h.WriteToken(jsontext.String("frames"))
-		if err := frames(e.Frames).Encode(enc); err != nil {
+		if err := frames(e.Frames).encode(enc); err != nil {
 			return err
 		}
 	}
@@ -242,16 +242,16 @@ func (e PacketReceived) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("header"))
-	if err := e.Header.Encode(enc); err != nil {
+	if err := e.Header.encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.String("raw"))
-	if err := e.Raw.Encode(enc); err != nil {
+	if err := e.Raw.encode(enc); err != nil {
 		return err
 	}
 	if len(e.Frames) > 0 {
 		h.WriteToken(jsontext.String("frames"))
-		if err := frames(e.Frames).Encode(enc); err != nil {
+		if err := frames(e.Frames).encode(enc); err != nil {
 			return err
 		}
 	}
@@ -282,11 +282,11 @@ func (e VersionNegotiationReceived) Encode(enc *jsontext.Encoder, _ time.Time) e
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("header"))
-	if err := e.Header.Encode(enc); err != nil {
+	if err := e.Header.encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.String("supported_versions"))
-	if err := versions(e.SupportedVersions).Encode(enc); err != nil {
+	if err := versions(e.SupportedVersions).encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.EndObject)
@@ -304,11 +304,11 @@ func (e VersionNegotiationSent) Encode(enc *jsontext.Encoder, _ time.Time) error
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("header"))
-	if err := e.Header.Encode(enc); err != nil {
+	if err := e.Header.encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.String("supported_versions"))
-	if err := versions(e.SupportedVersions).Encode(enc); err != nil {
+	if err := versions(e.SupportedVersions).encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.EndObject)
@@ -326,11 +326,11 @@ func (e PacketBuffered) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("header"))
-	if err := e.Header.Encode(enc); err != nil {
+	if err := e.Header.encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.String("raw"))
-	if err := e.Raw.Encode(enc); err != nil {
+	if err := e.Raw.encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.String("trigger"))
@@ -352,11 +352,11 @@ func (e PacketDropped) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("header"))
-	if err := e.Header.Encode(enc); err != nil {
+	if err := e.Header.encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.String("raw"))
-	if err := e.Raw.Encode(enc); err != nil {
+	if err := e.Raw.encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.String("trigger"))
@@ -446,7 +446,7 @@ func (e PacketLost) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("header"))
-	if err := e.Header.Encode(enc); err != nil {
+	if err := e.Header.encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.String("trigger"))
@@ -628,7 +628,7 @@ func (e ParametersSet) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	}
 	if e.PreferredAddress != nil {
 		h.WriteToken(jsontext.String("preferred_address"))
-		if err := e.PreferredAddress.Encode(enc); err != nil {
+		if err := e.PreferredAddress.encode(enc); err != nil {
 			return err
 		}
 	}
@@ -650,7 +650,7 @@ type PreferredAddress struct {
 	StatelessResetToken protocol.StatelessResetToken
 }
 
-func (a PreferredAddress) Encode(enc *jsontext.Encoder) error {
+func (a PreferredAddress) encode(enc *jsontext.Encoder) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	if a.IPv4.IsValid() {

--- a/qlog/frame.go
+++ b/qlog/frame.go
@@ -75,7 +75,7 @@ type DatagramFrame struct {
 	Length int64
 }
 
-func (fs frames) Encode(enc *jsontext.Encoder) error {
+func (fs frames) encode(enc *jsontext.Encoder) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginArray)
 	for _, f := range fs {
@@ -149,11 +149,11 @@ func encodePingFrame(enc *jsontext.Encoder, _ *PingFrame) error {
 
 type ackRanges []wire.AckRange
 
-func (ars ackRanges) Encode(enc *jsontext.Encoder) error {
+func (ars ackRanges) encode(enc *jsontext.Encoder) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginArray)
 	for _, r := range ars {
-		if err := ackRange(r).Encode(enc); err != nil {
+		if err := ackRange(r).encode(enc); err != nil {
 			return err
 		}
 	}
@@ -163,7 +163,7 @@ func (ars ackRanges) Encode(enc *jsontext.Encoder) error {
 
 type ackRange wire.AckRange
 
-func (ar ackRange) Encode(enc *jsontext.Encoder) error {
+func (ar ackRange) encode(enc *jsontext.Encoder) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginArray)
 	h.WriteToken(jsontext.Int(int64(ar.Smallest)))
@@ -184,7 +184,7 @@ func encodeAckFrame(enc *jsontext.Encoder, f *AckFrame) error {
 		h.WriteToken(jsontext.Float(milliseconds(f.DelayTime)))
 	}
 	h.WriteToken(jsontext.String("acked_ranges"))
-	if err := ackRanges(f.AckRanges).Encode(enc); err != nil {
+	if err := ackRanges(f.AckRanges).encode(enc); err != nil {
 		return err
 	}
 	hasECN := f.ECT0 > 0 || f.ECT1 > 0 || f.ECNCE > 0
@@ -255,7 +255,7 @@ func encodeNewTokenFrame(enc *jsontext.Encoder, f *NewTokenFrame) error {
 	h.WriteToken(jsontext.String("frame_type"))
 	h.WriteToken(jsontext.String("new_token"))
 	h.WriteToken(jsontext.String("token"))
-	if err := (Token{Raw: f.Token}).Encode(enc); err != nil {
+	if err := (Token{Raw: f.Token}).encode(enc); err != nil {
 		return err
 	}
 	h.WriteToken(jsontext.EndObject)

--- a/qlog/packet_header.go
+++ b/qlog/packet_header.go
@@ -11,7 +11,7 @@ type Token struct {
 	Raw []byte
 }
 
-func (t Token) Encode(enc *jsontext.Encoder) error {
+func (t Token) encode(enc *jsontext.Encoder) error {
 	h := encoderHelper{enc: enc}
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("data"))
@@ -31,7 +31,7 @@ type PacketHeader struct {
 	Token            *Token
 }
 
-func (h PacketHeader) Encode(enc *jsontext.Encoder) error {
+func (h PacketHeader) encode(enc *jsontext.Encoder) error {
 	helper := encoderHelper{enc: enc}
 	helper.WriteToken(jsontext.BeginObject)
 	helper.WriteToken(jsontext.String("packet_type"))
@@ -65,7 +65,7 @@ func (h PacketHeader) Encode(enc *jsontext.Encoder) error {
 	}
 	if h.Token != nil {
 		helper.WriteToken(jsontext.String("token"))
-		if err := h.Token.Encode(enc); err != nil {
+		if err := h.Token.encode(enc); err != nil {
 			return err
 		}
 	}
@@ -78,7 +78,7 @@ type PacketHeaderVersionNegotiation struct {
 	DestConnectionID ArbitraryLenConnectionID
 }
 
-func (h PacketHeaderVersionNegotiation) Encode(enc *jsontext.Encoder) error {
+func (h PacketHeaderVersionNegotiation) encode(enc *jsontext.Encoder) error {
 	helper := encoderHelper{enc: enc}
 	helper.WriteToken(jsontext.BeginObject)
 	helper.WriteToken(jsontext.String("packet_type"))

--- a/qlog/packet_header_test.go
+++ b/qlog/packet_header_test.go
@@ -16,7 +16,7 @@ func checkHeader(t *testing.T, hdr *PacketHeader, expected map[string]any) {
 
 	var buf bytes.Buffer
 	enc := jsontext.NewEncoder(&buf)
-	require.NoError(t, hdr.Encode(enc))
+	require.NoError(t, hdr.encode(enc))
 	data := buf.Bytes()
 	require.True(t, json.Valid(data))
 	checkEncoding(t, data, expected)


### PR DESCRIPTION
We only need to export the `Encode` function for `Event`s, but not for any of the helper structs.