### PR TITLE
ci: fix path to QPACK fuzzer for OSS-Fuzz

### DIFF
--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -7,7 +7,7 @@ go env
 # fuzz qpack
 cd $GOPATH/src/github.com/quic-go/qpack
 
-compile_native_go_fuzzer_v2 github.com/quic-go/qpack/fuzzing FuzzDecode qpack_decode_fuzzer
+compile_native_go_fuzzer_v2 github.com/quic-go/qpack FuzzDecode qpack_decode_fuzzer
 )
 
 (


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix QPACK fuzzer module path in OSS-Fuzz build script
Corrects the module path passed to `compile_native_go_fuzzer_v2` in [oss-fuzz.sh](https://github.com/quic-go/quic-go/pull/5612/files#diff-857b8ac91ce0728a3684db7bff7d929b9818b1cfaeeb81499fea2f08aa39bc05) from `github.com/quic-go/qpack/fuzzing` to `github.com/quic-go/qpack`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ab5e86.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->