### PR TITLE
handshake: disable FIPS 140 enforcement for Initial AEAD

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ matrix.go == '1.26.x' }}
         env:
           GODEBUG: fips140=only
-        run: go test -v ./internal/handshake -run 'TestToken|TestRetry'
+        run: go test -v ./internal/handshake -run 'TestToken|TestRetry|TestInitial'
       - name: Run benchmark tests
         run: go test -v -run=^$ -benchtime 0.5s -bench=. ./...
       - name: Upload coverage to Codecov

--- a/internal/handshake/fips140_go126.go
+++ b/internal/handshake/fips140_go126.go
@@ -1,0 +1,9 @@
+//go:build go1.26
+
+package handshake
+
+import "crypto/fips140"
+
+func withoutFIPSEnforcement(f func()) {
+	fips140.WithoutEnforcement(f)
+}

--- a/internal/handshake/fips140_legacy.go
+++ b/internal/handshake/fips140_legacy.go
@@ -1,0 +1,7 @@
+//go:build !go1.26
+
+package handshake
+
+func withoutFIPSEnforcement(f func()) {
+	f()
+}

--- a/internal/handshake/initial_aead.go
+++ b/internal/handshake/initial_aead.go
@@ -47,7 +47,7 @@ func NewInitialAEAD(connID protocol.ConnectionID, pers protocol.Perspective, v p
 		encrypter := initialSuite.AEAD(myKey, myIV)
 		decrypter := initialSuite.AEAD(otherKey, otherIV)
 
-		sealer = newLongHeaderSealer(encrypter, newHeaderProtector(initialSuite, mySecret, true, v))
+		sealer = newLongHeaderSealer(encrypter, newAESHeaderProtector(initialSuite, mySecret, true, hkdfHeaderProtectionLabel(v)))
 		opener = newLongHeaderOpener(decrypter, newAESHeaderProtector(initialSuite, otherSecret, true, hkdfHeaderProtectionLabel(v)))
 	})
 	return sealer, opener

--- a/internal/handshake/initial_aead.go
+++ b/internal/handshake/initial_aead.go
@@ -21,38 +21,44 @@ const (
 	hkdfLabelIVV2  = "quicv2 iv"
 )
 
-func getSalt(v protocol.Version) []byte {
-	if v == protocol.Version2 {
-		return quicSaltV2
-	}
-	return quicSaltV1
-}
-
 var initialSuite = getCipherSuite(tls.TLS_AES_128_GCM_SHA256)
 
 // NewInitialAEAD creates a new AEAD for Initial encryption / decryption.
 func NewInitialAEAD(connID protocol.ConnectionID, pers protocol.Perspective, v protocol.Version) (LongHeaderSealer, LongHeaderOpener) {
-	clientSecret, serverSecret := computeSecrets(connID, v)
-	var mySecret, otherSecret []byte
-	if pers == protocol.PerspectiveClient {
-		mySecret = clientSecret
-		otherSecret = serverSecret
-	} else {
-		mySecret = serverSecret
-		otherSecret = clientSecret
-	}
-	myKey, myIV := computeInitialKeyAndIV(mySecret, v)
-	otherKey, otherIV := computeInitialKeyAndIV(otherSecret, v)
+	var sealer LongHeaderSealer
+	var opener LongHeaderOpener
+	// The keys for the Initial AEAD are derived from the connection ID and constants defined in RFC 9001, Section 5.2.
+	// By design, the Initial encryption level provides no confidentiality against any attacker who has read the RFC.
+	// Its sole purpose is integrity protection. The Initial encryption level is therefore out of scope for FIPS 140.
+	// See also this thread on the IETF QUIC mailing list: https://mailarchive.ietf.org/arch/msg/quic/k2kl2W_n5WDEZBbt3O31Ef2XBbM.
+	withoutFIPSEnforcement(func() {
+		clientSecret, serverSecret := computeSecrets(connID, v)
+		var mySecret, otherSecret []byte
+		if pers == protocol.PerspectiveClient {
+			mySecret = clientSecret
+			otherSecret = serverSecret
+		} else {
+			mySecret = serverSecret
+			otherSecret = clientSecret
+		}
+		myKey, myIV := computeInitialKeyAndIV(mySecret, v)
+		otherKey, otherIV := computeInitialKeyAndIV(otherSecret, v)
 
-	encrypter := initialSuite.AEAD(myKey, myIV)
-	decrypter := initialSuite.AEAD(otherKey, otherIV)
+		encrypter := initialSuite.AEAD(myKey, myIV)
+		decrypter := initialSuite.AEAD(otherKey, otherIV)
 
-	return newLongHeaderSealer(encrypter, newHeaderProtector(initialSuite, mySecret, true, v)),
-		newLongHeaderOpener(decrypter, newAESHeaderProtector(initialSuite, otherSecret, true, hkdfHeaderProtectionLabel(v)))
+		sealer = newLongHeaderSealer(encrypter, newHeaderProtector(initialSuite, mySecret, true, v))
+		opener = newLongHeaderOpener(decrypter, newAESHeaderProtector(initialSuite, otherSecret, true, hkdfHeaderProtectionLabel(v)))
+	})
+	return sealer, opener
 }
 
 func computeSecrets(connID protocol.ConnectionID, v protocol.Version) (clientSecret, serverSecret []byte) {
-	initialSecret, err := hkdf.Extract(crypto.SHA256.New, connID.Bytes(), getSalt(v))
+	salt := quicSaltV1
+	if v == protocol.Version2 {
+		salt = quicSaltV2
+	}
+	initialSecret, err := hkdf.Extract(crypto.SHA256.New, connID.Bytes(), salt)
 	if err != nil {
 		panic(fmt.Errorf("quic: HKDF-Extract invocation failed unexpectedly: %v", err))
 	}

--- a/internal/handshake/initial_aead.go
+++ b/internal/handshake/initial_aead.go
@@ -47,8 +47,8 @@ func NewInitialAEAD(connID protocol.ConnectionID, pers protocol.Perspective, v p
 		encrypter := initialSuite.AEAD(myKey, myIV)
 		decrypter := initialSuite.AEAD(otherKey, otherIV)
 
-		sealer = newLongHeaderSealer(encrypter, newAESHeaderProtector(initialSuite, mySecret, true, hkdfHeaderProtectionLabel(v)))
-		opener = newLongHeaderOpener(decrypter, newAESHeaderProtector(initialSuite, otherSecret, true, hkdfHeaderProtectionLabel(v)))
+		sealer = newLongHeaderSealer(encrypter, newHeaderProtector(initialSuite, mySecret, true, v))
+		opener = newLongHeaderOpener(decrypter, newHeaderProtector(initialSuite, otherSecret, true, v))
 	})
 	return sealer, opener
 }


### PR DESCRIPTION
Part of #5077.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable FIPS 140 enforcement during Initial AEAD key derivation
> - Adds a `withoutFIPSEnforcement` helper that wraps a function with `fips140.WithoutEnforcement` on Go 1.26 builds, and is a no-op on earlier versions ([fips140_go126.go](https://github.com/quic-go/quic-go/pull/5640/files#diff-0ee51304af4f8e30c6aec84fe6a8e63af5fddf964d281556d290b69cfefb8ecd), [fips140_legacy.go](https://github.com/quic-go/quic-go/pull/5640/files#diff-250e87a561db9762ba63ea4ecacd88592f6336ba1e67ebab4a3e091f099d2dd0)).
> - Wraps the key derivation and AEAD/header protector construction in `NewInitialAEAD` with this helper, since Initial packet crypto uses salts not approved under FIPS 140.
> - Replaces `newAESHeaderProtector` with `newHeaderProtector` for the `LongHeaderOpener` inside this block.
> - Adds `TestInitial` to the FIPS 140 CI test filter in [unit.yml](https://github.com/quic-go/quic-go/pull/5640/files#diff-e17ac7ab478a18e9dac875e191cc3e0d754fab62eddddfb05d4619495be927d9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 582ee0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->