### PR TITLE
fix(synctest): add fallback implementation for Go 1.24 without GOEXPERIMENT

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,41 @@
+# Testing Guide
+
+## Running Tests
+
+### Go 1.24
+
+When using Go 1.24, tests require the `synctest` experiment to be enabled:
+
+```bash
+GOEXPERIMENT=synctest go test ./...
+```
+
+Or use the provided helper script:
+
+```bash
+./run-tests.sh
+```
+
+### Go 1.25+
+
+For Go 1.25 and later, the `synctest` package is stable and no special flags are needed:
+
+```bash
+go test ./...
+```
+
+## Why GOEXPERIMENT=synctest?
+
+The test suite uses the `testing/synctest` package for time simulation in tests. This allows tests that use `time.Sleep()` to run instantly by simulating time rather than waiting in real-time.
+
+- **Go 1.24**: `testing/synctest` is experimental and requires `GOEXPERIMENT=synctest`
+- **Go 1.25+**: `testing/synctest` is stable and works by default
+
+## Build vs Test Requirements
+
+- **Building**: The project includes a fallback implementation that allows building without the synctest experiment
+- **Testing**: Full test suite requires the synctest experiment on Go 1.24 for time simulation features
+
+## CI Configuration
+
+The CI configuration (`.github/workflows/unit.yml`) automatically sets `GOEXPERIMENT=synctest` for Go 1.24 builds.

--- a/internal/synctest/synctest_default.go
+++ b/internal/synctest/synctest_default.go
@@ -1,0 +1,17 @@
+//go:build !go1.25 && !goexperiment.synctest
+
+package synctest
+
+import (
+	"testing"
+)
+
+// Test runs the test function without synctest support (fallback for Go <1.25 without GOEXPERIMENT=synctest)
+func Test(t *testing.T, f func(t *testing.T)) {
+	f(t)
+}
+
+// Wait is a no-op when synctest is not available
+func Wait() {
+	// no-op: synctest not available
+}

--- a/internal/synctest/synctest_go124.go
+++ b/internal/synctest/synctest_go124.go
@@ -1,4 +1,4 @@
-//go:build go1.24 && !go1.25
+//go:build go1.24 && !go1.25 && goexperiment.synctest
 
 package synctest
 

--- a/internal/utils/log_test.go
+++ b/internal/utils/log_test.go
@@ -95,7 +95,8 @@ func TestAddTimestamp(t *testing.T) {
 	timestamp := b.String()[:b.Len()-6]
 	parsedTime, err := time.Parse(format, timestamp)
 	require.NoError(t, err)
-	require.WithinDuration(t, time.Now(), parsedTime, 25*time.Hour)
+	// Use 48-hour tolerance to account for timezone offsets when using date-only format
+	require.WithinDuration(t, time.Now(), parsedTime, 48*time.Hour)
 }
 
 func TestLogAddPrefixes(t *testing.T) {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Helper script to run tests with the required GOEXPERIMENT flag for Go 1.24
+# See .github/workflows/unit.yml for the CI configuration
+
+GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
+
+if [[ $GO_VERSION == 1.24.* ]]; then
+    echo "Running tests with GOEXPERIMENT=synctest for Go 1.24"
+    GOEXPERIMENT=synctest go test "$@" ./...
+elif [[ $GO_VERSION == 1.25.* ]]; then
+    echo "Running tests for Go 1.25 (synctest is stable)"
+    go test "$@" ./...
+else
+    echo "Warning: Untested Go version $GO_VERSION"
+    go test "$@" ./...
+fi


### PR DESCRIPTION
## Summary
Fixes build and test failures on Go 1.24 without GOEXPERIMENT=synctest.

## Changes
- Added fallback synctest implementation for Go 1.24 without experiment flag
- Fixed build constraints to support both experimental and non-experimental builds
- Fixed timezone-related flaky test in TestAddTimestamp (25h -> 48h tolerance)
- Added helper script and documentation for running tests

## Testing
- ✅ Build succeeds on Go 1.24 with and without GOEXPERIMENT=synctest
- ✅ All tests pass with `GOEXPERIMENT=synctest go test ./...`
- ✅ Compatible with existing CI configuration

## Files Modified
- `internal/synctest/synctest_go124.go` - Added goexperiment.synctest build constraint
- `internal/synctest/synctest_default.go` - New fallback implementation
- `internal/utils/log_test.go` - Fixed timezone tolerance in TestAddTimestamp
- `run-tests.sh` - New helper script for running tests
- `TESTING.md` - New documentation for test requirements

See TESTING.md for test requirements and TEST_FIX_SUMMARY.md for detailed fix information.


Assisted-By: Claude Sonnet 4.5