### PR TITLE
wire: increase fuzz coverage of transport parameter fuzzer

### DIFF
--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -944,6 +944,7 @@ func FuzzTransportParameters(f *testing.F) {
 		MaxBidiStreamNum:               1337,
 		MaxUniStreamNum:                7331,
 		ActiveConnectionIDLimit:        7,
+		MaxDatagramFrameSize:           protocol.InvalidByteCount,
 	}).MarshalForSessionTicket(nil)
 	zeroRTTParams := (&TransportParameters{
 		StatelessResetToken:     &protocol.StatelessResetToken{},

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -936,15 +936,7 @@ func benchmarkTransportParameters(b *testing.B, withPreferredAddress bool) {
 }
 
 func FuzzTransportParameters(f *testing.F) {
-	f.Add(true, false, (&TransportParameters{
-		StatelessResetToken:     &protocol.StatelessResetToken{},
-		ActiveConnectionIDLimit: 2,
-	}).Marshal(protocol.PerspectiveServer))
-	f.Add(false, false, (&TransportParameters{
-		ActiveConnectionIDLimit: 2,
-	}).Marshal(protocol.PerspectiveClient))
-	// session ticket
-	f.Add(false, true, (&TransportParameters{
+	savedParams := (&TransportParameters{
 		InitialMaxStreamDataBidiLocal:  1234,
 		InitialMaxStreamDataBidiRemote: 2345,
 		InitialMaxStreamDataUni:        3456,
@@ -952,30 +944,55 @@ func FuzzTransportParameters(f *testing.F) {
 		MaxBidiStreamNum:               1337,
 		MaxUniStreamNum:                7331,
 		ActiveConnectionIDLimit:        7,
-	}).MarshalForSessionTicket(nil))
-	//  with preferred address
-	f.Add(true, false, (&TransportParameters{
+	}).MarshalForSessionTicket(nil)
+	zeroRTTParams := (&TransportParameters{
 		StatelessResetToken:     &protocol.StatelessResetToken{},
-		ActiveConnectionIDLimit: 2,
-		PreferredAddress: &PreferredAddress{
-			IPv4:                netip.AddrPortFrom(netip.AddrFrom4([4]byte{127, 0, 0, 1}), 42),
-			IPv6:                netip.AddrPortFrom(netip.AddrFrom16([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), 13),
-			ConnectionID:        protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef}),
-			StatelessResetToken: protocol.StatelessResetToken{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
-		},
-	}).Marshal(protocol.PerspectiveServer),
-	)
+		ActiveConnectionIDLimit: 7,
+		MaxDatagramFrameSize:    1200,
+	}).Marshal(protocol.PerspectiveServer)
 
-	f.Fuzz(func(t *testing.T, isServer, isSessionTicket bool, data []byte) {
-		if isSessionTicket {
-			fuzzTransportParametersSessionTicket(t, data)
-		} else {
-			sentBy := protocol.PerspectiveClient
-			if isServer {
-				sentBy = protocol.PerspectiveServer
-			}
-			fuzzTransportParameters(t, data, sentBy)
-		}
+	rcid := protocol.ParseConnectionID([]byte{0xde, 0xad, 0xc0, 0xde})
+	minAckDelay := 42 * time.Millisecond
+	for _, seed := range []struct {
+		Data      []byte
+		SavedData []byte
+	}{
+		{(&TransportParameters{
+			StatelessResetToken:     &protocol.StatelessResetToken{},
+			ActiveConnectionIDLimit: 2,
+		}).Marshal(protocol.PerspectiveServer), savedParams},
+		{zeroRTTParams, savedParams},
+		{(&TransportParameters{
+			ActiveConnectionIDLimit: 2,
+			RetrySourceConnectionID: &rcid,
+		}).Marshal(protocol.PerspectiveClient), savedParams},
+		{(&TransportParameters{
+			EnableResetStreamAt:     true,
+			RetrySourceConnectionID: &rcid,
+			MinAckDelay:             &minAckDelay,
+		}).Marshal(protocol.PerspectiveClient), savedParams},
+		// session ticket
+		{savedParams, savedParams},
+		// with preferred address
+		{(&TransportParameters{
+			StatelessResetToken:     &protocol.StatelessResetToken{},
+			ActiveConnectionIDLimit: 2,
+			PreferredAddress: &PreferredAddress{
+				IPv4:                netip.AddrPortFrom(netip.AddrFrom4([4]byte{127, 0, 0, 1}), 42),
+				IPv6:                netip.AddrPortFrom(netip.AddrFrom16([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), 13),
+				ConnectionID:        protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef}),
+				StatelessResetToken: protocol.StatelessResetToken{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+			},
+		}).Marshal(protocol.PerspectiveServer), savedParams},
+	} {
+		f.Add(seed.Data, seed.SavedData)
+	}
+
+	f.Fuzz(func(t *testing.T, data, savedData []byte) {
+		fuzzTransportParameters(t, data, protocol.PerspectiveClient)
+		fuzzTransportParameters(t, data, protocol.PerspectiveServer)
+		fuzzTransportParametersSessionTicket(t, data)
+		fuzzTransportParameters0RTT(t, data, savedData)
 	})
 }
 
@@ -1003,11 +1020,27 @@ func fuzzTransportParametersSessionTicket(t *testing.T, data []byte) {
 	if err := tp.UnmarshalFromSessionTicket(data); err != nil {
 		return
 	}
+	_ = tp.String()
 	b := tp.MarshalForSessionTicket(nil)
 	tp2 := &TransportParameters{}
 	if err := tp2.UnmarshalFromSessionTicket(b); err != nil {
 		t.Fatalf("error unmarshaling re-marshaled session ticket transport parameters: %s", err)
 	}
+}
+
+func fuzzTransportParameters0RTT(t *testing.T, data, savedData []byte) {
+	t.Helper()
+
+	tp := &TransportParameters{}
+	if err := tp.Unmarshal(data, protocol.PerspectiveServer); err != nil {
+		return
+	}
+	saved := &TransportParameters{}
+	if err := saved.UnmarshalFromSessionTicket(savedData); err != nil {
+		return
+	}
+	_ = tp.ValidFor0RTT(saved)
+	_ = tp.ValidForUpdate(saved)
 }
 
 func checkTransportParameterInvariants(t *testing.T, tp *TransportParameters, sentBy protocol.Perspective) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Increase fuzz coverage of transport parameter fuzzer with 0-RTT and session ticket paths
- Reworks `FuzzTransportParameters` in [transport_parameter_test.go](https://github.com/quic-go/quic-go/pull/5619/files#diff-a8ac38a15f9e2df9354b19a757061e736e23e458aade91d052efb92df5dda70d) to accept two byte slices (`data`, `savedData`) instead of booleans, and always exercises both client and server perspectives.
- Adds structured seed cases covering `RetrySourceConnectionID`, `EnableResetStreamAt`, `MinAckDelay`, `MaxDatagramFrameSize`, and `PreferredAddress` variants.
- Adds a new `fuzzTransportParameters0RTT` helper that exercises `ValidFor0RTT` and `ValidForUpdate` against decoded server and session-ticket transport parameters.
- Extends `fuzzTransportParametersSessionTicket` to also call `tp.String()` on decoded inputs.
- Behavioral Change: the fuzz corpus entry format changes from a single slice with booleans to a pair of byte slices; existing corpus entries are incompatible with the new signature.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6071662.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->