### PR TITLE
ackhandler: fix counting of packets queued for PTO probing

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -1044,11 +1044,12 @@ func (h *sentPacketHandler) QueueProbePacket(encLevel protocol.EncryptionLevel) 
 	if p == nil {
 		return false
 	}
-	h.queueFramesForRetransmission(p)
 	// TODO: don't declare the packet lost here.
 	// Keep track of acknowledged frames instead.
-	h.removeFromBytesInFlight(p)
+	// Call DeclareLost before queueFramesForRetransmission, which clears the packet's frames.
 	pnSpace.history.DeclareLost(pn)
+	h.removeFromBytesInFlight(p)
+	h.queueFramesForRetransmission(p)
 	return true
 }
 


### PR DESCRIPTION
When an old packet is queued for retransmission to be able to send a PTO probe packet, it needs to removed from the outstanding packet count.