### PR TITLE
congestion: add pluggable CongestionController interface

### DIFF
--- a/cc_adapter.go
+++ b/cc_adapter.go
@@ -1,0 +1,73 @@
+package quic
+
+import (
+	"github.com/quic-go/quic-go/internal/congestion"
+	"github.com/quic-go/quic-go/internal/monotime"
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+// ccAdapter wraps a public CongestionController to satisfy the internal
+// congestion.SendAlgorithmWithDebugInfos interface.
+// This allows users to inject custom congestion controllers without exposing internal types.
+type ccAdapter struct {
+	cc CongestionController
+}
+
+var _ congestion.SendAlgorithmWithDebugInfos = &ccAdapter{}
+
+// TimeUntilSend disables pacing for custom congestion controllers.
+func (a *ccAdapter) TimeUntilSend(_ protocol.ByteCount) monotime.Time { return 0 }
+
+// HasPacingBudget always returns true, disabling pacing for custom congestion controllers.
+func (a *ccAdapter) HasPacingBudget(_ monotime.Time) bool { return true }
+
+// MaybeExitSlowStart is a no-op for custom congestion controllers.
+func (a *ccAdapter) MaybeExitSlowStart() {}
+
+// InSlowStart returns false; custom controllers manage their own slow start state.
+func (a *ccAdapter) InSlowStart() bool { return false }
+
+// InRecovery returns false; custom controllers manage their own recovery state.
+func (a *ccAdapter) InRecovery() bool { return false }
+
+// GetCongestionWindow returns 0; custom controllers express the window via CanSend.
+func (a *ccAdapter) GetCongestionWindow() protocol.ByteCount { return 0 }
+
+func (a *ccAdapter) OnPacketSent(
+	sentTime monotime.Time,
+	bytesInFlight protocol.ByteCount,
+	packetNumber protocol.PacketNumber,
+	bytes protocol.ByteCount,
+	isRetransmittable bool,
+) {
+	a.cc.OnPacketSent(sentTime.ToTime(), bytesInFlight, packetNumber, bytes, isRetransmittable)
+}
+
+func (a *ccAdapter) CanSend(bytesInFlight protocol.ByteCount) bool {
+	return a.cc.CanSend(bytesInFlight)
+}
+
+func (a *ccAdapter) OnPacketAcked(
+	number protocol.PacketNumber,
+	ackedBytes protocol.ByteCount,
+	priorInFlight protocol.ByteCount,
+	eventTime monotime.Time,
+) {
+	a.cc.OnPacketAcked(number, ackedBytes, priorInFlight, eventTime.ToTime())
+}
+
+func (a *ccAdapter) OnCongestionEvent(
+	number protocol.PacketNumber,
+	lostBytes protocol.ByteCount,
+	priorInFlight protocol.ByteCount,
+) {
+	a.cc.OnCongestionEvent(number, lostBytes, priorInFlight)
+}
+
+func (a *ccAdapter) OnRetransmissionTimeout(packetsRetransmitted bool) {
+	a.cc.OnRetransmissionTimeout(packetsRetransmitted)
+}
+
+func (a *ccAdapter) SetMaxDatagramSize(s protocol.ByteCount) {
+	a.cc.SetMaxDatagramSize(s)
+}

--- a/config.go
+++ b/config.go
@@ -124,6 +124,7 @@ func populateConfig(config *Config) *Config {
 		DisablePathMTUDiscovery:          config.DisablePathMTUDiscovery,
 		EnableStreamResetPartialDelivery: config.EnableStreamResetPartialDelivery,
 		Allow0RTT:                        config.Allow0RTT,
+		CongestionController:             config.CongestionController,
 		Tracer:                           config.Tracer,
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -86,8 +86,7 @@ func configWithNonZeroNonFunctionFields(t *testing.T) *Config {
 		}
 
 		switch fn := typ.Field(i).Name; fn {
-		case "GetConfigForClient", "RequireAddressValidation", "GetLogWriter", "AllowConnectionWindowIncrease", "Tracer":
-			// Can't compare functions.
+		case "GetConfigForClient", "RequireAddressValidation", "GetLogWriter", "AllowConnectionWindowIncrease", "Tracer", "CongestionController":
 		case "Versions":
 			f.Set(reflect.ValueOf([]Version{1, 2, 3}))
 		case "ConnectionIDLength":

--- a/congestion_control.go
+++ b/congestion_control.go
@@ -1,0 +1,55 @@
+package quic
+
+import (
+	"time"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+// ByteCount is the number of bytes.
+type ByteCount = protocol.ByteCount
+
+// PacketNumber is a QUIC packet number.
+type PacketNumber = protocol.PacketNumber
+
+// CongestionController is the interface for a pluggable congestion controller.
+// It is called by the QUIC connection to regulate the sending rate.
+//
+// Implementations must be safe for concurrent use.
+//
+// Note: pacing is handled separately by quic-go and is not part of this interface.
+// The congestion controller only controls the congestion window.
+type CongestionController interface {
+	// OnPacketSent is called when a packet containing retransmittable frames is sent.
+	OnPacketSent(
+		sentTime time.Time,
+		bytesInFlight ByteCount,
+		packetNumber PacketNumber,
+		bytes ByteCount,
+		isRetransmittable bool,
+	)
+
+	// CanSend returns true if the congestion controller allows sending a packet right now.
+	CanSend(bytesInFlight ByteCount) bool
+
+	// OnPacketAcked is called for each packet that is ACKed.
+	OnPacketAcked(
+		number PacketNumber,
+		ackedBytes ByteCount,
+		priorInFlight ByteCount,
+		eventTime time.Time,
+	)
+
+	// OnCongestionEvent is called when packet loss is detected.
+	OnCongestionEvent(
+		number PacketNumber,
+		lostBytes ByteCount,
+		priorInFlight ByteCount,
+	)
+
+	// OnRetransmissionTimeout is called when a retransmission timeout occurs.
+	OnRetransmissionTimeout(packetsRetransmitted bool)
+
+	// SetMaxDatagramSize is called when the maximum datagram size changes.
+	SetMaxDatagramSize(size ByteCount)
+}

--- a/connection.go
+++ b/connection.go
@@ -310,18 +310,7 @@ var newConnection = func(
 	)
 	s.preSetup()
 	s.rttStats.SetInitialRTT(rtt)
-	s.sentPacketHandler = ackhandler.NewSentPacketHandler(
-		0,
-		protocol.ByteCount(s.config.InitialPacketSize),
-		s.rttStats,
-		&s.connStats,
-		clientAddressValidated,
-		s.conn.capabilities().ECN,
-		s.receivedPacketHandler.IgnorePacketsBelow,
-		s.perspective,
-		s.qlogger,
-		s.logger,
-	)
+	s.sentPacketHandler = newSentPacketHandlerForConn(s, 0, clientAddressValidated)
 	s.maxPayloadSizeEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
 	statelessResetToken := statelessResetter.GetStatelessResetToken(srcConnID)
 	params := &wire.TransportParameters{
@@ -439,18 +428,7 @@ var newClientConnection = func(
 	)
 	s.ctx, s.ctxCancel = context.WithCancelCause(ctx)
 	s.preSetup()
-	s.sentPacketHandler = ackhandler.NewSentPacketHandler(
-		initialPacketNumber,
-		protocol.ByteCount(s.config.InitialPacketSize),
-		s.rttStats,
-		&s.connStats,
-		false, // has no effect
-		s.conn.capabilities().ECN,
-		s.receivedPacketHandler.IgnorePacketsBelow,
-		s.perspective,
-		s.qlogger,
-		s.logger,
-	)
+	s.sentPacketHandler = newSentPacketHandlerForConn(s, initialPacketNumber, false)
 	s.maxPayloadSizeEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
 	oneRTTStream := newCryptoStream()
 	params := &wire.TransportParameters{
@@ -507,6 +485,41 @@ var newClientConnection = func(
 		}
 	}
 	return &wrappedConn{Conn: s}
+}
+
+func newSentPacketHandlerForConn(
+	s *Conn,
+	initialPN protocol.PacketNumber,
+	clientAddressValidated bool,
+) ackhandler.SentPacketHandler {
+	if s.config.CongestionController != nil {
+		cc := &ccAdapter{cc: s.config.CongestionController()}
+		return ackhandler.NewSentPacketHandlerWithCC(
+			initialPN,
+			protocol.ByteCount(s.config.InitialPacketSize),
+			s.rttStats,
+			&s.connStats,
+			clientAddressValidated,
+			s.conn.capabilities().ECN,
+			s.receivedPacketHandler.IgnorePacketsBelow,
+			s.perspective,
+			s.qlogger,
+			s.logger,
+			cc,
+		)
+	}
+	return ackhandler.NewSentPacketHandler(
+		initialPN,
+		protocol.ByteCount(s.config.InitialPacketSize),
+		s.rttStats,
+		&s.connStats,
+		clientAddressValidated,
+		s.conn.capabilities().ECN,
+		s.receivedPacketHandler.IgnorePacketsBelow,
+		s.perspective,
+		s.qlogger,
+		s.logger,
+	)
 }
 
 func (c *Conn) preSetup() {

--- a/integrationtests/self/congestion_control_test.go
+++ b/integrationtests/self/congestion_control_test.go
@@ -1,0 +1,153 @@
+package self_test
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingCC is a CongestionController that records how many times each method was called.
+type recordingCC struct {
+	onPacketSentCalls  atomic.Int32
+	onPacketAckedCalls atomic.Int32
+	canSendCalls       atomic.Int32
+}
+
+func (c *recordingCC) OnPacketSent(_ time.Time, _ quic.ByteCount, _ quic.PacketNumber, _ quic.ByteCount, _ bool) {
+	c.onPacketSentCalls.Add(1)
+}
+
+func (c *recordingCC) CanSend(_ quic.ByteCount) bool {
+	c.canSendCalls.Add(1)
+	return true
+}
+
+func (c *recordingCC) OnPacketAcked(_ quic.PacketNumber, _ quic.ByteCount, _ quic.ByteCount, _ time.Time) {
+	c.onPacketAckedCalls.Add(1)
+}
+
+func (c *recordingCC) OnCongestionEvent(_ quic.PacketNumber, _ quic.ByteCount, _ quic.ByteCount) {}
+
+func (c *recordingCC) OnRetransmissionTimeout(_ bool) {}
+
+func (c *recordingCC) SetMaxDatagramSize(_ quic.ByteCount) {}
+
+func TestCustomCongestionController(t *testing.T) {
+	var cc recordingCC
+
+	ln, err := quic.Listen(
+		newUDPConnLocalhost(t),
+		getTLSConfig(),
+		getQuicConfig(nil),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, err := ln.Accept(ctx)
+		if err != nil {
+			return
+		}
+		str, err := conn.AcceptStream(ctx)
+		if err != nil {
+			return
+		}
+		io.Copy(str, str) //nolint:errcheck
+		str.Close()       //nolint:errcheck
+		// Let the client close it.
+		<-conn.Context().Done()
+	}()
+
+	conn, err := quic.Dial(
+		ctx,
+		newUDPConnLocalhost(t),
+		ln.Addr(),
+		getTLSClientConfig(),
+		getQuicConfig(&quic.Config{CongestionController: func() quic.CongestionController { return &cc }}),
+	)
+	require.NoError(t, err)
+
+	str, err := conn.OpenStreamSync(ctx)
+	require.NoError(t, err)
+
+	data := GeneratePRData(32 * 1024)
+	_, err = str.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, str.Close())
+
+	got, err := io.ReadAll(str)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+
+	conn.CloseWithError(0, "")
+	<-serverDone
+
+	assert.Greater(t, cc.onPacketSentCalls.Load(), int32(0), "OnPacketSent should have been called")
+	assert.Greater(t, cc.onPacketAckedCalls.Load(), int32(0), "OnPacketAcked should have been called")
+	assert.Greater(t, cc.canSendCalls.Load(), int32(0), "CanSend should have been called")
+}
+
+func TestDefaultCongestionController(t *testing.T) {
+	ln, err := quic.Listen(
+		newUDPConnLocalhost(t),
+		getTLSConfig(),
+		getQuicConfig(nil),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, err := ln.Accept(ctx)
+		if err != nil {
+			return
+		}
+		str, err := conn.AcceptStream(ctx)
+		if err != nil {
+			return
+		}
+		io.Copy(str, str) //nolint:errcheck
+		str.Close()       //nolint:errcheck
+		<-conn.Context().Done()
+	}()
+
+	conn, err := quic.Dial(
+		ctx,
+		newUDPConnLocalhost(t),
+		ln.Addr(),
+		getTLSClientConfig(),
+		getQuicConfig(nil), // nil CC = use default NewReno
+	)
+	require.NoError(t, err)
+
+	str, err := conn.OpenStreamSync(ctx)
+	require.NoError(t, err)
+
+	data := GeneratePRData(32 * 1024)
+	_, err = str.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, str.Close())
+
+	got, err := io.ReadAll(str)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+
+	conn.CloseWithError(0, "")
+	<-serverDone
+}

--- a/interface.go
+++ b/interface.go
@@ -167,6 +167,12 @@ type Config struct {
 	// This allows the sending of QUIC packets that fully utilize the available MTU of the path.
 	// Path MTU discovery is only available on systems that allow setting of the Don't Fragment (DF) bit.
 	DisablePathMTUDiscovery bool
+	// CongestionController is a constructor for a per-connection congestion controller.
+	// It is called once per connection. If nil, the default NewReno controller is used.
+	//
+	// Note: the pacing layer is separate from the congestion controller
+	// and cannot be customized via this interface.
+	CongestionController func() CongestionController
 	// Allow0RTT allows the application to decide if a 0-RTT connection attempt should be accepted.
 	// Only valid for the server.
 	Allow0RTT bool

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -89,9 +89,10 @@ type sentPacketHandler struct {
 
 	bytesInFlight protocol.ByteCount
 
-	congestion congestion.SendAlgorithmWithDebugInfos
-	rttStats   *utils.RTTStats
-	connStats  *utils.ConnectionStats
+	congestion       congestion.SendAlgorithmWithDebugInfos
+	customCongestion congestion.SendAlgorithmWithDebugInfos // non-nil if set via NewSentPacketHandlerWithCC
+	rttStats         *utils.RTTStats
+	connStats        *utils.ConnectionStats
 
 	// The number of times a PTO has been sent without receiving an ack.
 	ptoCount uint32
@@ -129,14 +130,61 @@ func NewSentPacketHandler(
 	qlogger qlogwriter.Recorder,
 	logger utils.Logger,
 ) SentPacketHandler {
-	congestion := congestion.NewCubicSender(
-		congestion.DefaultClock{},
-		rttStats,
-		connStats,
-		initialMaxDatagramSize,
-		true, // use Reno
-		qlogger,
+	return newSentPacketHandler(
+		initialPN, initialMaxDatagramSize, rttStats, connStats,
+		clientAddressValidated, enableECN, ignorePacketsBelow, pers, qlogger, logger,
+		nil,
 	)
+}
+
+// NewSentPacketHandlerWithCC is like NewSentPacketHandler but uses cc as the congestion
+// controller instead of the default NewReno/Cubic sender. If cc is nil, the default is used.
+func NewSentPacketHandlerWithCC(
+	initialPN protocol.PacketNumber,
+	initialMaxDatagramSize protocol.ByteCount,
+	rttStats *utils.RTTStats,
+	connStats *utils.ConnectionStats,
+	clientAddressValidated bool,
+	enableECN bool,
+	ignorePacketsBelow func(protocol.PacketNumber),
+	pers protocol.Perspective,
+	qlogger qlogwriter.Recorder,
+	logger utils.Logger,
+	cc congestion.SendAlgorithmWithDebugInfos,
+) SentPacketHandler {
+	return newSentPacketHandler(
+		initialPN, initialMaxDatagramSize, rttStats, connStats,
+		clientAddressValidated, enableECN, ignorePacketsBelow, pers, qlogger, logger,
+		cc,
+	)
+}
+
+func newSentPacketHandler(
+	initialPN protocol.PacketNumber,
+	initialMaxDatagramSize protocol.ByteCount,
+	rttStats *utils.RTTStats,
+	connStats *utils.ConnectionStats,
+	clientAddressValidated bool,
+	enableECN bool,
+	ignorePacketsBelow func(protocol.PacketNumber),
+	pers protocol.Perspective,
+	qlogger qlogwriter.Recorder,
+	logger utils.Logger,
+	customCC congestion.SendAlgorithmWithDebugInfos,
+) *sentPacketHandler {
+	var cc congestion.SendAlgorithmWithDebugInfos
+	if customCC != nil {
+		cc = customCC
+	} else {
+		cc = congestion.NewCubicSender(
+			congestion.DefaultClock{},
+			rttStats,
+			connStats,
+			initialMaxDatagramSize,
+			true, // use Reno
+			qlogger,
+		)
+	}
 
 	h := &sentPacketHandler{
 		peerCompletedAddressValidation: pers == protocol.PerspectiveServer,
@@ -147,7 +195,8 @@ func NewSentPacketHandler(
 		lostPackets:                    *newLostPacketTracker(64),
 		rttStats:                       rttStats,
 		connStats:                      connStats,
-		congestion:                     congestion,
+		congestion:                     cc,
+		customCongestion:               customCC,
 		ignorePacketsBelow:             ignorePacketsBelow,
 		perspective:                    pers,
 		qlogger:                        qlogger,
@@ -1131,13 +1180,15 @@ func (h *sentPacketHandler) MigratedPath(now monotime.Time, initialMaxDatagramSi
 	for pn := range h.appDataPackets.history.PathProbes() {
 		h.appDataPackets.history.RemovePathProbe(pn)
 	}
-	h.congestion = congestion.NewCubicSender(
-		congestion.DefaultClock{},
-		h.rttStats,
-		h.connStats,
-		initialMaxDatagramSize,
-		true, // use Reno
-		h.qlogger,
-	)
+	if h.customCongestion == nil {
+		h.congestion = congestion.NewCubicSender(
+			congestion.DefaultClock{},
+			h.rttStats,
+			h.connStats,
+			initialMaxDatagramSize,
+			true, // use Reno
+			h.qlogger,
+		)
+	}
 	h.setLossDetectionTimer(now)
 }


### PR DESCRIPTION
> This PR implements a minimal pluggable congestion control interface.
# Summary
  - Defines a public CongestionController interface in the root package
  - Adds a CongestionController field to quic.Config
  - Wires the custom controller into the connection via an internal adapter (ccAdapter)
  - Exports ByteCount and PacketNumber as type aliases for use in the interface

# Design decisions
- Pacing is kept separate and disabled when a custom controller is used.
- An internal adapter bridges the public API to quic-go’s internal interface, stubbing out internal-only methods.
- On path migration, custom controllers remain active (user handles migration), while the default Cubic/Reno recreates.
- When Config.CongestionController is nil, behavior is unchanged.

# Testing
  - TestCustomCongestionController: verifies that OnPacketSent, OnPacketAcked, and CanSend are called when a custom
  controller is injected via Config
  - TestDefaultCongestionController: verifies default behavior is unchanged when no controller is set
  - All existing tests pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pluggable `CongestionController` interface to QUIC `Config`
> - Introduces a public `CongestionController` interface in [`congestion_control.go`](https://github.com/quic-go/quic-go/pull/5680/files#diff-60b6b07aa4d13b01f668a1443a8c2aff19162f7eb364e1884b7aa4d68afb3849) with hooks: `OnPacketSent`, `CanSend`, `OnPacketAcked`, `OnCongestionEvent`, `OnRetransmissionTimeout`, and `SetMaxDatagramSize`.
> - Adds a `CongestionController` field to [`Config`](https://github.com/quic-go/quic-go/pull/5680/files#diff-189ad68e1729b49c973b8a4baa0ac4a7058d274d5b52abe852ac21a28accf8cf); when nil, the default NewReno/Cubic sender is used.
> - A new [`ccAdapter`](https://github.com/quic-go/quic-go/pull/5680/files#diff-2daebc733d03f9eb735b780fdd3dc72e5438678c3d538d2b86f5162edeb19e33) wraps the public interface to satisfy the internal `congestion.SendAlgorithmWithDebugInfos`, with pacing disabled (always returns `TimeUntilSend=0`, `HasPacingBudget=true`).
> - `NewSentPacketHandlerWithCC` in [`sent_packet_handler.go`](https://github.com/quic-go/quic-go/pull/5680/files#diff-1b07e69952acf6b257bb638e9aaa4befe03cbceaf125eefe90f57873ce349247) allows injecting a custom controller; path migration preserves the custom controller instead of resetting to Cubic.
> - Behavioral Change: custom congestion controllers disable pacing entirely, and `InSlowStart`/`InRecovery` always return false for the internal pacing logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f32258c. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->