### PR TITLE
http3: make Transport.MaxResponseBytes an int

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -59,7 +59,7 @@ type ClientConn struct {
 
 	// maxResponseHeaderBytes specifies a limit on how many response bytes are
 	// allowed in the server's response header.
-	maxResponseHeaderBytes uint64
+	maxResponseHeaderBytes int
 
 	// disableCompression, if true, prevents the Transport from requesting compression with an
 	// "Accept-Encoding: gzip" request header when the Request contains no existing Accept-Encoding value.
@@ -82,7 +82,7 @@ func newClientConn(
 	additionalSettings map[uint64]uint64,
 	streamHijacker func(FrameType, quic.ConnectionTracingID, *quic.Stream, error) (hijacked bool, err error),
 	uniStreamHijacker func(StreamType, quic.ConnectionTracingID, *quic.ReceiveStream, error) (hijacked bool),
-	maxResponseHeaderBytes int64,
+	maxResponseHeaderBytes int,
 	disableCompression bool,
 	logger *slog.Logger,
 ) *ClientConn {
@@ -95,7 +95,7 @@ func newClientConn(
 	if maxResponseHeaderBytes <= 0 {
 		c.maxResponseHeaderBytes = defaultMaxResponseHeaderBytes
 	} else {
-		c.maxResponseHeaderBytes = uint64(maxResponseHeaderBytes)
+		c.maxResponseHeaderBytes = maxResponseHeaderBytes
 	}
 	c.decoder = qpack.NewDecoder(func(hf qpack.HeaderField) {})
 	c.requestWriter = newRequestWriter()

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -147,7 +147,7 @@ func (c *Conn) openRequestStream(
 	requestWriter *requestWriter,
 	reqDone chan<- struct{},
 	disableCompression bool,
-	maxHeaderBytes uint64,
+	maxHeaderBytes int,
 ) (*RequestStream, error) {
 	c.streamMx.Lock()
 	maxStreamID := c.maxStreamID
@@ -193,8 +193,8 @@ func (c *Conn) openRequestStream(
 	), nil
 }
 
-func (c *Conn) decodeTrailers(r io.Reader, streamID quic.StreamID, hf *headersFrame, maxHeaderBytes uint64) (http.Header, error) {
-	if hf.Length > maxHeaderBytes {
+func (c *Conn) decodeTrailers(r io.Reader, streamID quic.StreamID, hf *headersFrame, maxHeaderBytes int) (http.Header, error) {
+	if hf.Length > uint64(maxHeaderBytes) {
 		maybeQlogInvalidHeadersFrame(c.qlogger, streamID, hf.Length)
 		return nil, fmt.Errorf("HEADERS frame too large: %d bytes (max: %d)", hf.Length, maxHeaderBytes)
 	}

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -170,7 +170,7 @@ type RequestStream struct {
 
 	decoder            *qpack.Decoder
 	requestWriter      *requestWriter
-	maxHeaderBytes     uint64
+	maxHeaderBytes     int
 	reqDone            chan<- struct{}
 	disableCompression bool
 	response           *http.Response
@@ -186,7 +186,7 @@ func newRequestStream(
 	reqDone chan<- struct{},
 	decoder *qpack.Decoder,
 	disableCompression bool,
-	maxHeaderBytes uint64,
+	maxHeaderBytes int,
 	rsp *http.Response,
 ) *RequestStream {
 	return &RequestStream{
@@ -329,7 +329,7 @@ func (s *RequestStream) ReadResponse() (*http.Response, error) {
 		s.str.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "expected first frame to be a HEADERS frame")
 		return nil, errors.New("http3: expected first frame to be a HEADERS frame")
 	}
-	if hf.Length > s.maxHeaderBytes {
+	if hf.Length > uint64(s.maxHeaderBytes) {
 		maybeQlogInvalidHeadersFrame(s.str.qlogger, s.str.StreamID(), hf.Length)
 		s.str.CancelRead(quic.StreamErrorCode(ErrCodeFrameError))
 		s.str.CancelWrite(quic.StreamErrorCode(ErrCodeFrameError))

--- a/http3/stream_test.go
+++ b/http3/stream_test.go
@@ -200,7 +200,7 @@ func TestRequestStream(t *testing.T) {
 		make(chan struct{}),
 		qpack.NewDecoder(func(qpack.HeaderField) {}),
 		true,
-		math.MaxUint64,
+		math.MaxInt,
 		&http.Response{},
 	)
 

--- a/http3/transport.go
+++ b/http3/transport.go
@@ -88,7 +88,7 @@ type Transport struct {
 	// MaxResponseHeaderBytes specifies a limit on how many response bytes are
 	// allowed in the server's response header.
 	// Zero means to use a default limit.
-	MaxResponseHeaderBytes int64
+	MaxResponseHeaderBytes int
 
 	// DisableCompression, if true, prevents the Transport from requesting compression with an
 	// "Accept-Encoding: gzip" request header when the Request contains no existing Accept-Encoding value.


### PR DESCRIPTION
Both `http.Server.MaxHeaderBytes` and `http3.Server.MaxHeaderBytes` are ints as well, so this is more consistent.