### PR TITLE
handshake: use crypto/tls.aeadAESGCMTLS13 to construct FIPS 140 AEAD

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ matrix.go == '1.26.x' }}
         env:
           GODEBUG: fips140=only
-        run: go test -v ./internal/handshake -run 'TestToken|TestRetry|TestInitial'
+        run: go test -v ./internal/handshake -run 'TestToken|TestRetry|TestInitial|TestDecode|TestEncrypt'
       - name: Run benchmark tests
         run: go test -v -run=^$ -benchtime 0.5s -bench=. ./...
       - name: Upload coverage to Codecov

--- a/internal/handshake/aead.go
+++ b/internal/handshake/aead.go
@@ -1,12 +1,13 @@
 package handshake
 
 import (
+	"crypto/cipher"
 	"encoding/binary"
 
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
-func createAEAD(suite cipherSuite, trafficSecret []byte, v protocol.Version) *xorNonceAEAD {
+func createAEAD(suite cipherSuite, trafficSecret []byte, v protocol.Version) cipher.AEAD {
 	keyLabel := hkdfLabelKeyV1
 	ivLabel := hkdfLabelIVV1
 	if v == protocol.Version2 {
@@ -19,14 +20,14 @@ func createAEAD(suite cipherSuite, trafficSecret []byte, v protocol.Version) *xo
 }
 
 type longHeaderSealer struct {
-	aead            *xorNonceAEAD
+	aead            cipher.AEAD
 	headerProtector headerProtector
 	nonceBuf        [8]byte
 }
 
 var _ LongHeaderSealer = &longHeaderSealer{}
 
-func newLongHeaderSealer(aead *xorNonceAEAD, headerProtector headerProtector) LongHeaderSealer {
+func newLongHeaderSealer(aead cipher.AEAD, headerProtector headerProtector) LongHeaderSealer {
 	if aead.NonceSize() != 8 {
 		panic("unexpected nonce size")
 	}
@@ -50,7 +51,7 @@ func (s *longHeaderSealer) Overhead() int {
 }
 
 type longHeaderOpener struct {
-	aead            *xorNonceAEAD
+	aead            cipher.AEAD
 	headerProtector headerProtector
 	highestRcvdPN   protocol.PacketNumber // highest packet number received (which could be successfully unprotected)
 
@@ -60,7 +61,7 @@ type longHeaderOpener struct {
 
 var _ LongHeaderOpener = &longHeaderOpener{}
 
-func newLongHeaderOpener(aead *xorNonceAEAD, headerProtector headerProtector) LongHeaderOpener {
+func newLongHeaderOpener(aead cipher.AEAD, headerProtector headerProtector) LongHeaderOpener {
 	if aead.NonceSize() != 8 {
 		panic("unexpected nonce size")
 	}

--- a/internal/handshake/aead_test.go
+++ b/internal/handshake/aead_test.go
@@ -1,8 +1,6 @@
 package handshake
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/rand"
 	"crypto/tls"
 	"fmt"
@@ -15,17 +13,13 @@ import (
 
 func getSealerAndOpener(t *testing.T, cs cipherSuite, v protocol.Version) (LongHeaderSealer, LongHeaderOpener) {
 	t.Helper()
-	key := make([]byte, 16)
+	trafficSecret := make([]byte, cs.Hash.Size())
 	hpKey := make([]byte, 16)
-	rand.Read(key)
+	rand.Read(trafficSecret)
 	rand.Read(hpKey)
-	block, err := aes.NewCipher(key)
-	require.NoError(t, err)
-	aead, err := cipher.NewGCM(block)
-	require.NoError(t, err)
-
-	return newLongHeaderSealer(&xorNonceAEAD{aead: aead}, newHeaderProtector(cs, hpKey, true, v)),
-		newLongHeaderOpener(&xorNonceAEAD{aead: aead}, newHeaderProtector(cs, hpKey, true, v))
+	aead := createAEAD(cs, trafficSecret, v)
+	return newLongHeaderSealer(aead, newHeaderProtector(cs, hpKey, true, v)),
+		newLongHeaderOpener(aead, newHeaderProtector(cs, hpKey, true, v))
 }
 
 func TestEncryptAndDecryptMessage(t *testing.T) {

--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/fips140"
 	"crypto/tls"
 	"fmt"
 
@@ -18,7 +19,7 @@ type cipherSuite struct {
 	ID     uint16
 	Hash   crypto.Hash
 	KeyLen int
-	AEAD   func(key, nonceMask []byte) *xorNonceAEAD
+	AEAD   func(key, nonceMask []byte) cipher.AEAD
 }
 
 func (s cipherSuite) IVLen() int { return aeadNonceLength }
@@ -36,7 +37,11 @@ func getCipherSuite(id uint16) cipherSuite {
 	}
 }
 
-func aeadAESGCMTLS13(key, nonceMask []byte) *xorNonceAEAD {
+func aeadAESGCMTLS13(key, nonceMask []byte) cipher.AEAD {
+	if fips140.Enabled() {
+		return aeadAESGCMTLS13FIPS140(key, nonceMask)
+	}
+
 	if len(nonceMask) != aeadNonceLength {
 		panic("tls: internal error: wrong nonce length")
 	}
@@ -54,7 +59,7 @@ func aeadAESGCMTLS13(key, nonceMask []byte) *xorNonceAEAD {
 	return ret
 }
 
-func aeadChaCha20Poly1305(key, nonceMask []byte) *xorNonceAEAD {
+func aeadChaCha20Poly1305(key, nonceMask []byte) cipher.AEAD {
 	if len(nonceMask) != aeadNonceLength {
 		panic("tls: internal error: wrong nonce length")
 	}

--- a/internal/handshake/cipher_suite_fips140.go
+++ b/internal/handshake/cipher_suite_fips140.go
@@ -1,0 +1,48 @@
+package handshake
+
+import (
+	"crypto/cipher"
+	_ "unsafe" // for go:linkname
+)
+
+// Reaching into crypto/tls is a bit of a hack, but it's the only way to get the FIPS 140
+// compliant AEAD, because the standard library doesn't yet expose the NewGCMForQUIC constructor
+// added in https://go-review.googlesource.com/c/go/+/723760.
+// See https://github.com/golang/go/issues/79219 for details.
+//
+// Once the standard library exposes the necessary constructors, we can use a shared code path
+// for both FIPS 140 and non-FIPS 140 modes.
+//
+//go:linkname cryptoTLSAEAD_AESGCMTLS13 crypto/tls.aeadAESGCMTLS13
+func cryptoTLSAEAD_AESGCMTLS13(key, nonceMask []byte) cipher.AEAD
+
+func aeadAESGCMTLS13FIPS140(key, nonceMask []byte) cipher.AEAD {
+	return &tls13AESGCMAEADFIPS140{aead: cryptoTLSAEAD_AESGCMTLS13(key, nonceMask)}
+}
+
+type tls13AESGCMAEADFIPS140 struct {
+	aead       cipher.AEAD
+	primedSeal bool
+}
+
+func (f *tls13AESGCMAEADFIPS140) NonceSize() int { return f.aead.NonceSize() }
+func (f *tls13AESGCMAEADFIPS140) Overhead() int  { return f.aead.Overhead() }
+
+func (f *tls13AESGCMAEADFIPS140) Seal(out, nonce, plaintext, additionalData []byte) []byte {
+	if !f.primedSeal {
+		f.primedSeal = true
+		if nonce[0]|nonce[1]|nonce[2]|nonce[3]|nonce[4]|nonce[5]|nonce[6]|nonce[7] != 0 {
+			// Go's TLS 1.3 AES-GCM AEAD learns the XOR mask from the first Seal
+			// call and enforces monotonically increasing packet numbers after that.
+			// QUIC packet numbers don't reset on key updates, so prime it with
+			// packet number 0 before the first real, non-zero packet number.
+			var zeroNonce [8]byte
+			f.aead.Seal(nil, zeroNonce[:], nil, nil)
+		}
+	}
+	return f.aead.Seal(out, nonce, plaintext, additionalData)
+}
+
+func (f *tls13AESGCMAEADFIPS140) Open(out, nonce, ciphertext, additionalData []byte) ([]byte, error) {
+	return f.aead.Open(out, nonce, ciphertext, additionalData)
+}

--- a/internal/handshake/initial_aead_test.go
+++ b/internal/handshake/initial_aead_test.go
@@ -272,21 +272,33 @@ func BenchmarkInitialAEAD(b *testing.B) {
 
 	b.ResetTimer()
 	b.Run("opening 100 bytes", func(b *testing.B) {
-		benchmarkOpen(b, serverOpener, clientSealer.Seal(nil, packetData[:100], 42, hdr), hdr)
+		sealer, _ := NewInitialAEAD(connectionID, protocol.PerspectiveClient, protocol.Version1)
+		_, opener := NewInitialAEAD(connectionID, protocol.PerspectiveServer, protocol.Version1)
+		benchmarkOpen(b, opener, sealer.Seal(nil, packetData[:100], 42, hdr), 42, hdr)
 	})
-	b.Run("opening 1200 bytes", func(b *testing.B) { benchmarkOpen(b, serverOpener, msg, hdr) })
+	b.Run("opening 1200 bytes", func(b *testing.B) {
+		sealer, _ := NewInitialAEAD(connectionID, protocol.PerspectiveClient, protocol.Version1)
+		_, opener := NewInitialAEAD(connectionID, protocol.PerspectiveServer, protocol.Version1)
+		benchmarkOpen(b, opener, sealer.Seal(nil, packetData, 42, hdr), 42, hdr)
+	})
 
-	b.Run("sealing 100 bytes", func(b *testing.B) { benchmarkSeal(b, clientSealer, packetData[:100], hdr) })
-	b.Run("sealing 1200 bytes", func(b *testing.B) { benchmarkSeal(b, clientSealer, packetData, hdr) })
+	b.Run("sealing 100 bytes", func(b *testing.B) {
+		sealer, _ := NewInitialAEAD(connectionID, protocol.PerspectiveClient, protocol.Version1)
+		benchmarkSeal(b, sealer, packetData[:100], hdr)
+	})
+	b.Run("sealing 1200 bytes", func(b *testing.B) {
+		sealer, _ := NewInitialAEAD(connectionID, protocol.PerspectiveClient, protocol.Version1)
+		benchmarkSeal(b, sealer, packetData, hdr)
+	})
 }
 
-func benchmarkOpen(b *testing.B, aead LongHeaderOpener, msg, hdr []byte) {
+func benchmarkOpen(b *testing.B, aead LongHeaderOpener, msg []byte, pn protocol.PacketNumber, hdr []byte) {
 	b.ReportAllocs()
 	dst := make([]byte, 0, 1500)
 
 	for b.Loop() {
 		dst = dst[:0]
-		if _, err := aead.Open(dst, msg, 42, hdr); err != nil {
+		if _, err := aead.Open(dst, msg, pn, hdr); err != nil {
 			b.Fatalf("opening failed: %s", err)
 		}
 	}

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -556,8 +556,8 @@ func TestKeyUpdateKeyPhaseSkipping(t *testing.T) {
 
 	// The server never received a packet at key phase 1.
 	// Make sure the key phase 0 is still there at a much later point.
-	data2 := client.Seal(nil, []byte(msg), 1, []byte(ad))
-	_, err = server.Open(nil, data2, now.Add(10*rttStats.PTO(true)), 1, protocol.KeyPhaseZero, []byte(ad))
+	data2 := client.Seal(nil, []byte(msg), 2, []byte(ad))
+	_, err = server.Open(nil, data2, now.Add(10*rttStats.PTO(true)), 2, protocol.KeyPhaseZero, []byte(ad))
 	require.NoError(t, err)
 	require.Empty(t, eventRecorder.Events())
 }


### PR DESCRIPTION
This PR changes the AES-GCM construction such that it should be compliant with FIPS-140 (see #5077).

As discussed on the issue, for this we need to use `gcm.NewGCMForTLS13`. Unfortunately, this function is hidden in an `internal` package (`crypto/internal/fips140/aes/gcm`), which prevents us from accessing it directly.

However, this function is called from `crypto/tls` in the unexported function `aeadAESGCMTLS13`, which is one of the functions that is white-listed for `go:linkname` (do we need to add quic-go to the hall-of-shame list?).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `crypto/tls.aeadAESGCMTLS13` for AES-GCM construction in FIPS140 mode
> - When FIPS 140 mode is active, `aeadAESGCMTLS13` in [cipher_suite.go](https://github.com/quic-go/quic-go/pull/5624/files#diff-98397ba38acdcfbbad83baae17287dceb2e0fad20ec50ad4f049943db6a5d5dd) delegates to a new FIPS-compliant path in [cipher_suite_fips140.go](https://github.com/quic-go/quic-go/pull/5624/files#diff-fb94c5ba4a22bccf1c3d42199625380b77757e61392526dd8bdca1d3a7a1e5ea) that links to `crypto/tls.aeadAESGCMTLS13` via `go:linkname`.
> - A wrapper type `tls13AESGCMAEADFIPS140` adapts the TLS AEAD to QUIC's usage: on the first non-zero `Seal` call, it primes the underlying AEAD with a zero-nonce seal so the XOR mask is established before the first real packet.
> - The `cipherSuite.AEAD` field and related sealer/opener types are widened from `*xorNonceAEAD` to `cipher.AEAD` to accommodate the new path.
> - Risk: the `go:linkname` reference to an unexported stdlib symbol may break on future Go versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07ee5d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->