### PR TITLE
handshake: pass cipherSuite by value instead of pointer

### DIFF
--- a/internal/handshake/aead.go
+++ b/internal/handshake/aead.go
@@ -6,7 +6,7 @@ import (
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
-func createAEAD(suite *cipherSuite, trafficSecret []byte, v protocol.Version) *xorNonceAEAD {
+func createAEAD(suite cipherSuite, trafficSecret []byte, v protocol.Version) *xorNonceAEAD {
 	keyLabel := hkdfLabelKeyV1
 	ivLabel := hkdfLabelIVV1
 	if v == protocol.Version2 {

--- a/internal/handshake/aead_test.go
+++ b/internal/handshake/aead_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getSealerAndOpener(t *testing.T, cs *cipherSuite, v protocol.Version) (LongHeaderSealer, LongHeaderOpener) {
+func getSealerAndOpener(t *testing.T, cs cipherSuite, v protocol.Version) (LongHeaderSealer, LongHeaderOpener) {
 	t.Helper()
 	key := make([]byte, 16)
 	hpKey := make([]byte, 16)
@@ -83,7 +83,7 @@ func TestEncryptAndDecryptHeader(t *testing.T) {
 	}
 }
 
-func testEncryptAndDecryptHeader(t *testing.T, cs *cipherSuite, v protocol.Version) {
+func testEncryptAndDecryptHeader(t *testing.T, cs cipherSuite, v protocol.Version) {
 	sealer, opener := getSealerAndOpener(t, cs, v)
 	var lastFourBitsDifferent int
 

--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -23,14 +23,14 @@ type cipherSuite struct {
 
 func (s cipherSuite) IVLen() int { return aeadNonceLength }
 
-func getCipherSuite(id uint16) *cipherSuite {
+func getCipherSuite(id uint16) cipherSuite {
 	switch id {
 	case tls.TLS_AES_128_GCM_SHA256:
-		return &cipherSuite{ID: tls.TLS_AES_128_GCM_SHA256, Hash: crypto.SHA256, KeyLen: 16, AEAD: aeadAESGCMTLS13}
+		return cipherSuite{ID: tls.TLS_AES_128_GCM_SHA256, Hash: crypto.SHA256, KeyLen: 16, AEAD: aeadAESGCMTLS13}
 	case tls.TLS_CHACHA20_POLY1305_SHA256:
-		return &cipherSuite{ID: tls.TLS_CHACHA20_POLY1305_SHA256, Hash: crypto.SHA256, KeyLen: 32, AEAD: aeadChaCha20Poly1305}
+		return cipherSuite{ID: tls.TLS_CHACHA20_POLY1305_SHA256, Hash: crypto.SHA256, KeyLen: 32, AEAD: aeadChaCha20Poly1305}
 	case tls.TLS_AES_256_GCM_SHA384:
-		return &cipherSuite{ID: tls.TLS_AES_256_GCM_SHA384, Hash: crypto.SHA384, KeyLen: 32, AEAD: aeadAESGCMTLS13}
+		return cipherSuite{ID: tls.TLS_AES_256_GCM_SHA384, Hash: crypto.SHA384, KeyLen: 32, AEAD: aeadAESGCMTLS13}
 	default:
 		panic(fmt.Sprintf("unknown cypher suite: %d", id))
 	}

--- a/internal/handshake/handshake_helpers_test.go
+++ b/internal/handshake/handshake_helpers_test.go
@@ -28,7 +28,7 @@ func TestSplitHexString(t *testing.T) {
 	require.Equal(t, []byte{0xde, 0xad, 0xbe, 0xef}, splitHexString(t, "dead beef"))
 }
 
-var cipherSuites = []*cipherSuite{
+var cipherSuites = []cipherSuite{
 	getCipherSuite(tls.TLS_AES_128_GCM_SHA256),
 	getCipherSuite(tls.TLS_AES_256_GCM_SHA384),
 	getCipherSuite(tls.TLS_CHACHA20_POLY1305_SHA256),

--- a/internal/handshake/header_protector.go
+++ b/internal/handshake/header_protector.go
@@ -24,7 +24,7 @@ func hkdfHeaderProtectionLabel(v protocol.Version) string {
 	return "quic hp"
 }
 
-func newHeaderProtector(suite *cipherSuite, trafficSecret []byte, isLongHeader bool, v protocol.Version) headerProtector {
+func newHeaderProtector(suite cipherSuite, trafficSecret []byte, isLongHeader bool, v protocol.Version) headerProtector {
 	hkdfLabel := hkdfHeaderProtectionLabel(v)
 	switch suite.ID {
 	case tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384:
@@ -44,7 +44,7 @@ type aesHeaderProtector struct {
 
 var _ headerProtector = &aesHeaderProtector{}
 
-func newAESHeaderProtector(suite *cipherSuite, trafficSecret []byte, isLongHeader bool, hkdfLabel string) headerProtector {
+func newAESHeaderProtector(suite cipherSuite, trafficSecret []byte, isLongHeader bool, hkdfLabel string) headerProtector {
 	hpKey := hkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, hkdfLabel, suite.KeyLen)
 	block, err := aes.NewCipher(hpKey)
 	if err != nil {
@@ -88,7 +88,7 @@ type chachaHeaderProtector struct {
 
 var _ headerProtector = &chachaHeaderProtector{}
 
-func newChaChaHeaderProtector(suite *cipherSuite, trafficSecret []byte, isLongHeader bool, hkdfLabel string) headerProtector {
+func newChaChaHeaderProtector(suite cipherSuite, trafficSecret []byte, isLongHeader bool, hkdfLabel string) headerProtector {
 	hpKey := hkdfExpandLabel(suite.Hash, trafficSecret, []byte{}, hkdfLabel, suite.KeyLen)
 
 	p := &chachaHeaderProtector{

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -24,7 +24,7 @@ const (
 	ad  = "Donec in velit neque."
 )
 
-func randomCipherSuite() *cipherSuite { return cipherSuites[mrand.IntN(len(cipherSuites))] }
+func randomCipherSuite() cipherSuite { return cipherSuites[mrand.IntN(len(cipherSuites))] }
 
 func setupEndpoints(t *testing.T, serverRTTStats *utils.RTTStats) (client, server *updatableAEAD, serverEventRecorder *events.Recorder) {
 	cs := randomCipherSuite()


### PR DESCRIPTION
Part of #3663.

This saves 5 allocations per handshake (per side):
```
name          old time/op    new time/op    delta
Handshake-16     598µs ± 3%     598µs ± 1%    ~     (p=0.905 n=10+9)

name          old alloc/op   new alloc/op   delta
Handshake-16     236kB ± 0%     236kB ± 0%  -0.14%  (p=0.000 n=10+10)

name          old allocs/op  new allocs/op  delta
Handshake-16     2.19k ± 0%     2.18k ± 0%  -0.40%  (p=0.000 n=10+10)
```