### PR TITLE
ci: enable ClusterFuzzLite batch fuzzing

### DIFF
--- a/.github/workflows/clusterfuzz-lite-batch.yml
+++ b/.github/workflows/clusterfuzz-lite-batch.yml
@@ -1,0 +1,33 @@
+name: ClusterFuzzLite batch fuzzing
+on:
+  schedule:
+    - cron: '0 0/6 * * *'
+permissions: read-all
+
+jobs:
+  BatchFuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+        - address
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: go
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 3600
+        mode: 'batch'
+        sanitizer: ${{ matrix.sanitizer }}
+        output-sarif: true
+        storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
+        storage-repo-branch: master
+        storage-repo-branch-coverage: gh-pages

--- a/.github/workflows/clusterfuzz-lite-prune.yml
+++ b/.github/workflows/clusterfuzz-lite-prune.yml
@@ -1,0 +1,26 @@
+name: ClusterFuzzLite pruning
+on:
+  schedule:
+    - cron: '0 2 * * *'
+permissions: read-all
+
+jobs:
+  Pruning:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: go
+    - name: Run Fuzzers
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 600
+        mode: 'prune'
+        output-sarif: true
+        storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
+        storage-repo-branch: master
+        storage-repo-branch-coverage: gh-pages


### PR DESCRIPTION
For https://github.com/quic-go/quic-go/issues/5604.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add ClusterFuzzLite batch fuzzing and pruning workflows
- Adds [clusterfuzz-lite-batch.yml](https://github.com/quic-go/quic-go/pull/5605/files#diff-132570da38bac149f132861c2ea52731d34a3dd7a58617d5ac3450b518fba0cb), a scheduled workflow that builds Go fuzzers with the address sanitizer and runs them in batch mode for 3600 seconds every 6 hours.
- Adds [clusterfuzz-lite-prune.yml](https://github.com/quic-go/quic-go/pull/5605/files#diff-aba0d2a5cc7df5988de7fdf5fd79a8f126eeb5d877f1331c246cf23b814f3672), a daily workflow that runs ClusterFuzzLite in prune mode for 600 seconds to trim the corpus.
- Both workflows emit SARIF output and push artifacts and coverage data to a configured storage repository using a secret-based URL.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 627d98f.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->