### PR TITLE
Perform max payload size estimation on datagram queueing

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -325,7 +325,7 @@ var newConnection = func(
 		s.qlogger,
 		s.logger,
 	)
-	s.currentMTUEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
+	s.currentMTUEstimate.Store(uint32(protocol.ByteCount(s.config.InitialPacketSize)))
 	statelessResetToken := statelessResetter.GetStatelessResetToken(srcConnID)
 	params := &wire.TransportParameters{
 		InitialMaxStreamDataBidiLocal:   protocol.ByteCount(s.config.InitialStreamReceiveWindow),
@@ -454,7 +454,7 @@ var newClientConnection = func(
 		s.qlogger,
 		s.logger,
 	)
-	s.currentMTUEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
+	s.currentMTUEstimate.Store(uint32(protocol.ByteCount(s.config.InitialPacketSize)))
 	oneRTTStream := newCryptoStream()
 	params := &wire.TransportParameters{
 		InitialMaxStreamDataBidiRemote: protocol.ByteCount(s.config.InitialStreamReceiveWindow),
@@ -3031,7 +3031,7 @@ func (c *Conn) SendDatagram(p []byte) error {
 	// Under many circumstances we could send a few more bytes.
 	maxDataLen := min(
 		f.MaxDataLen(c.peerParams.MaxDatagramFrameSize, c.version),
-		protocol.ByteCount(c.currentMTUEstimate.Load()),
+		estimateMaxPayloadSize(protocol.ByteCount(c.currentMTUEstimate.Load())),
 	)
 	if protocol.ByteCount(len(p)) > maxDataLen {
 		return &DatagramTooLargeError{MaxDatagramPayloadSize: int64(maxDataLen)}


### PR DESCRIPTION
We observed that sending specific sized QUIC datagrams would be silently dropped without any errors returned from `sendDatagram()`

This behavior is caused by mixed assumptions. `SendDatagram()` uses `currentMTUEstimate` as a direct max-payload-estimate instead of max-packet-size-estimate.

Initially `currentMTUEstimate` is in-fact initialized with max-payload-size as calculated by `currentMTUEstimate.Store(estimateMaxPayloadSize(s.config.InitialPacketSize))` [see here](https://github.com/quic-go/quic-go/compare/master...NordSecurity:quic-go:master?expand=1#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7L328). But later, whenever evaluating results from PMTU discovery - it is assumed that `currentMTUEstimate` stores max-packet-size instead of max-payload-size [see here](https://github.com/quic-go/quic-go/blob/8d53d495be2988903c9818ebf2714c54251556bc/connection.go#L2124). This triggers mtu increase even if MTU discovery is disabled. Causing `sendDatagram()` to attempt to send larger datagrams, than PacketPacker allows [here](https://github.com/quic-go/quic-go/blob/8d53d495be2988903c9818ebf2714c54251556bc/packet_packer.go#L667) 

This PR makes sure that `currentMTUEstimate` consistently reports max-packet-size, and adjusts `sendDatagram()` accordingly.