### PR TITLE
use default RTT (100ms) for 0-RTT if no prior estimate

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -516,7 +516,7 @@ func (c *Conn) preSetup() {
 		c.config.EnableStreamResetPartialDelivery,
 		false, // ACK_FREQUENCY is not supported yet
 	)
-	c.rttStats = &utils.RTTStats{}
+	c.rttStats = utils.NewRTTStats()
 	c.connFlowController = flowcontrol.NewConnectionFlowController(
 		protocol.ByteCount(c.config.InitialConnectionReceiveWindow),
 		protocol.ByteCount(c.config.MaxConnectionReceiveWindow),

--- a/connection_test.go
+++ b/connection_test.go
@@ -71,9 +71,9 @@ func connectionOptHandshakeConfirmed() testConnectionOpt {
 }
 
 func connectionOptRTT(rtt time.Duration) testConnectionOpt {
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	rttStats.UpdateRTT(rtt, 0)
-	return func(conn *Conn) { conn.rttStats = &rttStats }
+	return func(conn *Conn) { conn.rttStats = rttStats }
 }
 
 func connectionOptRetrySrcConnID(rcid protocol.ConnectionID) testConnectionOpt {
@@ -239,7 +239,7 @@ func TestConnectionHandleStreamRelatedFrames(t *testing.T) {
 
 func TestConnectionHandleConnectionFlowControlFrames(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	connFC := flowcontrol.NewConnectionFlowController(0, 0, nil, &utils.RTTStats{}, utils.DefaultLogger)
+	connFC := flowcontrol.NewConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
 	require.Zero(t, connFC.SendWindowSize())
 	tc := newServerTestConnection(t, mockCtrl, nil, false, connectionOptConnFlowController(connFC))
 	now := monotime.Now()
@@ -1009,7 +1009,7 @@ func TestConnectionHandshakeIdleTimeout(t *testing.T) {
 func TestConnectionTransportParameters(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	var eventRecorder events.Recorder
-	connFC := flowcontrol.NewConnectionFlowController(0, 0, nil, &utils.RTTStats{}, utils.DefaultLogger)
+	connFC := flowcontrol.NewConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
 	require.Zero(t, connFC.SendWindowSize())
 	tc := newServerTestConnection(t,
 		mockCtrl,
@@ -1062,7 +1062,7 @@ func TestConnectionTransportParameters(t *testing.T) {
 func TestConnectionHandleMaxStreamsFrame(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
-		connFC := flowcontrol.NewConnectionFlowController(0, 0, nil, &utils.RTTStats{}, utils.DefaultLogger)
+		connFC := flowcontrol.NewConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
 		tc := newServerTestConnection(t, mockCtrl, nil, false, connectionOptConnFlowController(connFC))
 		tc.conn.handleTransportParameters(&wire.TransportParameters{})
 

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -111,7 +111,7 @@ func testSentPacketHandlerSendAndAcknowledge(t *testing.T, encLevel protocol.Enc
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		&utils.ConnectionStats{},
 		false,
 		false,
@@ -165,7 +165,7 @@ func TestSentPacketHandlerAcknowledgeSkippedPacket(t *testing.T) {
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		&utils.ConnectionStats{},
 		false,
 		false,
@@ -213,14 +213,14 @@ func TestSentPacketHandlerRTTs(t *testing.T) {
 }
 
 func testSentPacketHandlerRTTs(t *testing.T, encLevel protocol.EncryptionLevel, usesAckDelay bool) {
-	var expectedRTTStats utils.RTTStats
+	expectedRTTStats := utils.NewRTTStats()
 	expectedRTTStats.SetMaxAckDelay(time.Second)
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	rttStats.SetMaxAckDelay(time.Second)
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		false,
 		false,
@@ -310,7 +310,7 @@ func testSentPacketHandlerAmplificationLimitServer(t *testing.T, addressValidate
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		&utils.ConnectionStats{},
 		addressValidated,
 		false,
@@ -380,7 +380,7 @@ func testSentPacketHandlerAmplificationLimitClient(t *testing.T, dropHandshake b
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -431,11 +431,11 @@ func testSentPacketHandlerAmplificationLimitClient(t *testing.T, dropHandshake b
 }
 
 func TestSentPacketHandlerDelayBasedLossDetection(t *testing.T) {
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -485,11 +485,11 @@ func TestSentPacketHandlerDelayBasedLossDetection(t *testing.T) {
 }
 
 func TestSentPacketHandlerPacketBasedLossDetection(t *testing.T) {
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -542,7 +542,7 @@ func testSentPacketHandlerPTO(t *testing.T, encLevel protocol.EncryptionLevel, p
 	var packets packetTracker
 	var eventRecorder events.Recorder
 
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	rttStats.SetMaxAckDelay(25 * time.Millisecond)
 	rttStats.UpdateRTT(500*time.Millisecond, 0)
 	rttStats.UpdateRTT(1000*time.Millisecond, 0)
@@ -550,7 +550,7 @@ func testSentPacketHandlerPTO(t *testing.T, encLevel protocol.EncryptionLevel, p
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -745,13 +745,13 @@ func testSentPacketHandlerPTO(t *testing.T, encLevel protocol.EncryptionLevel, p
 }
 
 func TestSentPacketHandlerPacketNumberSpacesPTO(t *testing.T) {
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	const rtt = time.Second
 	rttStats.UpdateRTT(rtt, 0)
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -843,7 +843,7 @@ func TestSentPacketHandler0RTT(t *testing.T) {
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -890,11 +890,11 @@ func TestSentPacketHandler0RTT(t *testing.T) {
 func TestSentPacketHandlerCongestion(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	cong := mocks.NewMockSendAlgorithmWithDebugInfos(mockCtrl)
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -990,11 +990,11 @@ func TestSentPacketHandlerRetry(t *testing.T) {
 func testSentPacketHandlerRetry(t *testing.T, rtt, expectedRTT time.Duration) {
 	var initialPackets, appDataPackets packetTracker
 
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -1041,11 +1041,11 @@ func testSentPacketHandlerRetry(t *testing.T, rtt, expectedRTT time.Duration) {
 }
 
 func TestSentPacketHandlerRetryAfterPTO(t *testing.T) {
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -1076,7 +1076,7 @@ func TestSentPacketHandlerRetryAfterPTO(t *testing.T) {
 
 	require.Equal(t, []protocol.PacketNumber{pn1, pn2}, packets.Lost)
 	// no RTT measurement is taken, since the PTO timer fired
-	require.Zero(t, rttStats.SmoothedRTT())
+	require.Equal(t, utils.DefaultInitialRTT, rttStats.SmoothedRTT())
 }
 
 func TestSentPacketHandlerECN(t *testing.T) {
@@ -1089,7 +1089,7 @@ func TestSentPacketHandlerECN(t *testing.T) {
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -1187,13 +1187,13 @@ func TestSentPacketHandlerECN(t *testing.T) {
 
 func TestSentPacketHandlerPathProbe(t *testing.T) {
 	const rtt = 10 * time.Millisecond // RTT of the original path
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	rttStats.UpdateRTT(rtt, 0)
 
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -1261,19 +1261,19 @@ func TestSentPacketHandlerPathProbe(t *testing.T) {
 	packets.Lost = packets.Lost[:0]
 	sph.MigratedPath(now, 1200)
 	require.Zero(t, sph.getBytesInFlight())
-	require.Zero(t, rttStats.SmoothedRTT())
+	require.Equal(t, utils.DefaultInitialRTT, rttStats.SmoothedRTT())
 	require.Equal(t, []protocol.PacketNumber{pn1, pn2}, packets.Lost)
 }
 
 func TestSentPacketHandlerPathProbeAckAndLoss(t *testing.T) {
 	const rtt = 10 * time.Millisecond // RTT of the original path
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	rttStats.UpdateRTT(rtt, 0)
 
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -1337,7 +1337,7 @@ func testSentPacketHandlerRandomized(t *testing.T, seed uint64) {
 	binary.BigEndian.PutUint64(b[:], seed)
 	r := rand.New(rand.NewChaCha8(b))
 
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	rtt := []time.Duration{10 * time.Millisecond, 100 * time.Millisecond, 1000 * time.Millisecond}[r.IntN(3)]
 	t.Logf("rtt: %dms", rtt.Milliseconds())
 	rttStats.UpdateRTT(rtt, 0) // RTT of the original path
@@ -1349,7 +1349,7 @@ func testSentPacketHandlerRandomized(t *testing.T, seed uint64) {
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -1418,7 +1418,7 @@ func TestSentPacketHandlerSpuriousLoss(t *testing.T) {
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		&utils.ConnectionStats{},
 		true,
 		false,
@@ -1549,11 +1549,11 @@ func BenchmarkSendAndAcknowledge(b *testing.B) {
 func benchmarkSendAndAcknowledge(b *testing.B, ackEvery, inFlight int) {
 	b.ReportAllocs()
 
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	sph := newSentPacketHandler(
 		0,
 		1200,
-		&rttStats,
+		rttStats,
 		&utils.ConnectionStats{},
 		true,
 		false,

--- a/internal/congestion/cubic_sender.go
+++ b/internal/congestion/cubic_sender.go
@@ -278,8 +278,8 @@ func (c *cubicSender) isCwndLimited(bytesInFlight protocol.ByteCount) bool {
 func (c *cubicSender) BandwidthEstimate() Bandwidth {
 	srtt := c.rttStats.SmoothedRTT()
 	if srtt == 0 {
-		// If we haven't measured an rtt, the bandwidth estimate is unknown.
-		return infBandwidth
+		// This should never happen, but if it does, avoid division by zero.
+		srtt = protocol.TimerGranularity
 	}
 	return BandwidthFromDelta(c.GetCongestionWindow(), srtt)
 }

--- a/internal/congestion/cubic_sender_test.go
+++ b/internal/congestion/cubic_sender_test.go
@@ -162,7 +162,6 @@ func TestCubicSenderExponentialSlowStart(t *testing.T) {
 	// At startup make sure we can send.
 	require.True(t, sender.sender.CanSend(0))
 	require.Zero(t, sender.sender.TimeUntilSend(0))
-	require.Equal(t, infBandwidth, sender.sender.BandwidthEstimate())
 
 	const numberOfAcks = 20
 	for range numberOfAcks {

--- a/internal/flowcontrol/connection_flow_controller_test.go
+++ b/internal/flowcontrol/connection_flow_controller_test.go
@@ -17,7 +17,7 @@ func TestConnectionFlowControlWindowUpdate(t *testing.T) {
 		100, // initial receive window
 		100, // max receive window
 		nil,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		utils.DefaultLogger,
 	)
 	require.False(t, fc.AddBytesRead(1))
@@ -28,7 +28,7 @@ func TestConnectionFlowControlWindowUpdate(t *testing.T) {
 
 func TestConnectionWindowAutoTuningNotAllowed(t *testing.T) {
 	// the RTT is 1 second
-	rttStats := &utils.RTTStats{}
+	rttStats := utils.NewRTTStats()
 	rttStats.UpdateRTT(time.Second, 0)
 	require.Equal(t, time.Second, rttStats.SmoothedRTT())
 
@@ -52,7 +52,7 @@ func TestConnectionWindowAutoTuningNotAllowed(t *testing.T) {
 }
 
 func TestConnectionFlowControlViolation(t *testing.T) {
-	fc := NewConnectionFlowController(100, 100, nil, &utils.RTTStats{}, utils.DefaultLogger)
+	fc := NewConnectionFlowController(100, 100, nil, utils.NewRTTStats(), utils.DefaultLogger)
 	require.NoError(t, fc.IncrementHighestReceived(40, monotime.Now()))
 	require.NoError(t, fc.IncrementHighestReceived(60, monotime.Now()))
 	err := fc.IncrementHighestReceived(1, monotime.Now())
@@ -62,7 +62,7 @@ func TestConnectionFlowControlViolation(t *testing.T) {
 }
 
 func TestConnectionFlowControllerReset(t *testing.T) {
-	fc := NewConnectionFlowController(0, 0, nil, &utils.RTTStats{}, utils.DefaultLogger)
+	fc := NewConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
 	fc.UpdateSendWindow(100)
 	fc.AddBytesSent(10)
 	require.Equal(t, protocol.ByteCount(90), fc.SendWindowSize())
@@ -71,7 +71,7 @@ func TestConnectionFlowControllerReset(t *testing.T) {
 }
 
 func TestConnectionFlowControllerResetAfterReading(t *testing.T) {
-	fc := NewConnectionFlowController(0, 0, nil, &utils.RTTStats{}, utils.DefaultLogger)
+	fc := NewConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
 	fc.AddBytesRead(1)
 	require.EqualError(t, fc.Reset(), "flow controller reset after reading data")
 }

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -19,13 +19,13 @@ func TestStreamFlowControlReceiving(t *testing.T) {
 			protocol.MaxByteCount,
 			protocol.MaxByteCount,
 			nil,
-			&utils.RTTStats{},
+			utils.NewRTTStats(),
 			utils.DefaultLogger,
 		),
 		100,
 		protocol.MaxByteCount,
 		protocol.MaxByteCount,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		utils.DefaultLogger,
 	)
 
@@ -52,13 +52,13 @@ func TestStreamFlowControllerFinalOffset(t *testing.T) {
 				protocol.MaxByteCount,
 				protocol.MaxByteCount,
 				nil,
-				&utils.RTTStats{},
+				utils.NewRTTStats(),
 				utils.DefaultLogger,
 			),
 			protocol.MaxByteCount,
 			protocol.MaxByteCount,
 			protocol.MaxByteCount,
-			&utils.RTTStats{},
+			utils.NewRTTStats(),
 			utils.DefaultLogger,
 		)
 	}
@@ -109,7 +109,7 @@ func TestStreamAbandoning(t *testing.T) {
 		100,
 		protocol.MaxByteCount,
 		nil,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		utils.DefaultLogger,
 	)
 	require.True(t, connFC.UpdateSendWindow(300))
@@ -119,7 +119,7 @@ func TestStreamAbandoning(t *testing.T) {
 		60,
 		protocol.MaxByteCount,
 		100,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		utils.DefaultLogger,
 	)
 
@@ -140,7 +140,7 @@ func TestStreamSendWindow(t *testing.T) {
 		protocol.MaxByteCount,
 		protocol.MaxByteCount,
 		nil,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		utils.DefaultLogger,
 	)
 	require.True(t, connFC.UpdateSendWindow(300))
@@ -150,7 +150,7 @@ func TestStreamSendWindow(t *testing.T) {
 		protocol.MaxByteCount,
 		protocol.MaxByteCount,
 		100,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		utils.DefaultLogger,
 	)
 	// first, we're limited by the stream flow controller
@@ -183,13 +183,13 @@ func TestStreamWindowUpdate(t *testing.T) {
 			protocol.MaxByteCount,
 			protocol.MaxByteCount,
 			nil,
-			&utils.RTTStats{},
+			utils.NewRTTStats(),
 			utils.DefaultLogger,
 		),
 		100,
 		100,
 		protocol.MaxByteCount,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		utils.DefaultLogger,
 	)
 	require.Zero(t, fc.GetWindowUpdate(monotime.Now()))
@@ -221,7 +221,7 @@ func TestStreamConnectionWindowUpdate(t *testing.T) {
 		100,
 		protocol.MaxByteCount,
 		nil,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		utils.DefaultLogger,
 	)
 	fc := NewStreamFlowController(
@@ -230,7 +230,7 @@ func TestStreamConnectionWindowUpdate(t *testing.T) {
 		1000,
 		protocol.MaxByteCount,
 		protocol.MaxByteCount,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		utils.DefaultLogger,
 	)
 
@@ -243,7 +243,7 @@ func TestStreamConnectionWindowUpdate(t *testing.T) {
 
 func TestStreamWindowAutoTuning(t *testing.T) {
 	// the RTT is 1 second
-	rttStats := &utils.RTTStats{}
+	rttStats := utils.NewRTTStats()
 	rttStats.UpdateRTT(time.Second, 0)
 	require.Equal(t, time.Second, rttStats.SmoothedRTT())
 

--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -70,7 +70,7 @@ func TestErrorBeforeClientHelloGeneration(t *testing.T) {
 		&wire.TransportParameters{},
 		tlsConf,
 		false,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("client"),
 		protocol.Version1,
@@ -92,7 +92,7 @@ func TestMessageReceivedAtWrongEncryptionLevel(t *testing.T) {
 		&wire.TransportParameters{StatelessResetToken: &token},
 		testdata.GetTLSConfig(),
 		false,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("server"),
 		protocol.Version1,
@@ -221,7 +221,7 @@ func TestHandshake(t *testing.T) {
 	_, _, clientErr, _, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2}, &wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		false,
 	)
@@ -235,7 +235,7 @@ func TestHelloRetryRequest(t *testing.T) {
 	_, _, clientErr, _, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2}, &wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		false,
 	)
@@ -267,7 +267,7 @@ func TestWithClientAuth(t *testing.T) {
 	_, _, clientErr, _, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2}, &wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		false,
 	)
@@ -283,7 +283,7 @@ func TestTransportParameters(t *testing.T) {
 		cTransportParameters,
 		clientConf,
 		false,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("client"),
 		protocol.Version1,
@@ -302,7 +302,7 @@ func TestTransportParameters(t *testing.T) {
 		sTransportParameters,
 		serverConf,
 		false,
-		&utils.RTTStats{},
+		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("server"),
 		protocol.Version1,
@@ -335,7 +335,7 @@ func TestNewSessionTicketAtWrongEncryptionLevel(t *testing.T) {
 	client, _, clientErr, _, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2}, &wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		false,
 	)
@@ -354,7 +354,7 @@ func TestHandlingNewSessionTicketFails(t *testing.T) {
 	client, _, clientErr, _, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2}, &wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		false,
 	)
@@ -375,7 +375,7 @@ func TestSessionResumption(t *testing.T) {
 	client, _, clientErr, server, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2}, &wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		false,
 	)
@@ -389,8 +389,8 @@ func TestSessionResumption(t *testing.T) {
 	require.False(t, server.ConnectionState().DidResume)
 	require.False(t, client.ConnectionState().DidResume)
 
-	clientRTTStats := &utils.RTTStats{}
-	serverRTTStats := &utils.RTTStats{}
+	clientRTTStats := utils.NewRTTStats()
+	serverRTTStats := utils.NewRTTStats()
 	client, _, clientErr, server, _, serverErr = handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
@@ -416,7 +416,7 @@ func TestSessionResumptionDisabled(t *testing.T) {
 	client, _, clientErr, server, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2}, &wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		false,
 	)
@@ -434,7 +434,7 @@ func TestSessionResumptionDisabled(t *testing.T) {
 	client, _, clientErr, server, _, serverErr = handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2}, &wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		false,
 	)
@@ -457,7 +457,7 @@ func Test0RTT(t *testing.T) {
 	client, _, clientErr, server, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2, InitialMaxData: initialMaxData},
 		true,
@@ -475,7 +475,7 @@ func Test0RTT(t *testing.T) {
 	client, clientEvents, clientErr, server, serverEvents, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2, InitialMaxData: initialMaxData},
 		true,
@@ -520,7 +520,7 @@ func Test0RTTRejectionOnTransportParametersChanged(t *testing.T) {
 	client, _, clientErr, server, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		&utils.RTTStats{}, &utils.RTTStats{},
+		utils.NewRTTStats(), utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2, InitialMaxData: initialMaxData},
 		true,
@@ -535,11 +535,11 @@ func Test0RTTRejectionOnTransportParametersChanged(t *testing.T) {
 	require.False(t, server.ConnectionState().DidResume)
 	require.False(t, client.ConnectionState().DidResume)
 
-	clientRTTStats := &utils.RTTStats{}
+	clientRTTStats := utils.NewRTTStats()
 	client, clientEvents, clientErr, server, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
-		clientRTTStats, &utils.RTTStats{},
+		clientRTTStats, utils.NewRTTStats(),
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2},
 		&wire.TransportParameters{ActiveConnectionIDLimit: 2, InitialMaxData: initialMaxData - 1},
 		true,

--- a/internal/utils/rtt_stats.go
+++ b/internal/utils/rtt_stats.go
@@ -90,7 +90,7 @@ func (r *RTTStats) UpdateRTT(sendDelta, ackDelay time.Duration) {
 	minRTT := time.Duration(r.minRTT.Load())
 	if !r.hasMeasurement || minRTT > sendDelta {
 		minRTT = sendDelta
-		r.minRTT.Store(int64(sendDelta))
+		r.minRTT.Store(sendDelta.Nanoseconds())
 	}
 
 	// Correct for ackDelay if information received from the peer results in a
@@ -100,18 +100,18 @@ func (r *RTTStats) UpdateRTT(sendDelta, ackDelay time.Duration) {
 	if sample-minRTT >= ackDelay {
 		sample -= ackDelay
 	}
-	r.latestRTT.Store(int64(sample))
+	r.latestRTT.Store(sample.Nanoseconds())
 	// First time call.
 	if !r.hasMeasurement {
 		r.hasMeasurement = true
-		r.smoothedRTT.Store(int64(sample))
-		r.meanDeviation.Store(int64(sample / 2))
+		r.smoothedRTT.Store(sample.Nanoseconds())
+		r.meanDeviation.Store(sample.Nanoseconds() / 2)
 	} else {
 		smoothedRTT := r.SmoothedRTT()
 		meanDev := time.Duration(oneMinusBeta*float32(r.MeanDeviation()/time.Microsecond)+rttBeta*float32((smoothedRTT-sample).Abs()/time.Microsecond)) * time.Microsecond
 		newSmoothedRTT := time.Duration((float32(smoothedRTT/time.Microsecond)*oneMinusAlpha)+(float32(sample/time.Microsecond)*rttAlpha)) * time.Microsecond
-		r.meanDeviation.Store(int64(meanDev))
-		r.smoothedRTT.Store(int64(newSmoothedRTT))
+		r.meanDeviation.Store(meanDev.Nanoseconds())
+		r.smoothedRTT.Store(newSmoothedRTT.Nanoseconds())
 	}
 }
 

--- a/internal/utils/rtt_stats_test.go
+++ b/internal/utils/rtt_stats_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestRTTStatsDefaults(t *testing.T) {
-	var rttStats RTTStats
-	require.Zero(t, rttStats.MinRTT())
-	require.Zero(t, rttStats.SmoothedRTT())
+	rttStats := NewRTTStats()
+	require.Equal(t, DefaultInitialRTT, rttStats.MinRTT())
+	require.Equal(t, DefaultInitialRTT, rttStats.SmoothedRTT())
 }
 
 func TestRTTStatsSmoothedRTT(t *testing.T) {
-	var rttStats RTTStats
+	rttStats := NewRTTStats()
 	// verify that ack_delay is ignored in the first measurement
 	rttStats.UpdateRTT(300*time.Millisecond, 100*time.Millisecond)
 	require.Equal(t, 300*time.Millisecond, rttStats.LatestRTT())
@@ -31,7 +31,7 @@ func TestRTTStatsSmoothedRTT(t *testing.T) {
 }
 
 func TestRTTStatsMinRTT(t *testing.T) {
-	var rttStats RTTStats
+	rttStats := NewRTTStats()
 	rttStats.UpdateRTT(200*time.Millisecond, 0)
 	require.Equal(t, 200*time.Millisecond, rttStats.MinRTT())
 	rttStats.UpdateRTT(10*time.Millisecond, 0)
@@ -48,7 +48,7 @@ func TestRTTStatsMinRTT(t *testing.T) {
 }
 
 func TestRTTStatsMaxAckDelay(t *testing.T) {
-	var rttStats RTTStats
+	rttStats := NewRTTStats()
 	rttStats.SetMaxAckDelay(42 * time.Minute)
 	require.Equal(t, 42*time.Minute, rttStats.MaxAckDelay())
 }
@@ -58,7 +58,7 @@ func TestRTTStatsComputePTO(t *testing.T) {
 		maxAckDelay = 42 * time.Minute
 		rtt         = time.Second
 	)
-	var rttStats RTTStats
+	rttStats := NewRTTStats()
 	rttStats.SetMaxAckDelay(maxAckDelay)
 	rttStats.UpdateRTT(rtt, 0)
 	require.Equal(t, rtt, rttStats.SmoothedRTT())
@@ -69,13 +69,13 @@ func TestRTTStatsComputePTO(t *testing.T) {
 
 func TestRTTStatsPTOWithShortRTT(t *testing.T) {
 	const rtt = time.Microsecond
-	var rttStats RTTStats
+	rttStats := NewRTTStats()
 	rttStats.UpdateRTT(rtt, 0)
 	require.Equal(t, rtt+protocol.TimerGranularity, rttStats.PTO(true))
 }
 
 func TestRTTStatsUpdateWithBadSendDeltas(t *testing.T) {
-	var rttStats RTTStats
+	rttStats := NewRTTStats()
 	const initialRtt = 10 * time.Millisecond
 	rttStats.UpdateRTT(initialRtt, 0)
 	require.Equal(t, initialRtt, rttStats.MinRTT())
@@ -94,7 +94,7 @@ func TestRTTStatsUpdateWithBadSendDeltas(t *testing.T) {
 }
 
 func TestRTTStatsRestore(t *testing.T) {
-	var rttStats RTTStats
+	rttStats := NewRTTStats()
 	rttStats.SetInitialRTT(10 * time.Second)
 	require.Equal(t, 10*time.Second, rttStats.LatestRTT())
 	require.Equal(t, 10*time.Second, rttStats.SmoothedRTT())
@@ -107,7 +107,7 @@ func TestRTTStatsRestore(t *testing.T) {
 }
 
 func TestRTTMeasurementAfterRestore(t *testing.T) {
-	var rttStats RTTStats
+	rttStats := NewRTTStats()
 	const rtt = 10 * time.Millisecond
 	rttStats.UpdateRTT(rtt, 0)
 	require.Equal(t, rtt, rttStats.LatestRTT())
@@ -118,7 +118,7 @@ func TestRTTMeasurementAfterRestore(t *testing.T) {
 }
 
 func TestRTTStatsResetForPathMigration(t *testing.T) {
-	var rttStats RTTStats
+	rttStats := NewRTTStats()
 	rttStats.SetMaxAckDelay(42 * time.Millisecond)
 	rttStats.UpdateRTT(time.Second, 0)
 	rttStats.UpdateRTT(10*time.Second, 0)
@@ -127,10 +127,10 @@ func TestRTTStatsResetForPathMigration(t *testing.T) {
 	require.NotZero(t, rttStats.SmoothedRTT())
 
 	rttStats.ResetForPathMigration()
-	require.Zero(t, rttStats.MinRTT())
-	require.Zero(t, rttStats.LatestRTT())
-	require.Zero(t, rttStats.SmoothedRTT())
-	require.Equal(t, 2*defaultInitialRTT, rttStats.PTO(false))
+	require.Equal(t, DefaultInitialRTT, rttStats.MinRTT())
+	require.Equal(t, DefaultInitialRTT, rttStats.LatestRTT())
+	require.Equal(t, DefaultInitialRTT, rttStats.SmoothedRTT())
+	require.Equal(t, 2*DefaultInitialRTT, rttStats.PTO(false))
 	// make sure that max_ack_delay was not reset
 	require.Equal(t, 42*time.Millisecond, rttStats.MaxAckDelay())
 

--- a/qlog/benchmark_test.go
+++ b/qlog/benchmark_test.go
@@ -34,7 +34,7 @@ func BenchmarkConnectionTracing(b *testing.B) {
 	tracer := trace.AddProducer()
 	b.Cleanup(func() { tracer.Close() })
 
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	rttStats.UpdateRTT(1337*time.Millisecond, 0)
 	rttStats.UpdateRTT(1000*time.Millisecond, 10*time.Millisecond)
 	rttStats.UpdateRTT(800*time.Millisecond, 100*time.Millisecond)

--- a/qlog/event_test.go
+++ b/qlog/event_test.go
@@ -568,7 +568,7 @@ func TestPacketDropped(t *testing.T) {
 }
 
 func TestMetricsUpdated(t *testing.T) {
-	var rttStats utils.RTTStats
+	rttStats := utils.NewRTTStats()
 	rttStats.UpdateRTT(15*time.Millisecond, 0)
 	rttStats.UpdateRTT(20*time.Millisecond, 0)
 	rttStats.UpdateRTT(25*time.Millisecond, 0)


### PR DESCRIPTION
The RTT is encoded in the token. However, it's not required for the client to send the token, so we might end up with no RTT estimate whatsoever. Similarly, on the client side, we also store the RTT in the `TokenStore`, but its use is optional as well.