### PR TITLE
wire: limit size of frames to split off in the frame fuzzer

### DIFF
--- a/internal/wire/frame_parser_test.go
+++ b/internal/wire/frame_parser_test.go
@@ -918,6 +918,12 @@ func FuzzFrames(f *testing.F) {
 		if encLevel != protocol.EncryptionInitial && encLevel != protocol.EncryptionHandshake && encLevel != protocol.Encryption1RTT && encLevel != protocol.Encryption0RTT {
 			return
 		}
+		// maxSize is used to split off frames from the original frame (in the case of CRYPTO and STREAM frames),
+		// and to truncate ACK frames.
+		// This happens at the packet boundary, so values larger than the packet size are not interesting.
+		if maxSize > 10_000 {
+			return
+		}
 
 		parser := NewFrameParser(true, true, true)
 		parser.SetAckDelayExponent(protocol.DefaultAckDelayExponent)


### PR DESCRIPTION
This will resolve https://issues.oss-fuzz.com/issues/510115719 and https://issues.oss-fuzz.com/issues/506317004.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Limit `maxSize` to 10,000 in `FuzzFrames` to skip uninteresting large values
> In [frame_parser_test.go](https://github.com/quic-go/quic-go/pull/5628/files#diff-7592b59be8e11d92b98b10064a0aa9da7b1d4260766c5ac4044c451d5d051af6), the `FuzzFrames` fuzz test now returns early when `maxSize` exceeds 10,000. Values above this threshold are not interesting since `maxSize` is only used for splitting CRYPTO/STREAM frames and truncating ACK frames.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d55224a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->