### PR TITLE
ci: generate fuzz coverage report from OSS-Fuzz corpus

### DIFF
--- a/.github/workflows/oss-fuzz-coverage.yml
+++ b/.github/workflows/oss-fuzz-coverage.yml
@@ -1,0 +1,79 @@
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master # for debugging
+
+permissions: read-all
+
+jobs:
+  fuzz-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: quic-go
+      - uses: actions/checkout@v6
+        with:
+          repository: google/oss-fuzz
+          path: oss-fuzz
+      - uses: google-github-actions/setup-gcloud@v3
+      - name: List fuzz targets
+        id: fuzz_targets
+        run: |
+          targets=$(awk '/^build_native_go_fuzzer / && $4 ~ /^[A-Za-z0-9_]+$/ { print $4 }' quic-go/oss-fuzz.sh)
+          echo "$targets"
+          target_count=$(awk 'NF { count++ } END { print count + 0 }' <<< "$targets")
+          test "$target_count" -ge 5
+          {
+            echo 'targets<<EOF'
+            echo "$targets"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Use local oss-fuzz.sh
+        working-directory: oss-fuzz
+        run: |
+          cp "$GITHUB_WORKSPACE/quic-go/oss-fuzz.sh" projects/quic-go/oss-fuzz.sh
+          sed -i -e 's/^RUN cp/# RUN cp/' -e 's/^# COPY oss-fuzz.sh/COPY oss-fuzz.sh/' projects/quic-go/Dockerfile
+      - name: Download backup corpus
+        working-directory: oss-fuzz
+        env:
+          FUZZ_TARGETS: ${{ steps.fuzz_targets.outputs.targets }}
+        run: |
+          bucket="gs://quic-go-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer"
+          while read -r target; do
+            test -n "$target" || continue
+            mkdir -p "corpus/$target"
+            gsutil cp "$bucket/quic-go_$target/latest.zip" "corpus/$target.zip"
+            unzip -q "corpus/$target.zip" -d "corpus/$target"
+            rm "corpus/$target.zip"
+            test -n "$(find "corpus/$target" -type f -print -quit)"
+          done <<< "$FUZZ_TARGETS"
+      - name: Build coverage fuzzers
+        working-directory: oss-fuzz
+        run: |
+          python3 infra/helper.py build_image --no-pull quic-go
+          python3 infra/helper.py build_fuzzers --sanitizer coverage --mount_path /root/go/src/github.com/quic-go/quic-go quic-go "$GITHUB_WORKSPACE/quic-go"
+      - name: Generate coverage
+        working-directory: oss-fuzz
+        run: |
+          set -o pipefail
+          echo "mode: set" > "$GITHUB_WORKSPACE/quic-go/fuzz-coverage.out"
+          for corpus_dir in corpus/*; do
+            test -d "$corpus_dir" || continue
+            target=${corpus_dir#corpus/}
+            python3 infra/helper.py coverage --no-serve --fuzz-target "$target" --corpus-dir "corpus/$target" quic-go
+            sed "s#^/out/#$(pwd)/build/out/quic-go/#" build/out/quic-go/fuzz.cov | tail -n +2 >> "$GITHUB_WORKSPACE/quic-go/fuzz-coverage.out"
+          done
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v6
+        if: github.event_name != 'pull_request'
+        with:
+          working-directory: ./quic-go
+          files: fuzz-coverage.out
+          disable_search: true
+          flags: fuzz
+          name: OSS-Fuzz
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/oss-fuzz-coverage.yml
+++ b/.github/workflows/oss-fuzz-coverage.yml
@@ -49,6 +49,7 @@ jobs:
           FUZZ_TARGETS: ${{ steps.fuzz_targets.outputs.targets }}
         run: |
           bucket="gs://quic-go-corpus.clusterfuzz-external.appspot.com/libFuzzer"
+          mkdir -p corpus
           while read -r target; do
             test -n "$target" || continue
             gcloud storage cp --recursive "$bucket/quic-go_$target" corpus/

--- a/.github/workflows/oss-fuzz-coverage.yml
+++ b/.github/workflows/oss-fuzz-coverage.yml
@@ -2,11 +2,10 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
-  pull_request:
-    branches:
-      - master # for debugging
 
-permissions: read-all
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   fuzz-coverage:
@@ -19,6 +18,10 @@ jobs:
         with:
           repository: google/oss-fuzz
           path: oss-fuzz
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.OSS_FUZZ_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.OSS_FUZZ_GCP_SERVICE_ACCOUNT }}
       - uses: google-github-actions/setup-gcloud@v3
       - name: List fuzz targets
         id: fuzz_targets
@@ -46,7 +49,7 @@ jobs:
           while read -r target; do
             test -n "$target" || continue
             mkdir -p "corpus/$target"
-            gsutil cp "$bucket/quic-go_$target/latest.zip" "corpus/$target.zip"
+            gcloud storage cp "$bucket/quic-go_$target/latest.zip" "corpus/$target.zip"
             unzip -q "corpus/$target.zip" -d "corpus/$target"
             rm "corpus/$target.zip"
             test -n "$(find "corpus/$target" -type f -print -quit)"
@@ -69,7 +72,6 @@ jobs:
           done
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
-        if: github.event_name != 'pull_request'
         with:
           working-directory: ./quic-go
           files: fuzz-coverage.out

--- a/.github/workflows/oss-fuzz-coverage.yml
+++ b/.github/workflows/oss-fuzz-coverage.yml
@@ -43,18 +43,16 @@ jobs:
         run: |
           cp "$GITHUB_WORKSPACE/quic-go/oss-fuzz.sh" projects/quic-go/oss-fuzz.sh
           sed -i -e 's/^RUN cp/# RUN cp/' -e 's/^# COPY oss-fuzz.sh/COPY oss-fuzz.sh/' projects/quic-go/Dockerfile
-      - name: Download backup corpus
+      - name: Download corpus
         working-directory: oss-fuzz
         env:
           FUZZ_TARGETS: ${{ steps.fuzz_targets.outputs.targets }}
         run: |
-          bucket="gs://quic-go-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer"
+          bucket="gs://quic-go-corpus.clusterfuzz-external.appspot.com/libFuzzer"
           while read -r target; do
             test -n "$target" || continue
-            mkdir -p "corpus/$target"
-            gcloud storage cp "$bucket/quic-go_$target/latest.zip" "corpus/$target.zip"
-            unzip -q "corpus/$target.zip" -d "corpus/$target"
-            rm "corpus/$target.zip"
+            gcloud storage cp --recursive "$bucket/quic-go_$target" corpus/
+            mv "corpus/quic-go_$target" "corpus/$target"
             test -n "$(find "corpus/$target" -type f -print -quit)"
           done <<< "$FUZZ_TARGETS"
       - name: Build coverage fuzzers

--- a/.github/workflows/oss-fuzz-coverage.yml
+++ b/.github/workflows/oss-fuzz-coverage.yml
@@ -2,6 +2,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
+  pull_request:
+    branches:
+      - master # for debugging
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add nightly CI workflow to generate fuzz coverage reports from OSS-Fuzz corpus
- Adds [oss-fuzz-coverage.yml](.github/workflows/oss-fuzz-coverage.yml), a GitHub Actions workflow that runs nightly, on `workflow_dispatch`, and on PRs to `master`.
- Extracts fuzz target names from `quic-go/oss-fuzz.sh`, downloads existing corpora from GCS, builds coverage-instrumented OSS-Fuzz targets, and aggregates per-target coverage into a single `fuzz-coverage.out` file.
- Uploads the aggregated coverage to Codecov with the `fuzz` flag and name `OSS-Fuzz` using `CODECOV_TOKEN`.
- Risk: requires GCS access and Google Cloud workload identity credentials to be configured as repository variables.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7849084.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->