### PR TITLE
expose the StreamType

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -16,6 +16,16 @@ import (
 // The StreamID is the ID of a QUIC stream.
 type StreamID = protocol.StreamID
 
+// The StreamType is the type of a QUIC stream (unidirectional or bidirectional).
+type StreamType = protocol.StreamType
+
+const (
+	// StreamTypeUni is a unidirectional stream
+	StreamTypeUni = protocol.StreamTypeUni
+	// StreamTypeBidi is a bidirectional stream
+	StreamTypeBidi = protocol.StreamTypeBidi
+)
+
 // A Version is a QUIC version number.
 type Version = protocol.Version
 


### PR DESCRIPTION
The StreamType is returned from an exported method on the StreamID.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `StreamType` and stream type constants in the public API
> Adds `StreamType` as an exported type alias for `protocol.StreamType` in [interface.go](https://github.com/quic-go/quic-go/pull/5585/files#diff-189ad68e1729b49c973b8a4baa0ac4a7058d274d5b52abe852ac21a28accf8cf), along with `StreamTypeUni` and `StreamTypeBidi` constants, making QUIC stream type values available to callers without importing internal packages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e204e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->