### PR TITLE
fix flaky TestStreamsMapOutgoingRandomizedWithCancellation

### DIFF
--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -521,7 +521,6 @@ func TestStreamsMapOutgoingRandomizedWithCancellation(t *testing.T) {
 		maxStream := firstStream + 4*(n-1)
 		var limits []protocol.StreamID
 		seen := make(map[protocol.StreamID]struct{})
-		var lastStreamSeen protocol.StreamID
 		var numCancelledSeen int
 		for limit < maxStream {
 			add := 4 * protocol.StreamID(rand.IntN(n/5)+1)
@@ -532,7 +531,8 @@ func TestStreamsMapOutgoingRandomizedWithCancellation(t *testing.T) {
 			t.Logf("setting stream limit to %d", limit)
 			m.SetMaxStream(limit)
 
-			for lastStreamSeen < min(maxStream, limit) {
+			expectedOpened := int((min(maxStream, limit)-firstStream)/4) + 1
+			for len(seen) < expectedOpened {
 				select {
 				case res := <-resultChan:
 					if errors.Is(res.err, context.Canceled) {
@@ -540,8 +540,8 @@ func TestStreamsMapOutgoingRandomizedWithCancellation(t *testing.T) {
 					} else {
 						require.NoError(t, res.err)
 						require.NotContains(t, seen, res.str.id)
+						require.LessOrEqual(t, res.str.id, min(maxStream, limit))
 						seen[res.str.id] = struct{}{}
-						lastStreamSeen = res.str.id
 					}
 				case <-time.After(time.Second):
 					t.Fatalf("timed out waiting for stream to open")
@@ -549,6 +549,15 @@ func TestStreamsMapOutgoingRandomizedWithCancellation(t *testing.T) {
 			}
 		}
 		require.Len(t, seen, n)
+		for numCancelledSeen < numCancelled {
+			select {
+			case res := <-resultChan:
+				require.ErrorIs(t, res.err, context.Canceled)
+				numCancelledSeen++
+			case <-time.After(time.Second):
+				t.Fatalf("timed out waiting for stream opening to be canceled")
+			}
+		}
 		t.Logf("saw %d streams, %d cancelled", len(seen), numCancelledSeen)
 		require.Equal(t, numCancelled, numCancelledSeen)
 


### PR DESCRIPTION
Fixes #5479.

The test assumed stream-open results were received in stream ID order. Since Goroutines report results after leaving the stream-map lock, higher stream IDs can arrive before lower ones, causing the test to stop waiting too early and fail intermittently.

According to Codecov, this is currently our flakiest test:
<img width="1047" height="266" alt="Screenshot 2026-05-24 at 20 45 48" src="https://github.com/user-attachments/assets/0c7d5d49-0b48-431d-85fb-a621bc770f64" />

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky `TestStreamsMapOutgoingRandomizedWithCancellation` test
> The test was unreliable due to imprecise progress tracking via `lastStreamSeen`. It now computes `expectedOpened` from the current stream limit and `firstStream` spacing, waits until that many unique stream IDs are observed, and asserts each opened stream ID does not exceed the current limit. A drain loop then waits for all expected cancellations, asserting `context.Canceled` for each and failing on timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ea8a35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->