### PR TITLE
fix .gitignore entry for fuzzing testdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@ fuzzing/*/sonarprofile
 fuzzing/*/suppressions
 fuzzing/*/corpus/
 
-testdata/fuzz/
+**/testdata/fuzz/
 
 gomock_reflect_*/


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `.gitignore` to recursively ignore `testdata/fuzz/` in all subdirectories
Changes the ignore pattern in [.gitignore](.gitignore) from `testdata/fuzz/` (root-only) to `**/testdata/fuzz/` so fuzzing testdata is excluded in any subdirectory, not just at the repo root.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0cbecb.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->