### PR TITLE
add a way for the user to get current datagram limit

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -94,7 +94,7 @@ func (e *StreamError) Error() string {
 
 // DatagramTooLargeError is returned from Conn.SendDatagram if the payload is too large to be sent.
 type DatagramTooLargeError struct {
-	MaxDatagramPayloadSize int64
+	MaxDatagramPayloadSize uint16
 }
 
 func (e *DatagramTooLargeError) Is(target error) bool {

--- a/interface.go
+++ b/interface.go
@@ -226,4 +226,10 @@ type ConnectionState struct {
 	Version Version
 	// GSO says if generic segmentation offload is used.
 	GSO bool
+	// MaxDatagramSize is the maximum size of a datagram payload that can be sent.
+	// This is the minimum of the peer's advertised limit and the maximum frame size
+	// according to the current MTU, connection ID length, and encryption overhead.
+	// This value may change as the MTU estimate is updated.
+	// If SupportsDatagrams is false, this value is 0.
+	MaxDatagramSize uint16 
 }


### PR DESCRIPTION
Resolves #4259 

expose maximum datagram size in ConnectionState

Add MaxDatagramSize field to ConnectionState that reports the maximum datagram payload size that can be sent. This value is calculated as the minimum of:
- The peer's advertised datagram frame size limit
- The maximum frame size according to current MTU, connection ID length, and encryption overhead

The calculation uses the actual packet number length (via PeekPacketNumber) rather than the maximum possible length for better accuracy.

Also add an integration test that verifies the reported value works and that value+1 does not work.

cc @marten-seemann @chungthuang 