### PR TITLE
simplify ReceiveStream.Read implementation

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -184,9 +184,7 @@ func (s *ReceiveStream) readImpl(p []byte) (hasStreamWindowUpdate bool, hasConnW
 				}
 			}
 			s.mutex.Lock()
-			if s.currentFrame == nil {
-				s.dequeueNextFrame()
-			}
+			s.dequeueNextFrame()
 		}
 
 		if bytesRead > len(p) {


### PR DESCRIPTION
1. Simplify check for stream cancellations 
2. Don't arm the deadline timer if there's data to read

No functional change expected.