### PR TITLE
fix: `TestAddTimestamp` parse time in local timezone

### DIFF
--- a/internal/utils/log_test.go
+++ b/internal/utils/log_test.go
@@ -93,7 +93,7 @@ func TestAddTimestamp(t *testing.T) {
 	DefaultLogger.SetLogLevel(LogLevelInfo)
 	DefaultLogger.Infof("info")
 	timestamp := b.String()[:b.Len()-6]
-	parsedTime, err := time.Parse(format, timestamp)
+	parsedTime, err := time.ParseInLocation(format, timestamp, time.Local)
 	require.NoError(t, err)
 	require.WithinDuration(t, time.Now(), parsedTime, 25*time.Hour)
 }


### PR DESCRIPTION
Current `TestAddTimestamp` parse the given timestamp in UTC. In rare cases (see #5399), the hours diff can be more than 25 hours. As the fix, we should respect the local timezone as we parse the timestamp.

Fix #5399 