### PR TITLE
honor context cancellation in OpenStreamSync

### DIFF
--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -155,6 +155,52 @@ func testStreamsMapOutgoingLimits(t *testing.T, perspective protocol.Perspective
 	})
 }
 
+// This test checks that OpenStreamSync returns the context error when the context is canceled
+// at the same time that the stream limit is increased (see https://github.com/quic-go/quic-go/issues/5659).
+// The race is inherently hard to trigger: even without the fix, this test only fails intermittently.
+// To gain confidence in the fix, run it many times (e.g. 10000 times) with the race detector enabled.
+func TestStreamsMapOutgoingOpenStreamSyncCancel(t *testing.T) {
+	queued := make(chan struct{}, 1)
+	m := newOutgoingStreamsMap(
+		protocol.StreamTypeUni,
+		func(id protocol.StreamID) *mockStream { return &mockStream{id: id} },
+		func(f wire.Frame) { queued <- struct{}{} },
+		protocol.PerspectiveClient,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	type result struct {
+		str *mockStream
+		err error
+	}
+	resultChan := make(chan result, 1)
+	go func() {
+		str, err := m.OpenStreamSync(ctx)
+		resultChan <- result{str: str, err: err}
+	}()
+
+	select {
+	case <-queued:
+	case <-time.After(time.Second):
+		t.Fatal("OpenStreamSync did not queue")
+	}
+
+	cancel()
+	m.SetMaxStream(protocol.FirstOutgoingUniStreamClient)
+
+	select {
+	case res := <-resultChan:
+		require.ErrorIs(t, res.err, context.Canceled)
+		require.Nil(t, res.str)
+	case <-time.After(time.Second):
+		t.Fatal("OpenStreamSync did not return after the context was canceled")
+	}
+
+	str, err := m.OpenStream()
+	require.NoError(t, err)
+	require.Equal(t, protocol.FirstOutgoingUniStreamClient, str.id)
+}
+
 func TestStreamsMapOutgoingConcurrentOpenStreamSync(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		m := newOutgoingStreamsMap(


### PR DESCRIPTION
Fixes #5659.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `OpenStreamSync` to return context error when context is canceled while queued
> Previously, `outgoingStreamsMap.OpenStreamSync` only checked `closeErr` and stream availability after waking from the wait queue, ignoring a canceled or expired context. Now, after wake-up, it also checks the context error, removes the waiter from `openQueue`, and calls `maybeUnblockOpenSync` before returning the context error. A new test in [streams_map_outgoing_test.go](https://github.com/quic-go/quic-go/pull/5660/files#diff-8b3c2ff63754a94b3009a0e285ac50168b14a263fd155561f2790d683581fb8a) covers the cancel-while-queued case and verifies the next waiter can still open a stream.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1f60ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->