### PR TITLE
handshake: disable FIPS 140 enforcement for the Retry AEAD

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -45,9 +45,10 @@ jobs:
           TIMESCALE_FACTOR: 20
         run: go test -v -shuffle on ./...
       - name: Run handshake tests in FIPS140 mode
+        if: ${{ matrix.go == '1.26.x' }}
         env:
           GODEBUG: fips140=only
-        run: go test -v ./internal/handshake -run TestToken
+        run: go test -v ./internal/handshake -run 'TestToken|TestRetry'
       - name: Run benchmark tests
         run: go test -v -run=^$ -benchtime 0.5s -bench=. ./...
       - name: Upload coverage to Codecov

--- a/internal/handshake/retry_go125.go
+++ b/internal/handshake/retry_go125.go
@@ -1,3 +1,5 @@
+//go:build !go1.26
+
 package handshake
 
 import (

--- a/internal/handshake/retry_go126.go
+++ b/internal/handshake/retry_go126.go
@@ -1,0 +1,70 @@
+//go:build go1.26
+
+package handshake
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/fips140"
+	"fmt"
+	"sync"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+// used for QUIC v1 (RFC 9000)
+var retryAEADv1 = initAEAD([16]byte{0xbe, 0x0c, 0x69, 0x0b, 0x9f, 0x66, 0x57, 0x5a, 0x1d, 0x76, 0x6b, 0x54, 0xe3, 0x68, 0xc8, 0x4e})
+
+// used for QUIC v2 (RFC 9369)
+var retryAEADv2 = initAEAD([16]byte{0x8f, 0xb4, 0xb0, 0x1b, 0x56, 0xac, 0x48, 0xe2, 0x60, 0xfb, 0xcb, 0xce, 0xad, 0x7c, 0xcc, 0x92})
+
+func initAEAD(key [16]byte) cipher.AEAD {
+	aes, err := aes.NewCipher(key[:])
+	if err != nil {
+		panic(err)
+	}
+	var aead cipher.AEAD
+	// Retry packet authentication uses the fixed key and nonce specified by RFC 9000.
+	// It acts as an integrity tag for the Retry packet itself, protecting against
+	// accidental modification and making injection harder. It is not used to encrypt
+	// packet contents and therefore outside the scope of FIPS 140 enforcement.
+	fips140.WithoutEnforcement(func() {
+		var err error
+		aead, err = cipher.NewGCM(aes)
+		if err != nil {
+			panic(err)
+		}
+	})
+	return aead
+}
+
+var (
+	retryBuf     bytes.Buffer
+	retryMutex   sync.Mutex
+	retryNonceV1 = [12]byte{0x46, 0x15, 0x99, 0xd3, 0x5d, 0x63, 0x2b, 0xf2, 0x23, 0x98, 0x25, 0xbb}
+	retryNonceV2 = [12]byte{0xd8, 0x69, 0x69, 0xbc, 0x2d, 0x7c, 0x6d, 0x99, 0x90, 0xef, 0xb0, 0x4a}
+)
+
+// GetRetryIntegrityTag calculates the integrity tag on a Retry packet
+func GetRetryIntegrityTag(retry []byte, origDestConnID protocol.ConnectionID, version protocol.Version) *[16]byte {
+	retryMutex.Lock()
+	defer retryMutex.Unlock()
+
+	retryBuf.WriteByte(uint8(origDestConnID.Len()))
+	retryBuf.Write(origDestConnID.Bytes())
+	retryBuf.Write(retry)
+	defer retryBuf.Reset()
+
+	var tag [16]byte
+	var sealed []byte
+	if version == protocol.Version2 {
+		sealed = retryAEADv2.Seal(tag[:0], retryNonceV2[:], nil, retryBuf.Bytes())
+	} else {
+		sealed = retryAEADv1.Seal(tag[:0], retryNonceV1[:], nil, retryBuf.Bytes())
+	}
+	if len(sealed) != 16 {
+		panic(fmt.Sprintf("unexpected Retry integrity tag length: %d", len(sealed)))
+	}
+	return &tag
+}


### PR DESCRIPTION
Retry packet authentication uses the fixed key and nonce specified by RFC 9000. It acts as an integrity tag for the Retry packet itself, protecting against accidental modification and making injection harder. It is not used to encrypt packet contents and therefore outside the scope of FIPS 140 enforcement.

Part of #5077.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable FIPS 140 enforcement for the AEAD used in QUIC Retry integrity tag computation
> - Splits the Retry integrity tag implementation into two build-tagged files: [retry_go125.go](https://github.com/quic-go/quic-go/pull/5630/files#diff-bedcf4d6ec0604d98314f3de901c7e83849defdbf6a56ef8845e1e1f8e84ec87) for Go ≤1.25 and [retry_go126.go](https://github.com/quic-go/quic-go/pull/5630/files#diff-bc9b84448cbf99ccf48ed05688fbe3fdac1a149b6ce7ee0ba78157a36675f91b) for Go 1.26+.
> - On Go 1.26, `initAEAD` wraps AES-GCM construction in `fips140.WithoutEnforcement`, allowing Retry AEAD initialization when `GODEBUG=fips140=only` is set (the RFC-mandated fixed keys are not FIPS-approved).
> - CI now runs FIPS 140 handshake tests only on Go 1.26.x and expands coverage to include `TestRetry` alongside `TestToken`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1391d0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->