### PR TITLE
ci: run ClusterFuzz Lite without corpus repo on forks

### DIFF
--- a/.github/workflows/clusterfuzz-lite-pr.yml
+++ b/.github/workflows/clusterfuzz-lite-pr.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   PR:
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     env:
       # Forked PRs don't receive repository secrets, so they run without corpus storage.
       CLUSTERFUZZ_LITE_STORAGE_REPO: >-

--- a/.github/workflows/clusterfuzz-lite-pr.yml
+++ b/.github/workflows/clusterfuzz-lite-pr.yml
@@ -10,6 +10,13 @@ permissions:
 
 jobs:
   PR:
+    env:
+      # Forked PRs don't receive repository secrets, so they run without corpus storage.
+      CLUSTERFUZZ_LITE_STORAGE_REPO: >-
+        ${{
+          github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id &&
+          format('https://{0}@github.com/quic-go/clusterfuzzlite-storage.git', secrets.CLUSTERFUZZ_LITE_STORAGE) || ''
+        }}
     runs-on: ${{ fromJSON(vars['CLUSTERFUZZ_LITE_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
@@ -21,17 +28,15 @@ jobs:
         - address
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
-      id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         language: go
         github-token: ${{ secrets.GITHUB_TOKEN }}
         sanitizer: ${{ matrix.sanitizer }}
-        storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
+        storage-repo: ${{ env.CLUSTERFUZZ_LITE_STORAGE_REPO }}
         storage-repo-branch: master
         storage-repo-branch-coverage: gh-pages
     - name: Run Fuzzers (${{ matrix.sanitizer }})
-      id: run
       uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,6 +45,6 @@ jobs:
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
         parallel-fuzzing: true
-        storage-repo: https://${{ secrets.CLUSTERFUZZ_LITE_STORAGE }}@github.com/quic-go/clusterfuzzlite-storage.git
+        storage-repo: ${{ env.CLUSTERFUZZ_LITE_STORAGE_REPO }}
         storage-repo-branch: master
         storage-repo-branch-coverage: gh-pages


### PR DESCRIPTION
PRs from forked repositories don't receive repository secrets, so we can only they run without corpus storage.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run ClusterFuzz Lite without corpus repo on forked PRs
> - Sets `CLUSTERFUZZ_LITE_STORAGE_REPO` to the secret-based repo URL only when the PR originates from the same repo; forks receive an empty string, allowing fuzzing to run without access to the private storage repo.
> - Skips the PR fuzzing job entirely when the author is `dependabot[bot]`.
> - Replaces hardcoded `storage-repo` inputs in `build_fuzzers` and `run_fuzzers` steps with the new env var in [clusterfuzz-lite-pr.yml](.github/workflows/clusterfuzz-lite-pr.yml).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb9ba67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->