### PR TITLE
ci: generate Codecov coverage report from OSS-Fuzz corpus

### DIFF
--- a/.github/workflows/oss-fuzz-converage.yml
+++ b/.github/workflows/oss-fuzz-converage.yml
@@ -1,0 +1,34 @@
+name: Fuzz Coverage → CodeCov
+
+on:
+  schedule:
+    - cron: '0 2 * * *' 
+  workflow_dispatch: # allows manual trigger
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  fuzz-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.x"
+      - name: Install gsutil (gcloud)
+        uses: google-github-actions/setup-gcloud@v3
+      - name: Download latest OSS-Fuzz corpus
+        run: |
+          mkdir -p testdata/fuzz
+          gsutil -m cp -r 'gs://quic-go-corpus.clusterfuzz-external.appspot.com/*' testdata/fuzz/ || true
+      - name: Generate fuzz coverage report
+        run: go test -coverprofile=fuzz-coverage.out -coverpkg=./... ./... -run=^$
+      - name: Upload to CodeCov (separate "fuzz" flag)
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./fuzz-coverage.out
+          flags: fuzz
+          name: oss-fuzz-coverage
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,10 @@ coverage:
       default:
         threshold: 0.5
     patch: false
+
+flags:
+  fuzz:
+    joined: false  # don't merge fuzz coverage into main coverage report
+    statuses:
+      - type: project
+        informational: true  # don't fail a PR because of fuzz coverage


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Generate Codecov coverage report from OSS-Fuzz corpus in CI
- Adds [oss-fuzz-converage.yml](https://github.com/quic-go/quic-go/pull/5614/files#diff-f2189db0bd6af0d5dcec8648c09d4984ae5bd3505fdee42b19f3abca2768bc4f), a nightly cron workflow (also triggered manually and on PRs to master) that downloads the latest OSS-Fuzz corpus via `gsutil` and runs `go test` to produce a coverage profile.
- Uploads the resulting report to Codecov with the `fuzz` flag and name `oss-fuzz-coverage`; upload failures do not block CI.
- Updates [codecov.yml](https://github.com/quic-go/quic-go/pull/5614/files#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40db) to treat the `fuzz` flag as a standalone report — it is not merged into main coverage and posts only an informational project status.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 58886c2. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->