### PR TITLE
run `go fix` across the entire codebase

### DIFF
--- a/conn_id_manager_test.go
+++ b/conn_id_manager_test.go
@@ -186,7 +186,7 @@ func TestConnIDManagerConnIDRotation(t *testing.T) {
 	// Note that we're missing the connection ID with sequence number 2.
 	// It will be received later.
 	var queuedConnIDs []protocol.ConnectionID
-	for i := 0; i < protocol.MaxActiveConnectionIDs-1; i++ {
+	for i := range protocol.MaxActiveConnectionIDs - 1 {
 		b := make([]byte, 4)
 		rand.Read(b)
 		connID := protocol.ParseConnectionID(b)

--- a/example/main.go
+++ b/example/main.go
@@ -41,7 +41,7 @@ type Size interface {
 func generatePRData(l int) []byte {
 	res := make([]byte, l)
 	seed := uint64(1)
-	for i := 0; i < l; i++ {
+	for i := range l {
 		seed = seed * 48271 % 2147483647
 		res[i] = byte(seed)
 	}
@@ -81,7 +81,7 @@ func setupHandler(www string) http.Handler {
 
 	mux.HandleFunc("/demo/tiles", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "<html><head><style>img{width:40px;height:40px;}</style></head><body>")
-		for i := 0; i < 200; i++ {
+		for i := range 200 {
 			fmt.Fprintf(w, `<img src="/demo/tile?cachebust=%d">`, i)
 		}
 		io.WriteString(w, "</body></html>")

--- a/frame_sorter_test.go
+++ b/frame_sorter_test.go
@@ -1368,7 +1368,7 @@ func TestFrameSorterGapHandling(t *testing.T) {
 
 func TestFrameSorterTooManyGaps(t *testing.T) {
 	s := newFrameSorter()
-	for i := 0; i < protocol.MaxStreamFrameSorterGaps; i++ {
+	for i := range protocol.MaxStreamFrameSorterGaps {
 		require.NoError(t, s.Push([]byte("foobar"), protocol.ByteCount(i*7), nil))
 	}
 	require.Equal(t, protocol.MaxStreamFrameSorterGaps, s.gaps.Len())
@@ -1412,7 +1412,7 @@ func testFrameSorterRandomized(t *testing.T, dataLen protocol.ByteCount, injectD
 	random.Read(data)
 
 	frames := make([]frame, num)
-	for i := 0; i < num; i++ {
+	for i := range num {
 		b := make([]byte, dataLen)
 		offset := i * int(dataLen)
 		copy(b, data[offset:offset+int(dataLen)])
@@ -1432,7 +1432,7 @@ func testFrameSorterRandomized(t *testing.T, dataLen protocol.ByteCount, injectD
 		callbacks = append(callbacks, tr)
 	}
 	if injectDuplicates {
-		for i := 0; i < num/10; i++ {
+		for range num / 10 {
 			cb, tr := getFrameSorterTestCallback(t)
 			df := frames[mrand.IntN(len(frames))]
 			require.NoError(t, s.Push(df.data, df.offset, cb))
@@ -1441,7 +1441,7 @@ func testFrameSorterRandomized(t *testing.T, dataLen protocol.ByteCount, injectD
 	}
 	if injectOverlaps {
 		finalOffset := num * dataLen
-		for i := 0; i < num/3; i++ {
+		for range num / 3 {
 			cb, tr := getFrameSorterTestCallback(t)
 			startOffset := protocol.ByteCount(mrand.IntN(int(finalOffset)))
 			endOffset := startOffset + protocol.ByteCount(mrand.IntN(int(finalOffset-startOffset)))

--- a/framer.go
+++ b/framer.go
@@ -102,7 +102,7 @@ func (f *framer) Append(
 	f.mutex.Lock()
 	// pop STREAM frames, until less than 128 bytes are left in the packet
 	numActiveStreams := f.streamQueue.Len()
-	for i := 0; i < numActiveStreams; i++ {
+	for range numActiveStreams {
 		if protocol.MinStreamFrameSize > maxLen {
 			break
 		}

--- a/framer_test.go
+++ b/framer_test.go
@@ -211,7 +211,7 @@ func testFramerDataBlocked(t *testing.T, fits bool) {
 
 func TestFramerDetectsFrameDoS(t *testing.T) {
 	framer := newFramer(flowcontrol.NewConnectionFlowController(0, 0, nil, nil, nil))
-	for i := 0; i < maxControlFrames-1; i++ {
+	for i := range maxControlFrames - 1 {
 		framer.QueueControlFrame(&wire.PingFrame{})
 		framer.QueueControlFrame(&wire.PingFrame{})
 		require.False(t, framer.QueuedTooManyControlFrames())
@@ -230,13 +230,13 @@ func TestFramerDetectsFrameDoS(t *testing.T) {
 func TestFramerDetectsFramePathResponseDoS(t *testing.T) {
 	framer := newFramer(flowcontrol.NewConnectionFlowController(0, 0, nil, nil, nil))
 	var pathResponses []*wire.PathResponseFrame
-	for i := 0; i < 2*maxPathResponses; i++ {
+	for range 2 * maxPathResponses {
 		var f wire.PathResponseFrame
 		binary.BigEndian.PutUint64(f.Data[:], rand.Uint64())
 		pathResponses = append(pathResponses, &f)
 		framer.QueueControlFrame(&f)
 	}
-	for i := 0; i < maxPathResponses; i++ {
+	for i := range maxPathResponses {
 		require.True(t, framer.HasData())
 		frames, _, length := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
 		require.Len(t, frames, 1)

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -233,15 +233,13 @@ func (c *rawConn) handleControlStream(str *quic.ReceiveStream) {
 			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeSettingsError), "missing QUIC Datagram support")
 			return
 		}
-		c.qloggerWG.Add(1)
-		go func() {
-			defer c.qloggerWG.Done()
+		c.qloggerWG.Go(func() {
 			if err := c.receiveDatagrams(); err != nil {
 				if c.logger != nil {
 					c.logger.Debug("receiving datagrams failed", "error", err)
 				}
 			}
-		}()
+		})
 	}
 
 	if c.controlStrHandler != nil {

--- a/http3/headers.go
+++ b/http3/headers.go
@@ -343,7 +343,7 @@ func extractAnnouncedTrailers(header http.Header) http.Header {
 
 	trailers := make(http.Header)
 	for _, rawVal := range rawTrailers {
-		for _, val := range strings.Split(rawVal, ",") {
+		for val := range strings.SplitSeq(rawVal, ",") {
 			trailers[http.CanonicalHeaderKey(textproto.TrimString(val))] = nil
 		}
 	}

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -220,7 +220,7 @@ func (w *responseWriter) writeHeader(status int) error {
 	// Handle trailer fields
 	if vals, ok := w.header["Trailer"]; ok {
 		for _, val := range vals {
-			for _, trailer := range strings.Split(val, ",") {
+			for trailer := range strings.SplitSeq(val, ",") {
 				// We need to convert to the canonical header key value here because this will be called when using
 				// headers.Add or headers.Set.
 				trailer = textproto.CanonicalMIMEHeaderKey(strings.TrimSpace(trailer))

--- a/http3/server.go
+++ b/http3/server.go
@@ -528,14 +528,12 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 					Frame:    qlog.Frame{Frame: qlog.GoAwayFrame{StreamID: nextStreamID}},
 				})
 			}
-			wg.Add(1)
 			// Send the GOAWAY frame in a separate Goroutine.
 			// Sending might block if the peer didn't grant enough flow control credit.
 			// Write is guaranteed to return once the connection is closed.
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				_, _ = ctrlStr.Write((&goAwayFrame{StreamID: nextStreamID}).Append(nil))
-			}()
+			})
 			ctx = s.closeCtx
 			continue
 		}
@@ -546,13 +544,11 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 		}
 
 		nextStreamID = str.StreamID() + 4
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			// HandleRequestStream will return once the request has been handled,
 			// or the underlying connection is closed.
-			defer wg.Done()
 			hconn.HandleRequestStream(str)
-		}()
+		})
 	}
 	wg.Wait()
 	return handleErr

--- a/integrationtests/self/cancelation_test.go
+++ b/integrationtests/self/cancelation_test.go
@@ -352,7 +352,7 @@ func TestCancelAcceptStream(t *testing.T) {
 		defer cancel()
 		ticker := time.NewTicker(5 * time.Millisecond)
 		defer ticker.Stop()
-		for i := 0; i < numStreams; i++ {
+		for range numStreams {
 			<-ticker.C
 			str, err := serverConn.OpenUniStreamSync(ctx)
 			if err != nil {
@@ -573,7 +573,7 @@ func TestHeavyStreamCancellation(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < maxIncomingStreams; i++ {
+	for range maxIncomingStreams {
 		str, err := conn.OpenStreamSync(context.Background())
 		require.NoError(t, err)
 		handleStream(str)

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -286,7 +286,7 @@ func TestClosedConnectionsInAcceptQueue(t *testing.T) {
 
 	// accept all connections, and find the closed one
 	var closedConn *quic.Conn
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		conn, err := server.Accept(ctx)
 		require.NoError(t, err)
 		if conn.Context().Err() != nil {
@@ -313,7 +313,7 @@ func TestServerAcceptQueueOverflow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	// fill up the accept queue
-	for i := 0; i < protocol.MaxAcceptQueueSize; i++ {
+	for range protocol.MaxAcceptQueueSize {
 		conn, err := dialer.Dial(ctx, server.Addr(), getTLSClientConfig(), getQuicConfig(nil))
 		require.NoError(t, err)
 		defer conn.CloseWithError(0, "")

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	mrand "math/rand/v2"
 	"net"
 	"net/http"
@@ -174,7 +175,7 @@ func TestHTTPMultipleRequests(t *testing.T) {
 
 		cl := newHTTP3Client(t)
 		var eg errgroup.Group
-		for i := 0; i < 200; i++ {
+		for range 200 {
 			eg.Go(func() error {
 				resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
 				if err != nil {
@@ -204,7 +205,7 @@ func TestHTTPMultipleRequests(t *testing.T) {
 		cl := newHTTP3Client(t)
 		const num = 150
 
-		for i := 0; i < num; i++ {
+		for range num {
 			resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/prdata", port))
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -434,9 +435,7 @@ func TestHTTPRequestTrailers(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/client-trailers", func(w http.ResponseWriter, r *http.Request) {
 		trailerBeforeBody := make(http.Header)
-		for k, v := range r.Trailer {
-			trailerBeforeBody[k] = v
-		}
+		maps.Copy(trailerBeforeBody, r.Trailer)
 		trailerChan <- trailerBeforeBody
 
 		body, err := io.ReadAll(r.Body)
@@ -447,9 +446,7 @@ func TestHTTPRequestTrailers(t *testing.T) {
 		bodyChan <- string(body)
 
 		trailer := make(http.Header)
-		for k, v := range r.Trailer {
-			trailer[k] = v
-		}
+		maps.Copy(trailer, r.Trailer)
 		trailerChan <- trailer
 
 		w.WriteHeader(http.StatusOK)
@@ -977,7 +974,7 @@ func TestHTTPStreamedRequests(t *testing.T) {
 	require.Equal(t, 200, rsp.StatusCode)
 
 	reader := bufio.NewReader(rsp.Body)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		msg := fmt.Sprintf("Hello world, %d!\n", i)
 		fmt.Fprint(w, msg)
 		msgRcvd, err := reader.ReadString('\n')
@@ -1157,8 +1154,7 @@ func TestHTTPStreamer(t *testing.T) {
 	require.NoError(t, err)
 	tlsConf := getTLSClientConfigWithoutServerName()
 	tlsConf.NextProtos = []string{http3.NextProtoH3}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	conn, err := quic.Dial(ctx, newUDPConnLocalhost(t), &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port}, tlsConf, getQuicConfig(nil))
 	require.NoError(t, err)
 	defer conn.CloseWithError(0, "")

--- a/integrationtests/self/multiplex_test.go
+++ b/integrationtests/self/multiplex_test.go
@@ -205,8 +205,7 @@ func TestMultiplexingNonQUICPackets(t *testing.T) {
 		err  error
 	}
 	rcvdPackets := make(chan nonQUICPacket, numPackets)
-	receiveCtx, receiveCancel := context.WithCancel(context.Background())
-	defer receiveCancel()
+	receiveCtx := t.Context()
 	// start receiving non-QUIC packets
 	go func() {
 		for {

--- a/integrationtests/self/packetization_test.go
+++ b/integrationtests/self/packetization_test.go
@@ -92,7 +92,7 @@ func TestACKBundling(t *testing.T) {
 	require.NoError(t, err)
 	b := make([]byte, 1)
 	// Send numMsg 1-byte messages.
-	for i := 0; i < numMsg; i++ {
+	for i := range numMsg {
 		_, err = str.Write([]byte{uint8(i)})
 		require.NoError(t, err)
 		_, err = str.Read(b)
@@ -246,7 +246,7 @@ func testConnAndStreamDataBlocked(t *testing.T, limitStream, limitConn bool) {
 	}
 
 	var expectedBlockOffsets []protocol.ByteCount
-	for i := 0; i < numBatches; i++ {
+	for i := range numBatches {
 		var offset protocol.ByteCount
 		for _, s := range windowSizes[:i+1] {
 			offset += s

--- a/integrationtests/self/self_test.go
+++ b/integrationtests/self/self_test.go
@@ -45,7 +45,7 @@ var (
 func GeneratePRData(l int) []byte {
 	res := make([]byte, l)
 	seed := uint64(1)
-	for i := 0; i < l; i++ {
+	for i := range l {
 		seed = seed * 48271 % 2147483647
 		res[i] = byte(seed)
 	}

--- a/integrationtests/self/stream_test.go
+++ b/integrationtests/self/stream_test.go
@@ -20,7 +20,7 @@ func TestBidirectionalStreamMultiplexing(t *testing.T) {
 
 	runSendingPeer := func(conn *quic.Conn) error {
 		g := new(errgroup.Group)
-		for i := 0; i < numStreams; i++ {
+		for i := range numStreams {
 			str, err := conn.OpenStreamSync(context.Background())
 			if err != nil {
 				return err
@@ -48,7 +48,7 @@ func TestBidirectionalStreamMultiplexing(t *testing.T) {
 
 	runReceivingPeer := func(conn *quic.Conn) error {
 		g := new(errgroup.Group)
-		for i := 0; i < numStreams; i++ {
+		for range numStreams {
 			str, err := conn.AcceptStream(context.Background())
 			if err != nil {
 				return err
@@ -176,7 +176,7 @@ func TestUnidirectionalStreams(t *testing.T) {
 
 	runSendingPeer := func(conn *quic.Conn) error {
 		g := new(errgroup.Group)
-		for i := 0; i < numStreams; i++ {
+		for range numStreams {
 			str, err := conn.OpenUniStreamSync(context.Background())
 			if err != nil {
 				return err
@@ -193,7 +193,7 @@ func TestUnidirectionalStreams(t *testing.T) {
 
 	runReceivingPeer := func(conn *quic.Conn) error {
 		g := new(errgroup.Group)
-		for i := 0; i < numStreams; i++ {
+		for range numStreams {
 			str, err := conn.AcceptUniStream(context.Background())
 			if err != nil {
 				return err

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -165,7 +165,7 @@ func TestDropIncomingPackets(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	for i := 0; i < numPackets/2; i++ {
+	for range numPackets / 2 {
 		select {
 		case <-serverReceivedPackets:
 		case <-time.After(time.Second):
@@ -221,7 +221,7 @@ func TestDropOutgoingPackets(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	for i := 0; i < numPackets/2; i++ {
+	for range numPackets / 2 {
 		select {
 		case <-clientReceivedPackets:
 		case <-time.After(time.Second):
@@ -346,13 +346,13 @@ func TestConstantDelay(t *testing.T) { // no reordering expected here
 	require.NoError(t, err)
 
 	// send 100 packets
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		_, err := clientConn.Write(makePacket(t, protocol.PacketNumber(i), []byte("foobar"+strconv.Itoa(i))))
 		require.NoError(t, err)
 	}
 	require.Eventually(t, func() bool { return len(serverReceivedPackets) == 100 }, 5*time.Second, 10*time.Millisecond)
 	timeout := time.After(5 * time.Second)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		select {
 		case packet := <-serverReceivedPackets:
 			require.Equal(t, protocol.PacketNumber(i), readPacketNumber(t, packet))
@@ -406,7 +406,7 @@ func TestDelayOutgoingPackets(t *testing.T) {
 		require.NoError(t, err)
 	}
 	// the packets should have arrived immediately at the server
-	for i := 0; i < numPackets; i++ {
+	for range numPackets {
 		select {
 		case <-serverReceivedPackets:
 		case <-time.After(time.Second):

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -472,7 +472,7 @@ func testSentPacketHandlerAmplificationLimitServer(t *testing.T, addressValidate
 	// As long as we haven't sent out 3x the amount of bytes received, we can send out new packets,
 	// even if we go above the 3x limit by sending the last packet.
 	sph.ReceivedBytes(1000, monotime.Now())
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		require.Equal(t, SendAny, sph.SendMode(monotime.Now()))
 		pn := sph.PopPacketNumber(protocol.EncryptionInitial)
 		sph.SentPacket(monotime.Now(), pn, protocol.InvalidPacketNumber, nil, []Frame{{Frame: &wire.PingFrame{}}}, protocol.EncryptionInitial, protocol.ECNNon, 999, false, false)
@@ -487,7 +487,7 @@ func testSentPacketHandlerAmplificationLimitServer(t *testing.T, addressValidate
 	// receiving more data allows us to send out more packets
 	sph.ReceivedBytes(1000, monotime.Now())
 	require.NotZero(t, sph.GetLossDetectionTimeout())
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		require.Equal(t, SendAny, sph.SendMode(monotime.Now()))
 		pn := sph.PopPacketNumber(protocol.EncryptionInitial)
 		sph.SentPacket(monotime.Now(), pn, protocol.InvalidPacketNumber, nil, []Frame{{Frame: &wire.PingFrame{}}}, protocol.EncryptionInitial, protocol.ECNNon, 1000, false, false)

--- a/internal/congestion/cubic_sender_test.go
+++ b/internal/congestion/cubic_sender_test.go
@@ -250,7 +250,7 @@ func TestCubicSenderSlowStartPacketLossPRR(t *testing.T) {
 	// triggered the loss.
 	remainingPacketsInRecovery := sendWindowBeforeLoss/maxDatagramSize - 2
 
-	for i := protocol.ByteCount(0); i < remainingPacketsInRecovery; i++ {
+	for range remainingPacketsInRecovery {
 		sender.AckNPackets(1)
 		sender.SendAvailableSendWindow()
 		require.Equal(t, expectedSendWindow, sender.sender.GetCongestionWindow())

--- a/internal/congestion/cubic_test.go
+++ b/internal/congestion/cubic_test.go
@@ -93,7 +93,7 @@ func TestCubicAboveOriginWithFineGrainedCubing(t *testing.T) {
 	clock.Advance(600 * time.Millisecond)
 	currentCwnd = cubic.CongestionWindowAfterAck(maxDatagramSize, currentCwnd, rttMin, clock.Now())
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		clock.Advance(10 * time.Millisecond)
 		expectedCwnd := cubicConvexCwnd(initialCwnd, rttMin, clock.Now().Sub(initialTime))
 		nextCwnd := cubic.CongestionWindowAfterAck(maxDatagramSize, currentCwnd, rttMin, clock.Now())

--- a/internal/congestion/hybrid_slow_start_test.go
+++ b/internal/congestion/hybrid_slow_start_test.go
@@ -54,7 +54,7 @@ func TestHybridSlowStartWithDelay(t *testing.T) {
 
 	// Will not trigger since our lowest RTT in our burst is the same as the long
 	// term RTT provided.
-	for n := 0; n < hybridStartMinSamples; n++ {
+	for n := range hybridStartMinSamples {
 		require.False(t, slowStart.ShouldExitSlowStart(rtt+time.Duration(n)*time.Millisecond, rtt, 100))
 	}
 	endPacketNumber++

--- a/internal/handshake/aead_test.go
+++ b/internal/handshake/aead_test.go
@@ -81,7 +81,7 @@ func testEncryptAndDecryptHeader(t *testing.T, cs cipherSuite, v protocol.Versio
 	sealer, opener := getSealerAndOpener(t, cs, v)
 	var lastFourBitsDifferent int
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		sample := make([]byte, 16)
 		rand.Read(sample)
 		header := []byte{0xb5, 1, 2, 3, 4, 5, 6, 7, 8, 0xde, 0xad, 0xbe, 0xef}

--- a/internal/handshake/handshake_helpers_test.go
+++ b/internal/handshake/handshake_helpers_test.go
@@ -12,7 +12,7 @@ import (
 
 func splitHexString(t *testing.T, s string) (slice []byte) {
 	t.Helper()
-	for _, ss := range strings.Split(s, " ") {
+	for ss := range strings.SplitSeq(s, " ") {
 		if ss[0:2] == "0x" {
 			ss = ss[2:]
 		}

--- a/internal/handshake/header_protector.go
+++ b/internal/handshake/header_protector.go
@@ -110,7 +110,7 @@ func (p *chachaHeaderProtector) apply(sample []byte, firstByte *byte, hdrBytes [
 	if len(sample) != 16 {
 		panic("invalid sample size")
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		p.mask[i] = 0
 	}
 	cipher, err := chacha20.NewUnauthenticatedCipher(p.key[:], sample[4:])

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -136,7 +136,7 @@ func TestUpdatableAEADHeaderProtection(t *testing.T) {
 				server.SetWriteKey(cs, trafficSecret2)
 
 				var lastFiveBitsDifferent int
-				for i := 0; i < 100; i++ {
+				for range 100 {
 					sample := make([]byte, 16)
 					rand.Read(sample)
 					header := []byte{0xb5, 1, 2, 3, 4, 5, 6, 7, 8, 0xde, 0xad, 0xbe, 0xef}
@@ -215,7 +215,7 @@ func TestUpdatableAEADPacketNumbers(t *testing.T) {
 func TestAEADLimitReached(t *testing.T) {
 	client, _, _ := setupEndpoints(t, utils.NewRTTStats())
 	client.invalidPacketLimit = 10
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		_, err := client.Open(nil, []byte("foobar"), monotime.Now(), protocol.PacketNumber(i), protocol.KeyPhaseZero, []byte("ad"))
 		require.Equal(t, ErrDecryptionFailed, err)
 	}

--- a/internal/protocol/connection_id_test.go
+++ b/internal/protocol/connection_id_test.go
@@ -22,7 +22,7 @@ func TestGenerateRandomConnectionIDs(t *testing.T) {
 
 func TestGenerateRandomLengthDestinationConnectionIDs(t *testing.T) {
 	var has8ByteConnID, has20ByteConnID bool
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		c, err := GenerateConnectionIDForInitial()
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, c.Len(), 8)

--- a/internal/qerr/errorcodes_test.go
+++ b/internal/qerr/errorcodes_test.go
@@ -35,7 +35,7 @@ func TestTransportErrorCodeStringer(t *testing.T) {
 }
 
 func TestIsCryptoError(t *testing.T) {
-	for i := 0; i < 0x100; i++ {
+	for i := range 0x100 {
 		require.False(t, TransportErrorCode(i).IsCryptoError())
 	}
 	for i := 0x100; i < 0x200; i++ {

--- a/internal/utils/rand_test.go
+++ b/internal/utils/rand_test.go
@@ -14,7 +14,7 @@ func TestRandomNumbers(t *testing.T) {
 
 	var values [num]int32
 	var r Rand
-	for i := 0; i < num; i++ {
+	for i := range num {
 		v := r.Int31n(max)
 		require.GreaterOrEqual(t, v, int32(0))
 		require.Less(t, v, int32(max))

--- a/internal/wire/ack_frame_test.go
+++ b/internal/wire/ack_frame_test.go
@@ -115,7 +115,7 @@ func TestParseACKUseAckDelayExponent(t *testing.T) {
 	}
 	b, err := f.Append(nil, protocol.Version1)
 	require.NoError(t, err)
-	for i := uint8(0); i < 8; i++ {
+	for i := range uint8(8) {
 		typ, l, err := quicvarint.Parse(b)
 		require.NoError(t, err)
 		var frame AckFrame

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -56,7 +56,7 @@ func TestParseConnIDEOFLongHeader(t *testing.T) {
 	data := b[:len(b)-2] // cut the packet number
 	_, err = ParseConnectionID(data, 8)
 	require.NoError(t, err)
-	for i := 0; i < 1 /* first byte */ +4 /* version */ +1 /* conn ID lengths */ +6; /* dest conn ID */ i++ {
+	for i := range 1 /* first byte */ + 4 /* version */ + 1 /* conn ID lengths */ + 6 {
 		b := make([]byte, i)
 		copy(b, data[:i])
 		_, err := ParseConnectionID(b, 8)

--- a/internal/wire/stream_frame_test.go
+++ b/internal/wire/stream_frame_test.go
@@ -332,7 +332,7 @@ func TestStreamSplittingProducesCorrectLengthFramesWithoutDataLen(t *testing.T) 
 		Data:     []byte{0},
 	}
 	minFrameSize := f.Length(protocol.Version1)
-	for i := protocol.ByteCount(0); i < minFrameSize; i++ {
+	for i := range minFrameSize {
 		frame, needsSplit := f.MaybeSplitOffFrame(i, protocol.Version1)
 		require.True(t, needsSplit)
 		require.Nil(t, frame)
@@ -355,7 +355,7 @@ func TestStreamSplittingProducesCorrectLengthFramesWithDataLen(t *testing.T) {
 		Data:           []byte{0},
 	}
 	minFrameSize := f.Length(protocol.Version1)
-	for i := protocol.ByteCount(0); i < minFrameSize; i++ {
+	for i := range minFrameSize {
 		frame, needsSplit := f.MaybeSplitOffFrame(i, protocol.Version1)
 		require.True(t, needsSplit)
 		require.Nil(t, frame)

--- a/mtu_discoverer.go
+++ b/mtu_discoverer.go
@@ -216,7 +216,7 @@ func (h *mtuFinderAckHandler) OnAcked(wire.Frame) {
 		}
 	}
 	if j > 0 {
-		for i := 0; i < len(h.lost); i++ {
+		for i := range len(h.lost) {
 			if i+j < len(h.lost) {
 				h.lost[i] = h.lost[i+j]
 			} else {

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -725,7 +725,7 @@ func TestPackRetransmissions(t *testing.T) {
 
 func packMaxNumNonAckElicitingAcks(t *testing.T, tp *testPacketPacker, mockCtrl *gomock.Controller, maxPacketSize protocol.ByteCount) {
 	t.Helper()
-	for i := 0; i < protocol.MaxNonAckElicitingAcks; i++ {
+	for range protocol.MaxNonAckElicitingAcks {
 		tp.pnManager.EXPECT().PeekPacketNumber(protocol.Encryption1RTT).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)
 		tp.pnManager.EXPECT().PopPacketNumber(protocol.Encryption1RTT).Return(protocol.PacketNumber(0x42))
 		tp.sealingManager.EXPECT().Get1RTTSealer().Return(newMockShortHeaderSealer(mockCtrl), nil)

--- a/send_conn.go
+++ b/send_conn.go
@@ -80,10 +80,7 @@ func (c *sconn) Write(p []byte, gsoSize uint16, ecn protocol.ECN) error {
 		}
 		// send out the packets one by one
 		for len(p) > 0 {
-			l := len(p)
-			if l > int(gsoSize) {
-				l = int(gsoSize)
-			}
+			l := min(len(p), int(gsoSize))
 			if err := c.writePacket(p[:l], ai.addr, ai.oob, 0, ecn); err != nil {
 				return err
 			}

--- a/stateless_reset_test.go
+++ b/stateless_reset_test.go
@@ -12,7 +12,7 @@ func TestStatelessResetter(t *testing.T) {
 	t.Run("no key", func(t *testing.T) {
 		r1 := newStatelessResetter(nil)
 		r2 := newStatelessResetter(nil)
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			b := make([]byte, 15)
 			rand.Read(b)
 			connID := protocol.ParseConnectionID(b)

--- a/sys_conn_df_darwin.go
+++ b/sys_conn_df_darwin.go
@@ -78,13 +78,11 @@ func getMacOSVersion() (int, error) {
 	if err := unix.Uname(uname); err != nil {
 		return 0, err
 	}
-
-	release := string(uname.Release[:])
-	idx := strings.Index(release, ".")
-	if idx == -1 {
+	before, _, ok := strings.Cut(string(uname.Release[:]), ".")
+	if !ok {
 		return 0, nil
 	}
-	version, err := strconv.Atoi(release[:idx])
+	version, err := strconv.Atoi(before)
 	if err != nil {
 		return 0, err
 	}

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -151,7 +151,7 @@ func newConn(c OOBCapablePacketConn, supportsDF bool) (*oobConn, error) {
 			ECN: isECNEnabled(),
 		},
 	}
-	for i := 0; i < batchSize; i++ {
+	for i := range batchSize {
 		oobConn.messages[i].OOB = make([]byte, oobBufferSize)
 	}
 	return oobConn, nil

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -286,7 +286,7 @@ func (c *mockBatchConn) ReadBatch(ms []ipv4.Message, _ int) (int, error) {
 	for i := 0; i < c.numMsgRead; i++ {
 		require.Len(c.t, ms[i].Buffers, 1)
 		require.Len(c.t, ms[i].Buffers[0], protocol.MaxPacketBufferSize)
-		data := []byte(fmt.Sprintf("message %d", c.callCounter*c.numMsgRead+i))
+		data := fmt.Appendf(nil, "message %d", c.callCounter*c.numMsgRead+i)
 		ms[i].Buffers[0] = data
 		ms[i].N = len(data)
 	}
@@ -302,7 +302,7 @@ func TestReadsMultipleMessagesInOneBatch(t *testing.T) {
 	require.NoError(t, err)
 	oobConn.batchConn = bc
 
-	for i := 0; i < batchSize+1; i++ {
+	for i := range batchSize + 1 {
 		p, err := oobConn.ReadPacket()
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("message %d", i), string(p.data))

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func mockToken(num int) *ClientToken {
-	return &ClientToken{data: []byte(fmt.Sprintf("%d", num)), rtt: 1337 * time.Millisecond}
+	return &ClientToken{data: fmt.Appendf(nil, "%d", num), rtt: 1337 * time.Millisecond}
 }
 
 func TestTokenStoreSingleOrigin(t *testing.T) {


### PR DESCRIPTION
No functional change expected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply `go fix` modernizations across the codebase
> Applies Go 1.22+ idiom updates across the codebase using `go fix`.
>
> - Replaces index-based `for` loops with range-over-integer loops (e.g. `for i := range n`) throughout tests and production code
> - Replaces `strings.Split` with `strings.SplitSeq` for iterator-style string splitting in HTTP/3 header handling and test helpers
> - Replaces `wg.Add`/`go`/`defer wg.Done` patterns with `wg.Go(...)` in [http3/server.go](https://github.com/quic-go/quic-go/pull/5652/files#diff-415989f1994f2599ac390daa6df5e43c8970139c46fc4cda1c1c91e2457207f0) and [http3/conn.go](https://github.com/quic-go/quic-go/pull/5652/files#diff-1013b40fe17b4fea30bf9361791f55786ed5402c4541c3945208e252972a2a37)
> - Replaces `[]byte(fmt.Sprintf(...))` with `fmt.Appendf(nil, ...)` in test helpers
> - Replaces manual `min` logic in [send_conn.go](https://github.com/quic-go/quic-go/pull/5652/files#diff-7079110d65c69886586d1a21acb3426d8a668b443cd745f5199fe62b5ede9c0f) with the built-in `min()` function, and string parsing in [sys_conn_df_darwin.go](https://github.com/quic-go/quic-go/pull/5652/files#diff-58b6dba2edaef6f545a5aa39284d9e23d98a8417dd72a185051c768c3d5d83e8) with `strings.Cut`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11bc7d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->