### PR TITLE
ci: run benchmarks and send results to CodSpeed

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       packages: ${{ steps.list.outputs.packages }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25.x"
@@ -45,7 +45,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.list-packages.outputs.packages) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25.x"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,9 +13,37 @@ on:
   workflow_dispatch:
 
 jobs:
+  list-packages:
+    name: List Go packages with benchmarks
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.list.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.x"
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - id: list
+        run: |
+          all_pkgs=$(go list ./...)
+          pkgs_with_bench=()
+          for pkg in $all_pkgs; do
+            if go test -list '^Benchmark' "$pkg" | grep -q '^Benchmark'; then
+              pkgs_with_bench+=("$pkg")
+            fi
+          done
+          json=$(printf '%s\n' "${pkgs_with_bench[@]}" | jq -c -R -s 'split("\n") | del(.[] | select(. == ""))')
+          echo "packages=$json" >> $GITHUB_OUTPUT
+
   benchmarks:
-    name: Run benchmarks
+    name: Benchmarks (${{ matrix.package }})
+    needs: list-packages
     runs-on: codspeed-macro
+    strategy:
+      matrix:
+        package: ${{ fromJson(needs.list-packages.outputs.packages) }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -25,5 +53,5 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: walltime
-          run: go test -run=^$ -bench=. ./...
+          run: go test -run=^$ -bench=. ${{ matrix.package }}
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   benchmarks:
     name: Run benchmarks
-    runs-on: ubuntu-latest
+    runs-on: codspeed-macro
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,7 @@ name: Benchmarks
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:
@@ -54,4 +55,3 @@ jobs:
         with:
           mode: walltime
           run: go test -run=^$ -bench=. ${{ matrix.package }}
-          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: instrumentation
+          mode: walltime
           run: go test -run=^$ -bench=. ./...
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,8 @@
 name: Benchmarks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,26 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.x"
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          mode: instrumentation
+          run: go test -run=^$ -bench=. ./...
+          token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add CI workflow to run Go benchmarks with CodSpeed
Adds [benchmark.yml](.github/workflows/benchmark.yml), a GitHub Actions workflow that runs on pushes to `master`, pull requests, and manual dispatch. It dynamically discovers packages containing benchmarks by running `go test -list ^Benchmark` per package, then runs each discovered package's benchmarks via CodSpeedHQ/action@v4 in `walltime` mode on a `codspeed-macro` runner.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49a5447.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->