### PR TITLE
add a fuzzer for the frame sorter

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -34,4 +34,5 @@ build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzTransportPar
 build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzFrameParser http3_frame_fuzzer
 build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer_v2
 build_native_go_fuzzer github.com/quic-go/quic-go/internal/handshake FuzzHandshake handshake_fuzzer_v2
+build_native_go_fuzzer github.com/quic-go/quic-go FuzzFrameSorter frame_sorter_fuzzer
 build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzHeaderParsing http3_header_parsing_fuzzer

--- a/.github/workflows/clusterfuzz-coverage.yml
+++ b/.github/workflows/clusterfuzz-coverage.yml
@@ -36,6 +36,7 @@ jobs:
             http3_frame_fuzzer
             header_fuzzer_v2
             handshake_fuzzer_v2
+            frame_sorter_fuzzer
             http3_header_parsing_fuzzer
           )
 
@@ -47,9 +48,15 @@ jobs:
             echo "$target: downloading live corpus"
             rm -rf "$corpus_dir"
             mkdir -p "$corpus_dir"
-            gcloud storage cp --recursive "$source_dir/*" "$corpus_dir"
-            echo "$target: $(find "$corpus_dir" -type f | wc -l) corpus files"
+
+            gcloud storage cp --recursive "$source_dir/*" "$corpus_dir" || echo "$target: no live corpus found"
           done
+
+          corpus_files=$(find oss-fuzz/build/corpus/quic-go -type f | wc -l | tr -d ' ')
+          if [ "$corpus_files" = 0 ]; then
+            echo "no ClusterFuzz corpus files downloaded"
+            exit 1
+          fi
       - name: Summarize ClusterFuzz corpus
         run: |
           set -euo pipefail
@@ -66,6 +73,9 @@ jobs:
 
               target=$(basename "$corpus_dir")
               corpus_files=$(find "$corpus_dir" -type f | wc -l | tr -d ' ')
+              if [ "$corpus_files" = 0 ]; then
+                corpus_files="---"
+              fi
               echo "| \`$target\` | $corpus_files |"
             done
           } >> "$GITHUB_STEP_SUMMARY"

--- a/crypto_stream_test.go
+++ b/crypto_stream_test.go
@@ -157,8 +157,9 @@ func TestInitialCryptoStreamClientStatic(t *testing.T) {
 	skipIfDisableScramblingEnvSet(t)
 
 	str := newInitialCryptoStream(true)
-	clientHello := getClientHello(t, "quic-go.net")
-	_, err := str.Write(clientHello)
+	clientHello, err := getClientHello("quic-go.net")
+	require.NoError(t, err)
+	_, err = str.Write(clientHello)
 	require.NoError(t, err)
 	require.True(t, str.HasData())
 	_, err = str.Write([]byte("foobar"))
@@ -222,10 +223,14 @@ func TestInitialCryptoStreamClientRandomizedSizes(t *testing.T) {
 			var clientHello []byte
 			if serverName == "" || !strings.Contains(serverName, ".") || mrand.Int()%2 == 0 {
 				t.Logf("using a ClientHello without ECH, hostname: %q", serverName)
-				clientHello = getClientHello(t, serverName)
+				var err error
+				clientHello, err = getClientHello(serverName)
+				require.NoError(t, err)
 			} else {
 				t.Logf("using a ClientHello with ECH, hostname: %q", serverName)
-				clientHello = getClientHelloWithECH(t, serverName)
+				var err error
+				clientHello, err = getClientHelloWithECH(serverName)
+				require.NoError(t, err)
 			}
 			testInitialCryptoStreamClientRandomizedSizes(t, clientHello, serverName)
 		})

--- a/frame_sorter_test.go
+++ b/frame_sorter_test.go
@@ -2,9 +2,11 @@ package quic
 
 import (
 	rand "crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"math"
 	mrand "math/rand/v2"
+	"slices"
 	"testing"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -1509,4 +1511,198 @@ func TestFrameSorterPeek(t *testing.T) {
 	s.Push([]byte("qux"), 10, nil)
 	p = make([]byte, 10)
 	require.ErrorIs(t, s.Peek(0, p), errTooLittleData)
+}
+
+func FuzzFrameSorter(f *testing.F) {
+	const (
+		opPush uint8 = iota
+		opPop
+		opPeek
+		opSize = 5
+	)
+
+	const (
+		maxStreamLen = 1024
+		maxFrameLen  = 256
+		maxOps       = 128
+	)
+
+	type op struct {
+		Typ    byte
+		Offset int
+		Length int
+	}
+
+	for _, seed := range [][]op{
+		{
+			{Typ: opPush, Offset: 0, Length: 3},
+			{Typ: opPush, Offset: 3, Length: 3},
+			{Typ: opPop},
+		},
+		{
+			{Typ: opPush, Offset: 6, Length: 3},
+			{Typ: opPush, Offset: 0, Length: 3},
+			{Typ: opPush, Offset: 3, Length: 3},
+			{Typ: opPop},
+		},
+		{
+			{Typ: opPush, Offset: 0, Length: 6},
+			{Typ: opPush, Offset: 0, Length: 6},
+			{Typ: opPop},
+			{Typ: opPush, Offset: 0, Length: 6},
+		},
+		{
+			{Typ: opPush, Offset: 3, Length: 4},
+			{Typ: opPush, Offset: 5, Length: 4},
+			{Typ: opPush, Offset: 0, Length: 3},
+			{Typ: opPop},
+		},
+		{
+			{Typ: opPush, Offset: 3, Length: 3},
+			{Typ: opPush, Offset: 9, Length: 3},
+			{Typ: opPush, Offset: 5, Length: 10},
+			{Typ: opPush, Offset: 0, Length: 3},
+			{Typ: opPop},
+		},
+		{
+			{Typ: opPush, Offset: 0, Length: 6},
+			{Typ: opPeek, Offset: 0, Length: 3},
+			{Typ: opPush, Offset: 6, Length: 3},
+			{Typ: opPeek, Offset: 0, Length: 9},
+			{Typ: opPush, Offset: 10, Length: 3},
+			{Typ: opPeek, Offset: 0, Length: 12},
+		},
+	} {
+		// each operation is serialized as 1 byte op type, 2 bytes offset, and 2 bytes length
+		b := make([]byte, opSize*len(seed))
+		for i, op := range seed {
+			b[opSize*i] = op.Typ
+			binary.BigEndian.PutUint16(b[opSize*i+1:opSize*i+3], uint16(op.Offset))
+			binary.BigEndian.PutUint16(b[opSize*i+3:opSize*i+5], uint16(op.Length))
+		}
+		f.Add(b)
+	}
+
+	// use deterministic non-uniform data
+	streamData := make([]byte, maxStreamLen)
+	for i := range streamData {
+		streamData[i] = byte(31*i + 7)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data)%opSize != 0 || len(data) > opSize*maxOps {
+			return
+		}
+
+		s := newFrameSorter()
+		received := make([]bool, len(streamData))
+		var readPos protocol.ByteCount
+		var callbacks []callbackTracker
+
+		push := func(offset, length int) {
+			cb, tr := getFrameSorterTestCallback(t)
+			callbacks = append(callbacks, tr)
+			require.NoError(t, s.Push(streamData[offset:offset+length], protocol.ByteCount(offset), cb))
+			for i := max(offset, int(readPos)); i < offset+length; i++ {
+				received[i] = true
+			}
+		}
+
+		for len(data) > 0 {
+			op := op{
+				Typ:    data[0],
+				Offset: int(binary.BigEndian.Uint16(data[1:3])),
+				Length: int(binary.BigEndian.Uint16(data[3:5])),
+			}
+			data = data[opSize:]
+			if op.Offset >= len(streamData) || op.Length > maxFrameLen || op.Offset+op.Length > len(streamData) {
+				return
+			}
+
+			switch op.Typ {
+			case opPush:
+				push(op.Offset, op.Length)
+			case opPop:
+				readPos = frameSorterFuzzPop(t, s, streamData, received, readPos)
+			case opPeek:
+				frameSorterFuzzPeek(t, s, streamData, received, readPos, op.Offset, op.Length)
+			}
+		}
+
+		// Complete the stream so that all queued data is eventually popped or replaced.
+		// This lets us assert that every callback is called exactly once.
+		push(0, len(streamData))
+
+		for readPos < protocol.ByteCount(len(streamData)) {
+			readPos = frameSorterFuzzPop(t, s, streamData, received, readPos)
+		}
+		require.False(t, s.HasMoreData())
+		for _, cb := range callbacks {
+			require.True(t, cb.WasCalled())
+		}
+	})
+}
+
+func frameSorterFuzzPop(t *testing.T, s *frameSorter, streamData []byte, received []bool, readPos protocol.ByteCount) protocol.ByteCount {
+	t.Helper()
+
+	hasMoreData := func(received []bool) bool {
+		return slices.Contains(received, true)
+	}
+
+	offset, data, cb := s.Pop()
+	require.Equal(t, readPos, offset)
+
+	require.LessOrEqual(t, readPos, protocol.ByteCount(len(streamData)))
+	if readPos == protocol.ByteCount(len(streamData)) || !received[readPos] {
+		require.Nil(t, data)
+		require.Nil(t, cb)
+		require.Equal(t, hasMoreData(received[int(readPos):]), s.HasMoreData())
+		return readPos
+	}
+
+	require.NotEmpty(t, data)
+	nextGap := slices.Index(received[int(readPos):], false)
+	if nextGap == -1 {
+		nextGap = len(received) - int(readPos)
+	}
+	require.LessOrEqual(t, len(data), nextGap)
+	end := readPos + protocol.ByteCount(len(data))
+	require.LessOrEqual(t, end, protocol.ByteCount(len(streamData)))
+	require.Equal(t, streamData[readPos:end], data)
+	if cb != nil {
+		cb()
+	}
+	require.Equal(t, hasMoreData(received[int(end):]), s.HasMoreData())
+	return end
+}
+
+func frameSorterFuzzPeek(t *testing.T, s *frameSorter, streamData []byte, received []bool, readPos protocol.ByteCount, offset, length int) {
+	t.Helper()
+
+	p := make([]byte, length)
+	err := s.Peek(protocol.ByteCount(offset), p)
+
+	// Peek only succeeds if there is enough consecutive data queued starting at offset,
+	// and it only supports peeking from offsets where a frame starts.
+	if length == 0 {
+		require.NoError(t, err)
+		return
+	}
+
+	var mustSucceed bool
+	if protocol.ByteCount(offset) == readPos {
+		nextGap := slices.Index(received[offset:], false)
+		if nextGap == -1 {
+			nextGap = len(received) - offset
+		}
+		mustSucceed = length <= nextGap
+	}
+
+	if mustSucceed {
+		require.NoError(t, err)
+	} else if err != nil {
+		return
+	}
+	require.Equal(t, streamData[offset:offset+length], p)
 }

--- a/frame_sorter_test.go
+++ b/frame_sorter_test.go
@@ -1683,25 +1683,16 @@ func frameSorterFuzzPeek(t *testing.T, s *frameSorter, streamData []byte, receiv
 	p := make([]byte, length)
 	err := s.Peek(protocol.ByteCount(offset), p)
 
-	// Peek only succeeds if there is enough consecutive data queued starting at offset,
-	// and it only supports peeking from offsets where a frame starts.
-	if length == 0 {
-		require.NoError(t, err)
-		return
-	}
-
-	var mustSucceed bool
-	if protocol.ByteCount(offset) == readPos {
+	// Peek only supports peeking from offsets where a frame starts. The model only
+	// knows that frame boundaries are guaranteed at readPos, so when peeking from
+	// there with enough consecutive received data, Peek must succeed.
+	if length > 0 && protocol.ByteCount(offset) == readPos {
 		nextGap := slices.Index(received[offset:], false)
-		if nextGap == -1 {
-			nextGap = len(received) - offset
+		if nextGap == -1 || nextGap >= length {
+			require.NoError(t, err)
 		}
-		mustSucceed = length <= nextGap
 	}
-
-	if mustSucceed {
-		require.NoError(t, err)
-	} else if err != nil {
+	if err != nil {
 		return
 	}
 	require.Equal(t, streamData[offset:offset+length], p)

--- a/frame_sorter_test.go
+++ b/frame_sorter_test.go
@@ -2,7 +2,6 @@ package quic
 
 import (
 	rand "crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"math"
 	mrand "math/rand/v2"
@@ -1518,69 +1517,31 @@ func FuzzFrameSorter(f *testing.F) {
 		opPush uint8 = iota
 		opPop
 		opPeek
-		opSize = 5
 	)
 
+	// Each operation is encoded as 3 bytes: 1 byte op type, 1 byte offset, 1 byte length.
+	// maxStreamLen is chosen larger than protocol.MinStreamFrameBufferSize so that overlapping
+	// frames can be cut down to less than that threshold. This ensures the small-cut code path
+	// in frameSorter.push (which copies the cut frame and fires the doneCb early) is exercised,
+	// while still allowing un-cut frames to be at or above the minimum size.
 	const (
-		maxStreamLen = 1024
-		maxFrameLen  = 256
+		opSize       = 3
+		maxStreamLen = 256
 		maxOps       = 128
 	)
+	// If MinStreamFrameBufferSize is ever changed to grow beyond maxStreamLen,
+	// the small-cut path becomes unreachable. Keep them in sync.
+	require.Less(f, protocol.MinStreamFrameBufferSize, maxStreamLen)
 
-	type op struct {
-		Typ    byte
-		Offset int
-		Length int
-	}
-
-	for _, seed := range [][]op{
-		{
-			{Typ: opPush, Offset: 0, Length: 3},
-			{Typ: opPush, Offset: 3, Length: 3},
-			{Typ: opPop},
-		},
-		{
-			{Typ: opPush, Offset: 6, Length: 3},
-			{Typ: opPush, Offset: 0, Length: 3},
-			{Typ: opPush, Offset: 3, Length: 3},
-			{Typ: opPop},
-		},
-		{
-			{Typ: opPush, Offset: 0, Length: 6},
-			{Typ: opPush, Offset: 0, Length: 6},
-			{Typ: opPop},
-			{Typ: opPush, Offset: 0, Length: 6},
-		},
-		{
-			{Typ: opPush, Offset: 3, Length: 4},
-			{Typ: opPush, Offset: 5, Length: 4},
-			{Typ: opPush, Offset: 0, Length: 3},
-			{Typ: opPop},
-		},
-		{
-			{Typ: opPush, Offset: 3, Length: 3},
-			{Typ: opPush, Offset: 9, Length: 3},
-			{Typ: opPush, Offset: 5, Length: 10},
-			{Typ: opPush, Offset: 0, Length: 3},
-			{Typ: opPop},
-		},
-		{
-			{Typ: opPush, Offset: 0, Length: 6},
-			{Typ: opPeek, Offset: 0, Length: 3},
-			{Typ: opPush, Offset: 6, Length: 3},
-			{Typ: opPeek, Offset: 0, Length: 9},
-			{Typ: opPush, Offset: 10, Length: 3},
-			{Typ: opPeek, Offset: 0, Length: 12},
-		},
+	for _, seed := range [][]uint8{
+		{opPush, 0, 3, opPush, 3, 3, opPop, 0, 0},
+		{opPush, 6, 3, opPush, 0, 3, opPush, 3, 3, opPop, 0, 0},
+		{opPush, 0, 6, opPush, 0, 6, opPop, 0, 0, opPush, 0, 6},
+		{opPush, 3, 4, opPush, 5, 4, opPush, 0, 3, opPop, 0, 0},
+		{opPush, 3, 3, opPush, 9, 3, opPush, 5, 10, opPush, 0, 3, opPop, 0, 0},
+		{opPush, 0, 6, opPeek, 0, 3, opPush, 6, 3, opPeek, 0, 9, opPush, 10, 3, opPeek, 0, 12},
 	} {
-		// each operation is serialized as 1 byte op type, 2 bytes offset, and 2 bytes length
-		b := make([]byte, opSize*len(seed))
-		for i, op := range seed {
-			b[opSize*i] = op.Typ
-			binary.BigEndian.PutUint16(b[opSize*i+1:opSize*i+3], uint16(op.Offset))
-			binary.BigEndian.PutUint16(b[opSize*i+3:opSize*i+5], uint16(op.Length))
-		}
-		f.Add(b)
+		f.Add(seed)
 	}
 
 	// use deterministic non-uniform data
@@ -1608,24 +1569,19 @@ func FuzzFrameSorter(f *testing.F) {
 			}
 		}
 
-		for len(data) > 0 {
-			op := op{
-				Typ:    data[0],
-				Offset: int(binary.BigEndian.Uint16(data[1:3])),
-				Length: int(binary.BigEndian.Uint16(data[3:5])),
-			}
-			data = data[opSize:]
-			if op.Offset >= len(streamData) || op.Length > maxFrameLen || op.Offset+op.Length > len(streamData) {
+		for ; len(data) >= opSize; data = data[opSize:] {
+			op, offset, length := data[0], int(data[1]), int(data[2])
+			if offset+length > len(streamData) {
 				return
 			}
 
-			switch op.Typ {
+			switch op {
 			case opPush:
-				push(op.Offset, op.Length)
+				push(offset, length)
 			case opPop:
 				readPos = frameSorterFuzzPop(t, s, streamData, received, readPos)
 			case opPeek:
-				frameSorterFuzzPeek(t, s, streamData, received, readPos, op.Offset, op.Length)
+				frameSorterFuzzPeek(t, s, streamData, received, readPos, offset, length)
 			}
 		}
 

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -41,6 +41,7 @@ build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzTransportPar
 build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzFrameParser http3_frame_fuzzer
 build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer_v2
 build_native_go_fuzzer github.com/quic-go/quic-go/internal/handshake FuzzHandshake handshake_fuzzer_v2
+build_native_go_fuzzer github.com/quic-go/quic-go FuzzFrameSorter frame_sorter_fuzzer
 build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzHeaderParsing http3_header_parsing_fuzzer
 
 # for debugging

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -187,7 +187,8 @@ func testPackLongHeaders(t *testing.T, includeACK bool) {
 		tp.sealingManager.EXPECT().Get0RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
 		tp.sealingManager.EXPECT().Get1RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
 	}
-	clientHello := getClientHello(t, "quic-go.net")
+	clientHello, err := getClientHello("quic-go.net")
+	require.NoError(t, err)
 	tp.initialStream.Write(clientHello)
 	tp.initialStream.Write(make([]byte, 900-len(clientHello))) // add some more data
 	tp.packer.retransmissionQueue.addHandshake(&wire.PingFrame{})
@@ -902,7 +903,9 @@ func testPackProbePacket(t *testing.T, encLevel protocol.EncryptionLevel, perspe
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		tp.sealingManager.EXPECT().GetInitialSealer().Return(newMockShortHeaderSealer(mockCtrl), nil)
-		cryptoData = getClientHello(t, "")
+		var err error
+		cryptoData, err = getClientHello("")
+		require.NoError(t, err)
 		tp.packer.initialStream.Write(cryptoData)
 	case protocol.EncryptionHandshake:
 		tp.sealingManager.EXPECT().GetHandshakeSealer().Return(newMockShortHeaderSealer(mockCtrl), nil)

--- a/sni_test.go
+++ b/sni_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/binary"
+	"fmt"
 	"io"
 	mrand "math/rand/v2"
 	"testing"
@@ -18,20 +19,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func checkClientHello(t testing.TB, clientHello []byte) {
-	t.Helper()
-
+func checkClientHello(clientHello []byte) error {
 	conn := tls.QUICServer(&tls.QUICConfig{
 		TLSConfig: testdata.GetTLSConfig(),
 	})
-	require.NoError(t, conn.Start(context.Background()))
+	if err := conn.Start(context.Background()); err != nil {
+		return err
+	}
 	defer conn.Close()
-	require.NoError(t, conn.HandleData(tls.QUICEncryptionLevelInitial, clientHello))
+	return conn.HandleData(tls.QUICEncryptionLevelInitial, clientHello)
 }
 
-func getClientHello(t testing.TB, serverName string) []byte {
-	t.Helper()
-
+func getClientHello(serverName string) ([]byte, error) {
 	c := tls.QUICClient(&tls.QUICConfig{
 		TLSConfig: &tls.Config{
 			ServerName:         serverName,
@@ -44,17 +43,21 @@ func getClientHello(t testing.TB, serverName string) []byte {
 	b := make([]byte, mrand.IntN(200))
 	rand.Read(b)
 	c.SetTransportParameters(b)
-	require.NoError(t, c.Start(context.Background()))
+	if err := c.Start(context.Background()); err != nil {
+		return nil, err
+	}
 
 	ev := c.NextEvent()
-	require.Equal(t, tls.QUICWriteData, ev.Kind)
-	checkClientHello(t, ev.Data)
-	return ev.Data
+	if ev.Kind != tls.QUICWriteData {
+		return nil, fmt.Errorf("expected QUICWriteData event, got %v", ev.Kind)
+	}
+	if err := checkClientHello(ev.Data); err != nil {
+		return nil, err
+	}
+	return ev.Data, nil
 }
 
-func getClientHelloWithECH(t testing.TB, serverName string) []byte {
-	t.Helper()
-
+func getClientHelloWithECH(serverName string) ([]byte, error) {
 	// various constants from the standard library's (internal) hpke package
 	const (
 		DHKEM_X25519_HKDF_SHA256 = 0x20
@@ -83,8 +86,7 @@ func getClientHelloWithECH(t testing.TB, serverName string) []byte {
 		return builder.BytesOrPanic()
 	}
 
-	echKey, err := ecdh.X25519().GenerateKey(rand.Reader)
-	require.NoError(t, err)
+	echKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
 	echConfig := marshalECHConfig(42, echKey.PublicKey().Bytes(), serverName, 32)
 
 	builder := cryptobyte.NewBuilder(nil)
@@ -103,12 +105,18 @@ func getClientHelloWithECH(t testing.TB, serverName string) []byte {
 	b := make([]byte, mrand.IntN(200))
 	rand.Read(b)
 	c.SetTransportParameters(b)
-	require.NoError(t, c.Start(context.Background()))
+	if err := c.Start(context.Background()); err != nil {
+		return nil, err
+	}
 
 	ev := c.NextEvent()
-	require.Equal(t, tls.QUICWriteData, ev.Kind)
-	checkClientHello(t, ev.Data)
-	return ev.Data
+	if ev.Kind != tls.QUICWriteData {
+		return nil, fmt.Errorf("expected QUICWriteData event, got %v", ev.Kind)
+	}
+	if err := checkClientHello(ev.Data); err != nil {
+		return nil, err
+	}
+	return ev.Data, nil
 }
 
 // shuffleClientHelloExtensions takes a TLS 1.3 ClientHello message (without the record layer)
@@ -192,7 +200,9 @@ func shuffleClientHelloExtensions(t testing.TB, clientHello []byte) []byte {
 	newClientHello = append(newClientHello, lengthBytes...)
 	newClientHello = append(newClientHello, newBody...)
 	// check that it's actually valid
-	checkClientHello(t, newClientHello)
+	if err := checkClientHello(newClientHello); err != nil {
+		t.Fatalf("invalid ClientHello: %v", err)
+	}
 	return newClientHello
 }
 
@@ -209,7 +219,8 @@ func TestFindSNI(t *testing.T) {
 }
 
 func testFindSNI(t *testing.T, serverName string) {
-	clientHello := getClientHello(t, serverName)
+	clientHello, err := getClientHello(serverName)
+	require.NoError(t, err)
 	sniPos, sniLen, echPos, err := findSNIAndECH(clientHello)
 	require.NoError(t, err)
 	assert.Equal(t, -1, echPos)
@@ -230,7 +241,9 @@ func testFindSNI(t *testing.T, serverName string) {
 
 func TestFindSNIWithECH(t *testing.T) {
 	const serverName = "public.example"
-	clientHello := shuffleClientHelloExtensions(t, getClientHelloWithECH(t, serverName))
+	clientHello, err := getClientHelloWithECH(serverName)
+	require.NoError(t, err)
+	clientHello = shuffleClientHelloExtensions(t, clientHello)
 	sniPos, sniLen, echPos, err := findSNIAndECH(clientHello)
 	require.NoError(t, err)
 	require.NotEqual(t, -1, echPos)
@@ -250,10 +263,21 @@ func TestFindSNIWithECH(t *testing.T) {
 // and doesn't need to be run in ClusterFuzz.
 // It's still useful to find potential corner cases in the parser.
 func FuzzFindSNI(f *testing.F) {
-	f.Add(getClientHello(f, ""), 10)
-	f.Add(getClientHello(f, "google.com"), 20)
-	f.Add(getClientHello(f, "sub.do.ma.in.quic-go.net"), 30)
-	f.Add(getClientHelloWithECH(f, "quic-go.net"), 40)
+	addSeed := func(serverName string, maxSize int) {
+		ch, err := getClientHello(serverName)
+		require.NoError(f, err)
+		f.Add(ch, maxSize)
+	}
+	addSeedWithECH := func(serverName string, maxSize int) {
+		ch, err := getClientHelloWithECH(serverName)
+		require.NoError(f, err)
+		f.Add(ch, maxSize)
+	}
+
+	addSeed("", 10)
+	addSeed("google.com", 20)
+	addSeed("sub.do.ma.in.quic-go.net", 30)
+	addSeedWithECH("quic-go.net", 40)
 
 	f.Fuzz(func(t *testing.T, data []byte, maxSize int) {
 		cs := newInitialCryptoStream(true)

--- a/sys_conn_df_darwin_test.go
+++ b/sys_conn_df_darwin_test.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package quic
 
 import (


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `FuzzFrameSorter` fuzz target for the frame sorter
- Adds [FuzzFrameSorter](https://github.com/quic-go/quic-go/pull/5620/files#diff-76f32d10c820fd66fb2071b540f4e590e8a82e024bcb42fd0652312fc88c4f91) in the test suite, which drives `frameSorter` with randomized push/pop/peek operation sequences and validates callback invocation, offset alignment, and data correctness against a simple model.
- Registers `frame_sorter_fuzzer` in [build.sh](https://github.com/quic-go/quic-go/pull/5620/files#diff-2c10f02a79d6592981510922b30964df2d52d82b774ac3d337a535840bb4f3a8), [oss-fuzz.sh](https://github.com/quic-go/quic-go/pull/5620/files#diff-857b8ac91ce0728a3684db7bff7d929b9818b1cfaeeb81499fea2f08aa39bc05), and the [clusterfuzz-coverage workflow](https://github.com/quic-go/quic-go/pull/5620/files#diff-465ff64c41d201f5ba9732cb4868247ce07c29cec762ba7a4030b472d95a566a) so the target is built and included in corpus coverage runs.
- Refactors `getClientHello` and `getClientHelloWithECH` in [sni_test.go](https://github.com/quic-go/quic-go/pull/5620/files#diff-43f2212e9774cf9ec60aeb553f9216d6d6c50be37b33b1f7cd402a0520b382b5) to return `([]byte, error)` instead of calling `require` internally, updating all callers to handle errors explicitly.
- Adds a darwin build constraint to [sys_conn_df_darwin_test.go](https://github.com/quic-go/quic-go/pull/5620/files#diff-03f1259d69c8dd97548aa742cafa1ff0f09cadb6dcbcf2cdb1b5dd6b56446ef5) to exclude it from non-darwin builds.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99a35bd.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->