### PR TITLE
ci: use Go 1.25.6

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu" ]
-        go: [ "1.24.x", "1.25.x", "1.26.0-rc.1" ]
+        go: [ "1.24.x", "1.25.6", "1.26.0-rc.1" ]
         race: [ false ]
         include:
           - os: "ubuntu"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
-        go: [ "1.24.x", "1.25.x", "1.26.0-rc.1" ]
+        go: [ "1.24.x", "1.25.6", "1.26.0-rc.1" ]
     runs-on: ${{ fromJSON(vars[format('UNIT_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
     timeout-minutes: 30


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Pin CI workflows to Go 1.25.6 in [integration.yml](https://github.com/quic-go/quic-go/pull/5542/files#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8b) and [unit.yml](https://github.com/quic-go/quic-go/pull/5542/files#diff-e17ac7ab478a18e9dac875e191cc3e0d754fab62eddddfb05d4619495be927d9)
Update CI matrices to use Go `1.25.6` instead of `1.25.x` across integration and unit workflows.

#### 📍Where to Start
Start with the Go version matrix in [integration.yml](https://github.com/quic-go/quic-go/pull/5542/files#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8b) and [unit.yml](https://github.com/quic-go/quic-go/pull/5542/files#diff-e17ac7ab478a18e9dac875e191cc3e0d754fab62eddddfb05d4619495be927d9).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a509c3b. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>.github/workflows/integration.yml — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 13](https://github.com/quic-go/quic-go/blob/a509c3b29b96fa73c2b3edcb4d8067f815ee672a/.github/workflows/integration.yml#L13): Matrix `include` blocks on lines 12-20 still reference `go: "1.25.x"` but the main matrix now uses `"1.25.6"`. Since GitHub Actions `include` entries with non-matching values create new matrix combinations rather than modifying existing ones, this will result in additional unintended jobs running `1.25.x` separately, while the `1.25.6` jobs won't have race detection enabled or run on Windows/macOS. The `include` entries should be updated to use `"1.25.6"` to match the matrix change. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->