### PR TITLE
log build date and revisions in OSS-Fuzz build script

### DIFF
--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -2,15 +2,19 @@
 
 set -euo pipefail
 
+echo "Build date (UTC): $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
 go version
 go env
 
 # fuzz qpack
 cd $GOPATH/src/github.com/quic-go/qpack
+git log -1 --format='qpack revision: %H (%cI) %s'
 compile_native_go_fuzzer_v2 github.com/quic-go/qpack FuzzDecode qpack_decode_fuzzer
 
 # fuzz quic-go
 cd $GOPATH/src/github.com/quic-go/quic-go/
+git log -1 --format='quic-go revision: %H (%cI) %s'
 
 build_native_go_fuzzer() {
 	local pkg=$1


### PR DESCRIPTION
No functional change expected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log build date and git revisions in OSS-Fuzz build script
> Adds diagnostic logging to [oss-fuzz.sh](https://github.com/quic-go/quic-go/pull/5674/files#diff-857b8ac91ce0728a3684db7bff7d929b9818b1cfaeeb81499fea2f08aa39bc05) so build outputs are easier to trace. The script now prints the UTC timestamp at startup and runs `git log -1` in both the qpack and quic-go repo directories to emit the latest commit hash, date, and subject before fuzzers are built.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0af4dcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->