### PR TITLE
ci: fix ClusterFuzz coverage source paths

### DIFF
--- a/.github/workflows/clusterfuzz-coverage.yml
+++ b/.github/workflows/clusterfuzz-coverage.yml
@@ -73,7 +73,7 @@ jobs:
         working-directory: oss-fuzz
         run: |
           python3 infra/helper.py build_image --no-pull quic-go
-          python3 infra/helper.py build_fuzzers --sanitizer coverage --mount_path /root/go/src/github.com/quic-go/quic-go quic-go "$GITHUB_WORKSPACE"
+          python3 infra/helper.py build_fuzzers --sanitizer coverage --mount_path /src/quic-go quic-go "$GITHUB_WORKSPACE"
       - name: Generate coverage
         working-directory: oss-fuzz
         run: |
@@ -82,7 +82,7 @@ jobs:
       - name: Prepare Codecov coverage
         working-directory: oss-fuzz
         run: |
-          sed "s#^/out/root/go/src/github.com/quic-go/quic-go/#${GITHUB_WORKSPACE}/#" \
+          sed "s#^/out/src/quic-go/#${GITHUB_WORKSPACE}/#" \
             build/out/quic-go/fuzz.cov > "$GITHUB_WORKSPACE/clusterfuzz.coverprofile"
           test -s "$GITHUB_WORKSPACE/clusterfuzz.coverprofile"
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Fixes the ClusterFuzz coverage workflow to build under `/src/quic-go` so OSS-Fuzz can resolve Go source files during coverage report generation.







<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ClusterFuzz coverage source paths in CI workflow
> Updates [clusterfuzz-coverage.yml](https://github.com/quic-go/quic-go/pull/5663/files#diff-465ff64c41d201f5ba9732cb4868247ce07c29cec762ba7a4030b472d95a566a) to use `/src/quic-go` as the `--mount_path` instead of `/root/go/src/github.com/quic-go/quic-go`, and aligns the `sed` path-rewriting pattern to match the new build layout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 911d08d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->