### PR TITLE
http3: don't negotiate gzip for CONNECT requests

### DIFF
--- a/http3/stream.go
+++ b/http3/stream.go
@@ -296,11 +296,13 @@ func (s *RequestStream) sendRequestHeader(req *http.Request) error {
 	if s.sentRequest {
 		return errors.New("http3: invalid duplicate use of RequestStream.SendRequestHeader")
 	}
-	if !s.disableCompression && req.Method != http.MethodHead &&
+	s.isConnect = req.Method == http.MethodConnect
+	// Content-Encoding does not apply to CONNECT (and Extended CONNECT) requests:
+	// capsules are not content, so they are never gzipped even if gzip is negotiated.
+	if !s.disableCompression && req.Method != http.MethodHead && !s.isConnect &&
 		req.Header.Get("Accept-Encoding") == "" && req.Header.Get("Range") == "" {
 		s.requestedGzip = true
 	}
-	s.isConnect = req.Method == http.MethodConnect
 	s.sentRequest = true
 	return s.requestWriter.WriteRequestHeader(s.str.datagramStream, req, s.requestedGzip, s.str.StreamID(), s.str.qlogger)
 }

--- a/http3/stream_test.go
+++ b/http3/stream_test.go
@@ -233,3 +233,40 @@ func TestRequestStream(t *testing.T) {
 	require.Equal(t, 6, n)
 	require.Equal(t, []byte("foobar"), b[:n])
 }
+
+func TestRequestStreamGzipNotNegotiatedForConnect(t *testing.T) {
+	newRequestStreamForMethod := func(t *testing.T, method string) (*RequestStream, *bytes.Buffer) {
+		t.Helper()
+		mockCtrl := gomock.NewController(t)
+		qstr := NewMockDatagramStream(mockCtrl)
+		qstr.EXPECT().StreamID().Return(quic.StreamID(42)).AnyTimes()
+		var buf bytes.Buffer
+		qstr.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
+		clientConn, _ := newConnPair(t)
+		str := newRequestStream(
+			newStream(
+				qstr,
+				newRawConn(clientConn, false, nil, nil, nil, nil),
+				nil,
+				func(io.Reader, *headersFrame) error { return nil },
+				nil,
+			),
+			newRequestWriter(),
+			make(chan struct{}),
+			qpack.NewDecoder(),
+			false,
+			math.MaxInt,
+			&http.Response{},
+		)
+		req, err := http.NewRequest(method, "https://quic-go.net/", nil)
+		require.NoError(t, err)
+		require.NoError(t, str.SendRequestHeader(req))
+		return str, &buf
+	}
+
+	_, getBuf := newRequestStreamForMethod(t, http.MethodGet)
+	require.Equal(t, []string{"gzip"}, decodeHeader(t, getBuf)["accept-encoding"])
+
+	_, connectBuf := newRequestStreamForMethod(t, http.MethodConnect)
+	require.NotContains(t, decodeHeader(t, connectBuf), "accept-encoding")
+}


### PR DESCRIPTION
Content-Encoding does not apply to CONNECT or Extended CONNECT requests, since capsules are not content, so the client should not send `Accept-Encoding: gzip` on those requests even when compression is enabled. This skips gzip negotiation when the request method is CONNECT. Closes #4410.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gzip negotiation to skip `Accept-Encoding` for CONNECT requests in http3
> CONNECT and Extended CONNECT requests do not use Content-Encoding, so requesting gzip via `Accept-Encoding` is incorrect. In [stream.go](https://github.com/quic-go/quic-go/pull/5644/files#diff-78b9dd15996d79e5718e0b1a031fd73b67983fceb406305fb50ec797dbb558de), `s.isConnect` is now set before the gzip negotiation check, and the condition skips `requestedGzip` when the method is CONNECT. A test in [stream_test.go](https://github.com/quic-go/quic-go/pull/5644/files#diff-543e33e12efd3a6cd27e7cb27b437c4c5533906aee74e8f71a069a0959f6beef) verifies `Accept-Encoding` is present for GET and absent for CONNECT.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55a940a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->