### PR TITLE
rename fuzz targets of recently rewritten fuzz tests

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -29,9 +29,9 @@ build_native_go_fuzzer() {
 	compile_native_go_fuzzer_v2 "$pkg" "$fuzz" "$name"
 }
 
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzFrames frame_fuzzer
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzTransportParameters transportparameter_fuzzer
+build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzFrames frame_fuzzer_v2
+build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzTransportParameters transportparameter_fuzzer_v2
 build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzFrameParser http3_frame_fuzzer
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/handshake FuzzHandshake handshake_fuzzer
+build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer_v2
+build_native_go_fuzzer github.com/quic-go/quic-go/internal/handshake FuzzHandshake handshake_fuzzer_v2
 build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzHeaderParsing http3_header_parsing_fuzzer

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -4,7 +4,7 @@
 [![batch fuzz coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?flag=clusterfuzz-lite-batch&label=ClusterFuzz%20Lite%20Batch%20coverage&logo=codecov&logoColor=white&style=flat)](https://app.codecov.io/gh/quic-go/quic-go?flags%5B0%5D=clusterfuzz-lite-batch)
 
 Run the commands below from a local [`google/oss-fuzz`](https://github.com/google/oss-fuzz) checkout.
-Fuzz target names match the binary names listed in `oss-fuzz.sh` (for example, `frame_fuzzer`).
+Fuzz target names match the binary names listed in `oss-fuzz.sh` (for example, `frame_fuzzer_v2`).
 
 Update the base images:
 ```sh

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -36,11 +36,11 @@ build_native_go_fuzzer() {
 	compile_native_go_fuzzer_v2 "$pkg" "$fuzz" "$name"
 }
 
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzFrames frame_fuzzer
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzTransportParameters transportparameter_fuzzer
+build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzFrames frame_fuzzer_v2
+build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzTransportParameters transportparameter_fuzzer_v2
 build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzFrameParser http3_frame_fuzzer
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/handshake FuzzHandshake handshake_fuzzer
+build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer_v2
+build_native_go_fuzzer github.com/quic-go/quic-go/internal/handshake FuzzHandshake handshake_fuzzer_v2
 build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzHeaderParsing http3_header_parsing_fuzzer
 
 # for debugging


### PR DESCRIPTION
We recently rewrote all of our fuzz tests to use native Go fuzzing. The OSS-Fuzz corpus of these fuzz targets has grown enormously, to the point where the fuzzer is not finding even trivial code paths. Since we don’t have permissions to remove the existing OSS-Fuz corpus, renaming the fuzz targets should allow us to start with a fresh corpus.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename fuzz target binaries to append `_v2` suffix for rewritten fuzz tests
> Appends `_v2` to the output binary names for four fuzz targets (`frame_fuzzer`, `transportparameter_fuzzer`, `header_fuzzer`, `handshake_fuzzer`) in [.clusterfuzzlite/build.sh](https://github.com/quic-go/quic-go/pull/5648/files#diff-2c10f02a79d6592981510922b30964df2d52d82b774ac3d337a535840bb4f3a8) and [oss-fuzz.sh](https://github.com/quic-go/quic-go/pull/5648/files#diff-857b8ac91ce0728a3684db7bff7d929b9818b1cfaeeb81499fea2f08aa39bc05). Updates the example target name in [FUZZING.md](https://github.com/quic-go/quic-go/pull/5648/files#diff-a404cc9124c5456b0fa2c1747ffe9389fbfc044d6274ab1b772ea887bbfc42b5) to match. Risk: existing ClusterFuzzLite and OSS-Fuzz corpus entries tied to the old binary names will no longer map to the new targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c46b904.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->