### PR TITLE
http3: limit size of decompressed headers

### DIFF
--- a/http3/conn.go
+++ b/http3/conn.go
@@ -196,7 +196,7 @@ func (c *Conn) openRequestStream(
 func (c *Conn) decodeTrailers(r io.Reader, streamID quic.StreamID, hf *headersFrame, maxHeaderBytes int) (http.Header, error) {
 	if hf.Length > uint64(maxHeaderBytes) {
 		maybeQlogInvalidHeadersFrame(c.qlogger, streamID, hf.Length)
-		return nil, fmt.Errorf("HEADERS frame too large: %d bytes (max: %d)", hf.Length, maxHeaderBytes)
+		return nil, fmt.Errorf("http3: HEADERS frame too large: %d bytes (max: %d)", hf.Length, maxHeaderBytes)
 	}
 
 	b := make([]byte, hf.Length)

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"testing"
 
@@ -41,7 +42,7 @@ func testRequestHeaderParsing(t *testing.T, path string) {
 		{Name: ":method", Value: http.MethodGet},
 		{Name: "content-length", Value: "42"},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.MethodGet, req.Method)
 	require.Equal(t, path, req.URL.Path)
@@ -64,7 +65,7 @@ func TestRequestHeadersContentLength(t *testing.T) {
 			{Name: ":authority", Value: "quic-go.net"},
 			{Name: ":method", Value: http.MethodGet},
 		}
-		req, err := requestFromHeaders(decodeFromSlice(headers), nil)
+		req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(-1), req.ContentLength)
 	})
@@ -77,7 +78,7 @@ func TestRequestHeadersContentLength(t *testing.T) {
 			{Name: "content-length", Value: "42"},
 			{Name: "content-length", Value: "42"},
 		}
-		req, err := requestFromHeaders(decodeFromSlice(headers), nil)
+		req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 		require.NoError(t, err)
 		require.Equal(t, "42", req.Header.Get("Content-Length"))
 	})
@@ -107,7 +108,7 @@ func TestRequestHeadersContentLengthValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := requestFromHeaders(decodeFromSlice(tc.headers), nil)
+			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, nil)
 			if tc.errContains != "" {
 				require.ErrorContains(t, err, tc.errContains)
 			}
@@ -228,7 +229,7 @@ func TestRequestHeadersValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := requestFromHeaders(decodeFromSlice(tc.headers), nil)
+			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, nil)
 			require.EqualError(t, err, tc.err)
 			require.NotErrorAs(t, err, new(*qpackError))
 		})
@@ -243,7 +244,7 @@ func TestCookieHeader(t *testing.T) {
 		{Name: "cookie", Value: "cookie1=foobar1"},
 		{Name: "cookie", Value: "cookie2=foobar2"},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.Header{
 		"Cookie": []string{"cookie1=foobar1; cookie2=foobar2"},
@@ -259,7 +260,7 @@ func TestHeadersConcatenation(t *testing.T) {
 		{Name: "duplicate-header", Value: "1"},
 		{Name: "duplicate-header", Value: "2"},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.Header{
 		"Cache-Control":    []string{"max-age=0"},
@@ -272,7 +273,7 @@ func TestRequestHeadersConnect(t *testing.T) {
 		{Name: ":authority", Value: "quic-go.net"},
 		{Name: ":method", Value: http.MethodConnect},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.MethodConnect, req.Method)
 	require.Equal(t, "HTTP/3.0", req.Proto)
@@ -302,7 +303,7 @@ func TestRequestHeadersConnectValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := requestFromHeaders(decodeFromSlice(tc.headers), nil)
+			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, nil)
 			require.EqualError(t, err, tc.err)
 		})
 	}
@@ -316,7 +317,7 @@ func TestRequestHeadersExtendedConnect(t *testing.T) {
 		{Name: ":authority", Value: "quic-go.net"},
 		{Name: ":path", Value: "/foo?val=1337"},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.MethodConnect, req.Method)
 	require.Equal(t, "webtransport", req.Proto)
@@ -331,7 +332,7 @@ func TestRequestHeadersExtendedConnectRequestValidation(t *testing.T) {
 		{Name: ":authority", Value: "quic.clemente.io"},
 		{Name: ":path", Value: "/foo"},
 	}
-	_, err := requestFromHeaders(decodeFromSlice(headers), nil)
+	_, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 	require.EqualError(t, err, "extended CONNECT: :scheme, :path and :authority must not be empty")
 }
 
@@ -341,7 +342,7 @@ func TestResponseHeaderParsing(t *testing.T) {
 		{Name: "content-length", Value: "42"},
 	}
 	rsp := &http.Response{}
-	require.NoError(t, updateResponseFromHeaders(rsp, decodeFromSlice(headers), nil))
+	require.NoError(t, updateResponseFromHeaders(rsp, decodeFromSlice(headers), math.MaxInt, nil))
 	require.Equal(t, "HTTP/3.0", rsp.Proto)
 	require.Equal(t, 3, rsp.ProtoMajor)
 	require.Zero(t, rsp.ProtoMinor)
@@ -391,7 +392,7 @@ func TestResponseHeaderParsingValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := updateResponseFromHeaders(&http.Response{}, decodeFromSlice(tc.headers), nil)
+			err := updateResponseFromHeaders(&http.Response{}, decodeFromSlice(tc.headers), math.MaxInt, nil)
 			if tc.errContains != "" {
 				require.ErrorContains(t, err, tc.errContains)
 			}
@@ -416,7 +417,7 @@ func TestResponseHeaderParsingValidation(t *testing.T) {
 				{Name: ":status", Value: "404"},
 				{Name: tc.invalidField, Value: "some-value"},
 			}
-			err := updateResponseFromHeaders(&http.Response{}, decodeFromSlice(headers), nil)
+			err := updateResponseFromHeaders(&http.Response{}, decodeFromSlice(headers), math.MaxInt, nil)
 			require.EqualError(t, err, fmt.Sprintf("invalid header field name: %q", tc.invalidField))
 		})
 	}
@@ -429,7 +430,7 @@ func TestResponseTrailerFields(t *testing.T) {
 		{Name: "trailer", Value: "TRAILER3"},
 	}
 	var rsp http.Response
-	require.NoError(t, updateResponseFromHeaders(&rsp, decodeFromSlice(headers), nil))
+	require.NoError(t, updateResponseFromHeaders(&rsp, decodeFromSlice(headers), math.MaxInt, nil))
 	require.Equal(t, 0, len(rsp.Header))
 	require.Equal(t, http.Header(map[string][]string{
 		"Trailer1": nil,
@@ -443,13 +444,13 @@ func TestResponseTrailerParsingTE(t *testing.T) {
 		{Name: ":status", Value: "404"},
 		{Name: "te", Value: "trailers"},
 	}
-	require.NoError(t, updateResponseFromHeaders(&http.Response{}, decodeFromSlice(headers), nil))
+	require.NoError(t, updateResponseFromHeaders(&http.Response{}, decodeFromSlice(headers), math.MaxInt, nil))
 	headers = []qpack.HeaderField{
 		{Name: ":status", Value: "404"},
 		{Name: "te", Value: "not-trailers"},
 	}
 	require.EqualError(t,
-		updateResponseFromHeaders(&http.Response{}, decodeFromSlice(headers), nil),
+		updateResponseFromHeaders(&http.Response{}, decodeFromSlice(headers), math.MaxInt, nil),
 		`invalid TE header field value: "not-trailers"`)
 }
 
@@ -478,14 +479,14 @@ func TestQpackError(t *testing.T) {
 	t.Run("header parsing", func(t *testing.T) {
 		dec := qpack.NewDecoder()
 		decodeFn := dec.Decode(buf.Bytes()[:len(buf.Bytes())/2])
-		_, err := requestFromHeaders(decodeFn, nil)
+		_, err := requestFromHeaders(decodeFn, math.MaxInt, nil)
 		require.ErrorAs(t, err, new(*qpackError))
 	})
 
 	t.Run("trailer parsing", func(t *testing.T) {
 		dec := qpack.NewDecoder()
 		decodeFn := dec.Decode(buf.Bytes()[:len(buf.Bytes())/2])
-		_, err := parseTrailers(decodeFn, nil)
+		err := updateResponseFromHeaders(&http.Response{}, decodeFn, math.MaxInt, nil)
 		require.ErrorAs(t, err, new(*qpackError))
 	})
 }
@@ -517,7 +518,7 @@ func BenchmarkRequestFromHeaders(b *testing.B) {
 	dec := qpack.NewDecoder()
 	for b.Loop() {
 		decodeFn := dec.Decode(buf.Bytes())
-		if _, err := requestFromHeaders(decodeFn, nil); err != nil {
+		if _, err := requestFromHeaders(decodeFn, math.MaxInt, nil); err != nil {
 			b.Fatalf("failed to parse request: %v", err)
 		}
 	}

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -415,8 +415,9 @@ func testServerRequestHeaderTooLarge(t *testing.T, req *http.Request, maxHeaderB
 
 	go s.ServeQUICConn(serverConn)
 
-	expectStreamReadReset(t, str, quic.StreamErrorCode(ErrCodeFrameError))
-	expectStreamWriteReset(t, str, quic.StreamErrorCode(ErrCodeFrameError))
+	hfs := decodeHeader(t, str)
+	require.Equal(t, []string{"431"}, hfs[":status"])
+	expectStreamWriteReset(t, str, quic.StreamErrorCode(ErrCodeExcessiveLoad))
 	require.False(t, called)
 }
 

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -348,7 +348,7 @@ func (s *RequestStream) ReadResponse() (*http.Response, error) {
 		hfs = make([]qpack.HeaderField, 0, 16)
 	}
 	res := s.response
-	err = updateResponseFromHeaders(res, decodeFn, &hfs)
+	err = updateResponseFromHeaders(res, decodeFn, s.maxHeaderBytes, &hfs)
 	if s.str.qlogger != nil {
 		qlogParsedHeadersFrame(s.str.qlogger, s.str.StreamID(), hf, hfs)
 	}

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -25,7 +25,9 @@ import (
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/http3/qlog"
 	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
+	"github.com/quic-go/quic-go/testutils/events"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,11 +81,14 @@ func startHTTPServer(t *testing.T, mux *http.ServeMux, opts ...func(*http3.Serve
 	return conn.LocalAddr().(*net.UDPAddr).Port
 }
 
-func newHTTP3Client(t *testing.T) *http.Client {
+func newHTTP3Client(t *testing.T, opts ...func(*http3.Transport)) *http.Client {
 	tr := &http3.Transport{
 		TLSClientConfig:    getTLSClientConfigWithoutServerName(),
 		QUICConfig:         getQuicConfig(&quic.Config{MaxIdleTimeout: 10 * time.Second}),
 		DisableCompression: true,
+	}
+	for _, opt := range opts {
+		opt(tr)
 	}
 	addDialCallback(t, tr)
 	t.Cleanup(func() { tr.Close() })
@@ -241,6 +246,133 @@ func TestHTTPHeaders(t *testing.T) {
 	require.Equal(t, "bar", resp.Header.Get("foo"))
 	require.Equal(t, "ipsum", resp.Header.Get("lorem"))
 	require.Equal(t, echoHdr, resp.Header.Get("echo"))
+}
+
+func TestHTTPHeaderSizeLimitServer(t *testing.T) {
+	t.Run("large HEADERS frame", func(t *testing.T) {
+		const limit = 1024
+		hdr := make(http.Header)
+		for range 20 {
+			hdr.Add(randomString(50), randomString(50))
+		}
+		headersFrameSize := testHTTPHeaderSizeLimitServer(t, hdr, limit)
+		require.Greater(t, headersFrameSize, limit)
+	})
+
+	t.Run("large decompressed HEADERS frame", func(t *testing.T) {
+		const limit = 1024
+		hdr := make(http.Header)
+		for range 200 {
+			// This is a QPACK static table entry, so it will be compressed.
+			hdr.Add("content-type", "text/plain;charset=utf-8")
+		}
+		headersFrameSize := testHTTPHeaderSizeLimitServer(t, hdr, limit)
+		require.Less(t, headersFrameSize, limit)
+	})
+}
+
+func testHTTPHeaderSizeLimitServer(t *testing.T, hdr http.Header, limit int) (headersFrameSize int) {
+	mux := http.NewServeMux()
+	var handlerCalled bool
+	mux.HandleFunc("/headers", func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	})
+	port := startHTTPServer(t, mux, func(s *http3.Server) { s.MaxHeaderBytes = limit })
+
+	var eventRecorder events.Recorder
+	cl := newHTTP3Client(t, func(tr *http3.Transport) {
+		tr.QUICConfig = getQuicConfig(&quic.Config{
+			MaxIdleTimeout: 10 * time.Second,
+			Tracer:         newTracer(&eventRecorder),
+		})
+	})
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/headers", port), nil)
+	require.NoError(t, err)
+	req.Header = hdr
+
+	resp, err := cl.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusRequestHeaderFieldsTooLarge, resp.StatusCode)
+	require.False(t, handlerCalled)
+
+	for _, ev := range eventRecorder.Events(qlog.FrameCreated{}) {
+		fc := ev.(qlog.FrameCreated)
+		if _, ok := fc.Frame.Frame.(qlog.HeadersFrame); ok {
+			headersFrameSize = fc.Raw.Length
+			break
+		}
+	}
+	return headersFrameSize
+}
+
+func TestHTTPHeaderSizeLimitClient(t *testing.T) {
+	t.Run("large HEADERS frame", func(t *testing.T) {
+		const limit = 1024
+		hdr := make(http.Header)
+		for range 20 {
+			hdr.Add(randomString(50), randomString(50))
+		}
+		headersFrameSize, requestErr := testHTTPHeaderSizeLimitClient(t, hdr, limit)
+		require.ErrorContains(t, requestErr, "http3: HEADERS frame too large")
+		require.Greater(t, headersFrameSize, limit)
+	})
+
+	t.Run("large decompressed HEADERS frame", func(t *testing.T) {
+		const limit = 1024
+		hdr := make(http.Header)
+		for range 200 {
+			// This is a QPACK static table entry, so it will be compressed.
+			hdr.Add("content-type", "text/plain;charset=utf-8")
+		}
+		headersFrameSize, requestErr := testHTTPHeaderSizeLimitClient(t, hdr, limit)
+		require.ErrorContains(t, requestErr, "http3: headers too large")
+		require.Less(t, headersFrameSize, limit)
+	})
+}
+
+func testHTTPHeaderSizeLimitClient(t *testing.T, hdr http.Header, limit int) (headersFrameSize int, requestErr error) {
+	mux := http.NewServeMux()
+	var handlerCalled atomic.Bool
+	mux.HandleFunc("/headers", func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled.Store(true)
+		for k, v := range hdr {
+			for _, val := range v {
+				w.Header().Add(k, val)
+			}
+		}
+	})
+	port := startHTTPServer(t, mux)
+
+	var eventRecorder events.Recorder
+	cl := newHTTP3Client(t,
+		func(tr *http3.Transport) {
+			tr.MaxResponseHeaderBytes = limit
+			tr.QUICConfig = getQuicConfig(&quic.Config{
+				MaxIdleTimeout: 10 * time.Second,
+				Tracer:         newTracer(&eventRecorder),
+			})
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/headers", port), nil)
+	require.NoError(t, err)
+
+	_, requestErr = cl.Do(req)
+	require.Error(t, requestErr)
+	require.True(t, handlerCalled.Load())
+
+	var found bool
+	for _, ev := range eventRecorder.Events(qlog.FrameParsed{}) {
+		fp := ev.(qlog.FrameParsed)
+		if _, ok := fp.Frame.Frame.(qlog.HeadersFrame); ok {
+			headersFrameSize = fp.Raw.PayloadLength
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+	return headersFrameSize, requestErr
 }
 
 func TestHTTPTrailers(t *testing.T) {


### PR DESCRIPTION
Fixes #5429. Fixes #4747.