### PR TITLE
ci: use seed corpus for ClusterFuzzLite PR fuzzing

### DIFF
--- a/.github/workflows/clusterfuzz-lite-pr.yml
+++ b/.github/workflows/clusterfuzz-lite-pr.yml
@@ -24,12 +24,9 @@ jobs:
         language: go
         github-token: ${{ secrets.GITHUB_TOKEN }}
         sanitizer: ${{ matrix.sanitizer }}
-        # Optional but recommended: used to only run fuzzers that are affected
-        # by the PR.
-        # See later section on "Git repo for storage".
-        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
-        # storage-repo-branch: main   # Optional. Defaults to "main"
-        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+        storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
+        storage-repo-branch: master
+        storage-repo-branch-coverage: gh-pages
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
       uses: google/clusterfuzzlite/actions/run_fuzzers@v1
@@ -40,9 +37,6 @@ jobs:
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
         parallel-fuzzing: true
-        # Optional but recommended: used to download the corpus produced by
-        # batch fuzzing.
-        # See later section on "Git repo for storage".
-        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
-        # storage-repo-branch: main   # Optional. Defaults to "main"
-        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+        storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
+        storage-repo-branch: master
+        storage-repo-branch-coverage: gh-pages


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Configure storage repo for ClusterFuzzLite PR fuzzing to use seed corpus
Adds explicit storage configuration to the `build_fuzzers` and `run_fuzzers` steps in [clusterfuzz-lite-pr.yml](.github/workflows/clusterfuzz-lite-pr.yml), pointing to `quic-go/clusterfuzzlite-storage` with `master` as the corpus branch and `gh-pages` for coverage data. Previously these steps had no storage repo configured, so PR fuzzing runs could not use or persist the seed corpus.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized f488e5d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->