### PR TITLE
ci: add a summary ClusterFuzz corpus downloads

### DIFF
--- a/.github/workflows/clusterfuzz-coverage.yml
+++ b/.github/workflows/clusterfuzz-coverage.yml
@@ -50,6 +50,25 @@ jobs:
             gcloud storage cp --recursive "$source_dir/*" "$corpus_dir"
             echo "$target: $(find "$corpus_dir" -type f | wc -l) corpus files"
           done
+      - name: Summarize ClusterFuzz corpus
+        run: |
+          set -euo pipefail
+
+          corpus_root=oss-fuzz/build/corpus/quic-go
+          {
+            echo "## ClusterFuzz corpus"
+            echo
+            echo "| Fuzzer | Corpus files downloaded |"
+            echo "| --- | ---: |"
+
+            for corpus_dir in "$corpus_root"/*; do
+              [ -d "$corpus_dir" ] || continue
+
+              target=$(basename "$corpus_dir")
+              corpus_files=$(find "$corpus_dir" -type f | wc -l | tr -d ' ')
+              echo "| \`$target\` | $corpus_files |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Build coverage fuzzers
         working-directory: oss-fuzz
         run: |


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add per-fuzzer corpus file count to ClusterFuzz coverage job summary
Adds a step to the `coverage` job in [clusterfuzz-coverage.yml](https://github.com/quic-go/quic-go/pull/5662/files#diff-465ff64c41d201f5ba9732cb4868247ce07c29cec762ba7a4030b472d95a566a) that counts files in each fuzzer directory under `oss-fuzz/build/corpus/quic-go` and appends a Markdown table to the GitHub Actions step summary.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b4531a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->