### PR TITLE
http3: reduce memory allocation in writeHeader

### DIFF
--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -254,3 +254,12 @@ func TestResponseWriterTrailers(t *testing.T) {
 	// invalid trailers are ignored
 	require.NotContains(t, trailers, "content-length")
 }
+
+func BenchmarkWriteHeader(b *testing.B) {
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			rw := newTestResponseWriter(&testing.T{})
+			rw.writeHeader(200)
+		}
+	})
+}


### PR DESCRIPTION
goos: windows
goarch: amd64
pkg: github.com/quic-go/quic-go/http3
cpu: AMD Ryzen 7 7840HS w/ Radeon 780M Graphics
               │     old     │              new              │
               │   sec/op    │   sec/op     vs base          │
WriteHeader-16   2.254µ ± 1%   2.245µ ± 1%  ~ (p=0.470 n=10)

               │     old      │                 new                 │
               │     B/op     │     B/op      vs base               │
WriteHeader-16   5.821Ki ± 0%   5.691Ki ± 0%  -2.23% (p=0.000 n=10)

               │    old     │                new                │
               │ allocs/op  │ allocs/op   vs base               │
WriteHeader-16   103.0 ± 0%   100.0 ± 0%  -2.91% (p=0.000 n=10)