### PR TITLE
ci: update golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         go: [ "1.25.x", "1.26.x" ]
     env:
-      GOLANGCI_LINT_VERSION: v2.9.0
+      GOLANGCI_LINT_VERSION: v2.11.4
     name: golangci-lint (Go ${{ matrix.go }})
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Update golangci-lint to v2.11.4 in CI lint workflow
Bumps `GOLANGCI_LINT_VERSION` from `v2.9.0` to `v2.11.4` in [lint.yml](.github/workflows/lint.yml).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fef6c2.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->