### PR TITLE
ackhandler: remove ReceivedPacketHandler interface, use struct directly

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -371,7 +371,7 @@ var newConnection = func(
 		s.version,
 	)
 	s.cryptoStreamHandler = cs
-	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, s.receivedPacketHandler, s.datagramQueue, s.perspective)
+	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, &s.receivedPacketHandler, s.datagramQueue, s.perspective)
 	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen)
 	s.cryptoStreamManager = newCryptoStreamManager(s.initialStream, s.handshakeStream, s.oneRTTStream)
 	return &wrappedConn{Conn: s}
@@ -497,7 +497,7 @@ var newClientConnection = func(
 	s.cryptoStreamHandler = cs
 	s.cryptoStreamManager = newCryptoStreamManager(s.initialStream, s.handshakeStream, oneRTTStream)
 	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen)
-	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, s.receivedPacketHandler, s.datagramQueue, s.perspective)
+	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, &s.receivedPacketHandler, s.datagramQueue, s.perspective)
 	if len(tlsConf.ServerName) > 0 {
 		s.tokenStoreKey = tlsConf.ServerName
 	} else {
@@ -557,7 +557,7 @@ func (c *Conn) preSetup() {
 	c.lastPacketReceivedTime = now
 	c.creationTime = now
 
-	c.receivedPacketHandler = ackhandler.NewReceivedPacketHandler(c.logger)
+	c.receivedPacketHandler = *ackhandler.NewReceivedPacketHandler(c.logger)
 
 	c.datagramQueue = newDatagramQueue(c.scheduleSending, c.logger)
 	c.connState.Version = c.version

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -37,14 +37,3 @@ type SentPacketHandler interface {
 
 	MigratedPath(now monotime.Time, initialMaxPacketSize protocol.ByteCount)
 }
-
-// ReceivedPacketHandler handles ACKs needed to send for incoming packets
-type ReceivedPacketHandler interface {
-	IgnorePacketsBelow(protocol.PacketNumber)
-	IsPotentiallyDuplicate(protocol.PacketNumber, protocol.EncryptionLevel) bool
-	ReceivedPacket(pn protocol.PacketNumber, ecn protocol.ECN, encLevel protocol.EncryptionLevel, rcvTime monotime.Time, ackEliciting bool) error
-	DropPackets(protocol.EncryptionLevel)
-
-	GetAlarmTimeout() monotime.Time
-	GetAckFrame(_ protocol.EncryptionLevel, now monotime.Time, onlyIfQueued bool) *wire.AckFrame
-}

--- a/internal/ackhandler/received_packet_handler.go
+++ b/internal/ackhandler/received_packet_handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/quic-go/quic-go/internal/wire"
 )
 
-type receivedPacketHandler struct {
+type ReceivedPacketHandler struct {
 	initialPackets   *receivedPacketTracker
 	handshakePackets *receivedPacketTracker
 	appDataPackets   appDataReceivedPacketTracker
@@ -17,10 +17,8 @@ type receivedPacketHandler struct {
 	lowest1RTTPacket protocol.PacketNumber
 }
 
-var _ ReceivedPacketHandler = &receivedPacketHandler{}
-
-func NewReceivedPacketHandler(logger utils.Logger) ReceivedPacketHandler {
-	return &receivedPacketHandler{
+func NewReceivedPacketHandler(logger utils.Logger) *ReceivedPacketHandler {
+	return &ReceivedPacketHandler{
 		initialPackets:   newReceivedPacketTracker(),
 		handshakePackets: newReceivedPacketTracker(),
 		appDataPackets:   *newAppDataReceivedPacketTracker(logger),
@@ -28,7 +26,7 @@ func NewReceivedPacketHandler(logger utils.Logger) ReceivedPacketHandler {
 	}
 }
 
-func (h *receivedPacketHandler) ReceivedPacket(
+func (h *ReceivedPacketHandler) ReceivedPacket(
 	pn protocol.PacketNumber,
 	ecn protocol.ECN,
 	encLevel protocol.EncryptionLevel,
@@ -60,11 +58,11 @@ func (h *receivedPacketHandler) ReceivedPacket(
 	}
 }
 
-func (h *receivedPacketHandler) IgnorePacketsBelow(pn protocol.PacketNumber) {
+func (h *ReceivedPacketHandler) IgnorePacketsBelow(pn protocol.PacketNumber) {
 	h.appDataPackets.IgnoreBelow(pn)
 }
 
-func (h *receivedPacketHandler) DropPackets(encLevel protocol.EncryptionLevel) {
+func (h *ReceivedPacketHandler) DropPackets(encLevel protocol.EncryptionLevel) {
 	//nolint:exhaustive // 1-RTT packet number space is never dropped.
 	switch encLevel {
 	case protocol.EncryptionInitial:
@@ -79,11 +77,11 @@ func (h *receivedPacketHandler) DropPackets(encLevel protocol.EncryptionLevel) {
 	}
 }
 
-func (h *receivedPacketHandler) GetAlarmTimeout() monotime.Time {
+func (h *ReceivedPacketHandler) GetAlarmTimeout() monotime.Time {
 	return h.appDataPackets.GetAlarmTimeout()
 }
 
-func (h *receivedPacketHandler) GetAckFrame(encLevel protocol.EncryptionLevel, now monotime.Time, onlyIfQueued bool) *wire.AckFrame {
+func (h *ReceivedPacketHandler) GetAckFrame(encLevel protocol.EncryptionLevel, now monotime.Time, onlyIfQueued bool) *wire.AckFrame {
 	//nolint:exhaustive // 0-RTT packets can't contain ACK frames.
 	switch encLevel {
 	case protocol.EncryptionInitial:
@@ -104,7 +102,7 @@ func (h *receivedPacketHandler) GetAckFrame(encLevel protocol.EncryptionLevel, n
 	}
 }
 
-func (h *receivedPacketHandler) IsPotentiallyDuplicate(pn protocol.PacketNumber, encLevel protocol.EncryptionLevel) bool {
+func (h *ReceivedPacketHandler) IsPotentiallyDuplicate(pn protocol.PacketNumber, encLevel protocol.EncryptionLevel) bool {
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		if h.initialPackets != nil {


### PR DESCRIPTION
This slightly reduces allocations. Part of #3663.

```
name          old time/op    new time/op    delta
Handshake-16     669µs ± 3%     667µs ± 3%    ~     (p=0.184 n=48+44)

name          old alloc/op   new alloc/op   delta
Handshake-16     239kB ± 0%     239kB ± 0%  -0.09%  (p=0.001 n=39+38)

name          old allocs/op  new allocs/op  delta
Handshake-16     2.19k ± 0%     2.18k ± 0%  -0.11%  (p=0.000 n=37+39)
```