### PR TITLE
Handle nil UDP IP in qlog endpoint info

### DIFF
--- a/connection_logging.go
+++ b/connection_logging.go
@@ -265,12 +265,12 @@ func toQlogPacketType(pt protocol.PacketType) qlog.PacketType {
 }
 
 func toPathEndpointInfo(addr *net.UDPAddr) qlog.PathEndpointInfo {
-	if addr == nil {
+	if addr == nil || addr.IP == nil {
 		return qlog.PathEndpointInfo{}
 	}
 
 	var info qlog.PathEndpointInfo
-	if addr.IP == nil || addr.IP.To4() != nil {
+	if addr.IP.To4() != nil {
 		addrPort := netip.AddrPortFrom(netip.AddrFrom4([4]byte(addr.IP.To4())), uint16(addr.Port))
 		if addrPort.IsValid() {
 			info.IPv4 = addrPort

--- a/connection_logging_test.go
+++ b/connection_logging_test.go
@@ -141,3 +141,8 @@ func TestConnectionLoggingStartedConnectionEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestToPathEndpointInfoNilIP(t *testing.T) {
+	info := toPathEndpointInfo(&net.UDPAddr{Port: 1234})
+	require.Equal(t, qlog.PathEndpointInfo{}, info)
+}


### PR DESCRIPTION
Fixes #5687.

## Summary

This PR handles `net.UDPAddr` values whose `IP` field is nil when converting them to qlog endpoint information.

Previously, `toPathEndpointInfo` checked `addr.IP == nil` in the IPv4 branch condition, but then still called `addr.IP.To4()` inside that branch. For an address such as `&net.UDPAddr{Port: 1234}`, this could panic when converting the nil result to `[4]byte`.

The fix returns an empty `qlog.PathEndpointInfo` when the address or its IP is nil.

## Changes

- Return an empty `qlog.PathEndpointInfo` for nil `addr.IP`
- Avoid converting a nil `To4()` result to `[4]byte`
- Add a regression test for a `net.UDPAddr` with nil `IP`

## Testing

```bash
go test ./... -run 'Test(ToPathEndpointInfoNilIP|ConnectionLoggingStartedConnectionEvent)' -count=1
go test . -count=1
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nil IP panic in `toPathEndpointInfo` for UDP addresses
> Adds a nil-check for `addr.IP` at the start of `toPathEndpointInfo` in [connection_logging.go](https://github.com/quic-go/quic-go/pull/5688/files#diff-d002296ec0d92d036409a635f28c187c30bcf05c292aa2cc2a38f851b4772569), returning an empty `qlog.PathEndpointInfo` when `addr` or `addr.IP` is nil. Previously, passing a `*net.UDPAddr` with a nil IP would cause a runtime panic during array conversion. A regression test is added to cover the nil IP case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec9afa3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->