### PR TITLE
handshake: use new tls.QUICConfig.ClientHelloInfoConn API, avoid cloning tls.Config

### DIFF
--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -127,10 +127,7 @@ func NewCryptoSetupServer(
 	tlsConf = setupConfigForServer(tlsConf, localAddr, remoteAddr)
 
 	cs.tlsConf = tlsConf
-	cs.conn = tls.QUICServer(&tls.QUICConfig{
-		TLSConfig:           tlsConf,
-		EnableSessionEvents: true,
-	})
+	cs.conn = tls.QUICServer(getQUICConfig(tlsConf, localAddr, remoteAddr))
 	return cs
 }
 

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -87,8 +87,7 @@ func NewCryptoSetupClient(
 		version,
 	)
 
-	tlsConf = tlsConf.Clone()
-	tlsConf.MinVersion = tls.VersionTLS13
+	tlsConf = setupConfigForClient(tlsConf)
 	cs.tlsConf = tlsConf
 	cs.allow0RTT = enable0RTT
 

--- a/internal/handshake/tls_config_go126.go
+++ b/internal/handshake/tls_config_go126.go
@@ -7,6 +7,12 @@ import (
 	"net"
 )
 
+func setupConfigForClient(conf *tls.Config) *tls.Config {
+	conf = conf.Clone()
+	conf.MinVersion = tls.VersionTLS13
+	return conf
+}
+
 func setupConfigForServer(conf *tls.Config, localAddr, remoteAddr net.Addr) *tls.Config {
 	// Workaround for https://github.com/golang/go/issues/60506.
 	// This initializes the session tickets _before_ cloning the config.

--- a/internal/handshake/tls_config_go126.go
+++ b/internal/handshake/tls_config_go126.go
@@ -1,3 +1,5 @@
+//go:build !go1.27
+
 package handshake
 
 import (
@@ -36,4 +38,11 @@ func setupConfigForServer(conf *tls.Config, localAddr, remoteAddr net.Addr) *tls
 		}
 	}
 	return conf
+}
+
+func getQUICConfig(tlsConf *tls.Config, _, _ net.Addr) *tls.QUICConfig {
+	return &tls.QUICConfig{
+		TLSConfig:           tlsConf,
+		EnableSessionEvents: true,
+	}
 }

--- a/internal/handshake/tls_config_go126_test.go
+++ b/internal/handshake/tls_config_go126_test.go
@@ -1,3 +1,5 @@
+//go:build !go1.27
+
 package handshake
 
 import (

--- a/internal/handshake/tls_config_go127.go
+++ b/internal/handshake/tls_config_go127.go
@@ -1,0 +1,20 @@
+//go:build go1.27
+
+package handshake
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+func setupConfigForServer(conf *tls.Config, _, _ net.Addr) *tls.Config {
+	return conf
+}
+
+func getQUICConfig(tlsConf *tls.Config, localAddr, remoteAddr net.Addr) *tls.QUICConfig {
+	return &tls.QUICConfig{
+		TLSConfig:           tlsConf,
+		EnableSessionEvents: true,
+		ClientHelloInfoConn: &conn{localAddr: localAddr, remoteAddr: remoteAddr},
+	}
+}

--- a/internal/handshake/tls_config_go127.go
+++ b/internal/handshake/tls_config_go127.go
@@ -7,6 +7,10 @@ import (
 	"net"
 )
 
+func setupConfigForClient(conf *tls.Config) *tls.Config {
+	return conf
+}
+
 func setupConfigForServer(conf *tls.Config, _, _ net.Addr) *tls.Config {
 	return conf
 }


### PR DESCRIPTION
https://github.com/golang/go/issues/77631 and https://github.com/golang/go/issues/77363 were merged and will be released in Go 1.27.

This PR should be merged once we start testing Go 1.27 (rc) in CI.