### PR TITLE
remove special treatment for Go 1.24 in tests

### DIFF
--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -8,9 +8,7 @@ import (
 	"io"
 	mrand "math/rand/v2"
 	"net"
-	"runtime"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -308,13 +306,11 @@ func TestHandshakeWithPacketLoss(t *testing.T) {
 								defer ln.Close()
 
 								conn := test.fn(t, ln, clientConn, clientConf, timeout, data)
-								if !strings.HasPrefix(runtime.Version(), "go1.24") {
-									curveID := getCurveID(conn.ConnectionState().TLS)
-									if conf.postQuantum {
-										require.Equal(t, tls.X25519MLKEM768, curveID)
-									} else {
-										require.Equal(t, tls.CurveP384, curveID)
-									}
+								curveID := getCurveID(conn.ConnectionState().TLS)
+								if conf.postQuantum {
+									require.Equal(t, tls.X25519MLKEM768, curveID)
+								} else {
+									require.Equal(t, tls.CurveP384, curveID)
 								}
 
 								if pattern != dropPatternDropOneThirdOfPackets {

--- a/transport_test.go
+++ b/transport_test.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"math"
 	"net"
-	"runtime"
-	"strings"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -644,11 +642,6 @@ func TestTransportDialingVersionNegotiation(t *testing.T) {
 }
 
 func TestTransportReplaceWithClosed(t *testing.T) {
-	// synctest works slightly differently on Go 1.24,
-	// so we skip the test
-	if strings.HasPrefix(runtime.Version(), "go1.24") {
-		t.Skip("skipping on Go 1.24 due to synctest issues")
-	}
 	t.Run("local", func(t *testing.T) {
 		testTransportReplaceWithClosed(t, true)
 	})


### PR DESCRIPTION
This should have been part of #5561.