### PR TITLE
ci: run govulncheck on a schedule instead of on every push

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.x"
+          check-latest: true
+      - name: Run govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Run gcassert
         if: success() || failure() # run this step even if the previous one failed
         run: go tool gcassert ./...
+        # Only run govulncheck on pull requests, not on pushes (including merge commits to master).
+        # govulncheck queries the vulnerability database at runtime, so a newly disclosed vulnerability
+        # could otherwise cause the post-merge run to fail even though nothing in the repository changed,
+        # breaking master through no fault of the merged PR.
       - name: Run govulncheck
-        if: success() || failure() # run this step even if the previous one failed
+        if: ${{ (success() || failure()) && github.event_name == 'pull_request' }}
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
   golangci-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`govulncheck` queries the Go vulnerability database at runtime, so its result depends on external state rather than just the repository contents. Running it on every push (including merge commits to master) means a newly disclosed vulnerability can break master through no fault of the merged PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run govulncheck on a daily schedule instead of on every push
> - Adds a new [govulncheck.yml](.github/workflows/govulncheck.yml) workflow that runs `govulncheck` on a daily cron schedule (`17 4 * * *`) and on manual dispatch.
> - Restricts the existing `govulncheck` step in [lint.yml](.github/workflows/lint.yml) to pull request events only, preventing it from running on branch pushes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dee9f54.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->