### PR TITLE
fix maximum datagram size estimation after MTU discovery

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2128,8 +2128,10 @@ func (c *Conn) handleAckFrame(frame *wire.AckFrame, encLevel protocol.Encryption
 	}
 	// If one of the acknowledged packets was a Path MTU probe packet, this might have increased the Path MTU estimate.
 	if c.mtuDiscoverer != nil {
-		if mtu := c.mtuDiscoverer.CurrentSize(); mtu > protocol.ByteCount(c.maxPayloadSizeEstimate.Load()) {
-			c.maxPayloadSizeEstimate.Store(uint32(estimateMaxPayloadSize(mtu)))
+		mtu := c.mtuDiscoverer.CurrentSize()
+		maxPayloadSize := estimateMaxPayloadSize(mtu)
+		if maxPayloadSize > protocol.ByteCount(c.maxPayloadSizeEstimate.Load()) {
+			c.maxPayloadSizeEstimate.Store(uint32(maxPayloadSize))
 			c.sentPacketHandler.SetMaxDatagramSize(mtu)
 		}
 	}

--- a/connection.go
+++ b/connection.go
@@ -165,7 +165,7 @@ type Conn struct {
 	packer        packer
 	mtuDiscoverer mtuDiscoverer // initialized when the transport parameters are received
 
-	currentMTUEstimate atomic.Uint32
+	maxPayloadSizeEstimate atomic.Uint32
 
 	initialStream       *initialCryptoStream
 	handshakeStream     *cryptoStream
@@ -322,7 +322,7 @@ var newConnection = func(
 		s.qlogger,
 		s.logger,
 	)
-	s.currentMTUEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
+	s.maxPayloadSizeEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
 	statelessResetToken := statelessResetter.GetStatelessResetToken(srcConnID)
 	params := &wire.TransportParameters{
 		InitialMaxStreamDataBidiLocal:   protocol.ByteCount(s.config.InitialStreamReceiveWindow),
@@ -451,7 +451,7 @@ var newClientConnection = func(
 		s.qlogger,
 		s.logger,
 	)
-	s.currentMTUEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
+	s.maxPayloadSizeEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
 	oneRTTStream := newCryptoStream()
 	params := &wire.TransportParameters{
 		InitialMaxStreamDataBidiRemote: protocol.ByteCount(s.config.InitialStreamReceiveWindow),
@@ -2128,8 +2128,8 @@ func (c *Conn) handleAckFrame(frame *wire.AckFrame, encLevel protocol.Encryption
 	}
 	// If one of the acknowledged packets was a Path MTU probe packet, this might have increased the Path MTU estimate.
 	if c.mtuDiscoverer != nil {
-		if mtu := c.mtuDiscoverer.CurrentSize(); mtu > protocol.ByteCount(c.currentMTUEstimate.Load()) {
-			c.currentMTUEstimate.Store(uint32(mtu))
+		if mtu := c.mtuDiscoverer.CurrentSize(); mtu > protocol.ByteCount(c.maxPayloadSizeEstimate.Load()) {
+			c.maxPayloadSizeEstimate.Store(uint32(estimateMaxPayloadSize(mtu)))
 			c.sentPacketHandler.SetMaxDatagramSize(mtu)
 		}
 	}
@@ -3031,7 +3031,7 @@ func (c *Conn) SendDatagram(p []byte) error {
 	// Under many circumstances we could send a few more bytes.
 	maxDataLen := min(
 		f.MaxDataLen(c.peerParams.MaxDatagramFrameSize, c.version),
-		protocol.ByteCount(c.currentMTUEstimate.Load()),
+		protocol.ByteCount(c.maxPayloadSizeEstimate.Load()),
 	)
 	if protocol.ByteCount(len(p)) > maxDataLen {
 		return &DatagramTooLargeError{MaxDatagramPayloadSize: int64(maxDataLen)}

--- a/integrationtests/self/datagram_test.go
+++ b/integrationtests/self/datagram_test.go
@@ -147,7 +147,7 @@ func TestDatagramSizeLimitIncludesPacketOverhead(t *testing.T) {
 	require.NoError(t, err)
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(5*time.Second))
 	defer cancel()
 	clientConn, err := quic.Dial(
 		ctx,
@@ -167,7 +167,7 @@ func TestDatagramSizeLimitIncludesPacketOverhead(t *testing.T) {
 	defer serverConn.CloseWithError(0, "")
 
  	// wait for the MTU discovery to complete	
-	time.Sleep(time.Millisecond * 500)
+	time.Sleep(scaleDuration(time.Millisecond * 500))
 
 	// Find the maximum payload size reported by DatagramTooLargeError
 	var maxPayloadSize protocol.ByteCount
@@ -183,7 +183,7 @@ func TestDatagramSizeLimitIncludesPacketOverhead(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the datagram was actually delivered and data matches
-	serverCtx, serverCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	serverCtx, serverCancel := context.WithTimeout(ctx, scaleDuration(500*time.Millisecond))
 	defer serverCancel()
 	datagram, err := serverConn.ReceiveDatagram(serverCtx)
 	require.NoError(t, err, "datagram should be actually deliverable when respecting MaxDatagramPayloadSize")

--- a/integrationtests/self/datagram_test.go
+++ b/integrationtests/self/datagram_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
 	"github.com/quic-go/quic-go/testutils/simnet"
 
@@ -125,6 +126,69 @@ func TestDatagramSizeLimit(t *testing.T) {
 	datagram, err := serverConn.ReceiveDatagram(ctx)
 	require.NoError(t, err)
 	require.Equal(t, bytes.Repeat([]byte("b"), int(sizeErr.MaxDatagramPayloadSize)), datagram)
+}
+
+func TestDatagramSizeLimitIncludesPacketOverhead(t *testing.T) {
+	// This test verifies that MaxDatagramPayloadSize accounts for:
+	// 1. QUIC short header overhead (1 byte type + dest connID + packet number)
+	// 2. AEAD encryption overhead (authentication tag)
+	//
+	// When currentMTUEstimate becomes the limiting factor (peerParams.MaxDatagramFrameSize is large),
+	// the returned MaxDatagramPayloadSize should be MTU - overhead.
+
+	server, err := quic.Listen(
+		newUDPConnLocalhost(t),
+		getTLSConfig(),
+		getQuicConfig(&quic.Config{
+			EnableDatagrams:         true,
+			DisablePathMTUDiscovery: true,
+		}),
+	)
+	require.NoError(t, err)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	clientConn, err := quic.Dial(
+		ctx,
+		newUDPConnLocalhost(t),
+		server.Addr(),
+		getTLSClientConfig(),
+		getQuicConfig(&quic.Config{
+			EnableDatagrams:         true,
+			DisablePathMTUDiscovery: true,
+		}),
+	)
+	require.NoError(t, err)
+	defer clientConn.CloseWithError(0, "")
+
+	serverConn, err := server.Accept(ctx)
+	require.NoError(t, err)
+	defer serverConn.CloseWithError(0, "")
+
+ 	// wait for the MTU discovery to complete	
+	time.Sleep(time.Millisecond * 500)
+
+	// Find the maximum payload size reported by DatagramTooLargeError
+	var maxPayloadSize protocol.ByteCount
+	size := protocol.ByteCount(2000)
+	err = clientConn.SendDatagram(bytes.Repeat([]byte("x"), int(size)))
+	var sizeErr *quic.DatagramTooLargeError
+	require.ErrorAs(t, err, &sizeErr)
+	maxPayloadSize = protocol.ByteCount(sizeErr.MaxDatagramPayloadSize)
+	require.Greater(t, maxPayloadSize, protocol.ByteCount(0)) 
+
+	// Try to send a datagram with exactly MaxDatagramPayloadSize
+	err = clientConn.SendDatagram(bytes.Repeat([]byte("z"), int(maxPayloadSize)))
+	require.NoError(t, err)
+
+	// Verify the datagram was actually delivered and data matches
+	serverCtx, serverCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer serverCancel()
+	datagram, err := serverConn.ReceiveDatagram(serverCtx)
+	require.NoError(t, err, "datagram should be actually deliverable when respecting MaxDatagramPayloadSize")
+	require.Equal(t, int(maxPayloadSize), len(datagram))
+	require.Equal(t, bytes.Repeat([]byte("z"), int(maxPayloadSize)), datagram)
 }
 
 func TestDatagramLoss(t *testing.T) {

--- a/integrationtests/self/datagram_test.go
+++ b/integrationtests/self/datagram_test.go
@@ -3,6 +3,7 @@ package self_test
 import (
 	"bytes"
 	"context"
+	"io"
 	mrand "math/rand/v2"
 	"net"
 	"sync/atomic"
@@ -13,6 +14,8 @@ import (
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/qlog"
+	"github.com/quic-go/quic-go/testutils/events"
 	"github.com/quic-go/quic-go/testutils/simnet"
 
 	"github.com/stretchr/testify/assert"
@@ -128,35 +131,27 @@ func TestDatagramSizeLimit(t *testing.T) {
 	require.Equal(t, bytes.Repeat([]byte("b"), int(sizeErr.MaxDatagramPayloadSize)), datagram)
 }
 
-func TestDatagramSizeLimitIncludesPacketOverhead(t *testing.T) {
-	// This test verifies that MaxDatagramPayloadSize accounts for:
-	// 1. QUIC short header overhead (1 byte type + dest connID + packet number)
-	// 2. AEAD encryption overhead (authentication tag)
-	//
-	// When currentMTUEstimate becomes the limiting factor (peerParams.MaxDatagramFrameSize is large),
-	// the returned MaxDatagramPayloadSize should be MTU - overhead.
-
+func TestDatagramSizeLimitWithMTUDiscovery(t *testing.T) {
 	server, err := quic.Listen(
 		newUDPConnLocalhost(t),
 		getTLSConfig(),
-		getQuicConfig(&quic.Config{
-			EnableDatagrams:         true,
-			DisablePathMTUDiscovery: true,
-		}),
+		getQuicConfig(&quic.Config{EnableDatagrams: true}),
 	)
 	require.NoError(t, err)
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(5*time.Second))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	var eventRecorder events.Recorder
 	clientConn, err := quic.Dial(
 		ctx,
 		newUDPConnLocalhost(t),
 		server.Addr(),
 		getTLSClientConfig(),
 		getQuicConfig(&quic.Config{
-			EnableDatagrams:         true,
-			DisablePathMTUDiscovery: true,
+			InitialPacketSize: protocol.MinInitialPacketSize,
+			EnableDatagrams:   true,
+			Tracer:            newTracer(&eventRecorder),
 		}),
 	)
 	require.NoError(t, err)
@@ -166,29 +161,61 @@ func TestDatagramSizeLimitIncludesPacketOverhead(t *testing.T) {
 	require.NoError(t, err)
 	defer serverConn.CloseWithError(0, "")
 
- 	// wait for the MTU discovery to complete	
-	time.Sleep(scaleDuration(time.Millisecond * 500))
+	serverErrChan := make(chan error, 1)
+	go func() {
+		str, err := serverConn.AcceptStream(ctx)
+		if err != nil {
+			serverErrChan <- err
+			return
+		}
+		_, err = io.Copy(io.Discard, str)
+		serverErrChan <- err
+	}()
 
-	// Find the maximum payload size reported by DatagramTooLargeError
-	var maxPayloadSize protocol.ByteCount
-	size := protocol.ByteCount(2000)
-	err = clientConn.SendDatagram(bytes.Repeat([]byte("x"), int(size)))
-	var sizeErr *quic.DatagramTooLargeError
-	require.ErrorAs(t, err, &sizeErr)
-	maxPayloadSize = protocol.ByteCount(sizeErr.MaxDatagramPayloadSize)
-	require.Greater(t, maxPayloadSize, protocol.ByteCount(0)) 
-
-	// Try to send a datagram with exactly MaxDatagramPayloadSize
-	err = clientConn.SendDatagram(bytes.Repeat([]byte("z"), int(maxPayloadSize)))
+	str, err := clientConn.OpenStream()
 	require.NoError(t, err)
 
-	// Verify the datagram was actually delivered and data matches
-	serverCtx, serverCancel := context.WithTimeout(ctx, scaleDuration(500*time.Millisecond))
-	defer serverCancel()
-	datagram, err := serverConn.ReceiveDatagram(serverCtx)
-	require.NoError(t, err, "datagram should be actually deliverable when respecting MaxDatagramPayloadSize")
-	require.Equal(t, int(maxPayloadSize), len(datagram))
-	require.Equal(t, bytes.Repeat([]byte("z"), int(maxPayloadSize)), datagram)
+	data := bytes.Repeat([]byte("d"), 16*1024)
+	var discoveredMTU int
+	var checkedMTUUpdates int
+	var previousMaxPayloadSize int64
+	for discoveredMTU == 0 {
+		_, err = str.Write(data)
+		require.NoError(t, err)
+		events := eventRecorder.Events(qlog.MTUUpdated{})
+		for ; checkedMTUUpdates < len(events); checkedMTUUpdates++ {
+			update := events[checkedMTUUpdates].(qlog.MTUUpdated)
+			err = clientConn.SendDatagram(bytes.Repeat([]byte("x"), 2000))
+			var sizeErr *quic.DatagramTooLargeError
+			require.ErrorAs(t, err, &sizeErr)
+			maxPayloadSize := sizeErr.MaxDatagramPayloadSize
+			require.Greater(t, maxPayloadSize, int64(0))
+			require.Greater(t, maxPayloadSize, previousMaxPayloadSize)
+			require.Less(t, maxPayloadSize, int64(update.Value))
+			previousMaxPayloadSize = maxPayloadSize
+
+			datagramData := bytes.Repeat([]byte("z"), int(maxPayloadSize))
+			err = clientConn.SendDatagram(datagramData)
+			require.NoError(t, err)
+
+			datagram, err := serverConn.ReceiveDatagram(ctx)
+			require.NoError(t, err, "datagram should be deliverable when respecting MaxDatagramPayloadSize")
+			require.Equal(t, datagramData, datagram)
+
+			if update.Done {
+				discoveredMTU = update.Value
+			}
+		}
+		require.NoError(t, ctx.Err())
+	}
+	require.NoError(t, str.Close())
+
+	select {
+	case err := <-serverErrChan:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		require.NoError(t, ctx.Err())
+	}
 }
 
 func TestDatagramLoss(t *testing.T) {


### PR DESCRIPTION
Fixes #4983.

## Summary

- Fixes a bug where `MaxDatagramPayloadSize` incorrectly calculated the maximum datagram size after MTU discovery
- The bug was introduced in PR #4941 which stored the raw MTU value instead of the payload size (MTU minus header and AEAD overhead)
- Also renames `currentMTUEstimate` back to `maxPayloadSizeEstimate` for clarity

## Changes

- In `handleAckFrame`: use `estimateMaxPayloadSize(mtu)` when updating after MTU discovery instead of raw MTU
- Rename `currentMTUEstimate` to `maxPayloadSizeEstimate` to accurately reflect what it stores

## Test plan

- [x] Run `TestDatagramSizeLimitIncludesPacketOverhead` locally: PASS
- [x] Run all datagram tests: PASS

## Related

- Fixes the test added in PR #5649
- Reverts behavior to match what existed before PR #4941

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix maximum datagram size estimation after MTU discovery in `Conn`
> - Renames `currentMTUEstimate` to `maxPayloadSizeEstimate` in [connection.go](https://github.com/quic-go/quic-go/pull/5650/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7) and stores the result of `estimateMaxPayloadSize(mtu)` rather than the raw MTU value when a path MTU probe is acknowledged.
> - `SendDatagram` now caps payload size against the estimated payload size (MTU minus overhead) instead of the raw MTU, preventing overestimation after MTU discovery.
> - Adds `TestDatagramSizeLimitWithMTUDiscovery` in [datagram_test.go](https://github.com/quic-go/quic-go/pull/5650/files#diff-dcd6bfe78bf00f3b683ab9cd006bed2a3cea29b31efbacf249706a138c802bfb) to verify that datagram size limits track MTU discovery events and that payloads above the limit produce `DatagramTooLargeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0a416b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->