### PR TITLE
polish the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,6 @@ Please **DO NOT file a public issue** for exploitable vulnerabilities.
 
 If the issue is theoretical, non-exploitable, or related to an experimental feature, you may discuss it openly by filing a regular issue.
 
-## Reporting a non security bug
+## Reporting a non-security bug
 
 For bugs, feature requests, or other non-security concerns, please open a GitHub [issue](https://github.com/quic-go/quic-go/issues/new).


### PR DESCRIPTION
I believe the current policy was mostly copy-pasted from go-libp2p's security policy. This PR polishes the policy and makes it more applicable to quic-go.