### PR TITLE
make the frame sorter fuzz corpus accessible to OSS-Fuzz

### DIFF
--- a/frame_sorter_test.go
+++ b/frame_sorter_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"testing"
 
+	ossfuzzseeds "github.com/quic-go/go-ossfuzz-seeds"
 	"github.com/quic-go/quic-go/internal/protocol"
 
 	"github.com/stretchr/testify/require"
@@ -1533,6 +1534,7 @@ func FuzzFrameSorter(f *testing.F) {
 	// the small-cut path becomes unreachable. Keep them in sync.
 	require.Less(f, protocol.MinStreamFrameBufferSize, maxStreamLen)
 
+	corpus := ossfuzzseeds.New(f)
 	for _, seed := range [][]uint8{
 		{opPush, 0, 3, opPush, 3, 3, opPop, 0, 0},
 		{opPush, 6, 3, opPush, 0, 3, opPush, 3, 3, opPop, 0, 0},
@@ -1541,7 +1543,7 @@ func FuzzFrameSorter(f *testing.F) {
 		{opPush, 3, 3, opPush, 9, 3, opPush, 5, 10, opPush, 0, 3, opPop, 0, 0},
 		{opPush, 0, 6, opPeek, 0, 3, opPush, 6, 3, opPeek, 0, 9, opPush, 10, 3, opPeek, 0, 12},
 	} {
-		f.Add(seed)
+		corpus.Add(seed)
 	}
 
 	// use deterministic non-uniform data


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Expose `FuzzFrameSorter` corpus to OSS-Fuzz
Integrates the `go-ossfuzz-seeds` package into [frame_sorter_test.go](https://github.com/quic-go/quic-go/pull/5670/files#diff-76f32d10c820fd66fb2071b540f4e590e8a82e024bcb42fd0652312fc88c4f91) so the `FuzzFrameSorter` seed corpus is accessible to OSS-Fuzz. Seeds are now registered via an `ossfuzzseeds` corpus object instead of direct `f.Add` calls.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba685f3.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->