### PR TITLE
quicvarint: implement function to peek the next varint

### DIFF
--- a/quicvarint/io_test.go
+++ b/quicvarint/io_test.go
@@ -2,6 +2,7 @@ package quicvarint
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
 
@@ -113,4 +114,49 @@ func TestWriterFailure(t *testing.T) {
 	w := NewWriter(&nopWriter{})
 	err := w.WriteByte(0)
 	require.Equal(t, io.ErrShortBuffer, err)
+}
+
+type bufPeeker []byte
+
+func (p bufPeeker) Peek(b []byte) (int, error) {
+	if len(p) < len(b) {
+		return copy(b, p), io.ErrUnexpectedEOF
+	}
+	return copy(b, p), nil
+}
+
+func TestPeek(t *testing.T) {
+	for _, c := range []bufPeeker{
+		{0b00011001},                   // 1-byte
+		{0b01111011, 0xbd},             // 2-byte
+		{0b10011101, 0x7f, 0x3e, 0x7d}, // 4-byte
+		{0xc2, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c}, // 8-byte
+	} {
+		t.Run(fmt.Sprintf("%d bytes", len(c)), func(t *testing.T) {
+			peekVal, err := Peek(append(c, []byte("foobar")...)) // append some data, which doesn't matter
+			require.NoError(t, err)
+			parseVal, _, err := Parse(c)
+			require.NoError(t, err)
+			require.Equal(t, parseVal, peekVal)
+		})
+	}
+}
+
+func TestPeekErrors(t *testing.T) {
+	errorCases := []struct {
+		name  string
+		input bufPeeker
+	}{
+		{"empty input", bufPeeker{}},
+		{"2-byte, missing 1", bufPeeker{0b01000001}},
+		{"4-byte, missing 1", bufPeeker{0b10000000, 0, 0}},
+		{"8-byte, missing 1", bufPeeker{0b11000000, 0, 0, 0, 0, 0, 0}},
+	}
+
+	for _, tc := range errorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Peek(tc.input)
+			require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		})
+	}
 }


### PR DESCRIPTION
Peek doesn’t consume any more bytes than needed to parse the next QUIC varint.

~~Depends on #5501.~~ For #4405.