### PR TITLE
quicvarint: improve panic message for numbers larger 2^62

### DIFF
--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -20,6 +20,14 @@ const (
 	maxVarInt8 = 4611686018427387903
 )
 
+type varintLengthError struct {
+	Num uint64
+}
+
+func (e *varintLengthError) Error() string {
+	return fmt.Sprintf("value doesn't fit into 62 bits: %d", e.Num)
+}
+
 // Read reads a number in the QUIC varint format from r.
 func Read(r io.ByteReader) (uint64, error) {
 	firstByte, err := r.ReadByte()
@@ -118,7 +126,7 @@ func Append(b []byte, i uint64) []byte {
 			uint8(i >> 24), uint8(i >> 16), uint8(i >> 8), uint8(i),
 		}...)
 	}
-	panic(fmt.Sprintf("%#x doesn't fit into 62 bits", i))
+	panic(&varintLengthError{Num: i})
 }
 
 // AppendWithLen append i in the QUIC varint format with the desired length.
@@ -168,8 +176,5 @@ func Len(i uint64) int {
 	}
 	// Don't use a fmt.Sprintf here to format the error message.
 	// The function would then exceed the inlining budget.
-	panic(struct {
-		message string
-		num     uint64
-	}{"value doesn't fit into 62 bits: ", i})
+	panic(&varintLengthError{Num: i})
 }

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -2,6 +2,7 @@ package quicvarint
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"testing"
@@ -125,7 +126,10 @@ func TestVarintEncoding(t *testing.T) {
 	}
 
 	t.Run("panics when given a too large number (> 62 bit)", func(t *testing.T) {
-		require.Panics(t, func() { Append(nil, maxVarInt8+1) })
+		require.PanicsWithError(t,
+			fmt.Sprintf("value doesn't fit into 62 bits: %d", maxVarInt8+1),
+			func() { Append(nil, maxVarInt8+1) },
+		)
 	})
 }
 
@@ -203,7 +207,10 @@ func TestLen(t *testing.T) {
 	}
 
 	t.Run("panics on too large number", func(t *testing.T) {
-		require.Panics(t, func() { Len(maxVarInt8 + 1) })
+		require.PanicsWithError(t,
+			fmt.Sprintf("value doesn't fit into 62 bits: %d", maxVarInt8+1),
+			func() { Len(maxVarInt8 + 1) },
+		)
 	})
 }
 


### PR DESCRIPTION
Fixes #5396.