### PR TITLE
wire: use a valid size parameter for the frame fuzzer corpus

### DIFF
--- a/internal/wire/frame_parser_test.go
+++ b/internal/wire/frame_parser_test.go
@@ -851,7 +851,7 @@ func FuzzFrames(f *testing.F) {
 	} {
 		b, err := s.frame.Append(nil, version)
 		require.NoError(f, err)
-		corpus.Add(uint8(s.encLevel), uint16(0xffff), b)
+		corpus.Add(uint8(s.encLevel), uint16(protocol.MaxPacketBufferSize), b)
 	}
 
 	for _, fr := range []Frame{
@@ -903,7 +903,7 @@ func FuzzFrames(f *testing.F) {
 	} {
 		b, err := fr.Append(nil, version)
 		require.NoError(f, err)
-		maxSize := uint16(0xffff)
+		maxSize := uint16(protocol.MaxPacketBufferSize)
 		switch fr.(type) {
 		case *StreamFrame, *DatagramFrame:
 			maxSize = 256


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix fuzz corpus seed to use `protocol.MaxPacketBufferSize` as `maxSize` in `FuzzFrames`
Replaces the hardcoded `uint16(0xffff)` with `uint16(protocol.MaxPacketBufferSize)` in [frame_parser_test.go](https://github.com/quic-go/quic-go/pull/5629/files#diff-7592b59be8e11d92b98b10064a0aa9da7b1d4260766c5ac4044c451d5d051af6) when adding seeds to the fuzz corpus. This aligns the size limit used during fuzzing with the protocol-defined packet buffer size.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b968475.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->