### PR TITLE
ci: obtain coverage for ClusterFuzzLite Batch fuzzing

### DIFF
--- a/.github/workflows/clusterfuzz-lite-batch.yml
+++ b/.github/workflows/clusterfuzz-lite-batch.yml
@@ -16,24 +16,24 @@ jobs:
         sanitizer:
         - address
     steps:
-    - name: Build Fuzzers (${{ matrix.sanitizer }})
-      id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-      with:
-        language: go
-        sanitizer: ${{ matrix.sanitizer }}
-    - name: Run Fuzzers (${{ matrix.sanitizer }})
-      id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        fuzz-seconds: 3600
-        mode: 'batch'
-        sanitizer: ${{ matrix.sanitizer }}
-        output-sarif: true
-        storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
-        storage-repo-branch: master
-        storage-repo-branch-coverage: gh-pages
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 3600
+          mode: 'batch'
+          sanitizer: ${{ matrix.sanitizer }}
+          output-sarif: true
+          storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
+          storage-repo-branch: master
+          storage-repo-branch-coverage: gh-pages
 
   coverage:
     needs: batch-fuzzing
@@ -41,47 +41,47 @@ jobs:
     env:
       DOCKER_DEFAULT_PLATFORM: linux/amd64
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/checkout@v6
-      with:
-        repository: google/oss-fuzz
-        path: oss-fuzz
-    - uses: actions/checkout@v6
-      with:
-        repository: quic-go/clusterfuzzlite-storage
-        ref: master
-        path: clusterfuzzlite-storage
-        token: ${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}
-    - name: List fuzz targets
-      run: find clusterfuzzlite-storage/corpus -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort
-    - name: Prepare corpus
-      run: |
-        mkdir -p oss-fuzz/build/corpus
-        mv clusterfuzzlite-storage/corpus oss-fuzz/build/corpus/quic-go
-    - name: Use ClusterFuzzLite build script
-      run: |
-        cp .clusterfuzzlite/build.sh oss-fuzz/projects/quic-go/build.sh
-        sed -i '4i cd "$SRC/quic-go"' oss-fuzz/projects/quic-go/build.sh
-    - name: Build coverage fuzzers
-      working-directory: oss-fuzz
-      run: |
-        python3 infra/helper.py build_image --no-pull quic-go
-        python3 infra/helper.py build_fuzzers --sanitizer coverage --mount_path /src/quic-go quic-go "$GITHUB_WORKSPACE"
-    - name: Generate coverage
-      working-directory: oss-fuzz
-      run: python3 infra/helper.py coverage --no-corpus-download --no-serve quic-go
-    - name: Prepare Codecov coverage
-      working-directory: oss-fuzz
-      run: |
-        sed "s#^/out/src/quic-go/#${GITHUB_WORKSPACE}/#" \
-          build/out/quic-go/fuzz.cov > "$GITHUB_WORKSPACE/clusterfuzz-lite-batch.coverprofile"
-        test -s "$GITHUB_WORKSPACE/clusterfuzz-lite-batch.coverprofile"
-    - name: Upload coverage to Codecov
-      if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-      with:
-        disable_search: true
-        files: clusterfuzz-lite-batch.coverprofile
-        flags: clusterfuzz-lite-batch
-        name: ClusterFuzzLite batch fuzzing
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          repository: google/oss-fuzz
+          path: oss-fuzz
+      - uses: actions/checkout@v6
+        with:
+          repository: quic-go/clusterfuzzlite-storage
+          ref: master
+          path: clusterfuzzlite-storage
+          token: ${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}
+      - name: List fuzz targets
+        run: find clusterfuzzlite-storage/corpus -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort
+      - name: Prepare corpus
+        run: |
+          mkdir -p oss-fuzz/build/corpus
+          mv clusterfuzzlite-storage/corpus oss-fuzz/build/corpus/quic-go
+      - name: Use ClusterFuzzLite build script
+        run: |
+          cp .clusterfuzzlite/build.sh oss-fuzz/projects/quic-go/build.sh
+          sed -i '4i cd "$SRC/quic-go"' oss-fuzz/projects/quic-go/build.sh
+      - name: Build coverage fuzzers
+        working-directory: oss-fuzz
+        run: |
+          python3 infra/helper.py build_image --no-pull quic-go
+          python3 infra/helper.py build_fuzzers --sanitizer coverage --mount_path /src/quic-go quic-go "$GITHUB_WORKSPACE"
+      - name: Generate coverage
+        working-directory: oss-fuzz
+        run: python3 infra/helper.py coverage --no-corpus-download --no-serve quic-go
+      - name: Prepare Codecov coverage
+        working-directory: oss-fuzz
+        run: |
+          sed "s#^/out/src/quic-go/#${GITHUB_WORKSPACE}/#" \
+            build/out/quic-go/fuzz.cov > "$GITHUB_WORKSPACE/clusterfuzz-lite-batch.coverprofile"
+          test -s "$GITHUB_WORKSPACE/clusterfuzz-lite-batch.coverprofile"
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          disable_search: true
+          files: clusterfuzz-lite-batch.coverprofile
+          flags: clusterfuzz-lite-batch
+          name: ClusterFuzzLite batch fuzzing
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/clusterfuzz-lite-batch.yml
+++ b/.github/workflows/clusterfuzz-lite-batch.yml
@@ -8,7 +8,7 @@ permissions:
   security-events: write
 
 jobs:
-  BatchFuzzing:
+  batch-fuzzing:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -34,3 +34,54 @@ jobs:
         storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
         storage-repo-branch: master
         storage-repo-branch-coverage: gh-pages
+
+  coverage:
+    needs: batch-fuzzing
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_DEFAULT_PLATFORM: linux/amd64
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6
+      with:
+        repository: google/oss-fuzz
+        path: oss-fuzz
+    - uses: actions/checkout@v6
+      with:
+        repository: quic-go/clusterfuzzlite-storage
+        ref: master
+        path: clusterfuzzlite-storage
+        token: ${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}
+    - name: List fuzz targets
+      run: find clusterfuzzlite-storage/corpus -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort
+    - name: Prepare corpus
+      run: |
+        mkdir -p oss-fuzz/build/corpus
+        mv clusterfuzzlite-storage/corpus oss-fuzz/build/corpus/quic-go
+    - name: Use ClusterFuzzLite build script
+      run: |
+        cp .clusterfuzzlite/build.sh oss-fuzz/projects/quic-go/build.sh
+        sed -i '4i cd "$SRC/quic-go"' oss-fuzz/projects/quic-go/build.sh
+    - name: Build coverage fuzzers
+      working-directory: oss-fuzz
+      run: |
+        python3 infra/helper.py build_image --no-pull quic-go
+        python3 infra/helper.py build_fuzzers --sanitizer coverage --mount_path /src/quic-go quic-go "$GITHUB_WORKSPACE"
+    - name: Generate coverage
+      working-directory: oss-fuzz
+      run: python3 infra/helper.py coverage --no-corpus-download --no-serve quic-go
+    - name: Prepare Codecov coverage
+      working-directory: oss-fuzz
+      run: |
+        sed "s#^/out/src/quic-go/#${GITHUB_WORKSPACE}/#" \
+          build/out/quic-go/fuzz.cov > "$GITHUB_WORKSPACE/clusterfuzz-lite-batch.coverprofile"
+        test -s "$GITHUB_WORKSPACE/clusterfuzz-lite-batch.coverprofile"
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        disable_search: true
+        files: clusterfuzz-lite-batch.coverprofile
+        flags: clusterfuzz-lite-batch
+        name: ClusterFuzzLite batch fuzzing
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -1,7 +1,7 @@
 # Fuzzing
 
 [![Documentation](https://img.shields.io/badge/OSS--Fuzz-Introspector-red?style=flat)](https://introspector.oss-fuzz.com/project-profile?project=quic-go)
-
+[![batch fuzz coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?flag=clusterfuzz-lite-batch&label=ClusterFuzz%20Lite%20Batch%20coverage&logo=codecov&logoColor=white&style=flat)](https://app.codecov.io/gh/quic-go/quic-go?flags%5B0%5D=clusterfuzz-lite-batch)
 
 Run the commands below from a local [`google/oss-fuzz`](https://github.com/google/oss-fuzz) checkout.
 Fuzz target names match the binary names listed in `oss-fuzz.sh` (for example, `frame_fuzzer`).

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,6 @@ coverage:
       default:
         threshold: 0.5
     patch: false
+flags:
+  clusterfuzz-lite-batch:
+    joined: false


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add coverage job to ClusterFuzzLite batch fuzzing workflow
- Adds a `coverage` job to [clusterfuzz-lite-batch.yml](.github/workflows/clusterfuzz-lite-batch.yml) that runs after `batch-fuzzing`, builds coverage-instrumented fuzzers via OSS-Fuzz tooling, and generates a Go coverprofile from the fuzzing corpora.
- Uploads the resulting `clusterfuzz-lite-batch.coverprofile` to Codecov under the `clusterfuzz-lite-batch` flag, configured as `joined: false` in [codecov.yml](https://github.com/quic-go/quic-go/pull/5641/files#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40db).
- Adds a Codecov badge to [FUZZING.md](https://github.com/quic-go/quic-go/pull/5641/files#diff-a404cc9124c5456b0fa2c1747ffe9389fbfc044d6274ab1b772ea887bbfc42b5) showing batch fuzzing coverage.
- Renames the batch fuzzing job key from `BatchFuzzing` to `batch-fuzzing` to satisfy the `needs` reference from the new job.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd91770.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->