### PR TITLE
handshake: disable ChaCha20 code path in FIPS 140 mode

### DIFF
--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -2,6 +2,7 @@ package self_test
 
 import (
 	"context"
+	"crypto/fips140"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -121,6 +122,10 @@ func TestHandshakeCipherSuites(t *testing.T) {
 		tls.TLS_CHACHA20_POLY1305_SHA256,
 	} {
 		t.Run(tls.CipherSuiteName(suiteID), func(t *testing.T) {
+			if fips140.Enabled() && suiteID == tls.TLS_CHACHA20_POLY1305_SHA256 {
+				t.Skip("ChaCha20-Poly1305 is not allowed in FIPS 140-3 mode")
+			}
+
 			reset := qtls.SetCipherSuite(suiteID)
 			defer reset()
 

--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -29,6 +29,11 @@ func getCipherSuite(id uint16) cipherSuite {
 	case tls.TLS_AES_128_GCM_SHA256:
 		return cipherSuite{ID: tls.TLS_AES_128_GCM_SHA256, Hash: crypto.SHA256, KeyLen: 16, AEAD: aeadAESGCMTLS13}
 	case tls.TLS_CHACHA20_POLY1305_SHA256:
+		// The usual convention is to only panic on fips140.Enforced (and not on fips140.Enabled),
+		// but this function panics in the default case anyway, so we might as well panic here.
+		if fips140.Enabled() {
+			panic("tls: TLS_CHACHA20_POLY1305_SHA256 is not allowed in FIPS 140-3 mode")
+		}
 		return cipherSuite{ID: tls.TLS_CHACHA20_POLY1305_SHA256, Hash: crypto.SHA256, KeyLen: 32, AEAD: aeadChaCha20Poly1305}
 	case tls.TLS_AES_256_GCM_SHA384:
 		return cipherSuite{ID: tls.TLS_AES_256_GCM_SHA384, Hash: crypto.SHA384, KeyLen: 32, AEAD: aeadAESGCMTLS13}

--- a/internal/handshake/handshake_helpers_test.go
+++ b/internal/handshake/handshake_helpers_test.go
@@ -1,6 +1,7 @@
 package handshake
 
 import (
+	"crypto/fips140"
 	"crypto/tls"
 	"encoding/hex"
 	"strings"
@@ -31,5 +32,10 @@ func TestSplitHexString(t *testing.T) {
 var cipherSuites = []cipherSuite{
 	getCipherSuite(tls.TLS_AES_128_GCM_SHA256),
 	getCipherSuite(tls.TLS_AES_256_GCM_SHA384),
-	getCipherSuite(tls.TLS_CHACHA20_POLY1305_SHA256),
+}
+
+func init() {
+	if !fips140.Enabled() {
+		cipherSuites = append(cipherSuites, getCipherSuite(tls.TLS_CHACHA20_POLY1305_SHA256))
+	}
 }

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -1,6 +1,7 @@
 package handshake
 
 import (
+	"crypto/fips140"
 	"crypto/rand"
 	"crypto/tls"
 	"fmt"
@@ -76,6 +77,10 @@ func bothSides(ev qlogwriter.Event) []qlogwriter.Event {
 }
 
 func TestChaChaTestVector(t *testing.T) {
+	if fips140.Enabled() {
+		t.Skip("ChaCha20-Poly1305 is not allowed in FIPS 140-3 mode")
+	}
+
 	testCases := []struct {
 		name            string
 		version         protocol.Version
@@ -98,7 +103,7 @@ func TestChaChaTestVector(t *testing.T) {
 		t.Run(fmt.Sprintf("QUIC %s", tc.version), func(t *testing.T) {
 			secret := splitHexString(t, "9ac312a7f877468ebe69422748ad00a1 5443f18203a07d6060f688f30f21632b")
 			aead := newUpdatableAEAD(utils.NewRTTStats(), nil, nil, tc.version)
-			chacha := cipherSuites[2]
+			chacha := getCipherSuite(tls.TLS_CHACHA20_POLY1305_SHA256)
 			require.Equal(t, tls.TLS_CHACHA20_POLY1305_SHA256, chacha.ID)
 			aead.SetWriteKey(chacha, secret)
 			const pnOffset = 1

--- a/internal/qtls/cipher_suite_test.go
+++ b/internal/qtls/cipher_suite_test.go
@@ -1,6 +1,7 @@
 package qtls
 
 import (
+	"crypto/fips140"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -18,6 +19,10 @@ func TestCipherSuiteSelection(t *testing.T) {
 }
 
 func testCipherSuiteSelection(t *testing.T, cs uint16) {
+	if fips140.Enabled() && cs == tls.TLS_CHACHA20_POLY1305_SHA256 {
+		t.Skip("ChaCha20-Poly1305 is not allowed in FIPS 140-3 mode")
+	}
+
 	reset := SetCipherSuite(cs)
 	defer reset()
 


### PR DESCRIPTION
Cipher suite selection is crypto/tls' responsibility, since they disabled configurability of cipher suites a long time ago. As such, we _should_ be able to rely on ChaCha20 never being selected in FIPS 140 mode.

It seems easy enough though to explicitly disable the ChaCha20 code path ourselves, which might make FIPS 140 certification of quic-go easier.

This change will also (once #5077 is resolved) allow us to run quic-go's test suite with `GODEBUG=fips140=only`, which is nice.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable ChaCha20-Poly1305 cipher suite in FIPS 140-3 mode
> - `getCipherSuite` in [cipher_suite.go](https://github.com/quic-go/quic-go/pull/5633/files#diff-98397ba38acdcfbbad83baae17287dceb2e0fad20ec50ad4f049943db6a5d5dd) now panics if called with `TLS_CHACHA20_POLY1305_SHA256` when FIPS 140-3 mode is enabled, as ChaCha20 is not a FIPS-approved algorithm.
> - Test suites in `handshake` and `qtls` packages skip `TLS_CHACHA20_POLY1305_SHA256` test cases when FIPS mode is active, and the cipher is excluded from the shared `cipherSuites` test slice via an `init` guard.
> - Risk: any code path that passes `TLS_CHACHA20_POLY1305_SHA256` to `getCipherSuite` while running in FIPS mode will panic at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 134949c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->