### PR TITLE
ackhandler: fix qlogging of outstanding packet count

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -239,12 +239,12 @@ func (h *sentPacketHandler) ReceivedPacket(l protocol.EncryptionLevel, t monotim
 }
 
 func (h *sentPacketHandler) packetsInFlight() int {
-	packetsInFlight := h.appDataPackets.history.Len()
+	packetsInFlight := h.appDataPackets.history.NumOutstanding()
 	if h.handshakePackets != nil {
-		packetsInFlight += h.handshakePackets.history.Len()
+		packetsInFlight += h.handshakePackets.history.NumOutstanding()
 	}
 	if h.initialPackets != nil {
-		packetsInFlight += h.initialPackets.history.Len()
+		packetsInFlight += h.initialPackets.history.NumOutstanding()
 	}
 	return packetsInFlight
 }
@@ -351,8 +351,9 @@ func (h *sentPacketHandler) qlogMetricsUpdated() {
 		h.lastMetrics.BytesInFlight = metricsUpdatedEvent.BytesInFlight
 		updated = true
 	}
-	if h.lastMetrics.PacketsInFlight != h.packetsInFlight() {
-		metricsUpdatedEvent.PacketsInFlight = h.packetsInFlight()
+	packetsInFlight := h.packetsInFlight()
+	if h.lastMetrics.PacketsInFlight != packetsInFlight {
+		metricsUpdatedEvent.PacketsInFlight = packetsInFlight
 		h.lastMetrics.PacketsInFlight = metricsUpdatedEvent.PacketsInFlight
 		updated = true
 	}

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -203,6 +203,8 @@ func TestSentPacketHandlerAcknowledgeSkippedPacket(t *testing.T) {
 }
 
 func TestSentPacketHandlerRTTAckEliciting(t *testing.T) {
+	var eventRecorder events.Recorder
+
 	rttStats := utils.NewRTTStats()
 	sph := NewSentPacketHandler(
 		0,
@@ -213,18 +215,27 @@ func TestSentPacketHandlerRTTAckEliciting(t *testing.T) {
 		false,
 		nil,
 		protocol.PerspectiveClient,
-		nil,
+		&eventRecorder,
 		utils.DefaultLogger,
 	)
 
-	sendPacket := func(t *testing.T, ti monotime.Time, ackEliciting bool) protocol.PacketNumber {
+	getPacketsInFlight := func() int {
+		evs := eventRecorder.Events(qlog.MetricsUpdated{})
+		return evs[len(evs)-1].(qlog.MetricsUpdated).PacketsInFlight
+	}
+	getBytesInFlight := func() int {
+		evs := eventRecorder.Events(qlog.MetricsUpdated{})
+		return evs[len(evs)-1].(qlog.MetricsUpdated).BytesInFlight
+	}
+
+	sendPacket := func(t *testing.T, ti monotime.Time, size protocol.ByteCount, ackEliciting bool) protocol.PacketNumber {
 		t.Helper()
 		pn := sph.PopPacketNumber(protocol.Encryption1RTT)
 		var frames []Frame
 		if ackEliciting {
 			frames = []Frame{{Frame: &wire.PingFrame{}}}
 		}
-		sph.SentPacket(ti, pn, protocol.InvalidPacketNumber, nil, frames, protocol.Encryption1RTT, protocol.ECNNon, 1200, false, false)
+		sph.SentPacket(ti, pn, protocol.InvalidPacketNumber, nil, frames, protocol.Encryption1RTT, protocol.ECNNon, size, false, false)
 		return pn
 	}
 
@@ -235,28 +246,50 @@ func TestSentPacketHandlerRTTAckEliciting(t *testing.T) {
 	}
 
 	now := monotime.Now()
-	pn1 := sendPacket(t, now, true)
-	pn2 := sendPacket(t, now, false)
-	pn3 := sendPacket(t, now, true)
+	pn1 := sendPacket(t, now, 1200, true)
+	require.Equal(t, 1, getPacketsInFlight())
+	require.Equal(t, 1200, getBytesInFlight())
+	pn2 := sendPacket(t, now, 1100, false)
+	// Sending a non-ack-eliciting packet doesn't change bytes or packets in flight.
+	// Non-ack-eliciting packets are not included in congestion control.
+	require.Equal(t, 1, getPacketsInFlight())
+	require.Equal(t, 1200, getBytesInFlight())
+	pn3 := sendPacket(t, now, 1000, true)
+	require.Equal(t, 2, getPacketsInFlight())
+	require.Equal(t, 2200, getBytesInFlight())
 	// the RTT is recorded, since the largest acknowledged packet is ack-eliciting
 	now = now.Add(200 * time.Millisecond)
 	ackPackets(t, now, pn1, pn2, pn3)
 	require.Equal(t, 200*time.Millisecond, rttStats.LatestRTT())
+	require.Zero(t, getPacketsInFlight())
+	require.Zero(t, getBytesInFlight())
 
-	pn4 := sendPacket(t, now, false)
-	pn5 := sendPacket(t, now, false)
+	pn4 := sendPacket(t, now, 1200, false)
+	// non-ack-eliciting packets don't trigger metrics updates
+	require.Zero(t, getPacketsInFlight())
+	require.Zero(t, getBytesInFlight())
+	pn5 := sendPacket(t, now, 500, false)
+	require.Zero(t, getPacketsInFlight())
+	require.Zero(t, getBytesInFlight())
 	now = now.Add(500 * time.Millisecond)
 	// only non-ack-eliciting packets are newly acknowledged, so the RTT is not updated
 	ackPackets(t, now, pn2, pn3, pn4, pn5)
 	require.Equal(t, 200*time.Millisecond, rttStats.LatestRTT())
 
-	pn6 := sendPacket(t, now, true)
-	pn7 := sendPacket(t, now, false)
+	pn6 := sendPacket(t, now, 1400, true)
+	require.Equal(t, 1, getPacketsInFlight())
+	require.Equal(t, 1400, getBytesInFlight())
+	pn7 := sendPacket(t, now, 1100, false)
+	// non-ack-eliciting packet doesn't change metrics
+	require.Equal(t, 1, getPacketsInFlight())
+	require.Equal(t, 1400, getBytesInFlight())
 	now = now.Add(800 * time.Millisecond)
 	// largest acknowledged packet is not ack-eliciting, but one new ack-eliciting
 	// packet was acknowledged, so the RTT is updated
 	ackPackets(t, now, pn6, pn7)
 	require.Equal(t, 800*time.Millisecond, rttStats.LatestRTT())
+	require.Zero(t, getPacketsInFlight())
+	require.Zero(t, getBytesInFlight())
 }
 
 func TestSentPacketHandlerRTTAcrossPacketNumberSpaces(t *testing.T) {

--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -133,6 +133,10 @@ func (h *sentPacketHistory) Len() int {
 	return len(h.packets)
 }
 
+func (h *sentPacketHistory) NumOutstanding() int {
+	return h.numOutstanding
+}
+
 // Remove removes a packet from the sent packet history.
 // It must not be used for skipped packet numbers.
 func (h *sentPacketHistory) Remove(pn protocol.PacketNumber) error {

--- a/internal/ackhandler/sent_packet_history_test.go
+++ b/internal/ackhandler/sent_packet_history_test.go
@@ -47,6 +47,11 @@ func testSentPacketHistoryPacketTracking(t *testing.T, firstPacketAckEliciting b
 	require.Equal(t, []protocol.PacketNumber{0, 1, 2}, hist.getPacketNumbers())
 	require.Empty(t, slices.Collect(hist.SkippedPackets()))
 	require.Equal(t, 3, hist.Len())
+	if firstPacketAckEliciting {
+		require.Equal(t, 3, hist.NumOutstanding())
+	} else {
+		require.Equal(t, 2, hist.NumOutstanding())
+	}
 
 	// non-ack-eliciting packets are saved, but don't count as outstanding
 	hist.SentPacket(3, &packet{})
@@ -54,6 +59,11 @@ func testSentPacketHistoryPacketTracking(t *testing.T, firstPacketAckEliciting b
 	hist.SentPacket(5, &packet{})
 	hist.SentPacket(6, ackElicitingPacket())
 	require.Equal(t, []protocol.PacketNumber{0, 1, 2, 3, 4, 5, 6}, hist.getPacketNumbers())
+	if firstPacketAckEliciting {
+		require.Equal(t, 5, hist.NumOutstanding())
+	} else {
+		require.Equal(t, 4, hist.NumOutstanding())
+	}
 
 	// handle skipped packet numbers
 	hist.SkippedPacket(7)
@@ -64,6 +74,11 @@ func testSentPacketHistoryPacketTracking(t *testing.T, firstPacketAckEliciting b
 	require.Equal(t, []protocol.PacketNumber{0, 1, 2, 3, 4, 5, 6, 8, 9, 11}, hist.getPacketNumbers())
 	require.Equal(t, []protocol.PacketNumber{7, 10}, slices.Collect(hist.SkippedPackets()))
 	require.Equal(t, 12, hist.Len())
+	if firstPacketAckEliciting {
+		require.Equal(t, 7, hist.NumOutstanding())
+	} else {
+		require.Equal(t, 6, hist.NumOutstanding())
+	}
 }
 
 func TestSentPacketHistoryNonSequentialPacketNumberUse(t *testing.T) {


### PR DESCRIPTION
Non-ack-eliciting packets are not considered outstanding (and they don't count towards bytes in flight).

This is not yet the fix for the issue reported, but it does fix the incorrect qlog posted in https://github.com/quic-go/quic-go/issues/5535#issuecomment-3732329277.