### PR TITLE
http3: add validation logic for the :protocol pseudo-header field

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -96,7 +96,7 @@ func parseHeaders(decodeFn qpack.DecodeFunc, isRequest bool, sizeLimit int, head
 			case ":authority":
 				isDuplicatePseudoHeader = hdr.Authority != ""
 				hdr.Authority = h.Value
-			case ":protocol":
+			case ":protocol": // RFC 9220
 				isDuplicatePseudoHeader = hdr.Protocol != ""
 				hdr.Protocol = h.Value
 			case ":scheme":
@@ -195,6 +195,9 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	// Extended CONNECT, see https://datatracker.ietf.org/doc/html/rfc8441#section-4
 	isExtendedConnected := isConnect && hdr.Protocol != ""
 	if isExtendedConnected {
+		if !validExtendedConnectProtocol(hdr.Protocol) {
+			return nil, fmt.Errorf("invalid :protocol: %q", hdr.Protocol)
+		}
 		if hdr.Scheme == "" || hdr.Path == "" || hdr.Authority == "" {
 			return nil, errors.New("extended CONNECT: :scheme, :path and :authority must not be empty")
 		}
@@ -251,6 +254,14 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	}
 	req.Trailer = extractAnnouncedTrailers(req.Header)
 	return req, nil
+}
+
+func validExtendedConnectProtocol(protocol string) bool {
+	// RFC 9220 specifies that the semantics of the :protocol pseudo are the same as defined in RFC 8441.
+	// RFC 8441, Section 4 specifies that :protocol is a single value from the HTTP Upgrade Token Registry.
+	// RFC 9110, Section 16.7 specifies that HTTP Upgrade Token Registry uses token grammar.
+	// Therefore, ValidHeaderFieldName is the right syntax check here, despite the misleading name.
+	return httpguts.ValidHeaderFieldName(protocol)
 }
 
 // updateResponseFromHeaders sets up http.Response as an HTTP/3 response,

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -358,6 +358,18 @@ func TestRequestHeadersExtendedConnectRequestValidation(t *testing.T) {
 	require.EqualError(t, err, "extended CONNECT: :scheme, :path and :authority must not be empty")
 }
 
+func TestRequestHeadersExtendedConnectInvalidProtocol(t *testing.T) {
+	headers := []qpack.HeaderField{
+		{Name: ":protocol", Value: "HTTP/3.0"},
+		{Name: ":scheme", Value: "https"},
+		{Name: ":method", Value: http.MethodConnect},
+		{Name: ":authority", Value: "quic-go.net"},
+		{Name: ":path", Value: "/foo"},
+	}
+	_, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+	require.EqualError(t, err, `invalid :protocol: "HTTP/3.0"`)
+}
+
 func TestResponseHeaderParsing(t *testing.T) {
 	headers := []qpack.HeaderField{
 		{Name: ":status", Value: "200"},

--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -111,6 +111,9 @@ func (w *requestWriter) encodeHeaders(req *http.Request, addGzipHeader bool, tra
 
 	// http.NewRequest sets this field to HTTP/1.1
 	isExtendedConnect := isExtendedConnectRequest(req)
+	if isExtendedConnect && !validExtendedConnectProtocol(req.Proto) {
+		return nil, fmt.Errorf("invalid request :protocol %q", req.Proto)
+	}
 
 	var path string
 	if req.Method != http.MethodConnect || isExtendedConnect {

--- a/http3/request_writer_test.go
+++ b/http3/request_writer_test.go
@@ -129,6 +129,18 @@ func TestRequestWriterExtendedConnect(t *testing.T) {
 	require.Equal(t, "webtransport", headerFields[":protocol"])
 }
 
+func TestRequestWriterExtendedConnectInvalidProtocol(t *testing.T) {
+	// httptest.NewRequest does not properly support the CONNECT method
+	req, err := http.NewRequest(http.MethodConnect, "https://quic-go.net/", nil)
+	require.NoError(t, err)
+	req.Proto = "HTTP/3.0"
+	rw := newRequestWriter()
+	require.EqualError(t,
+		rw.WriteRequestHeader(&bytes.Buffer{}, req, false, 0, nil),
+		`invalid request :protocol "HTTP/3.0"`,
+	)
+}
+
 func TestRequestWriterTrailers(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "https://quic-go.net/upload", nil)
 	req.Trailer = http.Header{


### PR DESCRIPTION
The value in :protocol is an HTTP Upgrade Token, therefore stricter validation rules than for regular header field values apply.

This will resolve https://issues.oss-fuzz.com/issues/511320560.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add validation for the `:protocol` pseudo-header in HTTP/3 Extended CONNECT requests
> - Adds `validExtendedConnectProtocol` in [headers.go](https://github.com/quic-go/quic-go/pull/5639/files#diff-fd2fc9252b467e3ef8b4b4a45eafc66de3fab721b4de75b705da663b3e0f3160), which uses `httpguts.ValidHeaderFieldName` to enforce HTTP token syntax on `:protocol` values.
> - `requestFromHeaders` now rejects inbound Extended CONNECT requests whose `:protocol` value fails token validation, returning `invalid :protocol: %q`.
> - `requestWriter.encodeHeaders` in [request_writer.go](https://github.com/quic-go/quic-go/pull/5639/files#diff-26e7bb9b62686667822b50c4aaf21fd74417a19983a35d83408ac35d1de73bb9) now rejects outbound Extended CONNECT requests whose `req.Proto` fails the same check, returning `invalid request :protocol %q`.
> - Risk: previously accepted Extended CONNECT requests with non-token `:protocol` values (e.g. `"HTTP/3.0"`) will now fail on both read and write paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e0444a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->