### PR TITLE
don’t arm connection timer for connection ID retirement

### DIFF
--- a/conn_id_generator.go
+++ b/conn_id_generator.go
@@ -157,13 +157,6 @@ func (m *connIDGenerator) SetHandshakeComplete(connIDExpiry monotime.Time) {
 	}
 }
 
-func (m *connIDGenerator) NextRetireTime() monotime.Time {
-	if len(m.connIDsToRetire) == 0 {
-		return 0
-	}
-	return m.connIDsToRetire[0].t
-}
-
 func (m *connIDGenerator) RemoveRetiredConnIDs(now monotime.Time) {
 	if len(m.connIDsToRetire) == 0 {
 		return

--- a/conn_id_generator_test.go
+++ b/conn_id_generator_test.go
@@ -135,14 +135,6 @@ func TestConnIDGeneratorRetiring(t *testing.T) {
 		require.NoError(t, g.Retire(uint64(i+1), protocol.ParseConnectionID([]byte{9, 9, 9, 9}), t2))
 		retirements[added[i]] = t2
 
-		var nextRetirement monotime.Time
-		for _, r := range retirements {
-			if nextRetirement.IsZero() || r.Before(nextRetirement) {
-				nextRetirement = r
-			}
-		}
-		require.Equal(t, nextRetirement, g.NextRetireTime())
-
 		if rand.IntN(2) == 0 {
 			now = now.Add(time.Duration(rand.IntN(500)) * time.Millisecond)
 			g.RemoveRetiredConnIDs(now)

--- a/connection.go
+++ b/connection.go
@@ -885,9 +885,6 @@ func (c *Conn) maybeResetTimer() {
 		return
 	}
 
-	if t := c.connIDGenerator.NextRetireTime(); !t.IsZero() && t.Before(deadline) {
-		deadline = t
-	}
 	if !c.pacingDeadline.IsZero() && c.pacingDeadline.Before(deadline) {
 		deadline = c.pacingDeadline
 	}


### PR DESCRIPTION
It should be sufficient to retire connection IDs the next time the run loops wakes up anyway, e.g. when a packet is received, or when a new packet is sent.