### PR TITLE
ci: switch to native Go fuzzing for QPACK

### DIFF
--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -5,7 +5,9 @@ go env
 
 (
 # fuzz qpack
-compile_go_fuzzer github.com/quic-go/qpack/fuzzing Fuzz qpack_fuzzer
+cd $GOPATH/src/github.com/quic-go/qpack
+
+compile_native_go_fuzzer_v2 github.com/quic-go/qpack/fuzzing FuzzDecode qpack_decode_fuzzer
 )
 
 (


### PR DESCRIPTION
Depends on https://github.com/quic-go/qpack/pull/82.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch QPACK fuzzing to native Go fuzzer targeting `FuzzDecode`
> Updates [oss-fuzz.sh](https://github.com/quic-go/quic-go/pull/5603/files#diff-857b8ac91ce0728a3684db7bff7d929b9818b1cfaeeb81499fea2f08aa39bc05) to use `compile_native_go_fuzzer_v2` instead of `compile_go_fuzzer`, targeting the `FuzzDecode` function and producing `qpack_decode_fuzzer` as the output binary. The build now also changes into the qpack source directory before compiling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ba3d87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->