### PR TITLE
handshake: switch to crypto/hkdf instead of golang.org/x/crypto/hkdf

### DIFF
--- a/internal/handshake/hkdf.go
+++ b/internal/handshake/hkdf.go
@@ -2,9 +2,9 @@ package handshake
 
 import (
 	"crypto"
+	"crypto/hkdf"
 	"encoding/binary"
-
-	"golang.org/x/crypto/hkdf"
+	"fmt"
 )
 
 // hkdfExpandLabel HKDF expands a label as defined in RFC 8446, section 7.1.
@@ -18,10 +18,9 @@ func hkdfExpandLabel(hash crypto.Hash, secret, context []byte, label string, len
 	b[3+6+len(label)] = uint8(len(context))
 	b = append(b, context...)
 
-	out := make([]byte, length)
-	n, err := hkdf.Expand(hash.New, secret, b).Read(out)
-	if err != nil || n != length {
-		panic("quic: HKDF-Expand-Label invocation failed unexpectedly")
+	expanded, err := hkdf.Expand(hash.New, secret, string(b), length)
+	if err != nil {
+		panic(fmt.Errorf("quic: HKDF-Expand-Label invocation failed unexpectedly: %v", err))
 	}
-	return out
+	return expanded
 }


### PR DESCRIPTION
Unfortunately, this allocates more than the existing version:
```
name                                                 old time/op    new time/op    delta
HKDFExpandLabelOurs/TLS_AES_128_GCM_SHA256-16           333ns ± 4%     336ns ± 5%     ~     (p=0.280 n=19+19)
HKDFExpandLabelOurs/TLS_AES_256_GCM_SHA384-16           652ns ± 5%     669ns ± 6%   +2.46%  (p=0.028 n=20+20)
HKDFExpandLabelOurs/TLS_CHACHA20_POLY1305_SHA256-16     334ns ± 4%     340ns ± 4%   +1.63%  (p=0.016 n=19+20)
InitialAEADCreate-16                                   3.72µs ± 2%    3.83µs ± 5%   +2.74%  (p=0.001 n=17+20)
TokenGeneratorDecodeToken-16                           1.75µs ± 4%    1.78µs ± 3%   +1.61%  (p=0.001 n=17+19)

name                                                 old alloc/op   new alloc/op   delta
HKDFExpandLabelOurs/TLS_AES_128_GCM_SHA256-16            681B ± 0%      697B ± 0%   +2.35%  (p=0.000 n=20+20)
HKDFExpandLabelOurs/TLS_AES_256_GCM_SHA384-16          1.03kB ± 0%    1.15kB ± 0%  +10.84%  (p=0.000 n=20+20)
HKDFExpandLabelOurs/TLS_CHACHA20_POLY1305_SHA256-16      681B ± 0%      697B ± 0%   +2.35%  (p=0.000 n=20+20)
InitialAEADCreate-16                                   9.71kB ± 0%    9.84kB ± 0%   +1.32%  (p=0.000 n=20+20)
TokenGeneratorDecodeToken-16                           3.10kB ± 0%    3.14kB ± 0%   +1.29%  (p=0.000 n=20+20)

name                                                 old allocs/op  new allocs/op  delta
HKDFExpandLabelOurs/TLS_AES_128_GCM_SHA256-16            10.0 ± 0%      10.0 ± 0%     ~     (all equal)
HKDFExpandLabelOurs/TLS_AES_256_GCM_SHA384-16            10.0 ± 0%      10.0 ± 0%     ~     (all equal)
HKDFExpandLabelOurs/TLS_CHACHA20_POLY1305_SHA256-16      10.0 ± 0%      10.0 ± 0%     ~     (all equal)
InitialAEADCreate-16                                     99.0 ± 0%      99.0 ± 0%     ~     (all equal)
TokenGeneratorDecodeToken-16                             31.0 ± 0%      31.0 ± 0%     ~     (all equal)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch HKDF implementation from `golang.org/x/crypto/hkdf` to `crypto/hkdf`
> Replaces the external `golang.org/x/crypto/hkdf` package with the standard library `crypto/hkdf` (available since Go 1.24) across three files in the handshake package.
>
> - [`hkdf.go`](https://github.com/quic-go/quic-go/pull/5461/files#diff-a7de383f99a1628ba708665337175e583613a3c690cfe7a83ba3aa739327b5d3): `hkdfExpandLabel` now calls `hkdf.Expand` directly instead of reading from an `io.Reader`, removing the read-count verification.
> - [`initial_aead.go`](https://github.com/quic-go/quic-go/pull/5461/files#diff-b535c2ca7e2784a134b479c99aa3900a69f3e74a195db57b0cc58238e272fbdd): `computeSecrets` adopts the new `hkdf.Extract` signature that returns `(output, error)` and panics on failure.
> - [`token_protector.go`](https://github.com/quic-go/quic-go/pull/5461/files#diff-a21807ce2a9555e7f7dbd59d61d75a619ab04546a640cdb2af96267da183effa): `createAEAD` replaces `hkdf.New` + `io.ReadFull` with explicit `hkdf.Extract` + `hkdf.Expand` calls and a new `tokenProtectorHKDFInfo` constant.
> - Behavioral Change: error paths now panic via `fmt.Errorf`-wrapped errors rather than returning errors from `io.ReadFull`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7533f21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->