### PR TITLE
http3: move qlogging of frames into the frame parser

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -158,7 +158,7 @@ func (c *ClientConn) handleBidirectionalStreams(streamHijacker func(FrameType, q
 			},
 		}
 		go func() {
-			if _, err := fp.ParseNext(); err == errHijacked {
+			if _, err := fp.ParseNext(c.conn.qlogger); err == errHijacked {
 				return
 			}
 			if err != nil {

--- a/http3/http3_helper_test.go
+++ b/http3/http3_helper_test.go
@@ -292,7 +292,7 @@ func decodeHeader(t *testing.T, r io.Reader) map[string][]string {
 	fields := make(map[string][]string)
 	decoder := qpack.NewDecoder(nil)
 
-	frame, err := (&frameParser{r: r}).ParseNext()
+	frame, err := (&frameParser{r: r}).ParseNext(nil)
 	require.NoError(t, err)
 	require.IsType(t, &headersFrame{}, frame)
 	headersFrame := frame.(*headersFrame)

--- a/http3/request_writer_test.go
+++ b/http3/request_writer_test.go
@@ -21,7 +21,7 @@ func decodeRequest(t *testing.T, str io.Reader, streamID quic.StreamID, eventRec
 
 	r := io.LimitedReader{R: str, N: 1000}
 	fp := frameParser{r: &r}
-	frame, err := fp.ParseNext()
+	frame, err := fp.ParseNext(nil)
 	require.NoError(t, err)
 	require.IsType(t, &headersFrame{}, frame)
 	headersFrame := frame.(*headersFrame)

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -31,7 +31,7 @@ func (rw *testResponseWriter) DecodeHeaders(t *testing.T, idx int) map[string][]
 	decoder := qpack.NewDecoder(nil)
 
 	startLen := rw.buf.Len()
-	frame, err := (&frameParser{r: rw.buf}).ParseNext()
+	frame, err := (&frameParser{r: rw.buf}).ParseNext(nil)
 	require.NoError(t, err)
 	require.IsType(t, &headersFrame{}, frame)
 	payloadLen := frame.(*headersFrame).Length
@@ -65,7 +65,7 @@ func (rw *testResponseWriter) DecodeHeaders(t *testing.T, idx int) map[string][]
 func (rw *testResponseWriter) DecodeBody(t *testing.T) []byte {
 	t.Helper()
 
-	frame, err := (&frameParser{r: rw.buf}).ParseNext()
+	frame, err := (&frameParser{r: rw.buf}).ParseNext(nil)
 	if err == io.EOF {
 		return nil
 	}

--- a/http3/server.go
+++ b/http3/server.go
@@ -580,7 +580,7 @@ func (s *Server) handleRequest(
 		}
 	}
 	fp := &frameParser{closeConn: conn.CloseWithError, r: str, unknownFrameHandler: ufh}
-	frame, err := fp.ParseNext()
+	frame, err := fp.ParseNext(qlogger)
 	if err != nil {
 		if !errors.Is(err, errHijacked) {
 			str.CancelRead(quic.StreamErrorCode(ErrCodeRequestIncomplete))

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -102,7 +102,7 @@ func testServerSettings(t *testing.T, enableDatagrams bool, other map[uint64]uin
 	require.NoError(t, err)
 	require.EqualValues(t, streamTypeControlStream, typ)
 	fp := (&frameParser{r: bytes.NewReader(b[l:])})
-	f, err := fp.ParseNext()
+	f, err := fp.ParseNext(nil)
 	require.NoError(t, err)
 	require.IsType(t, &settingsFrame{}, f)
 	settingsFrame := f.(*settingsFrame)
@@ -214,7 +214,7 @@ func testServerRequestHandling(t *testing.T,
 	fp := frameParser{r: str}
 	var content []byte
 	for {
-		frame, err := fp.ParseNext()
+		frame, err := fp.ParseNext(nil)
 		if err == io.EOF {
 			break
 		}
@@ -489,7 +489,7 @@ func TestServerHTTPStreamHijacking(t *testing.T) {
 	hfs := decodeHeader(t, r)
 	require.Equal(t, hfs[":status"], []string{"200"})
 	fp := frameParser{r: r}
-	frame, err := fp.ParseNext()
+	frame, err := fp.ParseNext(nil)
 	require.NoError(t, err)
 	require.IsType(t, &dataFrame{}, frame)
 	dataFrame := frame.(*dataFrame)
@@ -822,7 +822,7 @@ func TestServerGracefulShutdown(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, streamTypeControlStream, typ)
 	fp := &frameParser{r: controlStr}
-	f, err := fp.ParseNext()
+	f, err := fp.ParseNext(nil)
 	require.NoError(t, err)
 	require.IsType(t, &settingsFrame{}, f)
 
@@ -832,7 +832,7 @@ func TestServerGracefulShutdown(t *testing.T) {
 		errChan <- s.Shutdown(shutdownCtx)
 	}()
 
-	f, err = fp.ParseNext()
+	f, err = fp.ParseNext(nil)
 	require.NoError(t, err)
 	require.Equal(t, &goAwayFrame{StreamID: 4}, f)
 

--- a/http3/stream_test.go
+++ b/http3/stream_test.go
@@ -108,6 +108,7 @@ func TestStreamInvalidFrame(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	qstr := NewMockDatagramStream(mockCtrl)
+	qstr.EXPECT().StreamID().Return(quic.StreamID(42)).AnyTimes()
 	qstr.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
 	qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 	clientConn, serverConn := newConnPair(t)
@@ -146,7 +147,7 @@ func TestStreamWrite(t *testing.T) {
 
 	startLen := buf.Len()
 	fp := frameParser{r: &buf}
-	f, err := fp.ParseNext()
+	f, err := fp.ParseNext(nil)
 	require.NoError(t, err)
 	f1Len := startLen - buf.Len()
 	require.Equal(t, &dataFrame{Length: 3}, f)
@@ -157,7 +158,7 @@ func TestStreamWrite(t *testing.T) {
 
 	startLen = buf.Len()
 	fp = frameParser{r: &buf}
-	f, err = fp.ParseNext()
+	f, err = fp.ParseNext(nil)
 	require.NoError(t, err)
 	f2Len := startLen - buf.Len()
 	require.Equal(t, &dataFrame{Length: 6}, f)


### PR DESCRIPTION
For frames other than HEADER frames. HEADER frames are a bit more complicated, since they 1. need a QPACK decoder and 2. have a length limit.