### PR TITLE
ci: add Go 1.27rc1 to tested Go versions

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.25.x", "1.26.x" ]
+        go: [ "1.25.x", "1.26.x", "1.27.0-rc.1" ]
     runs-on: ${{ fromJSON(vars['CROSS_COMPILE_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}
     name: "Cross Compilation (Go ${{matrix.go}})"
     timeout-minutes: 30

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu" ]
-        go: [ "1.25.x", "1.26.x" ]
+        go: [ "1.25.x", "1.26.x", "1.27.0-rc.1" ]
         race: [ false ]
         include:
           - os: "ubuntu"
@@ -49,7 +49,7 @@ jobs:
       - name: Run version negotiation tests
         run: go test ${{ env.RACEFLAG }} -v -timeout 30s -shuffle=on ./integrationtests/versionnegotiation ${{ env.QLOGFLAG }} 2>&1 | go-junit-report -set-exit-code -iocopy -out report_versionnegotiation.xml
       - name: Run FIPS 140 tests
-        if: ${{ matrix.go == '1.26.x' && (success() || failure()) }}
+        if: ${{ matrix.go != '1.25.x' && (success() || failure()) }}
         run: go test -v -timeout 1m -shuffle=on ./integrationtests/fips 2>&1 | go-junit-report -set-exit-code -iocopy -out report_fips.xml
       - name: Run self tests, using QUIC v1
         if: success() || failure() # run this step even if the previous one failed

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
-        go: [ "1.25.x", "1.26.x" ]
+        go: [ "1.25.x", "1.26.x", "1.27.0-rc.1" ]
     runs-on: ${{ fromJSON(vars[format('UNIT_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
     timeout-minutes: 30
@@ -45,7 +45,7 @@ jobs:
           TIMESCALE_FACTOR: 20
         run: go test -v -shuffle on ./...
       - name: Run handshake tests in FIPS140 mode
-        if: ${{ matrix.go == '1.26.x' }}
+        if: ${{ matrix.go != '1.25.x' }}
         env:
           GODEBUG: fips140=only
         run: go test -v ./internal/handshake -run 'TestToken|TestRetry|TestInitial|TestDecode|TestEncrypt'


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add Go 1.27rc1 to CI test matrix and expand FIPS 140 test coverage
- Adds `1.27.0-rc.1` to the Go version matrix in the [cross-compile](.github/workflows/cross-compile.yml), [integration](.github/workflows/integration.yml), and [unit](.github/workflows/unit.yml) workflows.
- Broadens the FIPS 140 test conditions in the integration and unit workflows from Go `1.26.x`-only to all versions except `1.25.x`, so FIPS tests now also run on `1.27.0-rc.1`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f56189.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->