### PR TITLE
wire: fuzz splitting of CRYPTO and DATAGRAM, truncation of ACK frames

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -3,7 +3,7 @@
 go version
 go env
 
-compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzFrameParser frame_fuzzer
+compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzFrames frame_fuzzer
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzTransportParameters transportparameter_fuzzer
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzFrameParser http3_frame_fuzzer
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer

--- a/internal/wire/frame_parser_test.go
+++ b/internal/wire/frame_parser_test.go
@@ -829,7 +829,7 @@ func benchmarkFrames(b *testing.B, frames ...Frame) {
 	}
 }
 
-func FuzzFrameParser(f *testing.F) {
+func FuzzFrames(f *testing.F) {
 	const version = protocol.Version1
 
 	for _, s := range []struct {
@@ -846,7 +846,7 @@ func FuzzFrameParser(f *testing.F) {
 	} {
 		b, err := s.frame.Append(nil, version)
 		require.NoError(f, err)
-		f.Add(uint8(s.encLevel), b)
+		f.Add(uint8(s.encLevel), uint16(0xffff), b)
 	}
 
 	for _, fr := range []Frame{
@@ -854,6 +854,7 @@ func FuzzFrameParser(f *testing.F) {
 		&StreamFrame{StreamID: 0x42, Fin: true},
 		&StreamFrame{StreamID: 0x42, Data: []byte("foobar"), Fin: true},
 		&StreamFrame{StreamID: 0x1337, Offset: 0xcafe, Data: []byte("foobar")},
+		&StreamFrame{Offset: quicvarint.Max, Data: []byte("foo")}, // exceeds maximum offset
 		&AckFrame{AckRanges: []AckRange{{Smallest: 1, Largest: 0x13}}},
 		&AckFrame{
 			AckRanges: []AckRange{{Smallest: 80, Largest: 100}, {Smallest: 1, Largest: 50}},
@@ -897,10 +898,17 @@ func FuzzFrameParser(f *testing.F) {
 	} {
 		b, err := fr.Append(nil, version)
 		require.NoError(f, err)
-		f.Add(uint8(protocol.Encryption1RTT), b)
+		maxSize := uint16(0xffff)
+		switch fr.(type) {
+		case *StreamFrame, *DatagramFrame:
+			maxSize = 256
+		case *AckFrame:
+			maxSize = 128
+		}
+		f.Add(uint8(protocol.Encryption1RTT), maxSize, b)
 	}
 
-	f.Fuzz(func(t *testing.T, encLevelRaw uint8, data []byte) {
+	f.Fuzz(func(t *testing.T, encLevelRaw uint8, maxSize uint16, data []byte) {
 		encLevel := protocol.EncryptionLevel(encLevelRaw)
 		if encLevel != protocol.EncryptionInitial && encLevel != protocol.EncryptionHandshake && encLevel != protocol.Encryption1RTT && encLevel != protocol.Encryption0RTT {
 			return
@@ -922,7 +930,7 @@ func FuzzFrameParser(f *testing.F) {
 			switch {
 			case frameType.IsStreamFrameType():
 				frame, l, err = parser.ParseStreamFrame(frameType, data, version)
-			case frameType == FrameTypeAck || frameType == FrameTypeAckECN:
+			case frameType.IsAckFrameType():
 				frame, l, err = parser.ParseAckFrame(frameType, data, encLevel, version)
 			case frameType == FrameTypeDatagramNoLength || frameType == FrameTypeDatagramWithLength:
 				frame, l, err = parser.ParseDatagramFrame(frameType, data, version)
@@ -946,19 +954,51 @@ func FuzzFrameParser(f *testing.F) {
 			startLen := len(b)
 			parsedLen := initialLen - len(data)
 			b, err = frame.Append(b, version)
-			if err != nil {
-				t.Fatalf("error writing frame %#v: %s", frame, err)
-			}
+			require.NoError(t, err)
 			frameLen := protocol.ByteCount(len(b) - startLen)
-			if frame.Length(version) != frameLen {
-				t.Fatalf("inconsistent frame length for %#v: expected %d, got %d", frame, frameLen, frame.Length(version))
+			require.Equal(t, frameLen, frame.Length(version), "re-serialized frame")
+			size := protocol.ByteCount(maxSize)
+			switch f := frame.(type) {
+			case *StreamFrame:
+				orig := slices.Clone(f.Data)
+				split, needsSplit := f.MaybeSplitOffFrame(size, version)
+				if split != nil {
+					require.LessOrEqual(t, split.Length(version), size, "split STREAM frame")
+					require.Equal(t, orig, append(slices.Clone(split.Data), f.Data...), "split STREAM frame data")
+					split.PutBack()
+				} else {
+					require.True(t, needsSplit || f.Length(version) <= size, "STREAM longer than maxSize but not split: len=%d maxSize=%d", f.Length(version), size)
+				}
+			case *CryptoFrame:
+				orig := slices.Clone(f.Data)
+				split, needsSplit := f.MaybeSplitOffFrame(size, version)
+				if split != nil {
+					require.LessOrEqual(t, split.Length(version), size, "split CRYPTO frame")
+					require.Equal(t, orig, append(slices.Clone(split.Data), f.Data...), "split CRYPTO frame data")
+				} else {
+					require.True(t, needsSplit || f.Length(version) <= size, "CRYPTO longer than maxSize but not split: len=%d maxSize=%d", f.Length(version), size)
+				}
+			case *AckFrame:
+				f.HasMissingRanges()
+				// Truncate requires maxSize to fit at least one ACK range;
+				// 64 bytes covers the worst case (8-byte varints, with ECN).
+				if size >= 64 {
+					f.Truncate(size, version)
+					require.LessOrEqual(t, f.Length(version), size, "truncated ACK")
+					checkFrameInvariants(t, f)
+				}
+			case *DatagramFrame:
+				if n := f.MaxDataLen(size, version); n > 0 && protocol.ByteCount(len(f.Data)) > n {
+					orig := f.Data
+					f.Data = f.Data[:n]
+					require.LessOrEqual(t, f.Length(version), size, "DATAGRAM with MaxDataLen")
+					f.Data = orig
+				}
 			}
 			if sf, ok := frame.(*StreamFrame); ok {
 				sf.PutBack()
 			}
-			if frameLen > protocol.ByteCount(parsedLen) {
-				t.Fatalf("serialized length (%d) is longer than parsed length (%d)", len(b), parsedLen)
-			}
+			require.LessOrEqual(t, frameLen, protocol.ByteCount(parsedLen), "serialized length vs parsed length")
 		}
 	})
 }

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -9,7 +9,7 @@ compile_native_go_fuzzer_v2 github.com/quic-go/qpack FuzzDecode qpack_decode_fuz
 
 # fuzz quic-go
 cd $GOPATH/src/github.com/quic-go/quic-go/
-compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzFrameParser frame_fuzzer
+compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzFrames frame_fuzzer
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzTransportParameters transportparameter_fuzzer
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/http3 FuzzFrameParser http3_frame_fuzzer
 compile_native_go_fuzzer_v2 github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Extend `FuzzFrames` to cover splitting of CRYPTO/DATAGRAM frames and truncation of ACK frames
- Renames `FuzzFrameParser` to `FuzzFrames` in the fuzz harness, build scripts ([build.sh](https://github.com/quic-go/quic-go/pull/5615/files#diff-2c10f02a79d6592981510922b30964df2d52d82b774ac3d337a535840bb4f3a8), [oss-fuzz.sh](https://github.com/quic-go/quic-go/pull/5615/files#diff-857b8ac91ce0728a3684db7bff7d929b9818b1cfaeeb81499fea2f08aa39bc05)), and the test file.
- Adds a `maxSize uint16` parameter to the fuzz corpus, allowing the harness to exercise size-dependent code paths for STREAM, CRYPTO, ACK, and DATAGRAM frames.
- For STREAM and CRYPTO frames, validates `MaybeSplitOffFrame` output; for ACK frames, calls `Truncate` and checks invariants; for DATAGRAM frames, uses `MaxDataLen` to verify length conformity.
- Adds a seed with `Offset` set to `quicvarint.Max` to cover the maximum stream offset edge case.
- Replaces manual failure checks with `require` assertions throughout.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized d16adbe.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->