### PR TITLE
bump Go version to 1.26 in go.mod files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quic-go/quic-go
 
-go 1.25
+go 1.26
 
 require (
 	github.com/quic-go/qpack v0.6.0

--- a/integrationtests/gomodvendor/go.mod
+++ b/integrationtests/gomodvendor/go.mod
@@ -1,6 +1,6 @@
 module test
 
-go 1.25
+go 1.26
 
 // The version doesn't matter here, as we're replacing it with the currently checked out code anyway.
 require github.com/quic-go/quic-go v0.21.0


### PR DESCRIPTION
Version in `go.mod` was  stale to go 1.25 although the golangci-lint was upgraded to 1.9.0. I spotted this while was working on something else.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update Go toolchain version to 1.26 in `go.mod` and `integrationtests/gomodvendor/go.mod` for builds and tooling
> Bump the `go` directive from 1.25 to 1.26 across module manifests to standardize build tooling.
>
> #### 📍Where to Start
> Start with [go.mod](https://github.com/quic-go/quic-go/pull/5574/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6) to verify the `go` version directive, then confirm the mirrored change in [integrationtests/gomodvendor/go.mod](https://github.com/quic-go/quic-go/pull/5574/files#diff-f2d1ee04d9bfcd87171ae87cde3e06381e41209cc75554be444d3d9320fa4f2a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 415e652.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->