### PR TITLE
fix(http3): don't apply Content-Encoding to CONNECT responses

### DIFF
--- a/http3/stream.go
+++ b/http3/stream.go
@@ -377,7 +377,8 @@ func (s *RequestStream) ReadResponse() (*http.Response, error) {
 	if (isInformational || isNoContent || isSuccessfulConnect) && res.ContentLength == -1 {
 		res.ContentLength = 0
 	}
-	if s.requestedGzip && res.Header.Get("Content-Encoding") == "gzip" {
+	responseHasContent := !isInformational && !isNoContent && !isSuccessfulConnect
+	if s.requestedGzip && responseHasContent && res.Header.Get("Content-Encoding") == "gzip" {
 		res.Header.Del("Content-Encoding")
 		res.Header.Del("Content-Length")
 		res.ContentLength = -1

--- a/http3/stream_test.go
+++ b/http3/stream_test.go
@@ -233,3 +233,55 @@ func TestRequestStream(t *testing.T) {
 	require.Equal(t, 6, n)
 	require.Equal(t, []byte("foobar"), b[:n])
 }
+
+func TestRequestStreamConnectDoesNotApplyContentEncoding(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	qstr := NewMockDatagramStream(mockCtrl)
+	qstr.EXPECT().StreamID().Return(quic.StreamID(42)).AnyTimes()
+	requestWriter := newRequestWriter()
+	clientConn, _ := newConnPair(t)
+	str := newRequestStream(
+		newStream(
+			qstr,
+			newRawConn(clientConn, false, nil, nil, nil, nil),
+			&httptrace.ClientTrace{},
+			func(io.Reader, *headersFrame) error { return nil },
+			nil,
+		),
+		requestWriter,
+		make(chan struct{}),
+		qpack.NewDecoder(),
+		false,
+		math.MaxInt,
+		&http.Response{},
+	)
+
+	req, err := http.NewRequest(http.MethodConnect, "http://quic-go.net:443", nil)
+	require.NoError(t, err)
+	qstr.EXPECT().Write(gomock.Any()).AnyTimes()
+	require.NoError(t, str.sendRequestHeader(req))
+
+	var rspBuf bytes.Buffer
+	rstr := NewMockDatagramStream(gomock.NewController(t))
+	rstr.EXPECT().StreamID().Return(quic.StreamID(42)).AnyTimes()
+	rstr.EXPECT().Write(gomock.Any()).Do(rspBuf.Write).AnyTimes()
+	rw := newResponseWriter(newStream(rstr, nil, nil, func(io.Reader, *headersFrame) error { return nil }, nil), nil, false, nil)
+	rw.header.Set("Content-Encoding", "gzip")
+	rw.WriteHeader(http.StatusOK)
+	rw.Flush()
+
+	buf := bytes.NewBuffer(rspBuf.Bytes())
+	buf.Write(getDataFrame([]byte("capsule-data")))
+	qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+
+	rsp, err := str.ReadResponse()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Equal(t, "gzip", rsp.Header.Get("Content-Encoding"))
+	require.Equal(t, int64(0), rsp.ContentLength)
+
+	b := make([]byte, 20)
+	n, err := str.Read(b)
+	require.NoError(t, err)
+	require.Equal(t, "capsule-data", string(b[:n]))
+}


### PR DESCRIPTION
## Summary
- Skip automatic gzip decompression for HTTP/3 responses without content
- Fixes corrupted CONNECT / Extended CONNECT stream data when a `Content-Encoding: gzip` header is present

## Problem
The client always transparently gunzipped responses when gzip was negotiated, including successful CONNECT responses. CONNECT responses don't carry HTTP content; capsules and tunneled data are sent directly on the stream and must not be decoded as gzip.

## Fix
Only apply Content-Encoding handling when the response is expected to have a body (not informational, 204, or successful CONNECT).

## Test plan
- [x] Added `TestRequestStreamConnectDoesNotApplyContentEncoding`
- [x] `go test ./http3/... -run TestRequestStreamConnectDoesNotApplyContentEncoding`

Fixes #4410

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ReadResponse` to skip gzip decoding for successful CONNECT responses
> Previously, `RequestStream.ReadResponse` applied gzip decoding to any response where the request asked for gzip and the `Content-Encoding: gzip` header was present, including successful CONNECT responses that carry a raw tunnel rather than encoded content.
>
> - Introduces a `responseHasContent` flag in [http3/stream.go](https://github.com/quic-go/quic-go/pull/5669/files#diff-78b9dd15996d79e5718e0b1a031fd73b67983fceb406305fb50ec797dbb558de) that is false for informational responses, `204 No Content`, and successful CONNECT responses.
> - Gzip decoding, `Content-Encoding` header removal, and body wrapping now only apply when `responseHasContent` is true.
> - Adds a regression test in [http3/stream_test.go](https://github.com/quic-go/quic-go/pull/5669/files#diff-543e33e12efd3a6cd27e7cb27b437c4c5533906aee74e8f71a069a0959f6beef) that verifies CONNECT responses preserve the `Content-Encoding` header and return raw bytes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb8ef9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->