### PR TITLE
ci: add a workflow to submit OSS-Fuzz coverage to Codecov

### DIFF
--- a/.github/workflows/clusterfuzz-coverage.yml
+++ b/.github/workflows/clusterfuzz-coverage.yml
@@ -1,0 +1,77 @@
+name: ClusterFuzz coverage
+on:
+  schedule:
+    - cron: '12 3,11,19 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_DEFAULT_PLATFORM: linux/amd64
+      CLUSTERFUZZ_CORPUS_BUCKET: quic-go-corpus.clusterfuzz-external.appspot.com
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          repository: google/oss-fuzz
+          path: oss-fuzz
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+      - name: Configure Google Cloud credentials
+        run: |
+          cat > "$RUNNER_TEMP/gcp-ossfuzz-user-credentials.json" <<'EOF'
+          ${{ secrets.GCP_OSSFUZZ_USER_CREDENTIALS }}
+          EOF
+          echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=$RUNNER_TEMP/gcp-ossfuzz-user-credentials.json" >> "$GITHUB_ENV"
+      - name: Download ClusterFuzz corpus
+        run: |
+          set -euo pipefail
+
+          targets=(
+            frame_fuzzer_v2
+            transportparameter_fuzzer_v2
+            http3_frame_fuzzer
+            header_fuzzer_v2
+            handshake_fuzzer_v2
+            http3_header_parsing_fuzzer
+          )
+
+          mkdir -p oss-fuzz/build/corpus/quic-go
+          for target in "${targets[@]}"; do
+            source_dir="gs://${CLUSTERFUZZ_CORPUS_BUCKET}/libFuzzer/quic-go_${target}"
+            corpus_dir="oss-fuzz/build/corpus/quic-go/${target}"
+
+            echo "$target: downloading live corpus"
+            rm -rf "$corpus_dir"
+            mkdir -p "$corpus_dir"
+            gcloud storage cp --recursive "$source_dir/*" "$corpus_dir"
+            echo "$target: $(find "$corpus_dir" -type f | wc -l) corpus files"
+          done
+      - name: Build coverage fuzzers
+        working-directory: oss-fuzz
+        run: |
+          python3 infra/helper.py build_image --no-pull quic-go
+          python3 infra/helper.py build_fuzzers --sanitizer coverage --mount_path /root/go/src/github.com/quic-go/quic-go quic-go "$GITHUB_WORKSPACE"
+      - name: Generate coverage
+        working-directory: oss-fuzz
+        run: |
+          rm -f build/out/quic-go/qpack_decode_fuzzer
+          python3 infra/helper.py coverage --no-corpus-download --no-serve quic-go
+      - name: Prepare Codecov coverage
+        working-directory: oss-fuzz
+        run: |
+          sed "s#^/out/root/go/src/github.com/quic-go/quic-go/#${GITHUB_WORKSPACE}/#" \
+            build/out/quic-go/fuzz.cov > "$GITHUB_WORKSPACE/clusterfuzz.coverprofile"
+          test -s "$GITHUB_WORKSPACE/clusterfuzz.coverprofile"
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          disable_search: true
+          files: clusterfuzz.coverprofile
+          flags: clusterfuzz
+          name: ClusterFuzz fuzzing
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -1,8 +1,8 @@
 # Fuzzing
 
 [![Documentation](https://img.shields.io/badge/OSS--Fuzz-Introspector-red?style=flat)](https://introspector.oss-fuzz.com/project-profile?project=quic-go)
-[![batch fuzz coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?flag=clusterfuzz-lite-batch&label=ClusterFuzz%20Lite%20Batch%20coverage&logo=codecov&logoColor=white&style=flat)](https://app.codecov.io/gh/quic-go/quic-go?flags%5B0%5D=clusterfuzz-lite-batch)
 [![ClusterFuzz coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?flag=clusterfuzz&label=ClusterFuzz%20coverage&logo=codecov&logoColor=white&style=flat)](https://app.codecov.io/gh/quic-go/quic-go?flags%5B0%5D=clusterfuzz)
+[![ClusterFuzz Lite Batch coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?flag=clusterfuzz-lite-batch&label=ClusterFuzz%20Lite%20Batch%20coverage&logo=codecov&logoColor=white&style=flat)](https://app.codecov.io/gh/quic-go/quic-go?flags%5B0%5D=clusterfuzz-lite-batch)
 
 Run the commands below from a local [`google/oss-fuzz`](https://github.com/google/oss-fuzz) checkout.
 Fuzz target names match the binary names listed in `oss-fuzz.sh` (for example, `frame_fuzzer_v2`).

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -2,6 +2,7 @@
 
 [![Documentation](https://img.shields.io/badge/OSS--Fuzz-Introspector-red?style=flat)](https://introspector.oss-fuzz.com/project-profile?project=quic-go)
 [![batch fuzz coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?flag=clusterfuzz-lite-batch&label=ClusterFuzz%20Lite%20Batch%20coverage&logo=codecov&logoColor=white&style=flat)](https://app.codecov.io/gh/quic-go/quic-go?flags%5B0%5D=clusterfuzz-lite-batch)
+[![ClusterFuzz coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?flag=clusterfuzz&label=ClusterFuzz%20coverage&logo=codecov&logoColor=white&style=flat)](https://app.codecov.io/gh/quic-go/quic-go?flags%5B0%5D=clusterfuzz)
 
 Run the commands below from a local [`google/oss-fuzz`](https://github.com/google/oss-fuzz) checkout.
 Fuzz target names match the binary names listed in `oss-fuzz.sh` (for example, `frame_fuzzer_v2`).

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,3 +19,5 @@ coverage:
 flags:
   clusterfuzz-lite-batch:
     joined: false
+  clusterfuzz:
+    joined: false


### PR DESCRIPTION
This uses the ClusterFuzz live corpus, so it should give us up-to-date results on coverage. This will be very useful when improving fuzzers.

Fixes #4036.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OSS-Fuzz coverage workflow to upload ClusterFuzz corpus results to Codecov
> - Adds [clusterfuzz-coverage.yml](https://github.com/quic-go/quic-go/pull/5655/files#diff-465ff64c41d201f5ba9732cb4868247ce07c29cec762ba7a4030b472d95a566a), a scheduled GitHub Actions workflow that downloads live ClusterFuzz corpora, builds oss-fuzz coverage fuzzers, generates a coverage report, and uploads it to Codecov under the `clusterfuzz` flag.
> - Adds a new `clusterfuzz` flag with `joined: false` in [codecov.yml](https://github.com/quic-go/quic-go/pull/5655/files#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40db) to track these uploads separately from other coverage sources.
> - Adds a 'ClusterFuzz coverage' badge to [FUZZING.md](https://github.com/quic-go/quic-go/pull/5655/files#diff-a404cc9124c5456b0fa2c1747ffe9389fbfc044d6274ab1b772ea887bbfc42b5) alongside the existing 'ClusterFuzz Lite Batch coverage' badge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f15104.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->