### PR TITLE
http3: add MaxHeaderValueCount

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/http/httptrace"
 	"net/textproto"
@@ -188,7 +189,7 @@ func (c *ClientConn) openRequestStream(
 	trace := httptrace.ContextClientTrace(ctx)
 	return newRequestStream(
 		newStream(hstr, c.rawConn, trace, func(r io.Reader, hf *headersFrame) error {
-			hdr, err := decodeTrailers(r, hf, maxHeaderBytes, c.decoder, c.qlogger, str.StreamID())
+			hdr, err := decodeTrailers(r, hf, maxHeaderBytes, math.MaxInt, c.decoder, c.qlogger, str.StreamID())
 			if err != nil {
 				return err
 			}

--- a/http3/headers.go
+++ b/http3/headers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/textproto"
 	"net/url"
@@ -51,7 +52,7 @@ var invalidHeaderFields = [...]string{
 	"upgrade",
 }
 
-func parseHeaders(decodeFn qpack.DecodeFunc, isRequest bool, sizeLimit int, headerFields *[]qpack.HeaderField) (header, error) {
+func parseHeaders(decodeFn qpack.DecodeFunc, isRequest bool, sizeLimit, maxHeaderValueCount int, headerFields *[]qpack.HeaderField) (header, error) {
 	hdr := header{Headers: make(http.Header)}
 	var readFirstRegularHeader, readContentLength bool
 	var contentLengthStr string
@@ -62,6 +63,10 @@ func parseHeaders(decodeFn qpack.DecodeFunc, isRequest bool, sizeLimit int, head
 				break
 			}
 			return header{}, &qpackError{err}
+		}
+		maxHeaderValueCount -= 1
+		if maxHeaderValueCount < 0 {
+			return header{}, errHeaderTooLarge
 		}
 		if headerFields != nil {
 			*headerFields = append(*headerFields, h)
@@ -182,7 +187,7 @@ func validateTrailerHeaderField(h qpack.HeaderField) error {
 	return nil
 }
 
-func parseTrailers(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *[]qpack.HeaderField) (http.Header, error) {
+func parseTrailers(decodeFn qpack.DecodeFunc, sizeLimit, maxHeaderValueCount int, headerFields *[]qpack.HeaderField) (http.Header, error) {
 	h := make(http.Header)
 	for {
 		hf, err := decodeFn()
@@ -194,6 +199,10 @@ func parseTrailers(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *[]qpa
 		}
 		if headerFields != nil {
 			*headerFields = append(*headerFields, hf)
+		}
+		maxHeaderValueCount -= 1
+		if maxHeaderValueCount < 0 {
+			return nil, errHeaderTooLarge
 		}
 		// RFC 9114, section 4.2.2:
 		// The size of a field list is calculated based on the uncompressed size of fields,
@@ -216,8 +225,8 @@ func parseTrailers(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *[]qpa
 	return h, nil
 }
 
-func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *[]qpack.HeaderField) (*http.Request, error) {
-	hdr, err := parseHeaders(decodeFn, true, sizeLimit, headerFields)
+func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit, maxHeaderValueCount int, headerFields *[]qpack.HeaderField) (*http.Request, error) {
+	hdr, err := parseHeaders(decodeFn, true, sizeLimit, maxHeaderValueCount, headerFields)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +313,7 @@ func validExtendedConnectProtocol(protocol string) bool {
 // It is only called for the HTTP header (and not the HTTP trailer).
 // It takes an http.Response as an argument to allow the caller to set the trailer later on.
 func updateResponseFromHeaders(rsp *http.Response, decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *[]qpack.HeaderField) error {
-	hdr, err := parseHeaders(decodeFn, false, sizeLimit, headerFields)
+	hdr, err := parseHeaders(decodeFn, false, sizeLimit, math.MaxInt, headerFields)
 	if err != nil {
 		return err
 	}
@@ -400,7 +409,7 @@ func writeTrailers(wr io.Writer, trailers http.Header, streamID quic.StreamID, q
 	return true, err
 }
 
-func decodeTrailers(r io.Reader, hf *headersFrame, maxHeaderBytes int, decoder *qpack.Decoder, qlogger qlogwriter.Recorder, streamID quic.StreamID) (http.Header, error) {
+func decodeTrailers(r io.Reader, hf *headersFrame, maxHeaderBytes, maxHeaderValueCountLimit int, decoder *qpack.Decoder, qlogger qlogwriter.Recorder, streamID quic.StreamID) (http.Header, error) {
 	if hf.Length > uint64(maxHeaderBytes) {
 		maybeQlogInvalidHeadersFrame(qlogger, streamID, hf.Length)
 		return nil, fmt.Errorf("http3: HEADERS frame too large: %d bytes (max: %d)", hf.Length, maxHeaderBytes)
@@ -417,7 +426,7 @@ func decodeTrailers(r io.Reader, hf *headersFrame, maxHeaderBytes int, decoder *
 		fields = make([]qpack.HeaderField, 0, 16)
 		headerFields = &fields
 	}
-	trailers, err := parseTrailers(decodeFn, maxHeaderBytes, headerFields)
+	trailers, err := parseTrailers(decodeFn, maxHeaderBytes, maxHeaderValueCountLimit, headerFields)
 	if err != nil {
 		maybeQlogInvalidHeadersFrame(qlogger, streamID, hf.Length)
 		return nil, err

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -47,7 +47,7 @@ func testRequestHeaderParsing(t *testing.T, path string) {
 		{Name: ":method", Value: http.MethodGet},
 		{Name: "content-length", Value: "42"},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.MethodGet, req.Method)
 	require.Equal(t, path, req.URL.Path)
@@ -73,7 +73,7 @@ func TestRequestHeadersContentLength(t *testing.T) {
 			{Name: ":authority", Value: "quic-go.net"},
 			{Name: ":method", Value: http.MethodGet},
 		}
-		req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+		req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, math.MaxInt, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(-1), req.ContentLength)
 	})
@@ -86,7 +86,7 @@ func TestRequestHeadersContentLength(t *testing.T) {
 			{Name: "content-length", Value: "42"},
 			{Name: "content-length", Value: "42"},
 		}
-		req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+		req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, math.MaxInt, nil)
 		require.NoError(t, err)
 		require.Equal(t, "42", req.Header.Get("Content-Length"))
 	})
@@ -116,7 +116,7 @@ func TestRequestHeadersContentLengthValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, nil)
+			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, math.MaxInt, nil)
 			if tc.errContains != "" {
 				require.ErrorContains(t, err, tc.errContains)
 			}
@@ -247,7 +247,7 @@ func TestRequestHeadersValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, nil)
+			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, math.MaxInt, nil)
 			if tc.errContains != "" {
 				require.ErrorContains(t, err, tc.errContains)
 			}
@@ -267,7 +267,7 @@ func TestCookieHeader(t *testing.T) {
 		{Name: "cookie", Value: "cookie1=foobar1"},
 		{Name: "cookie", Value: "cookie2=foobar2"},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.Header{
 		"Cookie": []string{"cookie1=foobar1; cookie2=foobar2"},
@@ -283,7 +283,7 @@ func TestHeadersConcatenation(t *testing.T) {
 		{Name: "duplicate-header", Value: "1"},
 		{Name: "duplicate-header", Value: "2"},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.Header{
 		"Cache-Control":    []string{"max-age=0"},
@@ -296,7 +296,7 @@ func TestRequestHeadersConnect(t *testing.T) {
 		{Name: ":authority", Value: "quic-go.net"},
 		{Name: ":method", Value: http.MethodConnect},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.MethodConnect, req.Method)
 	require.Equal(t, "HTTP/3.0", req.Proto)
@@ -326,7 +326,7 @@ func TestRequestHeadersConnectValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, nil)
+			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, math.MaxInt, nil)
 			require.EqualError(t, err, tc.err)
 		})
 	}
@@ -340,7 +340,7 @@ func TestRequestHeadersExtendedConnect(t *testing.T) {
 		{Name: ":authority", Value: "quic-go.net"},
 		{Name: ":path", Value: "/foo?val=1337"},
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.MethodConnect, req.Method)
 	require.Equal(t, "webtransport", req.Proto)
@@ -355,7 +355,7 @@ func TestRequestHeadersExtendedConnectRequestValidation(t *testing.T) {
 		{Name: ":authority", Value: "quic.clemente.io"},
 		{Name: ":path", Value: "/foo"},
 	}
-	_, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+	_, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, math.MaxInt, nil)
 	require.EqualError(t, err, "extended CONNECT: :scheme, :path and :authority must not be empty")
 }
 
@@ -367,7 +367,7 @@ func TestRequestHeadersExtendedConnectInvalidProtocol(t *testing.T) {
 		{Name: ":authority", Value: "quic-go.net"},
 		{Name: ":path", Value: "/foo"},
 	}
-	_, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+	_, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, math.MaxInt, nil)
 	require.EqualError(t, err, `invalid :protocol: "HTTP/3.0"`)
 }
 
@@ -492,7 +492,7 @@ func TestResponseTrailerParsingTE(t *testing.T) {
 func TestResponseTrailerParsing(t *testing.T) {
 	trailerHdr, err := parseTrailers(decodeFromSlice([]qpack.HeaderField{
 		{Name: "foo", Value: "42"},
-	}), math.MaxInt, nil)
+	}), math.MaxInt, math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, "42", trailerHdr.Get("Foo"))
 }
@@ -576,7 +576,7 @@ func TestResponseTrailerParsingValidation(t *testing.T) {
 			if sizeLimit == 0 {
 				sizeLimit = math.MaxInt
 			}
-			_, err := parseTrailers(decodeFromSlice(tc.headers), sizeLimit, nil)
+			_, err := parseTrailers(decodeFromSlice(tc.headers), sizeLimit, math.MaxInt, nil)
 			if tc.errIs != nil {
 				require.ErrorIs(t, err, tc.errIs)
 			}
@@ -600,7 +600,7 @@ func TestQpackError(t *testing.T) {
 	t.Run("header parsing", func(t *testing.T) {
 		dec := qpack.NewDecoder()
 		decodeFn := dec.Decode(buf.Bytes()[:len(buf.Bytes())/2])
-		_, err := requestFromHeaders(decodeFn, math.MaxInt, nil)
+		_, err := requestFromHeaders(decodeFn, math.MaxInt, math.MaxInt, nil)
 		require.ErrorAs(t, err, new(*qpackError))
 	})
 
@@ -639,7 +639,7 @@ func BenchmarkRequestFromHeaders(b *testing.B) {
 	dec := qpack.NewDecoder()
 	for b.Loop() {
 		decodeFn := dec.Decode(buf.Bytes())
-		if _, err := requestFromHeaders(decodeFn, math.MaxInt, nil); err != nil {
+		if _, err := requestFromHeaders(decodeFn, math.MaxInt, math.MaxInt, nil); err != nil {
 			b.Fatalf("failed to parse request: %v", err)
 		}
 	}
@@ -712,7 +712,7 @@ func FuzzHeaderParsing(f *testing.F) {
 			headers[i] = qpack.HeaderField{Name: p[0], Value: p[1]}
 		}
 
-		if req, err := requestFromHeaders(decodeFromSlice(headers), maxHeaderBytes, nil); err == nil {
+		if req, err := requestFromHeaders(decodeFromSlice(headers), maxHeaderBytes, math.MaxInt, nil); err == nil {
 			require.NotEmpty(t, req.Method, "request has empty Method")
 			require.NotNil(t, req.URL, "request has nil URL")
 			require.NotEmpty(t, req.Proto, "request has empty Proto")
@@ -740,7 +740,7 @@ func FuzzHeaderParsing(f *testing.F) {
 			requireValidFuzzHeader(t, rsp.Header, "response")
 		}
 
-		if trailers, err := parseTrailers(decodeFromSlice(headers), maxHeaderBytes, nil); err == nil {
+		if trailers, err := parseTrailers(decodeFromSlice(headers), maxHeaderBytes, math.MaxInt, nil); err == nil {
 			for name := range trailers {
 				require.Falsef(t, len(name) > 0 && name[0] == ':', "trailer contains pseudo header %q", name)
 			}

--- a/http3/server.go
+++ b/http3/server.go
@@ -141,6 +141,11 @@ type Server struct {
 	// used.
 	MaxHeaderBytes int
 
+	// MaxHeaderValueCount controls the maximum number of header values
+	// the server will read parsing the request HEADERS frame.
+	// If zero or negative, a default limit of 500 is used.
+	MaxHeaderValueCount int
+
 	// AdditionalSettings specifies additional HTTP/3 settings.
 	// It is invalid to specify any settings defined by RFC 9114 (HTTP/3) and RFC 9297 (HTTP Datagrams).
 	AdditionalSettings map[uint64]uint64
@@ -449,6 +454,7 @@ func (s *Server) newRawServerConn(conn *quic.Conn) (*RawServerConn, *quic.SendSt
 		connCtx,
 		s.Handler,
 		s.maxHeaderBytes(),
+		s.maxHeaderValueCount(),
 	)
 
 	// open the control stream and send a SETTINGS frame, it's also used to send a GOAWAY frame later
@@ -559,6 +565,16 @@ func (s *Server) maxHeaderBytes() int {
 		return http.DefaultMaxHeaderBytes
 	}
 	return s.MaxHeaderBytes
+}
+
+const defaultMaxHeaderValueCount = 500
+
+func (s *Server) maxHeaderValueCount() int {
+	if s.MaxHeaderValueCount <= 0 {
+		return defaultMaxHeaderValueCount
+	}
+
+	return s.MaxHeaderValueCount
 }
 
 // Close the server immediately, aborting requests and sending CONNECTION_CLOSE frames to connected clients.

--- a/http3/server_conn.go
+++ b/http3/server_conn.go
@@ -23,9 +23,10 @@ type RawServerConn struct {
 	idleTimeout time.Duration
 	idleTimer   *time.Timer
 
-	serverContext  context.Context
-	requestHandler http.Handler
-	maxHeaderBytes int
+	serverContext       context.Context
+	requestHandler      http.Handler
+	maxHeaderBytes      int
+	maxHeaderValueCount int
 
 	decoder *qpack.Decoder
 
@@ -42,15 +43,17 @@ func newRawServerConn(
 	serverContext context.Context,
 	requestHandler http.Handler,
 	maxHeaderBytes int,
+	maxHeaderValueCount int,
 ) *RawServerConn {
 	c := &RawServerConn{
-		idleTimeout:    idleTimeout,
-		serverContext:  serverContext,
-		requestHandler: requestHandler,
-		maxHeaderBytes: maxHeaderBytes,
-		decoder:        qpack.NewDecoder(),
-		qlogger:        qlogger,
-		logger:         logger,
+		idleTimeout:         idleTimeout,
+		serverContext:       serverContext,
+		requestHandler:      requestHandler,
+		maxHeaderBytes:      maxHeaderBytes,
+		maxHeaderValueCount: maxHeaderValueCount,
+		decoder:             qpack.NewDecoder(),
+		qlogger:             qlogger,
+		logger:              logger,
 	}
 	c.rawConn = *newRawConn(conn, enableDatagrams, c.onStreamsEmpty, nil, qlogger, logger)
 	if idleTimeout > 0 {
@@ -92,6 +95,13 @@ func (c *RawServerConn) requestMaxHeaderBytes() int {
 	return c.maxHeaderBytes
 }
 
+func (c *RawServerConn) requestMaxHeaderValueCount() int {
+	if c.maxHeaderValueCount <= 0 {
+		return defaultMaxHeaderValueCount
+	}
+	return c.maxHeaderValueCount
+}
+
 func (c *RawServerConn) openControlStream(settings *settingsFrame) (*quic.SendStream, error) {
 	return c.rawConn.openControlStream(settings)
 }
@@ -108,6 +118,7 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 	decoder := c.decoder
 	connCtx := c.serverContext
 	maxHeaderBytes := c.requestMaxHeaderBytes()
+	maxHeaderValueCount := c.requestMaxHeaderValueCount()
 
 	fp := &frameParser{closeConn: conn.CloseWithError, r: str, streamID: str.StreamID()}
 	frame, err := fp.ParseNext(qlogger)
@@ -141,7 +152,7 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 	if qlogger != nil {
 		hfs = make([]qpack.HeaderField, 0, 16)
 	}
-	req, err := requestFromHeaders(decodeFn, maxHeaderBytes, &hfs)
+	req, err := requestFromHeaders(decodeFn, maxHeaderBytes, maxHeaderValueCount, &hfs)
 	if qlogger != nil {
 		qlogParsedHeadersFrame(qlogger, str.StreamID(), hf, hfs)
 	}
@@ -175,7 +186,7 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 		contentLength = req.ContentLength
 	}
 	hstr := newStream(str, conn, nil, func(r io.Reader, hf *headersFrame) error {
-		trailers, err := decodeTrailers(r, hf, maxHeaderBytes, decoder, qlogger, str.StreamID())
+		trailers, err := decodeTrailers(r, hf, maxHeaderBytes, maxHeaderValueCount, decoder, qlogger, str.StreamID())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #5689.

This adds `Server.MaxHeaderValueCount` and applies it when parsing request headers and request trailers.

This adds a limit on the number of decoded header fields, in addition to the existing `MaxHeaderBytes` limit. The default is local for now because `net/http` doesn't expose a value for this yet.

If this approach looks right, I'll add tests for both request headers and request trailers.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MaxHeaderValueCount` limit to HTTP/3 server header parsing
> - Adds a `MaxHeaderValueCount` field to the `Server` struct, defaulting to 500, which limits the number of header fields allowed per request (initial headers and trailers).
> - Propagates the limit through `requestFromHeaders` and `decodeTrailers` in [http3/headers.go](https://github.com/quic-go/quic-go/pull/5692/files#diff-fd2fc9252b467e3ef8b4b4a45eafc66de3fab721b4de75b705da663b3e0f3160); exceeding it returns `errHeaderTooLarge`.
> - Client-side trailer decoding passes `math.MaxInt` to disable the limit for responses.
> - Behavioral Change: servers without explicit configuration now enforce a 500 header value limit per request by default, where previously no such limit existed.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized aa66760. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->