### PR TITLE
http3: add a fuzzer for request, response and trailer decoding

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -9,3 +9,4 @@ compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzFrameParser htt
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/tokens Fuzz token_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/handshake Fuzz handshake_fuzzer
+compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzRequestHeaders http3_request_headers_fuzzer

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -9,4 +9,4 @@ compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzFrameParser htt
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/tokens Fuzz token_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/handshake Fuzz handshake_fuzzer
-compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzRequestHeaders http3_request_headers_fuzzer
+compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzHeaderParsing http3_header_parsing_fuzzer

--- a/http3/headers.go
+++ b/http3/headers.go
@@ -175,6 +175,7 @@ func parseTrailers(decodeFn qpack.DecodeFunc, headerFields *[]qpack.HeaderField)
 		if hf.IsPseudo() {
 			return nil, fmt.Errorf("http3: received pseudo header in trailer: %s", hf.Name)
 		}
+		// TODO(#5601): validate header field names and values
 		h.Add(hf.Name, hf.Value)
 	}
 	return h, nil

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -544,12 +544,6 @@ func BenchmarkRequestFromHeaders(b *testing.B) {
 	}
 }
 
-// FuzzHeaderParsing fuzzes HTTP/3 header parsing and request/response construction.
-// Header fields are encoded as JSON (a [][2]string of [name, value] pairs) rather than as
-// QPACK-encoded bytes. This bypasses the QPACK decoder intentionally: QPACK is fuzzed
-// separately (in the qpack module), and feeding raw bytes through it would cause the fuzzer
-// to waste most of its budget on QPACK decode failures instead of exercising the HTTP/3
-// header validation logic in parseHeaders, requestFromHeaders, and updateResponseFromHeaders.
 func FuzzHeaderParsing(f *testing.F) {
 	for _, s := range [][]qpack.HeaderField{
 		{ // GET request
@@ -597,6 +591,9 @@ func FuzzHeaderParsing(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, data []byte) {
+		// Header fields are encoded as JSON (a [][2]string of [name, value] pairs) rather than as
+		// QPACK-encoded bytes. This bypasses the QPACK decoder intentionally: QPACK is fuzzed
+		// separately (in the qpack package).
 		var pairs [][2]string
 		if err := json.Unmarshal(data, &pairs); err != nil {
 			return

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -2,6 +2,7 @@ package http3
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -541,4 +542,104 @@ func BenchmarkRequestFromHeaders(b *testing.B) {
 			b.Fatalf("failed to parse request: %v", err)
 		}
 	}
+}
+
+// FuzzRequestHeaders fuzzes HTTP/3 header parsing and request/response construction.
+// Header fields are encoded as JSON (a [][2]string of [name, value] pairs) rather than as
+// QPACK-encoded bytes. This bypasses the QPACK decoder intentionally: QPACK is fuzzed
+// separately (in the qpack module), and feeding raw bytes through it would cause the fuzzer
+// to waste most of its budget on QPACK decode failures instead of exercising the HTTP/3
+// header validation logic in parseHeaders, requestFromHeaders, and updateResponseFromHeaders.
+func FuzzRequestHeaders(f *testing.F) {
+	for _, s := range [][]qpack.HeaderField{
+		{ // GET request
+			{Name: ":method", Value: "GET"},
+			{Name: ":scheme", Value: "https"},
+			{Name: ":path", Value: "/"},
+			{Name: ":authority", Value: "example.com"},
+		},
+		{ // POST with Content-Length
+			{Name: ":method", Value: "POST"},
+			{Name: ":scheme", Value: "https"},
+			{Name: ":path", Value: "/submit"},
+			{Name: ":authority", Value: "example.com"},
+			{Name: "content-length", Value: "42"},
+			{Name: "content-type", Value: "application/json"},
+		},
+		{ // CONNECT request
+			{Name: ":method", Value: "CONNECT"},
+			{Name: ":authority", Value: "proxy.example.com:443"},
+		},
+		{ // extended CONNECT
+			{Name: ":method", Value: "CONNECT"},
+			{Name: ":scheme", Value: "https"},
+			{Name: ":path", Value: "/webtransport"},
+			{Name: ":authority", Value: "example.com"},
+			{Name: ":protocol", Value: "webtransport"},
+		},
+		{ // 200 response
+			{Name: ":status", Value: "200"},
+			{Name: "content-type", Value: "text/html"},
+			{Name: "content-length", Value: "1024"},
+		},
+		{ // response with trailer announcement
+			{Name: ":status", Value: "200"},
+			{Name: "trailer", Value: "Checksum"},
+		},
+	} {
+		seedsStrings := make([][2]string, len(s))
+		for i, h := range s {
+			seedsStrings[i] = [2]string{h.Name, h.Value}
+		}
+		data, err := json.Marshal(seedsStrings)
+		require.NoError(f, err)
+		f.Add(data)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var pairs [][2]string
+		if err := json.Unmarshal(data, &pairs); err != nil {
+			return
+		}
+		headers := make([]qpack.HeaderField, len(pairs))
+		for i, p := range pairs {
+			headers[i] = qpack.HeaderField{Name: p[0], Value: p[1]}
+		}
+
+		req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+		if err != nil {
+			return
+		}
+		require.NotNil(t, req)
+		if req.Method == "" {
+			t.Fatal("request has empty method")
+		}
+		if req.URL == nil {
+			t.Fatal("request has nil URL")
+		}
+		if req.ProtoMajor != 3 {
+			t.Fatalf("expected ProtoMajor 3, got %d", req.ProtoMajor)
+		}
+		if req.ContentLength < -1 {
+			t.Fatalf("invalid ContentLength: %d", req.ContentLength)
+		}
+		if req.Proto == "" {
+			t.Fatal("request has empty Proto")
+		}
+		if req.Method != http.MethodConnect && req.Host == "" {
+			t.Fatal("non-CONNECT request has empty Host")
+		}
+
+		rsp := &http.Response{}
+		err = updateResponseFromHeaders(rsp, decodeFromSlice(headers), math.MaxInt, nil)
+		if err != nil {
+			return
+		}
+		if rsp.Proto != "HTTP/3.0" {
+			t.Fatalf("expected Proto HTTP/3.0, got %q", rsp.Proto)
+		}
+		if rsp.ContentLength < -1 {
+			t.Fatalf("invalid ContentLength: %d", rsp.ContentLength)
+		}
+	})
 }

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -594,11 +594,13 @@ func FuzzHeaderParsing(f *testing.F) {
 		// Header fields are encoded as JSON (a [][2]string of [name, value] pairs) rather than as
 		// QPACK-encoded bytes. This bypasses the QPACK decoder intentionally: QPACK is fuzzed
 		// separately (in the qpack package).
+		const maxPairs = 1000
+		const maxHeaderBytes = 50_000
 		var pairs [][2]string
 		if err := json.Unmarshal(data, &pairs); err != nil {
 			return
 		}
-		if len(pairs) > 1000 {
+		if len(pairs) > maxPairs {
 			// don't fuzz too many header fields all at once
 			return
 		}
@@ -607,7 +609,7 @@ func FuzzHeaderParsing(f *testing.F) {
 			headers[i] = qpack.HeaderField{Name: p[0], Value: p[1]}
 		}
 
-		if req, err := requestFromHeaders(decodeFromSlice(headers), 50_000, nil); err == nil {
+		if req, err := requestFromHeaders(decodeFromSlice(headers), maxHeaderBytes, nil); err == nil {
 			if req.Method == "" {
 				t.Fatal("request has empty Method")
 			}
@@ -648,7 +650,7 @@ func FuzzHeaderParsing(f *testing.F) {
 		}
 
 		rsp := &http.Response{}
-		if err := updateResponseFromHeaders(rsp, decodeFromSlice(headers), 50_000, nil); err == nil {
+		if err := updateResponseFromHeaders(rsp, decodeFromSlice(headers), maxHeaderBytes, nil); err == nil {
 			if rsp.Proto != "HTTP/3.0" {
 				t.Fatalf("expected Proto HTTP/3.0, got %q", rsp.Proto)
 			}

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -607,7 +607,7 @@ func FuzzHeaderParsing(f *testing.F) {
 			headers[i] = qpack.HeaderField{Name: p[0], Value: p[1]}
 		}
 
-		if req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil); err == nil {
+		if req, err := requestFromHeaders(decodeFromSlice(headers), 50_000, nil); err == nil {
 			if req.Method == "" {
 				t.Fatal("request has empty Method")
 			}
@@ -648,7 +648,7 @@ func FuzzHeaderParsing(f *testing.F) {
 		}
 
 		rsp := &http.Response{}
-		if err := updateResponseFromHeaders(rsp, decodeFromSlice(headers), math.MaxInt, nil); err == nil {
+		if err := updateResponseFromHeaders(rsp, decodeFromSlice(headers), 50_000, nil); err == nil {
 			if rsp.Proto != "HTTP/3.0" {
 				t.Fatalf("expected Proto HTTP/3.0, got %q", rsp.Proto)
 			}

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -544,13 +544,13 @@ func BenchmarkRequestFromHeaders(b *testing.B) {
 	}
 }
 
-// FuzzRequestHeaders fuzzes HTTP/3 header parsing and request/response construction.
+// FuzzHeaderParsing fuzzes HTTP/3 header parsing and request/response construction.
 // Header fields are encoded as JSON (a [][2]string of [name, value] pairs) rather than as
 // QPACK-encoded bytes. This bypasses the QPACK decoder intentionally: QPACK is fuzzed
 // separately (in the qpack module), and feeding raw bytes through it would cause the fuzzer
 // to waste most of its budget on QPACK decode failures instead of exercising the HTTP/3
 // header validation logic in parseHeaders, requestFromHeaders, and updateResponseFromHeaders.
-func FuzzRequestHeaders(f *testing.F) {
+func FuzzHeaderParsing(f *testing.F) {
 	for _, s := range [][]qpack.HeaderField{
 		{ // GET request
 			{Name: ":method", Value: "GET"},
@@ -606,40 +606,78 @@ func FuzzRequestHeaders(f *testing.F) {
 			headers[i] = qpack.HeaderField{Name: p[0], Value: p[1]}
 		}
 
-		req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
-		if err != nil {
-			return
-		}
-		require.NotNil(t, req)
-		if req.Method == "" {
-			t.Fatal("request has empty method")
-		}
-		if req.URL == nil {
-			t.Fatal("request has nil URL")
-		}
-		if req.ProtoMajor != 3 {
-			t.Fatalf("expected ProtoMajor 3, got %d", req.ProtoMajor)
-		}
-		if req.ContentLength < -1 {
-			t.Fatalf("invalid ContentLength: %d", req.ContentLength)
-		}
-		if req.Proto == "" {
-			t.Fatal("request has empty Proto")
-		}
-		if req.Method != http.MethodConnect && req.Host == "" {
-			t.Fatal("non-CONNECT request has empty Host")
+		if req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil); err == nil {
+			if req.Method == "" {
+				t.Fatal("request has empty Method")
+			}
+			if req.URL == nil {
+				t.Fatal("request has nil URL")
+			}
+			if req.Proto == "" {
+				t.Fatal("request has empty Proto")
+			}
+			if req.ProtoMajor != 3 || req.ProtoMinor != 0 {
+				t.Fatalf("expected HTTP/3.0, got %d.%d", req.ProtoMajor, req.ProtoMinor)
+			}
+			if req.ContentLength < -1 {
+				t.Fatalf("invalid ContentLength: %d", req.ContentLength)
+			}
+			if req.Header == nil {
+				t.Fatal("request has nil Header map")
+			}
+			if req.Method == http.MethodConnect && req.Proto == "HTTP/3.0" {
+				// regular CONNECT: :path must be empty, :authority must be set
+				if req.URL.Path != "" {
+					t.Fatal("CONNECT request has non-empty URL.Path")
+				}
+			}
+			if req.Method != http.MethodConnect {
+				if req.Host == "" {
+					t.Fatal("non-CONNECT request has empty Host")
+				}
+				if req.RequestURI == "" {
+					t.Fatal("non-CONNECT request has empty RequestURI")
+				}
+			}
+			for _, name := range []string{"connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade"} {
+				if req.Header.Get(name) != "" {
+					t.Fatalf("request contains connection-specific header %q", name)
+				}
+			}
 		}
 
 		rsp := &http.Response{}
-		err = updateResponseFromHeaders(rsp, decodeFromSlice(headers), math.MaxInt, nil)
-		if err != nil {
-			return
+		if err := updateResponseFromHeaders(rsp, decodeFromSlice(headers), math.MaxInt, nil); err == nil {
+			if rsp.Proto != "HTTP/3.0" {
+				t.Fatalf("expected Proto HTTP/3.0, got %q", rsp.Proto)
+			}
+			if rsp.ProtoMajor != 3 {
+				t.Fatalf("expected ProtoMajor 3, got %d", rsp.ProtoMajor)
+			}
+			if rsp.ContentLength < -1 {
+				t.Fatalf("invalid ContentLength: %d", rsp.ContentLength)
+			}
+			if rsp.Header == nil {
+				t.Fatal("response has nil Header map")
+			}
+			if rsp.Status == "" {
+				t.Fatal("response has empty Status")
+			}
+			for _, name := range []string{"connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade"} {
+				if rsp.Header.Get(name) != "" {
+					t.Fatalf("response contains connection-specific header %q", name)
+				}
+			}
 		}
-		if rsp.Proto != "HTTP/3.0" {
-			t.Fatalf("expected Proto HTTP/3.0, got %q", rsp.Proto)
-		}
-		if rsp.ContentLength < -1 {
-			t.Fatalf("invalid ContentLength: %d", rsp.ContentLength)
+
+		if trailers, err := parseTrailers(decodeFromSlice(headers), nil); err == nil {
+			for name := range trailers {
+				if len(name) > 0 && name[0] == ':' {
+					t.Fatalf("trailer contains pseudo header %q", name)
+				}
+			}
+			// TODO(#5601): once parseTrailers validates header field names and values,
+			// add assertions here
 		}
 	})
 }

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -598,6 +598,10 @@ func FuzzHeaderParsing(f *testing.F) {
 		if err := json.Unmarshal(data, &pairs); err != nil {
 			return
 		}
+		if len(pairs) > 1000 {
+			// don't fuzz too many header fields all at once
+			return
+		}
 		headers := make([]qpack.HeaderField, len(pairs))
 		for i, p := range pairs {
 			headers[i] = qpack.HeaderField{Name: p[0], Value: p[1]}

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -18,6 +18,7 @@ compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzFrameParser htt
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/tokens Fuzz token_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/handshake Fuzz handshake_fuzzer
+compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzRequestHeaders http3_request_headers_fuzzer
 
 if [ $SANITIZER == "coverage" ]; then
     # no need for corpora if coverage

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -18,7 +18,7 @@ compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzFrameParser htt
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/tokens Fuzz token_fuzzer
 compile_go_fuzzer github.com/quic-go/quic-go/fuzzing/handshake Fuzz handshake_fuzzer
-compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzRequestHeaders http3_request_headers_fuzzer
+compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzHeaderParsing http3_header_parsing_fuzzer
 
 if [ $SANITIZER == "coverage" ]; then
     # no need for corpora if coverage


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add fuzz test for HTTP/3 request, response, and trailer header parsing
- Adds `FuzzHeaderParsing` in [http3/headers_test.go](https://github.com/quic-go/quic-go/pull/5602/files#diff-f95985faceb231b07d7725e2546e40ee3d8eed3890235bab9980229782211c8a) to fuzz-test `requestFromHeaders`, `updateResponseFromHeaders`, and `parseTrailers` with JSON-encoded `[name,value]` header pairs.
- Asserts invariants on parsed results: valid method/proto, HTTP/3.0 version, valid `ContentLength`, no connection-specific headers, and no pseudo-headers in trailers.
- Registers the fuzzer in [.clusterfuzzlite/build.sh](https://github.com/quic-go/quic-go/pull/5602/files#diff-2c10f02a79d6592981510922b30964df2d52d82b774ac3d337a535840bb4f3a8) and [oss-fuzz.sh](https://github.com/quic-go/quic-go/pull/5602/files#diff-857b8ac91ce0728a3684db7bff7d929b9818b1cfaeeb81499fea2f08aa39bc05) as `http3_header_parsing_fuzzer`.
- Adds a TODO in [http3/headers.go](https://github.com/quic-go/quic-go/pull/5602/files#diff-fd2fc9252b467e3ef8b4b4a45eafc66de3fab721b4de75b705da663b3e0f3160) to validate header field names and values before adding them to the trailer map.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c2173b.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->