### PR TITLE
feat(allocation): Reduce HTTP/3 request header encoding allocations

### DIFF
--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -28,6 +28,36 @@ func decodeFromSlice(headers []qpack.HeaderField) qpack.DecodeFunc {
 	}
 }
 
+func newBenchmarkRequestHeaders() []qpack.HeaderField {
+	return []qpack.HeaderField{
+		{Name: ":path", Value: "/api/v1/users/12345"},
+		{Name: ":authority", Value: "quic-go.net"},
+		{Name: ":method", Value: http.MethodPost},
+		{Name: "content-type", Value: "application/json"},
+		{Name: "content-length", Value: "1024"},
+		{Name: "user-agent", Value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"},
+		{Name: "accept", Value: "application/json, text/plain, */*"},
+		{Name: "accept-encoding", Value: "gzip, deflate, br"},
+		{Name: "accept-language", Value: "en-US,en;q=0.9"},
+		{Name: "cache-control", Value: "no-cache"},
+		{Name: "cookie", Value: "session_id=abc123"},
+		{Name: "cookie", Value: "user_pref=dark_mode"},
+		{Name: "referer", Value: "https://quic-go.net/docs/http3/"},
+	}
+}
+
+func encodeBenchmarkRequestHeaders(t testing.TB) []byte {
+	t.Helper()
+
+	headers := newBenchmarkRequestHeaders()
+	var buf bytes.Buffer
+	enc := qpack.NewEncoder(&buf)
+	for _, hf := range headers {
+		require.NoError(t, enc.WriteField(hf))
+	}
+	return buf.Bytes()
+}
+
 func TestRequestHeaderParsing(t *testing.T) {
 	t.Run("regular path", func(t *testing.T) {
 		testRequestHeaderParsing(t, "/foo")
@@ -612,33 +642,25 @@ func TestQpackError(t *testing.T) {
 	})
 }
 
+func TestRequestFromHeadersAllocs(t *testing.T) {
+	encoded := encodeBenchmarkRequestHeaders(t)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		dec := qpack.NewDecoder()
+		decodeFn := dec.Decode(encoded)
+		_, err := requestFromHeaders(decodeFn, math.MaxInt, nil)
+		require.NoError(t, err)
+	})
+	t.Logf("requestFromHeaders allocations per run: %.0f", allocs)
+}
+
 func BenchmarkRequestFromHeaders(b *testing.B) {
 	b.ReportAllocs()
 
-	headers := []qpack.HeaderField{
-		{Name: ":path", Value: "/api/v1/users/12345"},
-		{Name: ":authority", Value: "quic-go.net"},
-		{Name: ":method", Value: http.MethodPost},
-		{Name: "content-type", Value: "application/json"},
-		{Name: "content-length", Value: "1024"},
-		{Name: "user-agent", Value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"},
-		{Name: "accept", Value: "application/json, text/plain, */*"},
-		{Name: "accept-encoding", Value: "gzip, deflate, br"},
-		{Name: "accept-language", Value: "en-US,en;q=0.9"},
-		{Name: "cache-control", Value: "no-cache"},
-		{Name: "cookie", Value: "session_id=abc123"},
-		{Name: "cookie", Value: "user_pref=dark_mode"},
-		{Name: "referer", Value: "https://quic-go.net/docs/http3/"},
-	}
-	var buf bytes.Buffer
-	enc := qpack.NewEncoder(&buf)
-	for _, hf := range headers {
-		require.NoError(b, enc.WriteField(hf))
-	}
-
+	encoded := encodeBenchmarkRequestHeaders(b)
 	dec := qpack.NewDecoder()
 	for b.Loop() {
-		decodeFn := dec.Decode(buf.Bytes())
+		decodeFn := dec.Decode(encoded)
 		if _, err := requestFromHeaders(decodeFn, math.MaxInt, nil); err != nil {
 			b.Fatalf("failed to parse request: %v", err)
 		}

--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -28,6 +28,14 @@ type requestWriter struct {
 	mutex     sync.Mutex
 	encoder   *qpack.Encoder
 	headerBuf *bytes.Buffer
+	scratch   requestWriterScratch
+}
+
+type requestWriterScratch struct {
+	trailerKeys      []string
+	trailerBuf       []byte
+	frameHeaderBuf   []byte
+	qlogHeaderFields []qlog.HeaderField
 }
 
 func newRequestWriter() *requestWriter {
@@ -36,15 +44,15 @@ func newRequestWriter() *requestWriter {
 	return &requestWriter{
 		encoder:   encoder,
 		headerBuf: headerBuf,
+		scratch: requestWriterScratch{
+			frameHeaderBuf:   make([]byte, 0, 16),
+			qlogHeaderFields: make([]qlog.HeaderField, 0, 16),
+		},
 	}
 }
 
 func (w *requestWriter) WriteRequestHeader(wr io.Writer, req *http.Request, gzip bool, streamID quic.StreamID, qlogger qlogwriter.Recorder) error {
-	buf := &bytes.Buffer{}
-	if err := w.writeHeaders(buf, req, gzip, streamID, qlogger); err != nil {
-		return err
-	}
-	if _, err := wr.Write(buf.Bytes()); err != nil {
+	if err := w.writeHeaders(wr, req, gzip, streamID, qlogger); err != nil {
 		return err
 	}
 	trace := httptrace.ContextClientTrace(req.Context())
@@ -58,28 +66,44 @@ func (w *requestWriter) writeHeaders(wr io.Writer, req *http.Request, gzip bool,
 	defer w.encoder.Close()
 	defer w.headerBuf.Reset()
 
+	scratch := &w.scratch
+	scratch.trailerKeys = scratch.trailerKeys[:0]
+	scratch.trailerBuf = scratch.trailerBuf[:0]
+	scratch.frameHeaderBuf = scratch.frameHeaderBuf[:0]
+	scratch.qlogHeaderFields = scratch.qlogHeaderFields[:0]
+
 	var trailers string
 	if len(req.Trailer) > 0 {
-		keys := make([]string, 0, len(req.Trailer))
 		for k := range req.Trailer {
 			if httpguts.ValidTrailerHeader(k) {
-				keys = append(keys, k)
+				scratch.trailerKeys = append(scratch.trailerKeys, k)
 			}
 		}
-		trailers = strings.Join(keys, ", ")
+		for i, k := range scratch.trailerKeys {
+			if i > 0 {
+				scratch.trailerBuf = append(scratch.trailerBuf, ',', ' ')
+			}
+			scratch.trailerBuf = append(scratch.trailerBuf, k...)
+		}
+		if len(scratch.trailerBuf) > 0 {
+			trailers = string(scratch.trailerBuf)
+		}
 	}
 
-	headerFields, err := w.encodeHeaders(req, gzip, trailers, actualContentLength(req), qlogger != nil)
+	var headerFields []qlog.HeaderField
+	if qlogger != nil {
+		headerFields = scratch.qlogHeaderFields
+	}
+	headerFields, err := w.encodeHeaders(req, gzip, trailers, actualContentLength(req), headerFields)
 	if err != nil {
 		return err
 	}
 
-	b := make([]byte, 0, 128)
-	b = (&headersFrame{Length: uint64(w.headerBuf.Len())}).Append(b)
+	scratch.frameHeaderBuf = (&headersFrame{Length: uint64(w.headerBuf.Len())}).Append(scratch.frameHeaderBuf)
 	if qlogger != nil {
-		qlogCreatedHeadersFrame(qlogger, streamID, len(b)+w.headerBuf.Len(), w.headerBuf.Len(), headerFields)
+		qlogCreatedHeadersFrame(qlogger, streamID, len(scratch.frameHeaderBuf)+w.headerBuf.Len(), w.headerBuf.Len(), headerFields)
 	}
-	if _, err := wr.Write(b); err != nil {
+	if _, err := wr.Write(scratch.frameHeaderBuf); err != nil {
 		return err
 	}
 	_, err = wr.Write(w.headerBuf.Bytes())
@@ -95,8 +119,8 @@ func isExtendedConnectRequest(req *http.Request) bool {
 // Contrary to what the godoc for the http.Request says,
 // we do respect the Proto field if the method is CONNECT.
 //
-// The returned header fields are only set if doQlog is true.
-func (w *requestWriter) encodeHeaders(req *http.Request, addGzipHeader bool, trailers string, contentLength int64, doQlog bool) ([]qlog.HeaderField, error) {
+// The returned header fields are only set if qlogHeaderFields is non-nil.
+func (w *requestWriter) encodeHeaders(req *http.Request, addGzipHeader bool, trailers string, contentLength int64, qlogHeaderFields []qlog.HeaderField) ([]qlog.HeaderField, error) {
 	host := req.Host
 	if host == "" {
 		host = req.URL.Host
@@ -228,22 +252,18 @@ func (w *requestWriter) encodeHeaders(req *http.Request, addGzipHeader bool, tra
 	traceHeaders := traceHasWroteHeaderField(trace)
 
 	// Header list size is ok. Write the headers.
-	var headerFields []qlog.HeaderField
-	if doQlog {
-		headerFields = make([]qlog.HeaderField, 0, len(req.Header))
-	}
 	enumerateHeaders(func(name, value string) {
 		name = strings.ToLower(name)
 		w.encoder.WriteField(qpack.HeaderField{Name: name, Value: value})
 		if traceHeaders {
 			traceWroteHeaderField(trace, name, value)
 		}
-		if doQlog {
-			headerFields = append(headerFields, qlog.HeaderField{Name: name, Value: value})
+		if qlogHeaderFields != nil {
+			qlogHeaderFields = append(qlogHeaderFields, qlog.HeaderField{Name: name, Value: value})
 		}
 	})
 
-	return headerFields, nil
+	return qlogHeaderFields, nil
 }
 
 // authorityAddr returns a given authority (a host/IP, or host:port / ip:port)

--- a/http3/request_writer_test.go
+++ b/http3/request_writer_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newBenchmarkRequestWriterRequest() *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "https://quic-go.net/index.html?foo=bar", nil)
+	req.AddCookie(&http.Cookie{Name: "foo", Value: "bar"})
+	req.AddCookie(&http.Cookie{Name: "baz", Value: "lorem ipsum"})
+	req.Header.Set("Accept", "application/json, text/plain, */*")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Referer", "https://quic-go.net/docs/http3/")
+	return req
+}
+
 func decodeRequest(t *testing.T, str io.Reader, streamID quic.StreamID, eventRecorder *events.Recorder) map[string]string {
 	t.Helper()
 
@@ -84,6 +95,18 @@ func testRequestWriterGzip(t *testing.T, gzip bool) {
 	case false:
 		require.NotContains(t, headerFields, "accept-encoding")
 	}
+}
+
+func TestWriteRequestHeaderAllocs(t *testing.T) {
+	req := newBenchmarkRequestWriterRequest()
+	rw := newRequestWriter()
+	buf := &bytes.Buffer{}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		buf.Reset()
+		require.NoError(t, rw.WriteRequestHeader(buf, req, false, 0, nil))
+	})
+	t.Logf("WriteRequestHeader allocations per run: %.0f", allocs)
 }
 
 func TestRequestWriterInvalidHostHeader(t *testing.T) {
@@ -165,4 +188,18 @@ func TestRequestWriterTrailers(t *testing.T) {
 		"trailer1": {"foo"},
 		"trailer2": {"bar"},
 	}, trailers)
+}
+
+func BenchmarkWriteRequestHeader(b *testing.B) {
+	req := newBenchmarkRequestWriterRequest()
+	rw := newRequestWriter()
+	buf := &bytes.Buffer{}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		buf.Reset()
+		if err := rw.WriteRequestHeader(buf, req, false, 0, nil); err != nil {
+			b.Fatalf("failed to write request headers: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
wip on https://github.com/quic-go/quic-go/issues/5528 


BenchmarkWriteRequestHeader improved from:
Before: 3228 ns/op, 464 B/op, 10 allocs/op
After: 1368 ns/op, 80 B/op, 6 allocs/op

This MR reduces transient allocations in the http3 request header encode path by moving per-call temporary state into reusable scratch buffers owned by requestWriter.
The main goal is to make requestWriter.WriteRequestHeader cheaper on the hot path without changing request validation, header ordering, or qlog behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce allocations in HTTP/3 request header encoding
> - Introduces `requestWriterScratch` in [request_writer.go](https://github.com/quic-go/quic-go/pull/5678/files#diff-26e7bb9b62686667822b50c4aaf21fd74417a19983a35d83408ac35d1de73bb9) to hold reusable buffers (`trailerKeys`, `trailerBuf`, `frameHeaderBuf`, `qlogHeaderFields`) across calls, avoiding per-request allocations.
> - `writeHeaders` now reuses scratch buffers for trailer key accumulation and frame header construction instead of allocating new slices or using `strings.Join`.
> - `encodeHeaders` accepts a `qlogHeaderFields` slice instead of a boolean, skipping allocation entirely when qlogging is disabled.
> - Adds allocation-counting tests (`TestRequestFromHeadersAllocs`, `TestWriteRequestHeaderAllocs`) and benchmarks to verify and track the improvement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4d49a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->