### PR TITLE
http3: add a fuzzer for frame parsing

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -5,6 +5,7 @@ go env
 
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzFrameParser frame_fuzzer
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzTransportParameters transportparameter_fuzzer
+compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzFrameParser http3_frame_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/header Fuzz header_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/tokens Fuzz token_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/handshake Fuzz handshake_fuzzer

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -448,10 +448,17 @@ func FuzzFrameParser(f *testing.F) {
 			}
 
 			switch f := fr.(type) {
+			case *dataFrame:
+				if _, err := io.CopyN(io.Discard, fp.r, int64(f.Length)); err != nil {
+					return
+				}
 			case *headersFrame:
 				// Type and length are each at least one varint byte; HTTP/3 caps the pair at frameHeaderLen.
 				if f.headerLen < 2 || f.headerLen > frameHeaderLen {
 					t.Fatalf("HEADERS: headerLen %d outside [2, %d]", f.headerLen, frameHeaderLen)
+				}
+				if _, err := io.CopyN(io.Discard, fp.r, int64(f.Length)); err != nil {
+					return
 				}
 			case *settingsFrame:
 				// Unset uses -1; a present SETTINGS_MAX_FIELD_SECTION_SIZE is non-negative (see parseSettingsFrame).

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -414,3 +414,63 @@ func TestParserGoAwayFrame(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, f, f2)
 }
+
+func FuzzFrameParser(f *testing.F) {
+	frames := []interface{ Append([]byte) []byte }{
+		&dataFrame{Length: 5},
+		&headersFrame{Length: 3},
+		&settingsFrame{
+			MaxFieldSectionSize: 1337,
+			Datagram:            true,
+			ExtendedConnect:     true,
+			Other:               map[uint64]uint64{0xdead: 0xbeef},
+		},
+		&goAwayFrame{StreamID: 42},
+	}
+	for _, fr := range frames {
+		f.Add(fr.Append(nil))
+	}
+
+	unknown := quicvarint.Append(nil, 0xdead)
+	unknown = quicvarint.Append(unknown, 6)
+	unknown = append(unknown, []byte("foobar")...)
+	f.Add(unknown)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fp := frameParser{
+			r:         bytes.NewReader(data),
+			closeConn: func(quic.ApplicationErrorCode, string) error { return nil },
+		}
+		for {
+			fr, err := fp.ParseNext(nil)
+			if err != nil {
+				return
+			}
+
+			switch f := fr.(type) {
+			case *headersFrame:
+				// Type and length are each at least one varint byte; HTTP/3 caps the pair at frameHeaderLen.
+				if f.headerLen < 2 || f.headerLen > frameHeaderLen {
+					t.Fatalf("HEADERS: headerLen %d outside [2, %d]", f.headerLen, frameHeaderLen)
+				}
+			case *settingsFrame:
+				// Unset uses -1; a present SETTINGS_MAX_FIELD_SECTION_SIZE is non-negative (see parseSettingsFrame).
+				if f.MaxFieldSectionSize != -1 && f.MaxFieldSectionSize < 0 {
+					t.Fatalf("SETTINGS: invalid MaxFieldSectionSize %d", f.MaxFieldSectionSize)
+				}
+				// Known settings are never stored in Other on a successful parse.
+				for id := range f.Other {
+					switch id {
+					case settingMaxFieldSectionSize, settingExtendedConnect, settingDatagram:
+						t.Fatalf("SETTINGS: known setting id %#x leaked into Other", id)
+					}
+				}
+			case *goAwayFrame:
+				// QUIC stream IDs fit in 62 bits; a negative value means uint64→int64 overflow in the parser.
+				if f.StreamID < 0 {
+					t.Fatalf("GOAWAY: negative StreamID %d", f.StreamID)
+				}
+			}
+		}
+	})
+}

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -14,6 +14,7 @@ cd $GOPATH/src/github.com/quic-go/quic-go/
 
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzFrameParser frame_fuzzer
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzTransportParameters transportparameter_fuzzer
+compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzFrameParser http3_frame_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/header Fuzz header_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/tokens Fuzz token_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/handshake Fuzz handshake_fuzzer


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add fuzzer for HTTP/3 frame parsing
Adds `FuzzFrameParser` in [http3/frames_test.go](https://github.com/quic-go/quic-go/pull/5595/files#diff-b7dae48b15585fe4352c7bd550a747aa897c1353848a87788ee939090712daea) to fuzz the HTTP/3 frame parser with seeded inputs covering `dataFrame`, `headersFrame`, `settingsFrame`, `goAwayFrame`, and unknown frame types. The fuzzer repeatedly calls `ParseNext` and asserts invariants on parsed output to surface panics or logic errors. Also registers the target as `http3_frame_fuzzer` in the ClusterFuzzLite and OSS-Fuzz build scripts.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7c0383.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->