### PR TITLE
ci: fix Codecov upload by untracking integrationtests before removal

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,7 +23,7 @@ jobs:
         run: go install github.com/jstemmer/go-junit-report/v2@v2.1.0
       - name: Remove integrationtests
         shell: bash
-        run: rm -rf integrationtests
+        run: git rm -r --cached integrationtests && rm -rf integrationtests
       - name: Run tests
         env:
           TIMESCALE_FACTOR: 10


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix Codecov upload in CI by untracking and removing `integrationtests` in [unit.yml](https://github.com/quic-go/quic-go/pull/5511/files#diff-e17ac7ab478a18e9dac875e191cc3e0d754fab62eddddfb05d4619495be927d9)
Update the unit workflow to run `git rm -r --cached integrationtests` before `rm -rf integrationtests` in [unit.yml](https://github.com/quic-go/quic-go/pull/5511/files#diff-e17ac7ab478a18e9dac875e191cc3e0d754fab62eddddfb05d4619495be927d9).

#### 📍Where to Start
Start with the 'Remove integrationtests' step in [unit.yml](https://github.com/quic-go/quic-go/pull/5511/files#diff-e17ac7ab478a18e9dac875e191cc3e0d754fab62eddddfb05d4619495be927d9).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 054bea3.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->