### PR TITLE
feat: add TriggerPTO API to force immediate PTO handling

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -223,6 +223,10 @@ type Conn struct {
 	connStateMutex sync.Mutex
 	connState      ConnectionState
 
+	// ptoRequested requests an immediate execution of PTO handling,
+	// regardless of the current PTO timer state.
+	ptoRequested atomic.Bool
+
 	logID     string
 	qlogTrace qlogwriter.Trace
 	qlogger   qlogwriter.Recorder
@@ -676,7 +680,8 @@ runLoop:
 		// Check for loss detection timeout.
 		// This could cause packets to be declared lost, and retransmissions to be enqueued.
 		now := monotime.Now()
-		if timeout := c.sentPacketHandler.GetLossDetectionTimeout(); !timeout.IsZero() && !timeout.After(now) {
+		if timeout := c.sentPacketHandler.GetLossDetectionTimeout(); !timeout.IsZero() &&
+			(!timeout.After(now) || c.ptoRequested.Swap(false)) {
 			if err := c.sentPacketHandler.OnLossDetectionTimeout(now); err != nil {
 				c.setCloseError(&closeError{err: err})
 				break runLoop
@@ -3139,6 +3144,20 @@ func (c *Conn) NextConnection(ctx context.Context) (*Conn, error) {
 		c.streamsMap.UseResetMaps()
 	}
 	return c, nil
+}
+
+// TriggerPTO requests immediate Probe Timeout (PTO) handling.
+//
+// This is intended for applications that have external knowledge that
+// connectivity is likely available again (for example, after a VPN
+// reconnect or a network-path change) and want to expedite QUIC's
+// recovery and probing logic instead of waiting for the PTO timer.
+//
+// Applications should not use this as part of normal operation, since
+// PTO handling is performed automatically by QUIC.
+func (c *Conn) TriggerPTO() {
+	c.ptoRequested.Store(true)
+	c.scheduleSending()
 }
 
 // estimateMaxPayloadSize estimates the maximum payload size for short header packets.


### PR DESCRIPTION
Fixes #5481.

Add a `Conn.TriggerPTO()` API that allows applications to request immediate PTO handling instead of waiting for the current PTO timer to expire.

This is intended for cases where the application has external knowledge that connectivity may be available again and wants to expedite QUIC's recovery and probing logic.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `TriggerPTO` method to `Conn` to force immediate PTO handling
> - Adds a new exported `Conn.TriggerPTO` method that sets an atomic `ptoRequested` flag and calls `scheduleSending` to wake the run loop.
> - The run loop in `Conn.run` now checks `ptoRequested` in addition to the scheduled timeout, invoking `sentPacketHandler.OnLossDetectionTimeout` immediately when the flag is set.
> - Behavioral Change: the loss detection path can now be triggered externally without waiting for the PTO timer to expire.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1308e6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->