### PR TITLE
ci: ignore integrationtests directory for Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,7 @@ coverage:
   ignore:
     - http3/gzip_reader.go
     - example/
+    - integrationtests/
     - interop/
     - internal/handshake/cipher_suite.go
     - internal/mocks/


### PR DESCRIPTION
Recently, the Codecov coverage report uploader has been failing since it was trying (for reasons I don't understand, but might be related to https://docs.codecov.com/docs/fixing-reports) to access files in the `integrationtests` directory.