### PR TITLE
fix flaky TestHTTP3Qlog

### DIFF
--- a/integrationtests/self/http_qlog_test.go
+++ b/integrationtests/self/http_qlog_test.go
@@ -75,8 +75,9 @@ func TestHTTP3Qlog(t *testing.T) {
 		t.Fatal("server didn't shut down")
 	}
 
-	assert.Zero(t, clientTrace.OpenRecorders(), "client recorders should be closed")
-	assert.Zero(t, serverTrace.OpenRecorders(), "server recorders should be closed")
+	// Recorders are closed in an AfterFunc, so we need to wait for them to be closed.
+	assert.Eventually(t, func() bool { return clientTrace.OpenRecorders() == 0 }, time.Second, 10*time.Millisecond, "client recorders should be closed")
+	assert.Eventually(t, func() bool { return serverTrace.OpenRecorders() == 0 }, time.Second, 10*time.Millisecond, "server recorders should be closed")
 	assert.Equal(t, []string{h3qlog.EventSchema}, clientTrace.SchemasChecked)
 	assert.Equal(t, []string{h3qlog.EventSchema}, serverTrace.SchemasChecked)
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Make `TestHTTP3Qlog` wait up to 1s with 10ms polling for `clientTrace.OpenRecorders()` and `serverTrace.OpenRecorders()` counts to reach zero in [http_qlog_test.go](https://github.com/quic-go/quic-go/pull/5532/files#diff-95d4c07f0e5c34da60bd15c1ce8fc147e0e92a5c95bca149624bda216474c02a)
Replace immediate zero-count assertions with `assert.Eventually` that polls every 10ms for up to 1s to wait for recorder closure triggered by an `AfterFunc` in [http_qlog_test.go](https://github.com/quic-go/quic-go/pull/5532/files#diff-95d4c07f0e5c34da60bd15c1ce8fc147e0e92a5c95bca149624bda216474c02a).

#### 📍Where to Start
Start with `TestHTTP3Qlog` in [http_qlog_test.go](https://github.com/quic-go/quic-go/pull/5532/files#diff-95d4c07f0e5c34da60bd15c1ce8fc147e0e92a5c95bca149624bda216474c02a).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 81c45f2.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->