### PR TITLE
ackhandler: remove unused declaredLost field in the packet

### DIFF
--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -24,12 +24,11 @@ type packet struct {
 	IsPathMTUProbePacket bool // We don't report the loss of Path MTU probe packets to the congestion controller.
 
 	includedInBytesInFlight bool
-	declaredLost            bool
 	isPathProbePacket       bool
 }
 
 func (p *packet) Outstanding() bool {
-	return !p.declaredLost && !p.IsPathMTUProbePacket && !p.isPathProbePacket && p.IsAckEliciting()
+	return !p.IsPathMTUProbePacket && !p.isPathProbePacket && p.IsAckEliciting()
 }
 
 func (p *packet) IsAckEliciting() bool {
@@ -48,7 +47,6 @@ func getPacket() *packet {
 	p.SendTime = 0
 	p.IsPathMTUProbePacket = false
 	p.includedInBytesInFlight = false
-	p.declaredLost = false
 	p.isPathProbePacket = false
 	return p
 }

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -436,7 +436,7 @@ func (h *sentPacketHandler) ReceivedAck(ack *wire.AckFrame, encLevel protocol.En
 	}
 	var acked1RTTPacket bool
 	for _, p := range ackedPackets {
-		if p.includedInBytesInFlight && !p.declaredLost {
+		if p.includedInBytesInFlight {
 			h.congestion.OnPacketAcked(p.PacketNumber, p.Length, priorInFlight, rcvTime)
 		}
 		if p.EncryptionLevel == protocol.Encryption1RTT {
@@ -1076,14 +1076,14 @@ func (h *sentPacketHandler) ResetForRetry(now monotime.Time) {
 		if firstPacketSendTime.IsZero() {
 			firstPacketSendTime = p.SendTime
 		}
-		if !p.declaredLost && p.IsAckEliciting() {
+		if p.IsAckEliciting() {
 			h.queueFramesForRetransmission(p)
 		}
 	}
 	// All application data packets sent at this point are 0-RTT packets.
 	// In the case of a Retry, we can assume that the server dropped all of them.
 	for _, p := range h.appDataPackets.history.Packets() {
-		if !p.declaredLost && p.IsAckEliciting() {
+		if p.IsAckEliciting() {
 			h.queueFramesForRetransmission(p)
 		}
 	}


### PR DESCRIPTION
`declaredLost` was never set to true. Instead, packets that are declared lost are immediately removed from the sent packet history.

No functional change expected, since every time `declaredLost` was accessed was as `!declaredLost` in an `if`.