### PR TITLE
ci: always use the latest Go patch release

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
+          check-latest: true
       - name: Get Date
         id: get-date
         run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
+          check-latest: true
       - name: Install go-junit-report
         run: go install github.com/jstemmer/go-junit-report/v2@v2.1.0
       - name: Set qlogger

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25.x"
+          check-latest: true
       - name: Check for //go:build ignore in .go files
         run: |
           IGNORED_FILES=$(grep -rl '//go:build ignore' . --include='*.go') || true
@@ -47,6 +48,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
+          check-latest: true
       - name: golangci-lint (Linux)
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
+          check-latest: true
       - run: go version
       - name: Install go-junit-report
         run: go install github.com/jstemmer/go-junit-report/v2@v2.1.0


### PR DESCRIPTION
GitHub Action Runners cache the available Go version and are only updated infrequently. This means that we'll often test with outdated patch versions.

This is especially relevant since the Go 1.25.6 release broke session resumption which was fixed in the Go 1.25.7 release.