### PR TITLE
http3: fix nil pointer dereference when Server.Logger is unset

### DIFF
--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -274,7 +274,9 @@ func (w *responseWriter) flushTrailers() {
 		return
 	}
 	if err := w.writeTrailers(); err != nil {
-		w.logger.Debug("could not write trailers", "error", err)
+		if w.logger != nil {
+			w.logger.Debug("could not write trailers", "error", err)
+		}
 	}
 }
 
@@ -291,7 +293,9 @@ func (w *responseWriter) Flush() {
 func (w *responseWriter) declareTrailer(k string) {
 	if !httpguts.ValidTrailerHeader(k) {
 		// Forbidden by RFC 9110, section 6.5.1.
-		w.logger.Debug("ignoring invalid trailer", slog.String("header", k))
+		if w.logger != nil {
+			w.logger.Debug("ignoring invalid trailer", slog.String("header", k))
+		}
 		return
 	}
 	if w.trailers == nil {


### PR DESCRIPTION
## Summary

The HTTP/3 server crashes with a nil pointer dereference when `Server.Logger` is not explicitly set and either:
- A trailer write fails (e.g., connection timeout during transfer)
- An invalid trailer is declared by a handler (e.g., `Trailer: Content-Length`)

## Stack Trace

Observed in the wild on v0.52.0:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x104aa3f14]

goroutine 69 [running]:
github.com/quic-go/quic-go/http3.(*responseWriter).flushTrailers(0x140004c2000)
        http3/response_writer.go:277 +0x184
github.com/quic-go/quic-go/http3.(*responseWriter).Flush(0x140004c2000)
        http3/response_writer.go:270 +0xdc
...
```

## Fix

`flushTrailers()` and `declareTrailer()` call `w.logger.Debug()` without checking for nil. This adds nil guards matching the existing pattern already used in `Flush()` at line 283.

## Workaround

Setting `Server.Logger` to any non-nil value (e.g., `slog.Default()`) avoids the crash.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nil pointer dereference in `responseWriter` when `Server.Logger` is unset
> Adds nil checks for `w.logger` in `flushTrailers` and `declareTrailer` in [response_writer.go](https://github.com/quic-go/quic-go/pull/5671/files#diff-a3a517d68f18d5817d6cdaabed2d89d8aecc9935a47e6f33c880cace8f91ec9d) before calling `Debug`. Previously, both methods would panic if `Server.Logger` was not set and a logging path was hit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5258028.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->