### PR TITLE
expose local and remote settings in ConnectionState

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -774,10 +774,16 @@ func (c *Conn) supportsDatagrams() bool {
 func (c *Conn) ConnectionState() ConnectionState {
 	c.connStateMutex.Lock()
 	defer c.connStateMutex.Unlock()
+
 	cs := c.cryptoStreamHandler.ConnectionState()
 	c.connState.TLS = cs.ConnectionState
 	c.connState.Used0RTT = cs.Used0RTT
-	c.connState.SupportsStreamResetPartialDelivery = c.peerParams.EnableResetStreamAt
+	if c.peerParams != nil {
+		c.connState.SupportsDatagrams.Remote = c.supportsDatagrams()
+		c.connState.SupportsStreamResetPartialDelivery.Remote = c.peerParams.EnableResetStreamAt
+	}
+	c.connState.SupportsDatagrams.Local = c.config.EnableDatagrams
+	c.connState.SupportsStreamResetPartialDelivery.Local = c.config.EnableStreamResetPartialDelivery
 	c.connState.GSO = c.conn.capabilities().GSO
 	return c.connState
 }
@@ -2342,9 +2348,6 @@ func (c *Conn) restoreTransportParameters(params *wire.TransportParameters) {
 	c.connIDGenerator.SetMaxActiveConnIDs(params.ActiveConnectionIDLimit)
 	c.connFlowController.UpdateSendWindow(params.InitialMaxData)
 	c.streamsMap.HandleTransportParameters(params)
-	c.connStateMutex.Lock()
-	c.connState.SupportsDatagrams = c.supportsDatagrams()
-	c.connStateMutex.Unlock()
 }
 
 func (c *Conn) handleTransportParameters(params *wire.TransportParameters) error {
@@ -2374,10 +2377,6 @@ func (c *Conn) handleTransportParameters(params *wire.TransportParameters) error
 		// the client's transport parameters.
 		close(c.earlyConnReadyChan)
 	}
-
-	c.connStateMutex.Lock()
-	c.connState.SupportsDatagrams = c.supportsDatagrams()
-	c.connStateMutex.Unlock()
 	return nil
 }
 

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -229,7 +229,7 @@ func (c *rawConn) handleControlStream(str *quic.ReceiveStream) {
 		// If datagram support was enabled on our side as well as on the server side,
 		// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
 		// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
-		if c.enableDatagrams && !c.ConnectionState().SupportsDatagrams {
+		if c.enableDatagrams && !c.ConnectionState().SupportsDatagrams.Remote {
 			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeSettingsError), "missing QUIC Datagram support")
 			return
 		}

--- a/integrationtests/self/datagram_test.go
+++ b/integrationtests/self/datagram_test.go
@@ -58,25 +58,28 @@ func testDatagramNegotiation(t *testing.T, serverEnableDatagram, clientEnableDat
 	require.NoError(t, err)
 	defer serverConn.CloseWithError(0, "")
 
+	serverState := serverConn.ConnectionState().SupportsDatagrams
+	clientState := clientConn.ConnectionState().SupportsDatagrams
+	require.Equal(t, serverEnableDatagram, serverState.Local, "server local datagram support")
+	require.Equal(t, clientEnableDatagram, serverState.Remote, "server view of client datagram support")
+	require.Equal(t, clientEnableDatagram, clientState.Local, "client local datagram support")
+	require.Equal(t, serverEnableDatagram, clientState.Remote, "client view of server datagram support")
+
 	if clientEnableDatagram {
-		require.True(t, serverConn.ConnectionState().SupportsDatagrams)
 		require.NoError(t, serverConn.SendDatagram([]byte("foo")))
 		datagram, err := clientConn.ReceiveDatagram(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []byte("foo"), datagram)
 	} else {
-		require.False(t, serverConn.ConnectionState().SupportsDatagrams)
 		require.Error(t, serverConn.SendDatagram([]byte("foo")))
 	}
 
 	if serverEnableDatagram {
-		require.True(t, clientConn.ConnectionState().SupportsDatagrams)
 		require.NoError(t, clientConn.SendDatagram([]byte("bar")))
 		datagram, err := serverConn.ReceiveDatagram(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []byte("bar"), datagram)
 	} else {
-		require.False(t, clientConn.ConnectionState().SupportsDatagrams)
 		require.Error(t, clientConn.SendDatagram([]byte("bar")))
 	}
 }

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -667,7 +667,8 @@ func TestGetConfigForClient(t *testing.T) {
 	defer conn.CloseWithError(0, "")
 
 	cs := conn.ConnectionState()
-	require.True(t, cs.SupportsDatagrams)
+	require.True(t, cs.SupportsDatagrams.Remote, "server should advertise datagram support")
+	require.True(t, cs.SupportsDatagrams.Local, "client should have datagram support enabled")
 
 	select {
 	case <-acceptDone:

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -896,7 +896,8 @@ func Test0RTTRejectedOnDatagramsDisabled(t *testing.T) {
 		defer ln.Close()
 		conn, sconn := check0RTTRejected(t, ln, clientConn, ln.Addr(), clientTLSConf, true)
 		defer conn.CloseWithError(0, "")
-		require.False(t, conn.ConnectionState().SupportsDatagrams)
+		require.False(t, conn.ConnectionState().SupportsDatagrams.Remote)
+		require.False(t, conn.ConnectionState().SupportsDatagrams.Local)
 
 		sconn.CloseWithError(0, "")
 		// The client should send 0-RTT packets, but the server doesn't process them.
@@ -1128,7 +1129,8 @@ func Test0RTTDatagrams(t *testing.T) {
 		)
 		require.NoError(t, err)
 		defer conn.CloseWithError(0, "")
-		require.True(t, conn.ConnectionState().SupportsDatagrams)
+		require.True(t, conn.ConnectionState().SupportsDatagrams.Remote)
+		require.True(t, conn.ConnectionState().SupportsDatagrams.Local)
 		require.NoError(t, conn.SendDatagram(msg))
 		select {
 		case <-conn.HandshakeComplete():

--- a/interface.go
+++ b/interface.go
@@ -194,13 +194,18 @@ type ClientInfo struct {
 type ConnectionState struct {
 	// TLS contains information about the TLS connection state, incl. the tls.ConnectionState.
 	TLS tls.ConnectionState
-	// SupportsDatagrams indicates whether the peer advertised support for QUIC datagrams (RFC 9221).
-	// When true, datagrams can be sent using the Conn's SendDatagram method.
-	// This is a unilateral declaration by the peer - receiving datagrams is only possible if
-	// datagram support was enabled locally via Config.EnableDatagrams.
-	SupportsDatagrams bool
-	// SupportsStreamResetPartialDelivery indicates whether the peer advertised support for QUIC Stream Resets with Partial Delivery.
-	SupportsStreamResetPartialDelivery bool
+	// SupportsDatagrams indicates support for QUIC datagrams (RFC 9221).
+	SupportsDatagrams struct {
+		// Remote is true if the peer advertised datagram support.
+		// Local is true if datagram support was enabled via Config.EnableDatagrams.
+		Remote, Local bool
+	}
+	// SupportsStreamResetPartialDelivery indicates support for QUIC Stream Resets with Partial Delivery.
+	SupportsStreamResetPartialDelivery struct {
+		// Remote is true if the peer advertised support.
+		// Local is true if support was enabled via Config.EnableStreamResetPartialDelivery.
+		Remote, Local bool
+	}
 	// Used0RTT says if 0-RTT resumption was used.
 	Used0RTT bool
 	// Version is the QUIC version of the QUIC connection.


### PR DESCRIPTION
This allows the application to check for datagram and reliable stream reset support for both the local and the remote side.