### PR TITLE
add Conn.MaxDatagramPayloadSize to query current datagram limit

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3026,19 +3026,30 @@ func (c *Conn) SendDatagram(p []byte) error {
 		return errors.New("datagram support disabled")
 	}
 
-	f := &wire.DatagramFrame{DataLenPresent: true}
-	// The payload size estimate is conservative.
-	// Under many circumstances we could send a few more bytes.
-	maxDataLen := min(
-		f.MaxDataLen(c.peerParams.MaxDatagramFrameSize, c.version),
-		protocol.ByteCount(c.currentMTUEstimate.Load()),
-	)
+	maxDataLen := c.currentMaxDatagramPayloadSize()
 	if protocol.ByteCount(len(p)) > maxDataLen {
 		return &DatagramTooLargeError{MaxDatagramPayloadSize: int64(maxDataLen)}
 	}
-	f.Data = make([]byte, len(p))
+	f := &wire.DatagramFrame{DataLenPresent: true, Data: make([]byte, len(p))}
 	copy(f.Data, p)
 	return c.datagramQueue.Add(f)
+}
+
+// MaxDatagramPayloadSize returns the maximum payload size that can currently
+// be sent using SendDatagram, or 0 if the peer did not enable datagram support.
+func (c *Conn) MaxDatagramPayloadSize() int64 {
+	if !c.supportsDatagrams() {
+		return 0
+	}
+	return int64(c.currentMaxDatagramPayloadSize())
+}
+
+func (c *Conn) currentMaxDatagramPayloadSize() protocol.ByteCount {
+	f := wire.DatagramFrame{DataLenPresent: true}
+	return min(
+		f.MaxDataLen(c.peerParams.MaxDatagramFrameSize, c.version),
+		protocol.ByteCount(c.currentMTUEstimate.Load()),
+	)
 }
 
 // ReceiveDatagram gets a message received in a QUIC datagram, as specified in RFC 9221.


### PR DESCRIPTION
Closes #4259.
Exposes the maximum datagram payload size that SendDatagram will accept, so callers can size payloads without guessing. The value was already computed internally; this just makes it queryable.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Conn.MaxDatagramPayloadSize` to query the current datagram payload limit
> Adds a `MaxDatagramPayloadSize()` method to `Conn` that returns the current maximum sendable datagram payload size as `int64`, or `0` if datagrams are not supported by the peer. The computation is extracted into a new `currentMaxDatagramPayloadSize()` helper, which is also used by `SendDatagram` to replace its previous inline calculation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e12e70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->