### PR TITLE
ci: set permissions on all CI workflows

### DIFF
--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -1,4 +1,7 @@
 name: Build interop Docker image
+
+permissions: read-all
+
 on: 
   push:
     branches:

--- a/.github/workflows/clusterfuzz-lite-batch.yml
+++ b/.github/workflows/clusterfuzz-lite-batch.yml
@@ -3,7 +3,9 @@ on:
   schedule:
     - cron: '0 0/6 * * *'
 
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   BatchFuzzing:

--- a/.github/workflows/clusterfuzz-lite-batch.yml
+++ b/.github/workflows/clusterfuzz-lite-batch.yml
@@ -2,6 +2,7 @@ name: ClusterFuzzLite batch fuzzing
 on:
   schedule:
     - cron: '0 0/6 * * *'
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/clusterfuzz-lite-pr.yml
+++ b/.github/workflows/clusterfuzz-lite-pr.yml
@@ -5,6 +5,7 @@ on:
       - '**'
 
 permissions: read-all
+
 jobs:
   PR:
     runs-on: ${{ fromJSON(vars['CLUSTERFUZZ_LITE_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}

--- a/.github/workflows/clusterfuzz-lite-pr.yml
+++ b/.github/workflows/clusterfuzz-lite-pr.yml
@@ -4,7 +4,9 @@ on:
     paths:
       - '**'
 
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   PR:

--- a/.github/workflows/clusterfuzz-lite-prune.yml
+++ b/.github/workflows/clusterfuzz-lite-prune.yml
@@ -3,7 +3,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   Pruning:

--- a/.github/workflows/clusterfuzz-lite-prune.yml
+++ b/.github/workflows/clusterfuzz-lite-prune.yml
@@ -2,6 +2,7 @@ name: ClusterFuzzLite pruning
 on:
   schedule:
     - cron: '0 2 * * *'
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,4 +1,7 @@
 on: [push, pull_request]
+
+permissions: read-all
+
 jobs:
   crosscompile:
     strategy:

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -4,6 +4,9 @@ permissions: read-all
 
 jobs:
   crosscompile:
+    permissions:
+      actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   integration:
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,5 +1,6 @@
 on: [push, pull_request]
 
+permissions: read-all
 
 jobs:
   unit:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Set explicit permissions on all CI workflows
Adds top-level `permissions: read-all` to most CI workflows to restrict the default GitHub Actions token scope. The clusterfuzz workflows get granular permissions (`contents: read`, `security-events: write`) and the cross-compile workflow also adds job-level `actions: write` to the `crosscompile` job.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9723503.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->