### PR TITLE
handshake: use cipher.NewGCMWithRandomNonce for token protector AEAD

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -44,6 +44,10 @@ jobs:
         env:
           TIMESCALE_FACTOR: 20
         run: go test -v -shuffle on ./...
+      - name: Run handshake tests in FIPS140 mode
+        env:
+          GODEBUG: fips140=only
+        run: go test -v ./internal/handshake -run TestToken
       - name: Run benchmark tests
         run: go test -v -run=^$ -benchtime 0.5s -bench=. ./...
       - name: Upload coverage to Codecov

--- a/internal/handshake/token_protector.go
+++ b/internal/handshake/token_protector.go
@@ -12,7 +12,7 @@ import (
 // TokenProtectorKey is the key used to encrypt both Retry and session resumption tokens.
 type TokenProtectorKey [32]byte
 
-const tokenNonceSize = 32
+const tokenSaltSize = 32
 
 // tokenProtector is used to create and verify a token
 type tokenProtector struct {
@@ -26,54 +26,50 @@ func newTokenProtector(key TokenProtectorKey) *tokenProtector {
 
 // NewToken encodes data into a new token.
 func (s *tokenProtector) NewToken(data []byte) ([]byte, error) {
-	var nonce [tokenNonceSize]byte
-	if _, err := rand.Read(nonce[:]); err != nil {
+	var salt [tokenSaltSize]byte
+	if _, err := rand.Read(salt[:]); err != nil {
 		return nil, err
 	}
-	aead, aeadNonce, err := s.createAEAD(nonce[:])
+	aead, err := s.createAEAD(salt[:])
 	if err != nil {
 		return nil, err
 	}
-	return append(nonce[:], aead.Seal(nil, aeadNonce, data, nil)...), nil
+	return append(salt[:], aead.Seal(nil, nil, data, nil)...), nil
 }
 
 // DecodeToken decodes a token.
 func (s *tokenProtector) DecodeToken(p []byte) ([]byte, error) {
-	if len(p) < tokenNonceSize {
+	if len(p) < tokenSaltSize {
 		return nil, fmt.Errorf("token too short: %d", len(p))
 	}
-	nonce := p[:tokenNonceSize]
-	aead, aeadNonce, err := s.createAEAD(nonce)
+	salt := p[:tokenSaltSize]
+	aead, err := s.createAEAD(salt)
 	if err != nil {
 		return nil, err
 	}
-	return aead.Open(nil, aeadNonce, p[tokenNonceSize:], nil)
+	return aead.Open(nil, nil, p[tokenSaltSize:], nil)
 }
 
 const tokenProtectorHKDFInfo = "quic-go token source"
 
-func (s *tokenProtector) createAEAD(nonce []byte) (cipher.AEAD, []byte, error) {
-	prk, err := hkdf.Extract(sha256.New, s.key[:], nonce)
+func (s *tokenProtector) createAEAD(salt []byte) (cipher.AEAD, error) {
+	prk, err := hkdf.Extract(sha256.New, s.key[:], salt)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	// expand to get key (32 bytes) and nonce (12 bytes) in one HKDF call
-	expanded, err := hkdf.Expand(sha256.New, prk, tokenProtectorHKDFInfo, 32+12)
+	key, err := hkdf.Expand(sha256.New, prk, tokenProtectorHKDFInfo, 32)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	key := expanded[:32] // use a 32 byte key, in order to select AES-256
-	aeadNonce := expanded[32:]
 
 	c, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	aead, err := cipher.NewGCM(c)
+	aead, err := cipher.NewGCMWithRandomNonce(c)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return aead, aeadNonce, nil
+	return aead, nil
 }

--- a/internal/handshake/token_protector.go
+++ b/internal/handshake/token_protector.go
@@ -47,6 +47,9 @@ func (s *tokenProtector) DecodeToken(p []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(p[tokenSaltSize:]) < aead.Overhead() {
+		return nil, fmt.Errorf("token too short: %d", len(p))
+	}
 	return aead.Open(nil, nil, p[tokenSaltSize:], nil)
 }
 

--- a/internal/handshake/token_protector_test.go
+++ b/internal/handshake/token_protector_test.go
@@ -64,4 +64,7 @@ func TestTokenProtectorTooShortTokens(t *testing.T) {
 
 	_, err := tp.DecodeToken([]byte("foobar"))
 	require.EqualError(t, err, "token too short: 6")
+
+	_, err = tp.DecodeToken(make([]byte, tokenSaltSize))
+	require.EqualError(t, err, "token too short: 32")
 }


### PR DESCRIPTION
For #5077.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `cipher.NewGCMWithRandomNonce` for token protector AEAD in handshake
> - Replaces the manually managed nonce in `tokenProtector` with `cipher.NewGCMWithRandomNonce`, which generates and embeds a random nonce internally on each `Seal` call.
> - `createAEAD` in [token_protector.go](https://github.com/quic-go/quic-go/pull/5625/files#diff-a21807ce2a9555e7f7dbd59d61d75a619ab04546a640cdb2af96267da183effa) now derives only a 32-byte key via HKDF (no derived nonce) and returns a GCMWithRandomNonce AEAD; callers pass `nil` as the nonce to `Seal`/`Open`.
> - `DecodeToken` now rejects payloads that are only the salt size or shorter than `aead.Overhead()`, with clearer error messages reporting the total input length.
> - Adds a CI step in [unit.yml](https://github.com/quic-go/quic-go/pull/5625/files#diff-e17ac7ab478a18e9dac875e191cc3e0d754fab62eddddfb05d4619495be927d9) that runs `TestToken` with `GODEBUG=fips140=only` to verify FIPS140 compatibility.
> - Risk: token format changes — tokens now include an embedded random nonce in the ciphertext, so previously issued tokens will fail to decode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edf7519.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->