### PR TITLE
ackhandler: only generate RTT sample for the last ack-eliciting packet

### DIFF
--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/http3/qlog"
 	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
+	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/testutils/events"
 
 	"github.com/stretchr/testify/assert"
@@ -1009,7 +1010,7 @@ func TestHTTP0RTT(t *testing.T) {
 		Conn:       newUDPConnLocalhost(t),
 		ServerAddr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
 		DelayPacket: func(_ quicproxy.Direction, _, _ net.Addr, data []byte) time.Duration {
-			if contains0RTTPacket(data) {
+			if containsPacketType(data, protocol.PacketType0RTT) {
 				num0RTTPackets.Add(1)
 			}
 			return scaleDuration(25 * time.Millisecond)

--- a/integrationtests/self/self_test.go
+++ b/integrationtests/self/self_test.go
@@ -312,9 +312,9 @@ func randomDuration(min, max time.Duration) time.Duration {
 	return min + time.Duration(rand.IntN(int(max-min)))
 }
 
-// contains0RTTPacket says if a packet contains a 0-RTT long header packet.
+// containsPacketType checks if a packet contains a long header packet of the specified type.
 // It correctly handles coalesced packets.
-func contains0RTTPacket(data []byte) bool {
+func containsPacketType(data []byte, packetType protocol.PacketType) bool {
 	for len(data) > 0 {
 		if !wire.IsLongHeaderPacket(data[0]) {
 			return false
@@ -323,7 +323,7 @@ func contains0RTTPacket(data []byte) bool {
 		if err != nil {
 			return false
 		}
-		if hdr.Type == protocol.PacketType0RTT {
+		if hdr.Type == packetType {
 			return true
 		}
 		data = rest

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -32,7 +32,7 @@ type zeroRTTCountingRouter struct {
 var _ simnet.Router = &zeroRTTCountingRouter{}
 
 func (r *zeroRTTCountingRouter) SendPacket(p simnet.Packet) error {
-	if contains0RTTPacket(p.Data) {
+	if containsPacketType(p.Data, protocol.PacketType0RTT) {
 		r.counter.Add(1)
 	}
 	return r.Router.SendPacket(p)


### PR DESCRIPTION
Fixes #5474.

This logic now works across packet number spaces. It avoids inflated RTT measurements when packets are buffered during the handshake.
