### PR TITLE
ci: remove stray golangci-lint rule for ConnectionTracing(ID|Key)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,14 +85,6 @@ linters:
           - staticcheck
         path: _test\.go
         text: 'SA1029:' # inappropriate key in call to context.WithValue
-      # WebTransport still relies on the ConnectionTracingID and ConnectionTracingKey.
-      # See https://github.com/quic-go/quic-go/issues/4405 for more details.
-      - linters:
-          - staticcheck
-        paths:
-          - http3/
-          - integrationtests/self/http_test.go
-        text: 'SA1019:.+quic\.ConnectionTracing(ID|Key)'
     paths:
       - internal/handshake/cipher_suite.go
       - third_party$


### PR DESCRIPTION
The `ConnectionTracingID` and `ConnectionTracingKey` were removed in the v0.59.0 release.