### PR TITLE
qlogwriter: fix storing of event schemas

### DIFF
--- a/qlogwriter/trace_test.go
+++ b/qlogwriter/trace_test.go
@@ -59,6 +59,11 @@ func TestTraceMetadata(t *testing.T) {
 			protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef}),
 			[]string{"urn:ietf:params:qlog:events:foo", "urn:ietf:params:qlog:events:bar"},
 		)
+
+		require.False(t, trace.SupportsSchemas("urn:ietf:params:qlog:events:baz"))
+		require.True(t, trace.SupportsSchemas("urn:ietf:params:qlog:events:foo"))
+		require.True(t, trace.SupportsSchemas("urn:ietf:params:qlog:events:bar"))
+
 		go trace.Run()
 		producer := trace.AddProducer()
 		producer.Close()

--- a/qlogwriter/writer.go
+++ b/qlogwriter/writer.go
@@ -115,6 +115,7 @@ func newFileSeq(w io.WriteCloser, pers string, odcid *ConnectionID, eventSchemas
 		runStopped:    make(chan struct{}),
 		encodeErr:     encodeErr,
 		events:        make(chan event, eventChanSize),
+		eventSchemas:  eventSchemas,
 	}
 }
 


### PR DESCRIPTION
HTTP/3 qlogging (and qlogging for any other application protocol) only works if the event schemas are actually stored.