### PR TITLE
remove deprecated ConnectionTracingID and ConnectionTracingKey

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -99,9 +99,6 @@ func (e *errCloseForRecreating) Error() string {
 
 var deadlineSendImmediately = monotime.Time(42 * time.Millisecond) // any value > time.Time{} and before time.Now() is fine
 
-var connTracingID atomic.Uint64              // to be accessed atomically
-func nextConnTracingID() ConnectionTracingID { return ConnectionTracingID(connTracingID.Add(1)) }
-
 type blockMode uint8
 
 const (

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -899,16 +899,11 @@ func TestHTTPConnContext(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var tracingID quic.ConnectionTracingID
 	select {
 	case ctx := <-connCtxChan:
 		serv, ok := ctx.Value(http3.ServerContextKey).(*http3.Server)
 		require.True(t, ok)
 		require.Equal(t, server, serv)
-
-		id, ok := ctx.Value(quic.ConnectionTracingKey).(quic.ConnectionTracingID)
-		require.True(t, ok)
-		tracingID = id
 	default:
 		t.Fatal("handler was not called")
 	}
@@ -922,10 +917,6 @@ func TestHTTPConnContext(t *testing.T) {
 		serv, ok := ctx.Value(http3.ServerContextKey).(*http3.Server)
 		require.True(t, ok)
 		require.Equal(t, server, serv)
-
-		id, ok := ctx.Value(quic.ConnectionTracingKey).(quic.ConnectionTracingID)
-		require.True(t, ok)
-		require.Equal(t, tracingID, id)
 	default:
 		t.Fatal("handler was not called")
 	}

--- a/interface.go
+++ b/interface.go
@@ -58,20 +58,6 @@ type TokenStore interface {
 // when the server rejects a 0-RTT connection attempt.
 var Err0RTTRejected = errors.New("0-RTT rejected")
 
-// ConnectionTracingKey can be used to associate a [logging.ConnectionTracer] with a [Conn].
-// It is set on the Conn.Context() context,
-// as well as on the context passed to logging.Tracer.NewConnectionTracer.
-//
-// Deprecated: Applications can set their own tracing key using Transport.ConnContext.
-var ConnectionTracingKey = connTracingCtxKey{}
-
-// ConnectionTracingID is the type of the context value saved under the ConnectionTracingKey.
-//
-// Deprecated: Applications can set their own tracing key using Transport.ConnContext.
-type ConnectionTracingID uint64
-
-type connTracingCtxKey struct{}
-
 // QUICVersionContextKey can be used to find out the QUIC version of a TLS handshake from the
 // context returned by tls.Config.ClientInfo.Context.
 var QUICVersionContextKey = handshake.QUICVersionContextKey

--- a/server.go
+++ b/server.go
@@ -800,7 +800,6 @@ func (s *baseServer) handleInitialImpl(p receivedPacket, hdr *wire.Header) error
 	} else {
 		cancel = cancel1
 	}
-	ctx = context.WithValue(ctx, ConnectionTracingKey, nextConnTracingID())
 	var qlogTrace qlogwriter.Trace
 	if config.Tracer != nil {
 		// Use the same connection ID that is passed to the client's GetLogWriter callback.

--- a/transport.go
+++ b/transport.go
@@ -283,9 +283,6 @@ func (t *Transport) doDial(
 		return nil, err
 	}
 
-	tracingID := nextConnTracingID()
-	ctx = context.WithValue(ctx, ConnectionTracingKey, tracingID)
-
 	t.mutex.Lock()
 	if t.closeErr != nil {
 		t.mutex.Unlock()


### PR DESCRIPTION
Now that we have a new API for WebTransport (#4405), we don't need the long deprecated `ConnectionTracingID` and the associated `ConnectionTracingKey` anymore.