### PR TITLE
add a method to query for the final size of a receive stream

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -1,6 +1,7 @@
 package quic
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -21,8 +22,9 @@ type ReceiveStream struct {
 
 	sender streamSender
 
-	frameQueue  *frameSorter
-	finalOffset protocol.ByteCount
+	frameQueue    *frameSorter
+	finalOffset   protocol.ByteCount
+	finalSizeChan chan struct{} // closed when the final size is known
 
 	currentFrame       []byte
 	currentFrameDone   func()
@@ -69,12 +71,39 @@ func newReceiveStream(
 		readChan:       make(chan struct{}, 1),
 		readOnce:       make(chan struct{}, 1),
 		finalOffset:    protocol.MaxByteCount,
+		finalSizeChan:  make(chan struct{}),
 	}
 }
 
 // StreamID returns the stream ID.
 func (s *ReceiveStream) StreamID() protocol.StreamID {
 	return s.streamID
+}
+
+// WaitForFinalSize waits until the receive stream's final size is known.
+// The final size is learned from a FIN or RESET_STREAM frame.
+// Most applications don't need this. It is mainly useful for protocol layers
+// that need exact stream final sizes, such as WebTransport flow control accounting.
+func (s *ReceiveStream) WaitForFinalSize(ctx context.Context) (int64, error) {
+	for {
+		s.mutex.Lock()
+		size := s.finalOffset
+		closeErr := s.closeForShutdownErr
+		finalSizeChan := s.finalSizeChan
+		s.mutex.Unlock()
+
+		if size != protocol.MaxByteCount {
+			return int64(size), nil
+		}
+		if closeErr != nil {
+			return 0, closeErr
+		}
+		select {
+		case <-finalSizeChan:
+		case <-ctx.Done():
+			return 0, context.Cause(ctx)
+		}
+	}
 }
 
 // Read reads data from the stream.
@@ -418,7 +447,7 @@ func (s *ReceiveStream) handleStreamFrameImpl(frame *wire.StreamFrame, now monot
 		return err
 	}
 	if frame.Fin {
-		s.finalOffset = maxOffset
+		s.setFinalOffset(maxOffset)
 	}
 	if s.cancelledLocally {
 		return nil
@@ -449,7 +478,7 @@ func (s *ReceiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame,
 	if err := s.flowController.UpdateHighestReceived(frame.FinalSize, true, now); err != nil {
 		return err
 	}
-	s.finalOffset = frame.FinalSize
+	s.setFinalOffset(frame.FinalSize)
 
 	// senders are allowed to reduce the reliable size, but frames might have been reordered
 	if (!s.cancelledRemotely && s.reliableSize == 0) || frame.ReliableSize < s.reliableSize {
@@ -472,6 +501,11 @@ func (s *ReceiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame,
 	s.cancelErr = &StreamError{StreamID: s.streamID, ErrorCode: frame.ErrorCode, Remote: true}
 	s.signalRead()
 	return nil
+}
+
+func (s *ReceiveStream) setFinalOffset(offset protocol.ByteCount) {
+	s.finalOffset = offset
+	s.closeFinalSizeChan()
 }
 
 func (s *ReceiveStream) getControlFrame(now monotime.Time) (_ ackhandler.Frame, ok, hasMore bool) {
@@ -514,8 +548,16 @@ func (s *ReceiveStream) SetReadDeadline(t time.Time) error {
 func (s *ReceiveStream) closeForShutdown(err error) {
 	s.mutex.Lock()
 	s.closeForShutdownErr = err
+	s.closeFinalSizeChan()
 	s.mutex.Unlock()
 	s.signalRead()
+}
+
+func (s *ReceiveStream) closeFinalSizeChan() {
+	if s.finalSizeChan != nil {
+		close(s.finalSizeChan)
+		s.finalSizeChan = nil
+	}
 }
 
 // signalRead performs a non-blocking send on the readChan

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -1,6 +1,7 @@
 package quic
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -541,6 +542,83 @@ func TestReceiveStreamImmediateFINs(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 }
 
+func TestReceiveStreamWaitForFinalSizeAfterFIN(t *testing.T) {
+	fc := newTestStreamFlowController(42)
+	str := newReceiveStream(42, nil, fc)
+
+	require.NoError(t, str.handleStreamFrame(&wire.StreamFrame{Data: []byte("foobar"), Fin: true}, monotime.Now()))
+
+	size, err := str.WaitForFinalSize(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 6, size)
+
+	str.closeForShutdown(assert.AnError)
+	size, err = str.WaitForFinalSize(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 6, size)
+}
+
+func TestReceiveStreamWaitForFinalSizeAfterCancelRead(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		fc := newTestStreamFlowController(42)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newReceiveStream(42, mockSender, fc)
+
+		type result struct {
+			size int64
+			err  error
+		}
+		resultChan := make(chan result, 1)
+		go func() {
+			size, err := str.WaitForFinalSize(context.Background())
+			resultChan <- result{size: size, err: err}
+		}()
+
+		synctest.Wait()
+		select {
+		case result := <-resultChan:
+			t.Fatalf("WaitForFinalSize returned before the final size was known: %v", result.err)
+		default:
+		}
+
+		mockSender.EXPECT().onHasStreamControlFrame(str.StreamID(), str)
+		str.CancelRead(1234)
+
+		synctest.Wait()
+		select {
+		case result := <-resultChan:
+			t.Fatalf("WaitForFinalSize returned after CancelRead, before the final size was known: %v", result.err)
+		default:
+		}
+
+		mockSender.EXPECT().onStreamCompleted(protocol.StreamID(42))
+		require.NoError(t, str.handleResetStreamFrame(
+			&wire.ResetStreamFrame{StreamID: 42, ErrorCode: 4321, FinalSize: 42},
+			monotime.Now(),
+		))
+
+		synctest.Wait()
+		select {
+		case result := <-resultChan:
+			require.NoError(t, result.err)
+			require.EqualValues(t, 42, result.size)
+		default:
+			t.Fatal("WaitForFinalSize did not return")
+		}
+	})
+}
+
+func TestReceiveStreamWaitForFinalSizeContextCanceled(t *testing.T) {
+	str := newReceiveStream(42, nil, nil)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(assert.AnError)
+
+	size, err := str.WaitForFinalSize(ctx)
+	require.Zero(t, size)
+	require.ErrorIs(t, err, assert.AnError)
+}
+
 func TestReceiveStreamCloseForShutdown(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
@@ -573,6 +651,10 @@ func TestReceiveStreamCloseForShutdown(t *testing.T) {
 
 		str.closeForShutdown(assert.AnError)
 		synctest.Wait()
+
+		size, err := str.WaitForFinalSize(context.Background())
+		require.Zero(t, size)
+		require.ErrorIs(t, err, assert.AnError)
 
 		select {
 		case err := <-readErrChan:

--- a/stream.go
+++ b/stream.go
@@ -158,6 +158,14 @@ func (s *Stream) CancelRead(errorCode StreamErrorCode) {
 	s.receiveStr.CancelRead(errorCode)
 }
 
+// WaitForReceiveFinalSize waits until the receive side's final size is known.
+// See [ReceiveStream.WaitForFinalSize] for more details.
+// Most applications don't need this. It is mainly useful for protocol layers
+// that need exact stream final sizes, such as WebTransport flow control accounting.
+func (s *Stream) WaitForReceiveFinalSize(ctx context.Context) (int64, error) {
+	return s.receiveStr.WaitForFinalSize(ctx)
+}
+
 // The Context is canceled as soon as the write-side of the stream is closed.
 // See [SendStream.Context] for more details.
 func (s *Stream) Context() context.Context {

--- a/stream_test.go
+++ b/stream_test.go
@@ -34,6 +34,20 @@ func TestStreamDeadlines(t *testing.T) {
 	require.Zero(t, n)
 }
 
+func TestStreamWaitForReceiveFinalSize(t *testing.T) {
+	const streamID protocol.StreamID = 1337
+	mockCtrl := gomock.NewController(t)
+	mockSender := NewMockStreamSender(mockCtrl)
+	fc := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
+	str := newStream(context.Background(), streamID, mockSender, fc, false)
+
+	require.NoError(t, str.handleStreamFrame(&wire.StreamFrame{Data: []byte("foobar"), Fin: true}, monotime.Now()))
+
+	size, err := str.WaitForReceiveFinalSize(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 6, size)
+}
+
 func TestStreamCompletion(t *testing.T) {
 	completeReadSide := func(
 		t *testing.T,


### PR DESCRIPTION
This is a highly specialized API that's only needed for applications that do flow control accounting on the application layer, for example as WebTransport over HTTP/3.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `WaitForFinalSize` method to `ReceiveStream` and `Stream`
> - Adds `ReceiveStream.WaitForFinalSize` in [receive_stream.go](https://github.com/quic-go/quic-go/pull/5693/files#diff-64d427149d1560f49d2c53dcd126759f078d0bd308a251ed5ab965a2c5e5dc1d) that blocks until the stream's final size is known (via FIN or RESET_STREAM), then returns the size as `int64`.
> - Uses a `finalSizeChan` channel closed on final offset determination; `closeForShutdown` also closes the channel so waiters unblock with the shutdown error.
> - Exposes `Stream.WaitForReceiveFinalSize` in [stream.go](https://github.com/quic-go/quic-go/pull/5693/files#diff-4f588cddf63cad8c5e4fc9685c5b200fb4daacf14be2bece09a8296d4e266d90) as a public wrapper delegating to the receive stream.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99e7adb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `WaitForFinalSize(ctx)` to the receive-stream API to wait until the final receive byte offset is determined.
  * Exposed this via `WaitForReceiveFinalSize(ctx)` on the stream-level API.
* **Bug Fixes**
  * Ensures the wait resolves correctly after FIN/RESET_STREAM, remains consistent after shutdown, and doesn’t complete prematurely on cancel-read.
  * When the provided context is canceled (including with a cause), it returns zero size and the cancellation error.
* **Tests**
  * Added new coverage for FIN, cancel-read followed by RESET_STREAM, context cancellation (with cause), and shutdown unblocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->