### PR TITLE
http3: implement new API to allow fine-grained control of connections

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -6,17 +6,16 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"net/http"
 	"net/http/httptrace"
 	"net/textproto"
+	"sync"
 	"time"
 
+	"github.com/quic-go/qpack"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3/qlog"
-	"github.com/quic-go/quic-go/quicvarint"
-
-	"github.com/quic-go/qpack"
+	"github.com/quic-go/quic-go/qlogwriter"
 )
 
 const (
@@ -33,6 +32,8 @@ const (
 	defaultMaxResponseHeaderBytes = 10 * 1 << 20 // 10 MB
 )
 
+var errGoAway = errors.New("connection in graceful shutdown")
+
 type errConnUnusable struct{ e error }
 
 func (e *errConnUnusable) Unwrap() error { return e.e }
@@ -47,11 +48,10 @@ var defaultQuicConfig = &quic.Config{
 
 // ClientConn is an HTTP/3 client doing requests to a single remote server.
 type ClientConn struct {
-	conn *Conn
+	conn    *quic.Conn
+	rawConn *rawConn
 
-	// Enable support for HTTP/3 datagrams (RFC 9297).
-	// If a QUICConfig is set, datagram support also needs to be enabled on the QUIC layer by setting enableDatagrams.
-	enableDatagrams bool
+	decoder *qpack.Decoder
 
 	// Additional HTTP/3 settings.
 	// It is invalid to specify any settings defined by RFC 9114 (HTTP/3) and RFC 9297 (HTTP Datagrams).
@@ -68,10 +68,14 @@ type ClientConn struct {
 	// However, if the user explicitly requested gzip it is not automatically uncompressed.
 	disableCompression bool
 
-	logger *slog.Logger
+	streamMx     sync.Mutex
+	maxStreamID  quic.StreamID
+	lastStreamID quic.StreamID
+
+	qlogger qlogwriter.Recorder
+	logger  *slog.Logger
 
 	requestWriter *requestWriter
-	decoder       *qpack.Decoder
 }
 
 var _ http.RoundTripper = &ClientConn{}
@@ -84,75 +88,161 @@ func newClientConn(
 	disableCompression bool,
 	logger *slog.Logger,
 ) *ClientConn {
+	var qlogger qlogwriter.Recorder
+	if qlogTrace := conn.QlogTrace(); qlogTrace != nil && qlogTrace.SupportsSchemas(qlog.EventSchema) {
+		qlogger = qlogTrace.AddProducer()
+	}
 	c := &ClientConn{
-		enableDatagrams:    enableDatagrams,
+		conn:               conn,
 		additionalSettings: additionalSettings,
 		disableCompression: disableCompression,
+		maxStreamID:        invalidStreamID,
+		lastStreamID:       invalidStreamID,
 		logger:             logger,
+		qlogger:            qlogger,
+		decoder:            qpack.NewDecoder(),
 	}
 	if maxResponseHeaderBytes <= 0 {
 		c.maxResponseHeaderBytes = defaultMaxResponseHeaderBytes
 	} else {
 		c.maxResponseHeaderBytes = maxResponseHeaderBytes
 	}
-	c.decoder = qpack.NewDecoder()
 	c.requestWriter = newRequestWriter()
-	c.conn = newConnection(
-		conn.Context(),
+	c.rawConn = newRawConn(
 		conn,
-		c.enableDatagrams,
-		false, // client
+		enableDatagrams,
+		c.onStreamsEmpty,
+		c.handleControlStream,
+		qlogger,
 		c.logger,
-		0,
 	)
 	// send the SETTINGs frame, using 0-RTT data, if possible
 	go func() {
-		if err := c.setupConn(); err != nil {
+		_, err := c.rawConn.openControlStream(&settingsFrame{
+			Datagram:            enableDatagrams,
+			Other:               additionalSettings,
+			MaxFieldSectionSize: int64(c.maxResponseHeaderBytes),
+		})
+		if err != nil {
 			if c.logger != nil {
-				c.logger.Debug("Setting up connection failed", "error", err)
+				c.logger.Debug("setting up connection failed", "error", err)
 			}
 			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeInternalError), "")
+			return
 		}
 	}()
-	go c.conn.handleUnidirectionalStreams()
 	return c
 }
 
 // OpenRequestStream opens a new request stream on the HTTP/3 connection.
 func (c *ClientConn) OpenRequestStream(ctx context.Context) (*RequestStream, error) {
-	return c.conn.openRequestStream(ctx, c.requestWriter, nil, c.disableCompression, c.maxResponseHeaderBytes)
+	return c.openRequestStream(ctx, c.requestWriter, nil, c.disableCompression, c.maxResponseHeaderBytes)
 }
 
-func (c *ClientConn) setupConn() error {
-	// open the control stream
-	str, err := c.conn.OpenUniStream()
+func (c *ClientConn) openRequestStream(
+	ctx context.Context,
+	requestWriter *requestWriter,
+	reqDone chan<- struct{},
+	disableCompression bool,
+	maxHeaderBytes int,
+) (*RequestStream, error) {
+	c.streamMx.Lock()
+	maxStreamID := c.maxStreamID
+	var nextStreamID quic.StreamID
+	if c.lastStreamID == invalidStreamID {
+		nextStreamID = 0
+	} else {
+		nextStreamID = c.lastStreamID + 4
+	}
+	c.streamMx.Unlock()
+	// Streams with stream ID equal to or greater than the stream ID carried in the GOAWAY frame
+	// will be rejected, see section 5.2 of RFC 9114.
+	if maxStreamID != invalidStreamID && nextStreamID >= maxStreamID {
+		return nil, errGoAway
+	}
+
+	str, err := c.conn.OpenStreamSync(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	b := make([]byte, 0, 64)
-	b = quicvarint.Append(b, streamTypeControlStream)
-	// send the SETTINGS frame
-	b = (&settingsFrame{
-		Datagram:            c.enableDatagrams,
-		Other:               c.additionalSettings,
-		MaxFieldSectionSize: int64(c.maxResponseHeaderBytes),
-	}).Append(b)
-	if c.conn.qlogger != nil {
-		sf := qlog.SettingsFrame{
-			MaxFieldSectionSize: int64(c.maxResponseHeaderBytes),
-			Other:               maps.Clone(c.additionalSettings),
+	c.streamMx.Lock()
+	c.lastStreamID = str.StreamID()
+	c.streamMx.Unlock()
+	hstr := c.rawConn.TrackStream(str)
+	rsp := &http.Response{}
+	trace := httptrace.ContextClientTrace(ctx)
+	return newRequestStream(
+		newStream(hstr, c.rawConn, trace, func(r io.Reader, hf *headersFrame) error {
+			hdr, err := decodeTrailers(r, hf, maxHeaderBytes, c.decoder, c.qlogger, str.StreamID())
+			if err != nil {
+				return err
+			}
+			rsp.Trailer = hdr
+			return nil
+		}, c.qlogger),
+		requestWriter,
+		reqDone,
+		c.decoder,
+		disableCompression,
+		maxHeaderBytes,
+		rsp,
+	), nil
+}
+
+func (c *ClientConn) handleUnidirectionalStream(str *quic.ReceiveStream) {
+	c.rawConn.handleUnidirectionalStream(str, false)
+}
+
+func (c *ClientConn) handleControlStream(str *quic.ReceiveStream, fp *frameParser) {
+	for {
+		f, err := fp.ParseNext(c.qlogger)
+		if err != nil {
+			var serr *quic.StreamError
+			if err == io.EOF || errors.As(err, &serr) {
+				c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")
+				return
+			}
+			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameError), "")
+			return
 		}
-		if c.enableDatagrams {
-			sf.Datagram = pointer(true)
+		// GOAWAY is the only frame allowed at this point:
+		// * unexpected frames are ignored by the frame parser
+		// * we don't support any extension that might add support for more frames
+		goaway, ok := f.(*goAwayFrame)
+		if !ok {
+			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
+			return
 		}
-		c.conn.qlogger.RecordEvent(qlog.FrameCreated{
-			StreamID: str.StreamID(),
-			Raw:      qlog.RawInfo{Length: len(b)},
-			Frame:    qlog.Frame{Frame: sf},
-		})
+		if goaway.StreamID%4 != 0 { // client-initiated, bidirectional streams
+			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
+			return
+		}
+		c.streamMx.Lock()
+		if c.maxStreamID != invalidStreamID && goaway.StreamID > c.maxStreamID {
+			c.streamMx.Unlock()
+			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
+			return
+		}
+		c.maxStreamID = goaway.StreamID
+		c.streamMx.Unlock()
+
+		hasActiveStreams := c.rawConn.hasActiveStreams()
+		// immediately close the connection if there are currently no active requests
+		if !hasActiveStreams {
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
+			return
+		}
 	}
-	_, err = str.Write(b)
-	return err
+}
+
+func (c *ClientConn) onStreamsEmpty() {
+	c.streamMx.Lock()
+	defer c.streamMx.Unlock()
+
+	// The server is performing a graceful shutdown.
+	if c.maxStreamID != invalidStreamID {
+		c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
+	}
 }
 
 // RoundTrip executes a request and returns a response
@@ -193,17 +283,17 @@ func (c *ClientConn) roundTrip(req *http.Request) (*http.Response, error) {
 		connCtx := c.conn.Context()
 		// wait for the server's SETTINGS frame to arrive
 		select {
-		case <-c.conn.ReceivedSettings():
+		case <-c.rawConn.ReceivedSettings():
 		case <-connCtx.Done():
 			return nil, context.Cause(connCtx)
 		}
-		if !c.conn.Settings().EnableExtendedConnect {
+		if !c.rawConn.Settings().EnableExtendedConnect {
 			return nil, errors.New("http3: server didn't enable Extended CONNECT")
 		}
 	}
 
 	reqDone := make(chan struct{})
-	str, err := c.conn.openRequestStream(
+	str, err := c.openRequestStream(
 		req.Context(),
 		c.requestWriter,
 		reqDone,
@@ -240,19 +330,19 @@ func (c *ClientConn) roundTrip(req *http.Request) (*http.Response, error) {
 // ReceivedSettings returns a channel that is closed once the server's HTTP/3 settings were received.
 // Settings can be obtained from the Settings method after the channel was closed.
 func (c *ClientConn) ReceivedSettings() <-chan struct{} {
-	return c.conn.ReceivedSettings()
+	return c.rawConn.ReceivedSettings()
 }
 
 // Settings returns the HTTP/3 settings for this connection.
 // It is only valid to call this function after the channel returned by ReceivedSettings was closed.
 func (c *ClientConn) Settings() *Settings {
-	return c.conn.Settings()
+	return c.rawConn.Settings()
 }
 
 // CloseWithError closes the connection with the given error code and message.
 // It is invalid to call this function after the connection was closed.
-func (c *ClientConn) CloseWithError(code ErrCode, msg string) error {
-	return c.conn.CloseWithError(quic.ApplicationErrorCode(code), msg)
+func (c *ClientConn) CloseWithError(code quic.ApplicationErrorCode, msg string) error {
+	return c.conn.CloseWithError(code, msg)
 }
 
 // Context returns a context that is cancelled when the connection is closed.
@@ -377,9 +467,23 @@ func (c *ClientConn) doRequest(req *http.Request, str *RequestStream) (*http.Res
 	return res, nil
 }
 
-// Conn returns the underlying HTTP/3 connection.
-// This method is only useful for advanced use cases, such as when the application needs to
-// open streams on the HTTP/3 connection (e.g. WebTransport).
-func (c *ClientConn) Conn() *Conn {
-	return c.conn
+// RawClientConn is a low-level HTTP/3 client connection.
+// It allows the application to take control of the stream accept loops,
+// giving the application the ability to handle streams originating from the server.
+type RawClientConn struct {
+	*ClientConn
+}
+
+// HandleUnidirectionalStream handles an incoming unidirectional stream.
+func (c *RawClientConn) HandleUnidirectionalStream(str *quic.ReceiveStream) {
+	c.rawConn.handleUnidirectionalStream(str, false)
+}
+
+// HandleBidirectionalStream handles an incoming bidirectional stream.
+func (c *ClientConn) HandleBidirectionalStream(str *quic.Stream) {
+	// According to RFC 9114, the server is not allowed to open bidirectional streams.
+	c.rawConn.CloseWithError(
+		quic.ApplicationErrorCode(ErrCodeStreamCreationError),
+		fmt.Sprintf("server opened bidirectional stream %d", str.StreamID()),
+	)
 }

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -81,6 +81,8 @@ func testClientSettings(t *testing.T, enableDatagrams bool, other map[uint64]uin
 }
 
 func encodeResponse(t *testing.T, status int) []byte {
+	t.Helper()
+
 	mockCtrl := gomock.NewController(t)
 	buf := &bytes.Buffer{}
 	rstr := NewMockDatagramStream(mockCtrl)
@@ -571,4 +573,230 @@ func TestClientRequestCancellation(t *testing.T) {
 	requestCancel()
 
 	expectStreamWriteReset(t, str, quic.StreamErrorCode(ErrCodeRequestCanceled))
+}
+
+func TestClientConnGoAway(t *testing.T) {
+	t.Run("no active streams", func(t *testing.T) {
+		testClientConnGoAway(t, false)
+	})
+
+	t.Run("active stream", func(t *testing.T) {
+		testClientConnGoAway(t, true)
+	})
+}
+
+func testClientConnGoAway(t *testing.T, withStream bool) {
+	var clientEventRecorder events.Recorder
+	localConn, peerConn := newConnPairWithRecorder(t, &clientEventRecorder, nil)
+
+	cc := (&Transport{}).NewClientConn(localConn)
+
+	var str *RequestStream
+	if withStream {
+		s, err := cc.OpenRequestStream(context.Background())
+		require.NoError(t, err)
+		str = s
+	}
+
+	// Peer sends control stream with SETTINGS and GOAWAY
+	b := quicvarint.Append(nil, streamTypeControlStream)
+	b = (&settingsFrame{}).Append(b)
+	b = (&goAwayFrame{StreamID: 8}).Append(b)
+	controlStr, err := peerConn.OpenUniStream()
+	require.NoError(t, err)
+	_, err = controlStr.Write(b)
+	require.NoError(t, err)
+
+	// The connection should be closed after the stream is closed
+	if withStream {
+		select {
+		case <-peerConn.Context().Done():
+			t.Fatal("connection closed")
+		case <-time.After(scaleDuration(10 * time.Millisecond)):
+		}
+
+		// The stream ID in the GOAWAY frame is 8, so it's possible to open stream 4.
+		str2, err := cc.OpenRequestStream(context.Background())
+		require.NoError(t, err)
+		str2.Close()
+		str2.CancelRead(1337)
+
+		// It's not possible to open stream 8.
+		_, err = cc.OpenRequestStream(context.Background())
+		require.ErrorIs(t, err, errGoAway)
+
+		str.Close()
+		str.CancelRead(1337)
+	}
+
+	select {
+	case <-peerConn.Context().Done():
+		require.ErrorIs(t,
+			context.Cause(peerConn.Context()),
+			&quic.ApplicationError{Remote: true, ErrorCode: quic.ApplicationErrorCode(ErrCodeNoError)},
+		)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for close")
+	}
+
+	expectedLen, expectedPayloadLen := expectedFrameLength(t, &goAwayFrame{StreamID: 8})
+	require.Equal(t,
+		[]qlogwriter.Event{
+			qlog.FrameParsed{
+				StreamID: controlStr.StreamID(),
+				Raw:      qlog.RawInfo{PayloadLength: expectedPayloadLen, Length: expectedLen},
+				Frame:    qlog.Frame{Frame: qlog.GoAwayFrame{StreamID: 8}},
+			},
+		},
+		filterQlogEventsForFrame(clientEventRecorder.Events(qlog.FrameParsed{}), qlog.GoAwayFrame{StreamID: 8}),
+	)
+}
+
+func TestClientConnGoAwayFailures(t *testing.T) {
+	t.Run("invalid frame", func(t *testing.T) {
+		b := (&settingsFrame{}).Append(nil)
+		// 1337 is invalid value for the Extended CONNECT setting
+		b = (&settingsFrame{Other: map[uint64]uint64{settingExtendedConnect: 1337}}).Append(b)
+		testClientConnGoAwayFailures(t, b, nil, ErrCodeFrameError)
+	})
+
+	t.Run("not a GOAWAY", func(t *testing.T) {
+		b := (&settingsFrame{}).Append(nil)
+		// GOAWAY is the only allowed frame type after SETTINGS
+		b = (&headersFrame{}).Append(b)
+		testClientConnGoAwayFailures(t, b, nil, ErrCodeFrameUnexpected)
+	})
+
+	t.Run("stream closed before GOAWAY", func(t *testing.T) {
+		testClientConnGoAwayFailures(t, (&settingsFrame{}).Append(nil), io.EOF, ErrCodeClosedCriticalStream)
+	})
+
+	t.Run("stream reset before GOAWAY", func(t *testing.T) {
+		testClientConnGoAwayFailures(t,
+			(&settingsFrame{}).Append(nil),
+			&quic.StreamError{Remote: true, ErrorCode: 42},
+			ErrCodeClosedCriticalStream,
+		)
+	})
+
+	t.Run("invalid stream ID", func(t *testing.T) {
+		data := (&settingsFrame{}).Append(nil)
+		data = (&goAwayFrame{StreamID: 1}).Append(data)
+		testClientConnGoAwayFailures(t, data, nil, ErrCodeIDError)
+	})
+
+	t.Run("increased stream ID", func(t *testing.T) {
+		localConn, peerConn := newConnPair(t)
+
+		cc := (&Transport{}).NewClientConn(localConn)
+
+		// need an active stream so the connection doesn't close after the first GOAWAY
+		_, err := cc.OpenRequestStream(context.Background())
+		require.NoError(t, err)
+
+		controlStr, err := peerConn.OpenUniStream()
+		require.NoError(t, err)
+		b := quicvarint.Append(nil, streamTypeControlStream)
+		b = (&settingsFrame{}).Append(b)
+		b = (&goAwayFrame{StreamID: 4}).Append(b)
+		b = (&goAwayFrame{StreamID: 8}).Append(b)
+		_, err = controlStr.Write(b)
+		require.NoError(t, err)
+
+		select {
+		case <-peerConn.Context().Done():
+			require.ErrorIs(t,
+				context.Cause(peerConn.Context()),
+				&quic.ApplicationError{Remote: true, ErrorCode: quic.ApplicationErrorCode(ErrCodeIDError)},
+			)
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for close")
+		}
+	})
+}
+
+func testClientConnGoAwayFailures(t *testing.T, data []byte, readErr error, expectedErr ErrCode) {
+	localConn, peerConn := newConnPair(t)
+
+	(&Transport{}).NewClientConn(localConn)
+
+	controlStr, err := peerConn.OpenUniStream()
+	require.NoError(t, err)
+	_, err = controlStr.Write(quicvarint.Append(nil, streamTypeControlStream))
+	require.NoError(t, err)
+
+	switch readErr {
+	case nil:
+		_, err = controlStr.Write(data)
+		require.NoError(t, err)
+	case io.EOF:
+		_, err = controlStr.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, controlStr.Close())
+	default:
+		// make sure the stream type is received
+		time.Sleep(scaleDuration(10 * time.Millisecond))
+		controlStr.CancelWrite(1337)
+	}
+
+	select {
+	case <-peerConn.Context().Done():
+		require.ErrorIs(t,
+			context.Cause(peerConn.Context()),
+			&quic.ApplicationError{Remote: true, ErrorCode: quic.ApplicationErrorCode(expectedErr)},
+		)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for close")
+	}
+}
+
+func TestClientConnHandleBidirectionalStream(t *testing.T) {
+	clientConn, serverConn := newConnPair(t)
+
+	cc := (&Transport{}).NewClientConn(clientConn)
+
+	str, err := clientConn.OpenStream()
+	require.NoError(t, err)
+	cc.HandleBidirectionalStream(str)
+
+	select {
+	case <-serverConn.Context().Done():
+		require.ErrorIs(t,
+			context.Cause(serverConn.Context()),
+			&quic.ApplicationError{Remote: true, ErrorCode: quic.ApplicationErrorCode(ErrCodeStreamCreationError)},
+		)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for connection close")
+	}
+}
+
+func TestRawClientConnHandleUnidirectionalStream(t *testing.T) {
+	clientConn, serverConn := newConnPair(t)
+
+	cc := (&Transport{}).NewRawClientConn(clientConn)
+
+	b := quicvarint.Append(nil, streamTypeControlStream)
+	b = (&settingsFrame{}).Append(b)
+	str, err := serverConn.OpenUniStream()
+	require.NoError(t, err)
+	_, err = str.Write(b)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	uniStr, err := clientConn.AcceptUniStream(ctx)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cc.HandleUnidirectionalStream(uniStr)
+	}()
+
+	select {
+	case <-cc.ReceivedSettings():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for settings")
+	}
+	require.NotNil(t, cc.Settings())
 }

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -6,308 +6,188 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
-	"net/http"
-	"net/http/httptrace"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3/qlog"
 	"github.com/quic-go/quic-go/qlogwriter"
 	"github.com/quic-go/quic-go/quicvarint"
-
-	"github.com/quic-go/qpack"
 )
 
 const maxQuarterStreamID = 1<<60 - 1
 
-var errGoAway = errors.New("connection in graceful shutdown")
-
 // invalidStreamID is a stream ID that is invalid. The first valid stream ID in QUIC is 0.
 const invalidStreamID = quic.StreamID(-1)
 
-// Conn is an HTTP/3 connection.
-// It has all methods from the quic.Conn expect for AcceptStream, AcceptUniStream,
-// SendDatagram and ReceiveDatagram.
-type Conn struct {
+// rawConn is an HTTP/3 connection.
+// It provides HTTP/3 specific functionality by wrapping a quic.Conn,
+// in particular handling of unidirectional HTTP/3 streams, SETTINGS and datagrams.
+type rawConn struct {
 	conn *quic.Conn
 
-	ctx context.Context
-
-	isServer bool
-	logger   *slog.Logger
+	logger *slog.Logger
 
 	enableDatagrams bool
 
-	decoder *qpack.Decoder
+	streamMx sync.Mutex
+	streams  map[quic.StreamID]*stateTrackingStream
 
-	streamMx     sync.Mutex
-	streams      map[quic.StreamID]*stateTrackingStream
-	lastStreamID quic.StreamID
-	maxStreamID  quic.StreamID
+	rcvdControlStr      atomic.Bool
+	rcvdQPACKEncoderStr atomic.Bool
+	rcvdQPACKDecoderStr atomic.Bool
+	controlStrHandler   func(*quic.ReceiveStream, *frameParser) // is called *after* the SETTINGS frame was parsed
+
+	onStreamsEmpty func()
 
 	settings         *Settings
 	receivedSettings chan struct{}
 
-	idleTimeout time.Duration
-	idleTimer   *time.Timer
-
 	qlogger qlogwriter.Recorder
 }
 
-func newConnection(
-	ctx context.Context,
+func newRawConn(
 	quicConn *quic.Conn,
 	enableDatagrams bool,
-	isServer bool,
+	onStreamsEmpty func(),
+	controlStrHandler func(*quic.ReceiveStream, *frameParser),
+	qlogger qlogwriter.Recorder,
 	logger *slog.Logger,
-	idleTimeout time.Duration,
-) *Conn {
-	var qlogger qlogwriter.Recorder
-	if qlogTrace := quicConn.QlogTrace(); qlogTrace != nil && qlogTrace.SupportsSchemas(qlog.EventSchema) {
-		qlogger = qlogTrace.AddProducer()
+) *rawConn {
+	return &rawConn{
+		conn:              quicConn,
+		logger:            logger,
+		enableDatagrams:   enableDatagrams,
+		receivedSettings:  make(chan struct{}),
+		streams:           make(map[quic.StreamID]*stateTrackingStream),
+		qlogger:           qlogger,
+		onStreamsEmpty:    onStreamsEmpty,
+		controlStrHandler: controlStrHandler,
 	}
-	c := &Conn{
-		ctx:              ctx,
-		conn:             quicConn,
-		isServer:         isServer,
-		logger:           logger,
-		idleTimeout:      idleTimeout,
-		enableDatagrams:  enableDatagrams,
-		decoder:          qpack.NewDecoder(),
-		receivedSettings: make(chan struct{}),
-		streams:          make(map[quic.StreamID]*stateTrackingStream),
-		maxStreamID:      invalidStreamID,
-		lastStreamID:     invalidStreamID,
-		qlogger:          qlogger,
-	}
-	if idleTimeout > 0 {
-		c.idleTimer = time.AfterFunc(idleTimeout, c.onIdleTimer)
-	}
-	return c
 }
 
-func (c *Conn) OpenStream() (*quic.Stream, error) {
-	return c.conn.OpenStream()
-}
-
-func (c *Conn) OpenStreamSync(ctx context.Context) (*quic.Stream, error) {
-	return c.conn.OpenStreamSync(ctx)
-}
-
-func (c *Conn) OpenUniStream() (*quic.SendStream, error) {
+func (c *rawConn) OpenUniStream() (*quic.SendStream, error) {
 	return c.conn.OpenUniStream()
 }
 
-func (c *Conn) OpenUniStreamSync(ctx context.Context) (*quic.SendStream, error) {
-	return c.conn.OpenUniStreamSync(ctx)
+// openControlStream opens the control stream and sends the SETTINGS frame.
+// It returns the control stream (needed by the server for sending GOAWAY later).
+func (c *rawConn) openControlStream(settings *settingsFrame) (*quic.SendStream, error) {
+	str, err := c.conn.OpenUniStream()
+	if err != nil {
+		return nil, err
+	}
+	b := make([]byte, 0, 64)
+	b = quicvarint.Append(b, streamTypeControlStream)
+	b = settings.Append(b)
+	if c.qlogger != nil {
+		sf := qlog.SettingsFrame{
+			MaxFieldSectionSize: settings.MaxFieldSectionSize,
+			Other:               maps.Clone(settings.Other),
+		}
+		if settings.Datagram {
+			sf.Datagram = pointer(true)
+		}
+		if settings.ExtendedConnect {
+			sf.ExtendedConnect = pointer(true)
+		}
+		c.qlogger.RecordEvent(qlog.FrameCreated{
+			StreamID: str.StreamID(),
+			Raw:      qlog.RawInfo{Length: len(b)},
+			Frame:    qlog.Frame{Frame: sf},
+		})
+	}
+	if _, err := str.Write(b); err != nil {
+		return nil, err
+	}
+	return str, nil
 }
 
-func (c *Conn) LocalAddr() net.Addr {
-	return c.conn.LocalAddr()
+func (c *rawConn) TrackStream(str *quic.Stream) *stateTrackingStream {
+	hstr := newStateTrackingStream(str, c, func(b []byte) error { return c.sendDatagram(str.StreamID(), b) })
+
+	c.streamMx.Lock()
+	c.streams[str.StreamID()] = hstr
+	c.streamMx.Unlock()
+	return hstr
 }
 
-func (c *Conn) RemoteAddr() net.Addr {
+func (c *rawConn) RemoteAddr() net.Addr {
 	return c.conn.RemoteAddr()
 }
 
-func (c *Conn) HandshakeComplete() <-chan struct{} {
-	return c.conn.HandshakeComplete()
-}
-
-func (c *Conn) ConnectionState() quic.ConnectionState {
+func (c *rawConn) ConnectionState() quic.ConnectionState {
 	return c.conn.ConnectionState()
 }
 
-func (c *Conn) onIdleTimer() {
-	c.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "idle timeout")
-}
-
-func (c *Conn) clearStream(id quic.StreamID) {
+func (c *rawConn) clearStream(id quic.StreamID) {
 	c.streamMx.Lock()
 	defer c.streamMx.Unlock()
 
 	delete(c.streams, id)
-	if c.idleTimeout > 0 && len(c.streams) == 0 {
-		c.idleTimer.Reset(c.idleTimeout)
-	}
-	// The server is performing a graceful shutdown.
-	// If no more streams are remaining, close the connection.
-	if c.maxStreamID != invalidStreamID {
-		if len(c.streams) == 0 {
-			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
-		}
+	if len(c.streams) == 0 {
+		c.onStreamsEmpty()
 	}
 }
 
-func (c *Conn) openRequestStream(
-	ctx context.Context,
-	requestWriter *requestWriter,
-	reqDone chan<- struct{},
-	disableCompression bool,
-	maxHeaderBytes int,
-) (*RequestStream, error) {
+func (c *rawConn) hasActiveStreams() bool {
 	c.streamMx.Lock()
-	maxStreamID := c.maxStreamID
-	var nextStreamID quic.StreamID
-	if c.lastStreamID == invalidStreamID {
-		nextStreamID = 0
-	} else {
-		nextStreamID = c.lastStreamID + 4
-	}
-	c.streamMx.Unlock()
-	// Streams with stream ID equal to or greater than the stream ID carried in the GOAWAY frame
-	// will be rejected, see section 5.2 of RFC 9114.
-	if maxStreamID != invalidStreamID && nextStreamID >= maxStreamID {
-		return nil, errGoAway
-	}
+	defer c.streamMx.Unlock()
 
-	str, err := c.OpenStreamSync(ctx)
-	if err != nil {
-		return nil, err
-	}
-	hstr := newStateTrackingStream(str, c, func(b []byte) error { return c.sendDatagram(str.StreamID(), b) })
-	c.streamMx.Lock()
-	c.streams[str.StreamID()] = hstr
-	c.lastStreamID = str.StreamID()
-	c.streamMx.Unlock()
-	rsp := &http.Response{}
-	trace := httptrace.ContextClientTrace(ctx)
-	return newRequestStream(
-		newStream(hstr, c, trace, func(r io.Reader, hf *headersFrame) error {
-			hdr, err := c.decodeTrailers(r, str.StreamID(), hf, maxHeaderBytes)
-			if err != nil {
-				return err
-			}
-			rsp.Trailer = hdr
-			return nil
-		}, c.qlogger),
-		requestWriter,
-		reqDone,
-		c.decoder,
-		disableCompression,
-		maxHeaderBytes,
-		rsp,
-	), nil
+	return len(c.streams) > 0
 }
 
-func (c *Conn) decodeTrailers(r io.Reader, streamID quic.StreamID, hf *headersFrame, maxHeaderBytes int) (http.Header, error) {
-	if hf.Length > uint64(maxHeaderBytes) {
-		maybeQlogInvalidHeadersFrame(c.qlogger, streamID, hf.Length)
-		return nil, fmt.Errorf("http3: HEADERS frame too large: %d bytes (max: %d)", hf.Length, maxHeaderBytes)
-	}
-
-	b := make([]byte, hf.Length)
-	if _, err := io.ReadFull(r, b); err != nil {
-		return nil, err
-	}
-	decodeFn := c.decoder.Decode(b)
-	var fields []qpack.HeaderField
-	if c.qlogger != nil {
-		fields = make([]qpack.HeaderField, 0, 16)
-	}
-	trailers, err := parseTrailers(decodeFn, &fields)
-	if err != nil {
-		maybeQlogInvalidHeadersFrame(c.qlogger, streamID, hf.Length)
-		return nil, err
-	}
-	if c.qlogger != nil {
-		qlogParsedHeadersFrame(c.qlogger, streamID, hf, fields)
-	}
-	return trailers, nil
-}
-
-// only used by the server
-func (c *Conn) acceptStream(ctx context.Context) (*stateTrackingStream, error) {
-	str, err := c.conn.AcceptStream(ctx)
-	if err != nil {
-		return nil, err
-	}
-	strID := str.StreamID()
-	hstr := newStateTrackingStream(str, c, func(b []byte) error { return c.sendDatagram(strID, b) })
-	c.streamMx.Lock()
-	c.streams[strID] = hstr
-	if c.idleTimeout > 0 {
-		if len(c.streams) == 1 {
-			c.idleTimer.Stop()
-		}
-	}
-	c.streamMx.Unlock()
-	return hstr, nil
-}
-
-func (c *Conn) CloseWithError(code quic.ApplicationErrorCode, msg string) error {
-	if c.idleTimer != nil {
-		c.idleTimer.Stop()
-	}
+func (c *rawConn) CloseWithError(code quic.ApplicationErrorCode, msg string) error {
 	return c.conn.CloseWithError(code, msg)
 }
 
-func (c *Conn) handleUnidirectionalStreams() {
-	var (
-		rcvdControlStr      atomic.Bool
-		rcvdQPACKEncoderStr atomic.Bool
-		rcvdQPACKDecoderStr atomic.Bool
-	)
-
-	for {
-		str, err := c.conn.AcceptUniStream(context.Background())
-		if err != nil {
-			if c.logger != nil {
-				c.logger.Debug("accepting unidirectional stream failed", "error", err)
-			}
-			return
+func (c *rawConn) handleUnidirectionalStream(str *quic.ReceiveStream, isServer bool) {
+	streamType, err := quicvarint.Read(quicvarint.NewReader(str))
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Debug("reading stream type on stream failed", "stream ID", str.StreamID(), "error", err)
 		}
-
-		go func(str *quic.ReceiveStream) {
-			streamType, err := quicvarint.Read(quicvarint.NewReader(str))
-			if err != nil {
-				if c.logger != nil {
-					c.logger.Debug("reading stream type on stream failed", "stream ID", str.StreamID(), "error", err)
-				}
-				return
-			}
-			// We're only interested in the control stream here.
-			switch streamType {
-			case streamTypeControlStream:
-			case streamTypeQPACKEncoderStream:
-				if isFirst := rcvdQPACKEncoderStr.CompareAndSwap(false, true); !isFirst {
-					c.CloseWithError(quic.ApplicationErrorCode(ErrCodeStreamCreationError), "duplicate QPACK encoder stream")
-				}
-				// Our QPACK implementation doesn't use the dynamic table yet.
-				return
-			case streamTypeQPACKDecoderStream:
-				if isFirst := rcvdQPACKDecoderStr.CompareAndSwap(false, true); !isFirst {
-					c.CloseWithError(quic.ApplicationErrorCode(ErrCodeStreamCreationError), "duplicate QPACK decoder stream")
-				}
-				// Our QPACK implementation doesn't use the dynamic table yet.
-				return
-			case streamTypePushStream:
-				if c.isServer {
-					// only the server can push
-					c.CloseWithError(quic.ApplicationErrorCode(ErrCodeStreamCreationError), "")
-				} else {
-					// we never increased the Push ID, so we don't expect any push streams
-					c.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
-				}
-				return
-			default:
-				str.CancelRead(quic.StreamErrorCode(ErrCodeStreamCreationError))
-				return
-			}
-			// Only a single control stream is allowed.
-			if isFirstControlStr := rcvdControlStr.CompareAndSwap(false, true); !isFirstControlStr {
-				c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeStreamCreationError), "duplicate control stream")
-				return
-			}
-			c.handleControlStream(str)
-		}(str)
+		return
 	}
+	// We're only interested in the control stream here.
+	switch streamType {
+	case streamTypeControlStream:
+	case streamTypeQPACKEncoderStream:
+		if isFirst := c.rcvdQPACKEncoderStr.CompareAndSwap(false, true); !isFirst {
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeStreamCreationError), "duplicate QPACK encoder stream")
+		}
+		// Our QPACK implementation doesn't use the dynamic table yet.
+		return
+	case streamTypeQPACKDecoderStream:
+		if isFirst := c.rcvdQPACKDecoderStr.CompareAndSwap(false, true); !isFirst {
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeStreamCreationError), "duplicate QPACK decoder stream")
+		}
+		// Our QPACK implementation doesn't use the dynamic table yet.
+		return
+	case streamTypePushStream:
+		if isServer {
+			// only the server can push
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeStreamCreationError), "")
+		} else {
+			// we never increased the Push ID, so we don't expect any push streams
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
+		}
+		return
+	default:
+		str.CancelRead(quic.StreamErrorCode(ErrCodeStreamCreationError))
+		return
+	}
+	// Only a single control stream is allowed.
+	if isFirstControlStr := c.rcvdControlStr.CompareAndSwap(false, true); !isFirstControlStr {
+		c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeStreamCreationError), "duplicate control stream")
+		return
+	}
+	c.handleControlStream(str)
 }
 
-func (c *Conn) handleControlStream(str *quic.ReceiveStream) {
+func (c *rawConn) handleControlStream(str *quic.ReceiveStream) {
 	fp := &frameParser{closeConn: c.conn.CloseWithError, r: str, streamID: str.StreamID()}
 	f, err := fp.ParseNext(c.qlogger)
 	if err != nil {
@@ -347,53 +227,12 @@ func (c *Conn) handleControlStream(str *quic.ReceiveStream) {
 		}()
 	}
 
-	// we don't support server push, hence we don't expect any GOAWAY frames from the client
-	if c.isServer {
-		return
-	}
-
-	for {
-		f, err := fp.ParseNext(c.qlogger)
-		if err != nil {
-			var serr *quic.StreamError
-			if err == io.EOF || errors.As(err, &serr) {
-				c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")
-				return
-			}
-			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameError), "")
-			return
-		}
-		// GOAWAY is the only frame allowed at this point:
-		// * unexpected frames are ignored by the frame parser
-		// * we don't support any extension that might add support for more frames
-		goaway, ok := f.(*goAwayFrame)
-		if !ok {
-			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
-			return
-		}
-		if goaway.StreamID%4 != 0 { // client-initiated, bidirectional streams
-			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
-			return
-		}
-		c.streamMx.Lock()
-		if c.maxStreamID != invalidStreamID && goaway.StreamID > c.maxStreamID {
-			c.streamMx.Unlock()
-			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
-			return
-		}
-		c.maxStreamID = goaway.StreamID
-		hasActiveStreams := len(c.streams) > 0
-		c.streamMx.Unlock()
-
-		// immediately close the connection if there are currently no active requests
-		if !hasActiveStreams {
-			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
-			return
-		}
+	if c.controlStrHandler != nil {
+		c.controlStrHandler(str, fp)
 	}
 }
 
-func (c *Conn) sendDatagram(streamID quic.StreamID, b []byte) error {
+func (c *rawConn) sendDatagram(streamID quic.StreamID, b []byte) error {
 	// TODO: this creates a lot of garbage and an additional copy
 	data := make([]byte, 0, len(b)+8)
 	quarterStreamID := uint64(streamID / 4)
@@ -411,7 +250,7 @@ func (c *Conn) sendDatagram(streamID quic.StreamID, b []byte) error {
 	return c.conn.SendDatagram(data)
 }
 
-func (c *Conn) receiveDatagrams() error {
+func (c *rawConn) receiveDatagrams() error {
 	for {
 		b, err := c.conn.ReceiveDatagram(context.Background())
 		if err != nil {
@@ -448,11 +287,11 @@ func (c *Conn) receiveDatagrams() error {
 
 // ReceivedSettings returns a channel that is closed once the peer's SETTINGS frame was received.
 // Settings can be optained from the Settings method after the channel was closed.
-func (c *Conn) ReceivedSettings() <-chan struct{} { return c.receivedSettings }
+func (c *rawConn) ReceivedSettings() <-chan struct{} { return c.receivedSettings }
 
 // Settings returns the settings received on this connection.
 // It is only valid to call this function after the channel returned by ReceivedSettings was closed.
-func (c *Conn) Settings() *Settings { return c.settings }
+func (c *rawConn) Settings() *Settings { return c.settings }
 
 // Context returns the context of the underlying QUIC connection.
-func (c *Conn) Context() context.Context { return c.ctx }
+func (c *rawConn) Context() context.Context { return c.conn.Context() }

--- a/http3/mock_clientconn_test.go
+++ b/http3/mock_clientconn_test.go
@@ -14,6 +14,7 @@ import (
 	http "net/http"
 	reflect "reflect"
 
+	quic "github.com/quic-go/quic-go"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -115,6 +116,42 @@ func (c *MockClientConnRoundTripCall) Do(f func(*http.Request) (*http.Response, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockClientConnRoundTripCall) DoAndReturn(f func(*http.Request) (*http.Response, error)) *MockClientConnRoundTripCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// handleUnidirectionalStream mocks base method.
+func (m *MockClientConn) handleUnidirectionalStream(arg0 *quic.ReceiveStream) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "handleUnidirectionalStream", arg0)
+}
+
+// handleUnidirectionalStream indicates an expected call of handleUnidirectionalStream.
+func (mr *MockClientConnMockRecorder) handleUnidirectionalStream(arg0 any) *MockClientConnhandleUnidirectionalStreamCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleUnidirectionalStream", reflect.TypeOf((*MockClientConn)(nil).handleUnidirectionalStream), arg0)
+	return &MockClientConnhandleUnidirectionalStreamCall{Call: call}
+}
+
+// MockClientConnhandleUnidirectionalStreamCall wrap *gomock.Call
+type MockClientConnhandleUnidirectionalStreamCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClientConnhandleUnidirectionalStreamCall) Return() *MockClientConnhandleUnidirectionalStreamCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClientConnhandleUnidirectionalStreamCall) Do(f func(*quic.ReceiveStream)) *MockClientConnhandleUnidirectionalStreamCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClientConnhandleUnidirectionalStreamCall) DoAndReturn(f func(*quic.ReceiveStream)) *MockClientConnhandleUnidirectionalStreamCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -27,7 +27,7 @@ const maxSmallResponseSize = 4096
 type responseWriter struct {
 	str *Stream
 
-	conn     *Conn
+	conn     *rawConn
 	header   http.Header
 	trailers map[string]struct{}
 	buf      []byte
@@ -63,7 +63,7 @@ var (
 	} = &responseWriter{}
 )
 
-func newResponseWriter(str *Stream, conn *Conn, isHead bool, logger *slog.Logger) *responseWriter {
+func newResponseWriter(str *Stream, conn *rawConn, isHead bool, logger *slog.Logger) *responseWriter {
 	return &responseWriter{
 		str:    str,
 		conn:   conn,

--- a/http3/server.go
+++ b/http3/server.go
@@ -7,12 +7,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"net"
 	"net/http"
-	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -21,9 +18,6 @@ import (
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3/qlog"
 	"github.com/quic-go/quic-go/qlogwriter"
-	"github.com/quic-go/quic-go/quicvarint"
-
-	"github.com/quic-go/qpack"
 )
 
 // NextProtoH3 is the ALPN protocol negotiated during the TLS handshake, for QUIC v1 and v2.
@@ -423,45 +417,19 @@ func (s *Server) removeListener(l *QUICListener) {
 	s.generateAltSvcHeader()
 }
 
-// handleConn handles the HTTP/3 exchange on a QUIC connection.
-// It blocks until all HTTP handlers for all streams have returned.
-func (s *Server) handleConn(conn *quic.Conn) error {
+func (s *Server) NewRawServerConn(conn *quic.Conn) (*RawServerConn, error) {
+	hconn, _, _, err := s.newRawServerConn(conn)
+	if err != nil {
+		return nil, err
+	}
+	return hconn, nil
+}
+
+func (s *Server) newRawServerConn(conn *quic.Conn) (*RawServerConn, *quic.SendStream, qlogwriter.Recorder, error) {
 	var qlogger qlogwriter.Recorder
 	if qlogTrace := conn.QlogTrace(); qlogTrace != nil && qlogTrace.SupportsSchemas(qlog.EventSchema) {
 		qlogger = qlogTrace.AddProducer()
 	}
-
-	// open the control stream and send a SETTINGS frame, it's also used to send a GOAWAY frame later
-	// when the server is gracefully closed
-	ctrlStr, err := conn.OpenUniStream()
-	if err != nil {
-		return fmt.Errorf("opening the control stream failed: %w", err)
-	}
-	b := make([]byte, 0, 64)
-	b = quicvarint.Append(b, streamTypeControlStream) // stream type
-	b = (&settingsFrame{
-		MaxFieldSectionSize: int64(s.maxHeaderBytes()),
-		Datagram:            s.EnableDatagrams,
-		ExtendedConnect:     true,
-		Other:               s.AdditionalSettings,
-	}).Append(b)
-	if qlogger != nil {
-		sf := qlog.SettingsFrame{
-			MaxFieldSectionSize: int64(s.maxHeaderBytes()),
-			ExtendedConnect:     pointer(true),
-			Other:               maps.Clone(s.AdditionalSettings),
-		}
-		if s.EnableDatagrams {
-			sf.Datagram = pointer(true)
-		}
-		qlogger.RecordEvent(qlog.FrameCreated{
-			StreamID: ctrlStr.StreamID(),
-			Raw:      qlog.RawInfo{Length: len(b)},
-			Frame:    qlog.Frame{Frame: sf},
-		})
-	}
-	ctrlStr.Write(b)
-
 	connCtx := conn.Context()
 	connCtx = context.WithValue(connCtx, ServerContextKey, s)
 	connCtx = context.WithValue(connCtx, http.LocalAddrContextKey, conn.LocalAddr())
@@ -472,19 +440,54 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 			panic("http3: ConnContext returned nil")
 		}
 	}
-
-	hconn := newConnection(
-		connCtx,
+	hconn := newRawServerConn(
 		conn,
 		s.EnableDatagrams,
-		true, // server
-		s.Logger,
 		s.IdleTimeout,
+		qlogger,
+		s.Logger,
+		connCtx,
+		s.Handler,
+		s.maxHeaderBytes(),
 	)
-	go hconn.handleUnidirectionalStreams()
+
+	// open the control stream and send a SETTINGS frame, it's also used to send a GOAWAY frame later
+	// when the server is gracefully closed
+	ctrlStr, err := hconn.openControlStream(&settingsFrame{
+		MaxFieldSectionSize: int64(s.maxHeaderBytes()),
+		Datagram:            s.EnableDatagrams,
+		ExtendedConnect:     true,
+		Other:               s.AdditionalSettings,
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("opening the control stream failed: %w", err)
+	}
+	return hconn, ctrlStr, qlogger, nil
+}
+
+// handleConn handles the HTTP/3 exchange on a QUIC connection.
+// It blocks until all HTTP handlers for all streams have returned.
+func (s *Server) handleConn(conn *quic.Conn) error {
+	hconn, ctrlStr, qlogger, err := s.newRawServerConn(conn)
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for {
+			str, err := conn.AcceptUniStream(context.Background())
+			if err != nil {
+				return
+			}
+			go hconn.HandleUnidirectionalStream(str)
+		}
+	}()
 
 	var nextStreamID quic.StreamID
-	var wg sync.WaitGroup
 	var handleErr error
 	var inGracefulShutdown bool
 	// Process all requests immediately.
@@ -495,10 +498,10 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 		// * before graceful shutdown: s.graceCtx
 		// * after graceful shutdown: s.closeCtx
 		// This allows us to keep accepting (and resetting) streams after graceful shutdown has started.
-		str, err := hconn.acceptStream(ctx)
+		str, err := conn.AcceptStream(ctx)
 		if err != nil {
 			// the underlying connection was closed (by either side)
-			if hconn.Context().Err() != nil {
+			if conn.Context().Err() != nil {
 				var appErr *quic.ApplicationError
 				if !errors.As(err, &appErr) || appErr.ErrorCode != quic.ApplicationErrorCode(ErrCodeNoError) {
 					handleErr = fmt.Errorf("accepting stream failed: %w", err)
@@ -507,7 +510,7 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 			}
 			// server (not gracefully) closed, close the connection immediately
 			if s.closeCtx.Err() != nil {
-				conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
+				hconn.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
 				handleErr = http.ErrServerClosed
 				break
 			}
@@ -548,10 +551,10 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 		nextStreamID = str.StreamID() + 4
 		wg.Add(1)
 		go func() {
-			// handleRequest will return once the request has been handled,
-			// or the underlying connection is closed
+			// HandleRequestStream will return once the request has been handled,
+			// or the underlying connection is closed.
 			defer wg.Done()
-			s.handleRequest(hconn, str, hconn.decoder, qlogger)
+			hconn.HandleRequestStream(str)
 		}()
 	}
 	wg.Wait()
@@ -563,158 +566,6 @@ func (s *Server) maxHeaderBytes() int {
 		return http.DefaultMaxHeaderBytes
 	}
 	return s.MaxHeaderBytes
-}
-
-func (s *Server) handleRequest(
-	conn *Conn,
-	str *stateTrackingStream,
-	decoder *qpack.Decoder,
-	qlogger qlogwriter.Recorder,
-) {
-	fp := &frameParser{closeConn: conn.CloseWithError, r: str}
-	frame, err := fp.ParseNext(qlogger)
-	if err != nil {
-		str.CancelRead(quic.StreamErrorCode(ErrCodeRequestIncomplete))
-		str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestIncomplete))
-		return
-	}
-	hf, ok := frame.(*headersFrame)
-	if !ok {
-		conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "expected first frame to be a HEADERS frame")
-		return
-	}
-	if hf.Length > uint64(s.maxHeaderBytes()) {
-		maybeQlogInvalidHeadersFrame(qlogger, str.StreamID(), hf.Length)
-		// stop the client from sending more data
-		str.CancelRead(quic.StreamErrorCode(ErrCodeExcessiveLoad))
-		// send a 431 Response (Request Header Fields Too Large)
-		s.rejectWithHeaderFieldsTooLarge(str, conn, qlogger)
-		return
-	}
-	headerBlock := make([]byte, hf.Length)
-	if _, err := io.ReadFull(str, headerBlock); err != nil {
-		maybeQlogInvalidHeadersFrame(qlogger, str.StreamID(), hf.Length)
-		str.CancelRead(quic.StreamErrorCode(ErrCodeRequestIncomplete))
-		str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestIncomplete))
-		return
-	}
-	decodeFn := decoder.Decode(headerBlock)
-	var hfs []qpack.HeaderField
-	if qlogger != nil {
-		hfs = make([]qpack.HeaderField, 0, 16)
-	}
-	req, err := requestFromHeaders(decodeFn, s.maxHeaderBytes(), &hfs)
-	if qlogger != nil {
-		qlogParsedHeadersFrame(qlogger, str.StreamID(), hf, hfs)
-	}
-	if err != nil {
-		if errors.Is(err, errHeaderTooLarge) {
-			// stop the client from sending more data
-			str.CancelRead(quic.StreamErrorCode(ErrCodeExcessiveLoad))
-			// send a 431 Response (Request Header Fields Too Large)
-			s.rejectWithHeaderFieldsTooLarge(str, conn, qlogger)
-			return
-		}
-
-		errCode := ErrCodeMessageError
-		var qpackErr *qpackError
-		if errors.As(err, &qpackErr) {
-			errCode = ErrCodeQPACKDecompressionFailed
-		}
-		str.CancelRead(quic.StreamErrorCode(errCode))
-		str.CancelWrite(quic.StreamErrorCode(errCode))
-		return
-	}
-
-	connState := conn.ConnectionState().TLS
-	req.TLS = &connState
-	req.RemoteAddr = conn.RemoteAddr().String()
-
-	// Check that the client doesn't send more data in DATA frames than indicated by the Content-Length header (if set).
-	// See section 4.1.2 of RFC 9114.
-	contentLength := int64(-1)
-	if _, ok := req.Header["Content-Length"]; ok && req.ContentLength >= 0 {
-		contentLength = req.ContentLength
-	}
-	hstr := newStream(str, conn, nil, func(r io.Reader, hf *headersFrame) error {
-		trailers, err := conn.decodeTrailers(r, str.StreamID(), hf, s.maxHeaderBytes())
-		if err != nil {
-			return err
-		}
-		req.Trailer = trailers
-		return nil
-	}, qlogger)
-	body := newRequestBody(hstr, contentLength, conn.Context(), conn.ReceivedSettings(), conn.Settings)
-	req.Body = body
-
-	if s.Logger != nil {
-		s.Logger.Debug("handling request", "method", req.Method, "host", req.Host, "uri", req.RequestURI)
-	}
-
-	ctx, cancel := context.WithCancel(conn.Context())
-	req = req.WithContext(ctx)
-	context.AfterFunc(str.Context(), cancel)
-
-	r := newResponseWriter(hstr, conn, req.Method == http.MethodHead, s.Logger)
-	handler := s.Handler
-	if handler == nil {
-		handler = http.DefaultServeMux
-	}
-
-	// It's the client's responsibility to decide which requests are eligible for 0-RTT.
-	var panicked bool
-	func() {
-		defer func() {
-			if p := recover(); p != nil {
-				panicked = true
-				if p == http.ErrAbortHandler {
-					return
-				}
-				// Copied from net/http/server.go
-				const size = 64 << 10
-				buf := make([]byte, size)
-				buf = buf[:runtime.Stack(buf, false)]
-				logger := s.Logger
-				if logger == nil {
-					logger = slog.Default()
-				}
-				logger.Error("http3: panic serving", "arg", p, "trace", string(buf))
-			}
-		}()
-		handler.ServeHTTP(r, req)
-	}()
-
-	if r.wasStreamHijacked() {
-		return
-	}
-
-	// abort the stream when there is a panic
-	if panicked {
-		str.CancelRead(quic.StreamErrorCode(ErrCodeInternalError))
-		str.CancelWrite(quic.StreamErrorCode(ErrCodeInternalError))
-		return
-	}
-
-	// response not written to the client yet, set Content-Length
-	if !r.headerWritten {
-		if _, haveCL := r.header["Content-Length"]; !haveCL {
-			r.header.Set("Content-Length", strconv.FormatInt(r.numWritten, 10))
-		}
-	}
-	r.Flush()
-	r.flushTrailers()
-
-	// If the EOF was read by the handler, CancelRead() is a no-op.
-	str.CancelRead(quic.StreamErrorCode(ErrCodeNoError))
-	str.Close()
-}
-
-func (s *Server) rejectWithHeaderFieldsTooLarge(str *stateTrackingStream, conn *Conn, qlogger qlogwriter.Recorder) {
-	hstr := newStream(str, conn, nil, nil, qlogger)
-	defer hstr.Close()
-	r := newResponseWriter(hstr, conn, false, s.Logger)
-	r.WriteHeader(http.StatusRequestHeaderFieldsTooLarge)
-	r.Flush()
 }
 
 // Close the server immediately, aborting requests and sending CONNECTION_CLOSE frames to connected clients.

--- a/http3/server_conn.go
+++ b/http3/server_conn.go
@@ -1,0 +1,261 @@
+package http3
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/quic-go/qpack"
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/qlogwriter"
+)
+
+// RawServerConn is an HTTP/3 server connection.
+// It can be used for advanced use cases where the application wants to manage the QUIC connection lifecycle.
+type RawServerConn struct {
+	rawConn rawConn
+
+	idleTimeout time.Duration
+	idleTimer   *time.Timer
+
+	serverContext  context.Context
+	requestHandler http.Handler
+	maxHeaderBytes int
+
+	decoder *qpack.Decoder
+
+	qlogger qlogwriter.Recorder
+	logger  *slog.Logger
+}
+
+func newRawServerConn(
+	conn *quic.Conn,
+	enableDatagrams bool,
+	idleTimeout time.Duration,
+	qlogger qlogwriter.Recorder,
+	logger *slog.Logger,
+	serverContext context.Context,
+	requestHandler http.Handler,
+	maxHeaderBytes int,
+) *RawServerConn {
+	c := &RawServerConn{
+		idleTimeout:    idleTimeout,
+		serverContext:  serverContext,
+		requestHandler: requestHandler,
+		maxHeaderBytes: maxHeaderBytes,
+		decoder:        qpack.NewDecoder(),
+		qlogger:        qlogger,
+		logger:         logger,
+	}
+	c.rawConn = *newRawConn(conn, enableDatagrams, c.onStreamsEmpty, nil, qlogger, logger)
+	if idleTimeout > 0 {
+		c.idleTimer = time.AfterFunc(idleTimeout, c.onIdleTimer)
+	}
+	return c
+}
+
+func (c *RawServerConn) onStreamsEmpty() {
+	if c.idleTimeout > 0 {
+		c.idleTimer.Reset(c.idleTimeout)
+	}
+}
+
+func (c *RawServerConn) onIdleTimer() {
+	c.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "idle timeout")
+}
+
+// CloseWithError closes the connection with the given error code and message.
+func (c *RawServerConn) CloseWithError(code quic.ApplicationErrorCode, msg string) error {
+	if c.idleTimer != nil {
+		c.idleTimer.Stop()
+	}
+	return c.rawConn.CloseWithError(code, msg)
+}
+
+// HandleRequestStream handles an HTTP/3 request on a bidirectional request stream.
+// The stream can either be obtained by calling AcceptStream on the underlying QUIC connection,
+// or (internally) by using the server's stream accept loop.
+func (c *RawServerConn) HandleRequestStream(str *quic.Stream) {
+	hstr := c.rawConn.TrackStream(str)
+	c.handleRequestStream(hstr)
+}
+
+func (c *RawServerConn) requestMaxHeaderBytes() int {
+	if c.maxHeaderBytes <= 0 {
+		return http.DefaultMaxHeaderBytes
+	}
+	return c.maxHeaderBytes
+}
+
+func (c *RawServerConn) openControlStream(settings *settingsFrame) (*quic.SendStream, error) {
+	return c.rawConn.openControlStream(settings)
+}
+
+func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
+	if c.idleTimeout > 0 {
+		// This only applies if the stream is the first active stream,
+		// but it's ok to stop a stopped timer.
+		c.idleTimer.Stop()
+	}
+
+	conn := &c.rawConn
+	qlogger := c.qlogger
+	decoder := c.decoder
+	connCtx := c.serverContext
+	maxHeaderBytes := c.requestMaxHeaderBytes()
+
+	fp := &frameParser{closeConn: conn.CloseWithError, r: str, streamID: str.StreamID()}
+	frame, err := fp.ParseNext(qlogger)
+	if err != nil {
+		str.CancelRead(quic.StreamErrorCode(ErrCodeRequestIncomplete))
+		str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestIncomplete))
+		return
+	}
+	hf, ok := frame.(*headersFrame)
+	if !ok {
+		conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "expected first frame to be a HEADERS frame")
+		return
+	}
+	if hf.Length > uint64(maxHeaderBytes) {
+		maybeQlogInvalidHeadersFrame(qlogger, str.StreamID(), hf.Length)
+		// stop the client from sending more data
+		str.CancelRead(quic.StreamErrorCode(ErrCodeExcessiveLoad))
+		// send a 431 Response (Request Header Fields Too Large)
+		c.rejectWithHeaderFieldsTooLarge(str)
+		return
+	}
+	headerBlock := make([]byte, hf.Length)
+	if _, err := io.ReadFull(str, headerBlock); err != nil {
+		maybeQlogInvalidHeadersFrame(qlogger, str.StreamID(), hf.Length)
+		str.CancelRead(quic.StreamErrorCode(ErrCodeRequestIncomplete))
+		str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestIncomplete))
+		return
+	}
+	decodeFn := decoder.Decode(headerBlock)
+	var hfs []qpack.HeaderField
+	if qlogger != nil {
+		hfs = make([]qpack.HeaderField, 0, 16)
+	}
+	req, err := requestFromHeaders(decodeFn, maxHeaderBytes, &hfs)
+	if qlogger != nil {
+		qlogParsedHeadersFrame(qlogger, str.StreamID(), hf, hfs)
+	}
+	if err != nil {
+		if errors.Is(err, errHeaderTooLarge) {
+			// stop the client from sending more data
+			str.CancelRead(quic.StreamErrorCode(ErrCodeExcessiveLoad))
+			// send a 431 Response (Request Header Fields Too Large)
+			c.rejectWithHeaderFieldsTooLarge(str)
+			return
+		}
+
+		errCode := ErrCodeMessageError
+		var qpackErr *qpackError
+		if errors.As(err, &qpackErr) {
+			errCode = ErrCodeQPACKDecompressionFailed
+		}
+		str.CancelRead(quic.StreamErrorCode(errCode))
+		str.CancelWrite(quic.StreamErrorCode(errCode))
+		return
+	}
+
+	connState := conn.ConnectionState().TLS
+	req.TLS = &connState
+	req.RemoteAddr = conn.RemoteAddr().String()
+
+	// Check that the client doesn't send more data in DATA frames than indicated by the Content-Length header (if set).
+	// See section 4.1.2 of RFC 9114.
+	contentLength := int64(-1)
+	if _, ok := req.Header["Content-Length"]; ok && req.ContentLength >= 0 {
+		contentLength = req.ContentLength
+	}
+	hstr := newStream(str, conn, nil, func(r io.Reader, hf *headersFrame) error {
+		trailers, err := decodeTrailers(r, hf, maxHeaderBytes, decoder, qlogger, str.StreamID())
+		if err != nil {
+			return err
+		}
+		req.Trailer = trailers
+		return nil
+	}, qlogger)
+	body := newRequestBody(hstr, contentLength, connCtx, conn.ReceivedSettings(), conn.Settings)
+	req.Body = body
+
+	if c.logger != nil {
+		c.logger.Debug("handling request", "method", req.Method, "host", req.Host, "uri", req.RequestURI)
+	}
+
+	ctx, cancel := context.WithCancel(connCtx)
+	req = req.WithContext(ctx)
+	context.AfterFunc(str.Context(), cancel)
+
+	r := newResponseWriter(hstr, conn, req.Method == http.MethodHead, c.logger)
+	handler := c.requestHandler
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+
+	// It's the client's responsibility to decide which requests are eligible for 0-RTT.
+	var panicked bool
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				panicked = true
+				if p == http.ErrAbortHandler {
+					return
+				}
+				// Copied from net/http/server.go
+				const size = 64 << 10
+				buf := make([]byte, size)
+				buf = buf[:runtime.Stack(buf, false)]
+				logger := c.logger
+				if logger == nil {
+					logger = slog.Default()
+				}
+				logger.Error("http3: panic serving", "arg", p, "trace", string(buf))
+			}
+		}()
+		handler.ServeHTTP(r, req)
+	}()
+
+	if r.wasStreamHijacked() {
+		return
+	}
+
+	// abort the stream when there is a panic
+	if panicked {
+		str.CancelRead(quic.StreamErrorCode(ErrCodeInternalError))
+		str.CancelWrite(quic.StreamErrorCode(ErrCodeInternalError))
+		return
+	}
+
+	// response not written to the client yet, set Content-Length
+	if !r.headerWritten {
+		if _, haveCL := r.header["Content-Length"]; !haveCL {
+			r.header.Set("Content-Length", strconv.FormatInt(r.numWritten, 10))
+		}
+	}
+	r.Flush()
+	r.flushTrailers()
+
+	// If the EOF was read by the handler, CancelRead() is a no-op.
+	str.CancelRead(quic.StreamErrorCode(ErrCodeNoError))
+	str.Close()
+}
+
+func (c *RawServerConn) rejectWithHeaderFieldsTooLarge(str *stateTrackingStream) {
+	hstr := newStream(str, &c.rawConn, nil, nil, c.qlogger)
+	defer hstr.Close()
+	r := newResponseWriter(hstr, &c.rawConn, false, c.logger)
+	r.WriteHeader(http.StatusRequestHeaderFieldsTooLarge)
+	r.Flush()
+}
+
+// HandleUnidirectionalStream handles an incoming unidirectional stream.
+func (c *RawServerConn) HandleUnidirectionalStream(str *quic.ReceiveStream) {
+	c.rawConn.handleUnidirectionalStream(str, true)
+}

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -36,7 +36,7 @@ type datagramStream interface {
 // When writing to and reading from the stream, data is framed in HTTP/3 DATA frames.
 type Stream struct {
 	datagramStream
-	conn        *Conn
+	conn        *rawConn
 	frameParser *frameParser
 
 	buf []byte // used as a temporary buffer when writing the HTTP/3 frame headers
@@ -51,7 +51,7 @@ type Stream struct {
 
 func newStream(
 	str datagramStream,
-	conn *Conn,
+	conn *rawConn,
 	trace *httptrace.ClientTrace,
 	parseTrailer func(io.Reader, *headersFrame) error,
 	qlogger qlogwriter.Recorder,
@@ -319,7 +319,7 @@ func (s *RequestStream) sendRequestTrailer(req *http.Request) error {
 // It is invalid to call it after Read has been called.
 func (s *RequestStream) ReadResponse() (*http.Response, error) {
 	if !s.sentRequest {
-		return nil, errors.New("http3: invalid duplicate use of RequestStream.ReadResponse before SendRequestHeader")
+		return nil, errors.New("http3: invalid use of RequestStream.ReadResponse before SendRequestHeader")
 	}
 	frame, err := s.str.frameParser.ParseNext(s.str.qlogger)
 	if err != nil {

--- a/http3/transport.go
+++ b/http3/transport.go
@@ -40,6 +40,7 @@ type RoundTripOpt struct {
 type clientConn interface {
 	OpenRequestStream(context.Context) (*RequestStream, error)
 	RoundTrip(*http.Request) (*http.Response, error)
+	handleUnidirectionalStream(*quic.ReceiveStream)
 }
 
 type roundTripperWithCount struct {
@@ -383,7 +384,17 @@ func (t *Transport) dial(ctx context.Context, hostname string) (*quic.Conn, clie
 	if err != nil {
 		return nil, nil, err
 	}
-	return conn, t.newClientConn(conn), nil
+	clientConn := t.newClientConn(conn)
+	go func() {
+		for {
+			str, err := conn.AcceptUniStream(context.Background())
+			if err != nil {
+				return
+			}
+			go clientConn.handleUnidirectionalStream(str)
+		}
+	}()
+	return conn, clientConn, nil
 }
 
 func (t *Transport) resolveUDPAddr(ctx context.Context, network, addr string) (*net.UDPAddr, error) {
@@ -421,7 +432,7 @@ func (t *Transport) removeClient(hostname string) {
 // Obtaining a ClientConn is only needed for more advanced use cases, such as
 // using Extended CONNECT for WebTransport or the various MASQUE protocols.
 func (t *Transport) NewClientConn(conn *quic.Conn) *ClientConn {
-	return newClientConn(
+	c := newClientConn(
 		conn,
 		t.EnableDatagrams,
 		t.AdditionalSettings,
@@ -429,6 +440,33 @@ func (t *Transport) NewClientConn(conn *quic.Conn) *ClientConn {
 		t.DisableCompression,
 		t.Logger,
 	)
+	go func() {
+		for {
+			str, err := conn.AcceptUniStream(context.Background())
+			if err != nil {
+				return
+			}
+			go c.handleUnidirectionalStream(str)
+		}
+	}()
+	return c
+}
+
+// NewRawClientConn creates a new low-level HTTP/3 client connection on top of a QUIC connection.
+// Unlike NewClientConn, the returned RawClientConn allows the application to take control
+// of the stream accept loops, by calling HandleUnidirectionalStream for incoming unidirectional
+// streams and HandleBidirectionalStream for incoming bidirectional streams.
+func (t *Transport) NewRawClientConn(conn *quic.Conn) *RawClientConn {
+	return &RawClientConn{
+		ClientConn: newClientConn(
+			conn,
+			t.EnableDatagrams,
+			t.AdditionalSettings,
+			t.MaxResponseHeaderBytes,
+			t.DisableCompression,
+			t.Logger,
+		),
+	}
 }
 
 // Close closes the QUIC connections that this Transport has used.

--- a/http3/transport_test.go
+++ b/http3/transport_test.go
@@ -551,9 +551,10 @@ func TestTransportCloseIdleConnections(t *testing.T) {
 
 func TestTransportClose(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
+	conn, _ := newConnPair(t)
 	tr := &Transport{
 		Dial: func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
-			return nil, nil
+			return conn, nil
 		},
 		newClientConn: func(*quic.Conn) clientConn {
 			cl := NewMockClientConn(mockCtrl)

--- a/integrationtests/self/http_raw_conn_test.go
+++ b/integrationtests/self/http_raw_conn_test.go
@@ -1,0 +1,174 @@
+package self_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/internal/synctest"
+	"github.com/quic-go/quic-go/quicvarint"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This test tests the HTTP/3 raw connection functionality,
+// which is primarily used by WebTransport.
+func TestHTTPRawConn(t *testing.T) {
+	const magicValue = 0x123456
+
+	synctest.Test(t, func(t *testing.T) {
+		const rtt = 10 * time.Millisecond
+
+		clientPacketConn, serverPacketConn, closeFn := newSimnetLink(t, rtt)
+		defer closeFn(t)
+
+		ln, err := quic.ListenEarly(
+			serverPacketConn,
+			http3.ConfigureTLSConfig(getTLSConfig()),
+			getQuicConfig(&quic.Config{EnableDatagrams: true}),
+		)
+		require.NoError(t, err)
+		defer ln.Close()
+
+		start := time.Now()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/data", func(w http.ResponseWriter, r *http.Request) { w.Write(PRData) })
+		server := &http3.Server{
+			Handler:         mux,
+			EnableDatagrams: true,
+		}
+		defer server.Close()
+
+		// run the server in a separate Goroutine, so we can make sure that SETTINGS are sent in 0.5-RTT data
+		errChan := make(chan error, 1)
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			serverConn, err := ln.Accept(ctx)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			rawServerConn, err := server.NewRawServerConn(serverConn)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			var wg sync.WaitGroup
+			wg.Add(2)
+			// accept and handle unidirectional streams opened by the client
+			go func() {
+				defer wg.Done()
+				for {
+					str, err := serverConn.AcceptUniStream(context.Background())
+					if err != nil {
+						return
+					}
+					go rawServerConn.HandleUnidirectionalStream(str)
+				}
+			}()
+			// accept and handle bidirectional streams opened by the client
+			go func() {
+				defer wg.Done()
+				for {
+					str, err := serverConn.AcceptStream(context.Background())
+					if err != nil {
+						return
+					}
+					v, _ := quicvarint.Peek(str)
+					if v == magicValue {
+						go func() {
+							// read the previously peeked value
+							quicvarint.Read(quicvarint.NewReader(str))
+							defer str.Close()
+							io.Copy(str, str)
+						}()
+					} else {
+						go rawServerConn.HandleRequestStream(str)
+					}
+				}
+			}()
+			wg.Wait()
+			<-serverConn.Context().Done()
+			errChan <- nil
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+		defer cancel()
+		clientConn, err := quic.Dial(
+			ctx,
+			clientPacketConn,
+			serverPacketConn.LocalAddr(),
+			http3.ConfigureTLSConfig(getTLSClientConfig()),
+			getQuicConfig(&quic.Config{EnableDatagrams: true}),
+		)
+		require.NoError(t, err)
+		defer clientConn.CloseWithError(0, "")
+
+		tr := &http3.Transport{
+			EnableDatagrams: true,
+		}
+		rawClientConn := tr.NewRawClientConn(clientConn)
+		// accept and handle unidirectional streams opened by the server
+		go func() {
+			for {
+				str, err := clientConn.AcceptUniStream(ctx)
+				if err != nil {
+					return
+				}
+				go rawClientConn.HandleUnidirectionalStream(str)
+			}
+		}()
+
+		select {
+		case <-rawClientConn.ReceivedSettings():
+			settings := rawClientConn.Settings()
+			require.True(t, settings.EnableDatagrams)
+			// the server sends SETTINGS in 0.5-RTT data, so they should be received after 1 RTT
+			require.Equal(t, rtt, time.Since(start))
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for HTTP/3 settings")
+		}
+
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/data", serverPacketConn.LocalAddr().(*net.UDPAddr)), nil)
+		require.NoError(t, err)
+		reqStr, err := rawClientConn.OpenRequestStream(ctx)
+		require.NoError(t, err)
+		require.NoError(t, reqStr.SendRequestHeader(req))
+		resp, err := reqStr.ReadResponse()
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		data, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, PRData, data)
+		require.NoError(t, resp.Body.Close())
+
+		str, err := clientConn.OpenStream()
+		require.NoError(t, err)
+		b := quicvarint.Append(nil, magicValue)
+		b = append(b, []byte("lorem ipsum dolor sit amet")...)
+		_, err = str.Write(b)
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+		data, err = io.ReadAll(str)
+		require.NoError(t, err)
+		require.Equal(t, []byte("lorem ipsum dolor sit amet"), data)
+
+		clientConn.CloseWithError(0, "")
+		select {
+		case err := <-errChan:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for server to close")
+		}
+	})
+}


### PR DESCRIPTION
This API will be used by WebTransport.

Fixes #4405.