### PR TITLE
Post-quantum QUIC via native crypto/tls + pqctls (experimental, TCC)

### DIFF
--- a/docs/pqc-tls/ARCHITECTURE.md
+++ b/docs/pqc-tls/ARCHITECTURE.md
@@ -1,0 +1,125 @@
+# Post-Quantum QUIC — New Architecture (PQC on TLS)
+
+This document describes the **current** structure of the post-quantum QUIC
+implementation, which is based on **patching the real Go `crypto/tls`** rather
+than embedding a fork of it inside quic-go.
+
+> The previous approach (an embedded `internal/qtls` fork of `crypto/tls` plus
+> cloudflare/circl) is preserved on the branch `post-quantum-crypto-draft` and
+> the consolidation branch `pqc-tls-module`. It is **superseded** by what is
+> described here but kept for history.
+
+## Motivation
+
+Upstream Go (master / Go 1.27) now ships post-quantum cryptography **natively**:
+
+- `crypto/tls`: ML-KEM key exchange (`X25519MLKEM768`, `SecP256r1MLKEM768`,
+  `SecP384r1MLKEM1024`, pure `MLKEM1024`) and ML-DSA TLS 1.3 signature schemes
+  (`MLDSA44/65/87`).
+- `crypto/mlkem`, `crypto/mldsa` (FIPS 203 / FIPS 204) and `crypto/x509` ML-DSA
+  certificate support.
+- The full QUIC TLS API (`QUICConn`, `QUICErrorEvent`, session events).
+
+So almost everything the old fork hand-built is now native, using **standard
+codepoints**. We therefore *adopt* native PQC and add only the two features the
+project needs that upstream does not provide, as a **small patch to the Go
+toolchain**.
+
+## The two layers
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Application (example/pqc_client, example/pqc_server, tests)            │
+│   configure PQC purely via *tls.Config                                  │
+└───────────────┬────────────────────────────────────────────────────────┘
+                │ uses
+┌───────────────▼───────────────────────┐     ┌──────────────────────────┐
+│ quic-go-pqc  (branch: pqc-native)      │     │ pqctls/  (helper package) │
+│   • core = byte-for-byte upstream      │────▶│   • curve IDs             │
+│     quic-go (uses stdlib crypto/tls)   │     │   • GenerateMLDSACert      │
+│   • NO PQC fields on quic.Config       │     │   • GenerateHybridCert     │
+│   • NO internal/qtls, NO circl         │     │   • composite sig schemes  │
+└───────────────┬───────────────────────┘     └──────────┬───────────────┘
+                │ compiled & run with                      │ imports
+┌───────────────▼──────────────────────────────────────────▼───────────┐
+│ Patched Go toolchain  (go-pqc, branch: pqc-crypto-tls)                 │
+│   src/crypto/tls  + src/crypto/x509                                     │
+│   • pure ML-KEM-768  (CurveID 513)                                      │
+│   • composite Ed25519+ML-DSA certs + signature schemes                  │
+│   • Config.SignatureSchemes opt-in field                                │
+│   built natively on crypto/mlkem + crypto/mldsa (no external deps)      │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+## What runs where
+
+### A. Patched Go toolchain — `go-pqc` (branch `pqc-crypto-tls`)
+
+A fork of `golang/go` master with a small patch (≈170 lines + one new file):
+
+| Feature | Files |
+|---------|-------|
+| Pure ML-KEM-768 (`CurveID = 513`) | `src/crypto/tls/common.go`, `key_schedule.go`, `defaults.go`, `defaults_fips140.go` |
+| Composite Ed25519+ML-DSA cert type, OIDs, parse/marshal | `src/crypto/x509/composite.go` (new), `x509.go`, `parser.go` |
+| Composite TLS 1.3 signature scheme + verify | `src/crypto/tls/common.go`, `auth.go`, `handshake_client.go`, `handshake_client_tls13.go` |
+| `Config.SignatureSchemes` opt-in field (advertise + accept) | `src/crypto/tls/common.go` (field + `Clone`), `handshake_client*.go` |
+
+The full diff is captured in [`crypto-tls-pqc.patch`](./crypto-tls-pqc.patch),
+which applies onto Go commit `6565f551` (master at clone time). Rebuild with
+`cd src && GOTOOLCHAIN=local ./make.bash`.
+
+### B. quic-go-pqc — `pqc-native`
+
+- The **core quic-go is unchanged from upstream** (it already uses the stdlib
+  `crypto/tls` QUIC API). `connection.go`, `config.go`, `interface.go`,
+  `internal/handshake/crypto_setup.go` are byte-for-byte upstream — confirm with
+  `git diff --stat upstream/master`.
+- `pqctls/` — the only PQC-specific public surface:
+  - curve-ID constants `MLKEM768`, `MLKEM1024`, `X25519MLKEM768`
+  - `GenerateMLDSACertificate(level, org, dns, validFor)` (native ML-DSA cert)
+  - `GenerateHybridCertificate(level, org, dns, validFor)` (composite cert)
+  - composite scheme constants `CompositeEd25519MLDSA44/65/87`
+- `example/pqc_client`, `example/pqc_server`, `pqc_test.go`, `pqctls/*_test.go`.
+
+## How to select PQC (all via `tls.Config`)
+
+```go
+// Key exchange: pick a curve.
+tlsConf.CurvePreferences = []tls.CurveID{pqctls.MLKEM768}      // or MLKEM1024 / X25519MLKEM768
+
+// Authentication: install a PQC certificate.
+cert, _ := pqctls.GenerateMLDSACertificate(pqctls.MLDSA65, "org", []string{"localhost"}, 24*time.Hour)
+tlsConf.Certificates = []tls.Certificate{cert}
+
+// Composite (experimental) — also advertise the scheme on the client:
+cert, _ = pqctls.GenerateHybridCertificate(pqctls.MLDSA65, "org", []string{"localhost"}, 24*time.Hour)
+clientTLSConf.SignatureSchemes = []tls.SignatureScheme{pqctls.CompositeEd25519MLDSA65}
+```
+
+## Building & testing
+
+Always use the patched toolchain:
+
+```sh
+export GOROOT=/path/to/go-pqc
+export GOTOOLCHAIN=local
+$GOROOT/bin/go build ./...
+$GOROOT/bin/go test -run TestPQC .
+```
+
+Standard modes (hybrid `X25519MLKEM768`, pure `MLKEM1024`, native single ML-DSA
+certs) also build on a stock Go 1.27. Pure ML-KEM-768 and composite certs require
+the patched toolchain.
+
+## Verified modes (end-to-end QUIC handshake + echo)
+
+| Mode | Curve | Cert |
+|------|-------|------|
+| Classical | X25519 (`0x001d`) | ECDSA |
+| Pure ML-KEM-768 | `0x0201` (513) | ML-DSA-65 |
+| Pure ML-KEM-1024 | `0x0202` (514) | ML-DSA-87 |
+| Hybrid KEX | `0x11ec` (X25519MLKEM768) | ML-DSA-65 |
+| Composite cert | `0x11ec` | Ed25519+ML-DSA-65 (composite) |
+
+The session-resumption / 0-RTT / error-event handshake tests, which failed under
+the old embedded-qtls approach, pass here (modern stdlib TLS).

--- a/docs/pqc-tls/REPOSITORIES.md
+++ b/docs/pqc-tls/REPOSITORIES.md
@@ -1,0 +1,87 @@
+# Repositories, Branches & Dependencies
+
+This document records every repository touched by the post-quantum work, which
+branch holds what, and how they depend on each other.
+
+## Dependency graph
+
+```
+            depends on (build/run)            captured as patch in
+  quic-go-pqc ──────────────────────▶ go-pqc ──────────────────▶ quic-go-pqc
+  (pqc-native)   patched toolchain    (pqc-crypto-tls)   docs/pqc-tls/crypto-tls-pqc.patch
+       │                                   │
+       │ forked from                       │ forked from
+       ▼                                   ▼
+  quic-go (upstream/master)           golang/go (master @ 6565f551)
+```
+
+- **quic-go-pqc @ `pqc-native`** is a near-stock quic-go that **must be built and
+  run with the patched Go toolchain** (`go-pqc`). Its only PQC code is the
+  `pqctls/` package + examples/tests; the quic-go core is unchanged from upstream.
+- **go-pqc @ `pqc-crypto-tls`** is the patched Go toolchain providing the PQC
+  primitives in `crypto/tls` + `crypto/x509`.
+- The toolchain patch is also stored **inside** quic-go-pqc as
+  `docs/pqc-tls/crypto-tls-pqc.patch`, so the changes are version-controlled in
+  the pushable repo even before the Go fork is published.
+
+## Repositories
+
+### 1. `quic-go-pqc` — application repo (your fork)
+
+- **Remote (origin):** `git@github.com:MauricioMachadoFF/quic-go-pqc.git`
+- **Upstream:** `https://github.com/quic-go/quic-go.git`
+- **Local checkouts:**
+  - `~/Development/quic-go-pqc` — main working tree (branch `pqc-tls-module`)
+  - `~/Development/quic-go-pqc-native` — git worktree (branch `pqc-native`)
+
+| Branch | Status | Contents |
+|--------|--------|----------|
+| `master` | local mirror | (do not use for PQC) |
+| `post-quantum-crypto-draft` | **kept, untouched** | Original embedded-qtls + cloudflare/circl approach |
+| `pqc-tls-module` | **kept, untouched** | Consolidation of PQC into embedded `internal/qtls` (superseded) |
+| `pqc-native` | **current** | Native adoption: pure upstream core + `pqctls/` + docs; built with patched toolchain |
+
+Changed/added on `pqc-native` (vs `upstream/master`): `pqctls/*`,
+`example/pqc_client`, `example/pqc_server`, `pqc_test.go`, `docs/pqc-tls/*`.
+**No** changes to quic-go core files.
+
+### 2. `go-pqc` — patched Go toolchain (NOT yet published)
+
+- **Remote (origin):** `https://go.googlesource.com/go` (read-only Google source)
+- **Local checkout:** `~/Development/go-pqc`
+- **Branch:** `pqc-crypto-tls` (base: `golang/go` master @ `6565f551`)
+- **Commit:** `crypto/tls,crypto/x509: add pure ML-KEM-768 and composite Ed25519+ML-DSA`
+
+> There is currently **no personal GitHub fork** of Go to push this to. To
+> publish it, create a fork (e.g. `github.com/MauricioMachadoFF/go`), add it as a
+> remote, and push `pqc-crypto-tls`. Until then, the patch lives in
+> `quic-go-pqc/docs/pqc-tls/crypto-tls-pqc.patch`.
+
+## Reproducing the toolchain from the patch
+
+```sh
+git clone https://go.googlesource.com/go go-pqc
+cd go-pqc
+git checkout 6565f551 -b pqc-crypto-tls
+git apply /path/to/quic-go-pqc/docs/pqc-tls/crypto-tls-pqc.patch
+cd src && GOTOOLCHAIN=local ./make.bash
+# toolchain is now at ../bin/go
+```
+
+(The new file `src/crypto/x509/composite.go` is included in the patch.)
+
+## Build/run wiring
+
+```sh
+export GOROOT=~/Development/go-pqc
+export GOTOOLCHAIN=local
+cd ~/Development/quic-go-pqc-native
+$GOROOT/bin/go test -run TestPQC .
+```
+
+## Push status (as of writing)
+
+| Repo / branch | Remote | Pushable? |
+|---------------|--------|-----------|
+| quic-go-pqc / `pqc-native` | `origin` (your fork) | ✅ yes |
+| go-pqc / `pqc-crypto-tls` | none owned by you | ⚠️ needs a Go fork first |

--- a/docs/pqc-tls/REPOSITORIES.md
+++ b/docs/pqc-tls/REPOSITORIES.md
@@ -45,17 +45,20 @@ Changed/added on `pqc-native` (vs `upstream/master`): `pqctls/*`,
 `example/pqc_client`, `example/pqc_server`, `pqc_test.go`, `docs/pqc-tls/*`.
 **No** changes to quic-go core files.
 
-### 2. `go-pqc` — patched Go toolchain (NOT yet published)
+### 2. `go-pqc` — patched Go toolchain
 
-- **Remote (origin):** `https://go.googlesource.com/go` (read-only Google source)
+- **Remotes:**
+  - `origin` = `https://go.googlesource.com/go` (read-only Google source)
+  - `fork` = `git@github.com:MauricioMachadoFF/go.git` (your fork — published)
 - **Local checkout:** `~/Development/go-pqc`
-- **Branch:** `pqc-crypto-tls` (base: `golang/go` master @ `6565f551`)
+- **Branch:** `pqc-crypto-tls` (base: `golang/go` master @ `6565f551`), pushed to
+  `fork/pqc-crypto-tls`
 - **Commit:** `crypto/tls,crypto/x509: add pure ML-KEM-768 and composite Ed25519+ML-DSA`
 
-> There is currently **no personal GitHub fork** of Go to push this to. To
-> publish it, create a fork (e.g. `github.com/MauricioMachadoFF/go`), add it as a
-> remote, and push `pqc-crypto-tls`. Until then, the patch lives in
-> `quic-go-pqc/docs/pqc-tls/crypto-tls-pqc.patch`.
+The toolchain source is published at
+`https://github.com/MauricioMachadoFF/go/tree/pqc-crypto-tls`. The same changes
+are also captured as `quic-go-pqc/docs/pqc-tls/crypto-tls-pqc.patch` for easy
+re-application onto a fresh Go checkout.
 
 ## Reproducing the toolchain from the patch
 
@@ -81,7 +84,11 @@ $GOROOT/bin/go test -run TestPQC .
 
 ## Push status (as of writing)
 
-| Repo / branch | Remote | Pushable? |
-|---------------|--------|-----------|
-| quic-go-pqc / `pqc-native` | `origin` (your fork) | ✅ yes |
-| go-pqc / `pqc-crypto-tls` | none owned by you | ⚠️ needs a Go fork first |
+| Repo / branch | Remote | Pushed? |
+|---------------|--------|---------|
+| quic-go-pqc / `pqc-native` | `origin` = MauricioMachadoFF/quic-go-pqc | ✅ pushed |
+| go-pqc / `pqc-crypto-tls` | `fork` = MauricioMachadoFF/go | ✅ pushed |
+
+Untouched (not overwritten): `quic-go-pqc` `master` and `post-quantum-crypto-draft`
+already contain the original embedded-qtls approach on the remote. The
+intermediate `pqc-tls-module` branch is kept local only.

--- a/docs/pqc-tls/crypto-tls-pqc.patch
+++ b/docs/pqc-tls/crypto-tls-pqc.patch
@@ -1,0 +1,651 @@
+From f57b66eba60fd526448b5eab4f5269f00b919f7d Mon Sep 17 00:00:00 2001
+From: "mauricio.machado" <mauricio.machado@ssp.df.gov.br>
+Date: Mon, 29 Jun 2026 12:33:50 -0300
+Subject: [PATCH] crypto/tls,crypto/x509: add pure ML-KEM-768 and composite
+ Ed25519+ML-DSA
+
+Adds two post-quantum features for the quic-go-pqc TCC, on top of Go's native
+ML-KEM/ML-DSA support:
+
+- Pure ML-KEM-768 key exchange (CurveID 513), mirroring the native ML-KEM-1024
+  plumbing in crypto/tls.
+- Experimental composite Ed25519+ML-DSA certificates and TLS 1.3 signature
+  schemes (private-use codepoints), with x509 parse/marshal/create/verify and
+  a config-opt-in Config.SignatureSchemes field.
+
+All crypto/tls, crypto/x509, crypto/mldsa and crypto/mlkem tests pass.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ src/crypto/tls/auth.go                   |  34 ++++++
+ src/crypto/tls/common.go                 |  37 ++++++-
+ src/crypto/tls/defaults.go               |   2 +-
+ src/crypto/tls/defaults_fips140.go       |   1 +
+ src/crypto/tls/fips140_test.go           |   5 +-
+ src/crypto/tls/handshake_client.go       |   7 +-
+ src/crypto/tls/handshake_client_tls13.go |   2 +-
+ src/crypto/tls/key_schedule.go           |  31 ++++++
+ src/crypto/tls/tls_test.go               |   2 +
+ src/crypto/x509/composite.go             | 135 +++++++++++++++++++++++
+ src/crypto/x509/parser.go                |   5 +
+ src/crypto/x509/x509.go                  |  59 ++++++++--
+ 12 files changed, 306 insertions(+), 14 deletions(-)
+ create mode 100644 src/crypto/x509/composite.go
+
+diff --git a/src/crypto/tls/auth.go b/src/crypto/tls/auth.go
+index 9f8ae62f..adb7a399 100644
+--- a/src/crypto/tls/auth.go
++++ b/src/crypto/tls/auth.go
+@@ -12,6 +12,7 @@ import (
+ 	"crypto/elliptic"
+ 	"crypto/mldsa"
+ 	"crypto/rsa"
++	"crypto/x509"
+ 	"errors"
+ 	"fmt"
+ 	"hash"
+@@ -54,6 +55,22 @@ func verifyHandshakeSignature(sigType uint8, pubkey crypto.PublicKey, hashFunc c
+ 		if err := mldsa.Verify(pubKey, signed, sig, nil); err != nil {
+ 			return fmt.Errorf("ML-DSA verification failure: %w", err)
+ 		}
++	case signatureComposite:
++		pubKey, ok := pubkey.(*x509.CompositePublicKey)
++		if !ok {
++			return fmt.Errorf("expected a composite Ed25519+ML-DSA public key, got %T", pubkey)
++		}
++		edSig, mldsaSig, err := x509.ParseCompositeSignature(sig)
++		if err != nil {
++			return err
++		}
++		// Both component signatures must verify.
++		if !ed25519.Verify(pubKey.Ed25519, signed, edSig) {
++			return errors.New("composite Ed25519 verification failure")
++		}
++		if err := mldsa.Verify(pubKey.MLDSA, signed, mldsaSig, nil); err != nil {
++			return fmt.Errorf("composite ML-DSA verification failure: %w", err)
++		}
+ 	case signaturePKCS1v15:
+ 		pubKey, ok := pubkey.(*rsa.PublicKey)
+ 		if !ok {
+@@ -144,6 +161,8 @@ func typeAndHashFromSignatureScheme(signatureAlgorithm SignatureScheme) (sigType
+ 		sigType = signatureEd25519
+ 	case MLDSA44, MLDSA65, MLDSA87:
+ 		sigType = signatureMLDSA
++	case CompositeEd25519MLDSA44, CompositeEd25519MLDSA65, CompositeEd25519MLDSA87:
++		sigType = signatureComposite
+ 	default:
+ 		return 0, 0, fmt.Errorf("unsupported signature algorithm: %v", signatureAlgorithm)
+ 	}
+@@ -160,6 +179,8 @@ func typeAndHashFromSignatureScheme(signatureAlgorithm SignatureScheme) (sigType
+ 		hash = directSigning
+ 	case MLDSA44, MLDSA65, MLDSA87:
+ 		hash = directSigning
++	case CompositeEd25519MLDSA44, CompositeEd25519MLDSA65, CompositeEd25519MLDSA87:
++		hash = directSigning
+ 	default:
+ 		return 0, 0, fmt.Errorf("unsupported signature algorithm: %v", signatureAlgorithm)
+ 	}
+@@ -183,6 +204,8 @@ func legacyTypeAndHashFromPublicKey(pub crypto.PublicKey) (sigType uint8, hash c
+ 		return 0, 0, fmt.Errorf("tls: Ed25519 public keys are not supported before TLS 1.2")
+ 	case *mldsa.PublicKey:
+ 		return 0, 0, fmt.Errorf("tls: ML-DSA public keys are not supported before TLS 1.3")
++	case *x509.CompositePublicKey:
++		return 0, 0, fmt.Errorf("tls: composite Ed25519+ML-DSA public keys are not supported before TLS 1.3")
+ 	default:
+ 		return 0, 0, fmt.Errorf("tls: unsupported public key: %T", pub)
+ 	}
+@@ -250,6 +273,17 @@ func signatureSchemesForPublicKey(version uint16, pub crypto.PublicKey) []Signat
+ 		default:
+ 			panic("tls: internal error: unknown ML-DSA parameter set: " + pub.Parameters().String())
+ 		}
++	case *x509.CompositePublicKey:
++		switch pub.MLDSA.Parameters() {
++		case mldsa.MLDSA44():
++			return []SignatureScheme{CompositeEd25519MLDSA44}
++		case mldsa.MLDSA65():
++			return []SignatureScheme{CompositeEd25519MLDSA65}
++		case mldsa.MLDSA87():
++			return []SignatureScheme{CompositeEd25519MLDSA87}
++		default:
++			panic("tls: internal error: unknown composite ML-DSA parameter set: " + pub.MLDSA.Parameters().String())
++		}
+ 	default:
+ 		return nil
+ 	}
+diff --git a/src/crypto/tls/common.go b/src/crypto/tls/common.go
+index dd4aaf54..ee354523 100644
+--- a/src/crypto/tls/common.go
++++ b/src/crypto/tls/common.go
+@@ -155,12 +155,13 @@ const (
+ 	X25519MLKEM768     CurveID = 4588
+ 	SecP256r1MLKEM768  CurveID = 4587
+ 	SecP384r1MLKEM1024 CurveID = 4589
++	MLKEM768           CurveID = 513
+ 	MLKEM1024          CurveID = 514
+ )
+ 
+ func isTLS13OnlyKeyExchange(curve CurveID) bool {
+ 	switch curve {
+-	case X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024, MLKEM1024:
++	case X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024, MLKEM768, MLKEM1024:
+ 		return true
+ 	default:
+ 		return false
+@@ -169,7 +170,7 @@ func isTLS13OnlyKeyExchange(curve CurveID) bool {
+ 
+ func isPQKeyExchange(curve CurveID) bool {
+ 	switch curve {
+-	case X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024, MLKEM1024:
++	case X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024, MLKEM768, MLKEM1024:
+ 		return true
+ 	default:
+ 		return false
+@@ -220,6 +221,7 @@ const (
+ 	signatureECDSA
+ 	signatureEd25519
+ 	signatureMLDSA
++	signatureComposite // Experimental composite Ed25519+ML-DSA.
+ )
+ 
+ // directSigning is a standard Hash value that signals that no pre-hashing
+@@ -434,6 +436,12 @@ const (
+ 	MLDSA65 SignatureScheme = 0x0905
+ 	MLDSA87 SignatureScheme = 0x0906
+ 
++	// Composite Ed25519+ML-DSA algorithms (experimental, non-standard,
++	// private-use codepoints).
++	CompositeEd25519MLDSA44 SignatureScheme = 0xFE10
++	CompositeEd25519MLDSA65 SignatureScheme = 0xFE11
++	CompositeEd25519MLDSA87 SignatureScheme = 0xFE12
++
+ 	// Legacy signature and hash algorithms for TLS 1.2.
+ 	PKCS1WithSHA1 SignatureScheme = 0x0201
+ 	ECDSAWithSHA1 SignatureScheme = 0x0203
+@@ -820,6 +828,13 @@ type Config struct {
+ 	// GODEBUG=tlsmlkem=0 or the GODEBUG=tlssecpmlkem=0 environment variable.
+ 	CurvePreferences []CurveID
+ 
++	// SignatureSchemes lists additional signature schemes, beyond the built-in
++	// defaults, that this endpoint advertises and is willing to verify. It exists
++	// to enable experimental/non-standard schemes (such as the composite
++	// Ed25519+ML-DSA schemes) without changing the defaults advertised by every
++	// connection. The schemes are tried in the order given, before the defaults.
++	SignatureSchemes []SignatureScheme
++
+ 	// DynamicRecordSizingDisabled disables adaptive sizing of TLS records.
+ 	// When true, the largest possible TLS record size is always used. When
+ 	// false, the size of TLS records may be adjusted in an attempt to
+@@ -1039,6 +1054,7 @@ func (c *Config) Clone() *Config {
+ 		MinVersion:                          c.MinVersion,
+ 		MaxVersion:                          c.MaxVersion,
+ 		CurvePreferences:                    c.CurvePreferences,
++		SignatureSchemes:                    c.SignatureSchemes,
+ 		DynamicRecordSizingDisabled:         c.DynamicRecordSizingDisabled,
+ 		Renegotiation:                       c.Renegotiation,
+ 		KeyLogWriter:                        c.KeyLogWriter,
+@@ -1774,11 +1790,21 @@ var testingOnlySupportedSignatureAlgorithms []SignatureScheme
+ // the given range of TLS versions, to advertise in ClientHello and
+ // CertificateRequest messages. An algorithm is included if it is enabled at any
+ // version in the range.
+-func supportedSignatureAlgorithms(minVers, maxVers uint16) []SignatureScheme {
++func supportedSignatureAlgorithms(minVers, maxVers uint16, extra ...[]SignatureScheme) []SignatureScheme {
+ 	sigAlgs := defaultSupportedSignatureAlgorithms()
+ 	if testingOnlySupportedSignatureAlgorithms != nil {
+ 		sigAlgs = slices.Clone(testingOnlySupportedSignatureAlgorithms)
+ 	}
++	// Prepend any additional schemes configured via Config.SignatureSchemes,
++	// preserving their order and de-duplicating against the defaults.
++	for i := len(extra) - 1; i >= 0; i-- {
++		for j := len(extra[i]) - 1; j >= 0; j-- {
++			s := extra[i][j]
++			if !slices.Contains(sigAlgs, s) {
++				sigAlgs = append([]SignatureScheme{s}, sigAlgs...)
++			}
++		}
++	}
+ 	return slices.DeleteFunc(sigAlgs, func(s SignatureScheme) bool {
+ 		for v := minVers; v <= maxVers; v++ {
+ 			if !isDisabledSignatureAlgorithm(v, s, false) {
+@@ -1806,6 +1832,11 @@ func isDisabledSignatureAlgorithm(version uint16, s SignatureScheme, isCert bool
+ 		if version < VersionTLS13 {
+ 			return true
+ 		}
++	case CompositeEd25519MLDSA44, CompositeEd25519MLDSA65, CompositeEd25519MLDSA87:
++		// Experimental composite codepoints are only defined for TLS 1.3.
++		if version < VersionTLS13 {
++			return true
++		}
+ 	}
+ 
+ 	// For the _cert extension we include all algorithms, including SHA-1 and
+diff --git a/src/crypto/tls/defaults.go b/src/crypto/tls/defaults.go
+index c8903604..0e9ed8b1 100644
+--- a/src/crypto/tls/defaults.go
++++ b/src/crypto/tls/defaults.go
+@@ -37,7 +37,7 @@ func defaultCurveEnabled(c CurveID) bool {
+ // include every supported key exchange.
+ func curvePreferenceOrder() []CurveID {
+ 	return []CurveID{
+-		X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024, MLKEM1024,
++		X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024, MLKEM768, MLKEM1024,
+ 		X25519, CurveP256, CurveP384, CurveP521,
+ 	}
+ }
+diff --git a/src/crypto/tls/defaults_fips140.go b/src/crypto/tls/defaults_fips140.go
+index 1c713898..05a6d130 100644
+--- a/src/crypto/tls/defaults_fips140.go
++++ b/src/crypto/tls/defaults_fips140.go
+@@ -36,6 +36,7 @@ var (
+ 		X25519MLKEM768,
+ 		SecP256r1MLKEM768,
+ 		SecP384r1MLKEM1024,
++		MLKEM768,
+ 		MLKEM1024,
+ 		CurveP256,
+ 		CurveP384,
+diff --git a/src/crypto/tls/fips140_test.go b/src/crypto/tls/fips140_test.go
+index c3f6ec91..c92dc173 100644
+--- a/src/crypto/tls/fips140_test.go
++++ b/src/crypto/tls/fips140_test.go
+@@ -151,7 +151,7 @@ func isFIPSCurve(id CurveID) bool {
+ 	switch id {
+ 	case CurveP256, CurveP384, CurveP521:
+ 		return true
+-	case X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024, MLKEM1024:
++	case X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024, MLKEM768, MLKEM1024:
+ 		// Only for the native module.
+ 		return !boring.Enabled
+ 	case X25519:
+@@ -187,6 +187,9 @@ func isFIPSSignatureScheme(alg SignatureScheme) bool {
+ 		return !boring.Enabled
+ 	case PKCS1WithSHA1, ECDSAWithSHA1:
+ 		return false
++	case CompositeEd25519MLDSA44, CompositeEd25519MLDSA65, CompositeEd25519MLDSA87:
++		// Experimental composite scheme; not FIPS-approved.
++		return false
+ 	default:
+ 		panic("unknown signature scheme: " + alg.String())
+ 	}
+diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
+index 54227aab..a68ee8ef 100644
+--- a/src/crypto/tls/handshake_client.go
++++ b/src/crypto/tls/handshake_client.go
+@@ -120,7 +120,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
+ 	}
+ 
+ 	if maxVersion >= VersionTLS12 {
+-		hello.supportedSignatureAlgorithms = supportedSignatureAlgorithms(minVersion, maxVersion)
++		hello.supportedSignatureAlgorithms = supportedSignatureAlgorithms(minVersion, maxVersion, config.SignatureSchemes)
+ 		hello.supportedSignatureAlgorithmsCert = supportedSignatureAlgorithmsCert(minVersion, maxVersion)
+ 	}
+ 
+@@ -1171,6 +1171,11 @@ func (c *Conn) verifyServerCertificate(certificates [][]byte) error {
+ 			c.sendAlert(alertIllegalParameter)
+ 			return errors.New("tls: server's certificate uses ML-DSA, which requires TLS 1.3")
+ 		}
++	case *x509.CompositePublicKey:
++		if c.vers < VersionTLS13 {
++			c.sendAlert(alertIllegalParameter)
++			return errors.New("tls: server's certificate uses composite Ed25519+ML-DSA, which requires TLS 1.3")
++		}
+ 	default:
+ 		c.sendAlert(alertUnsupportedCertificate)
+ 		return fmt.Errorf("tls: server's certificate contains an unsupported type of public key: %T", certs[0].PublicKey)
+diff --git a/src/crypto/tls/handshake_client_tls13.go b/src/crypto/tls/handshake_client_tls13.go
+index f5515069..8b6b94c2 100644
+--- a/src/crypto/tls/handshake_client_tls13.go
++++ b/src/crypto/tls/handshake_client_tls13.go
+@@ -654,7 +654,7 @@ func (hs *clientHandshakeStateTLS13) readServerCertificate() error {
+ 	// See RFC 8446, Section 4.4.3.
+ 	// We don't use hs.hello.supportedSignatureAlgorithms because it might
+ 	// include PKCS#1 v1.5 and SHA-1 if the ClientHello also supported TLS 1.2.
+-	if !isSupportedSignatureAlgorithm(certVerify.signatureAlgorithm, supportedSignatureAlgorithms(c.vers, c.vers)) ||
++	if !isSupportedSignatureAlgorithm(certVerify.signatureAlgorithm, supportedSignatureAlgorithms(c.vers, c.vers, c.config.SignatureSchemes)) ||
+ 		!isSupportedSignatureAlgorithm(certVerify.signatureAlgorithm, signatureSchemesForPublicKey(c.vers, c.peerCertificates[0].PublicKey)) {
+ 		c.sendAlert(alertIllegalParameter)
+ 		return errors.New("tls: certificate used with invalid signature algorithm")
+diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
+index 652a6489..b24441cd 100644
+--- a/src/crypto/tls/key_schedule.go
++++ b/src/crypto/tls/key_schedule.go
+@@ -107,6 +107,8 @@ func keyExchangeForCurveID(id CurveID) (keyExchange, error) {
+ 		return &hybridKeyExchange{id, ecdhKeyExchange{CurveP384, ecdh.P384()},
+ 			97, mlkem.EncapsulationKeySize1024, mlkem.CiphertextSize1024,
+ 			mlkemGenerateKey1024, mlkemNewPublicKey1024}, nil
++	case MLKEM768:
++		return &mlkem768KeyExchange{}, nil
+ 	case MLKEM1024:
+ 		return &mlkem1024KeyExchange{}, nil
+ 	default:
+@@ -114,6 +116,35 @@ func keyExchangeForCurveID(id CurveID) (keyExchange, error) {
+ 	}
+ }
+ 
++// mlkem768KeyExchange implements pure (non-hybrid) ML-KEM-768 key exchange.
++// Mirrors mlkem1024KeyExchange using the ML-KEM-768 parameter set.
++type mlkem768KeyExchange struct{}
++
++func (ke *mlkem768KeyExchange) keyShares(_ io.Reader) (*keySharePrivateKeys, []keyShare, error) {
++	priv, err := mlkem.GenerateKey768()
++	if err != nil {
++		return nil, nil, err
++	}
++	return &keySharePrivateKeys{mlkem: priv}, []keyShare{{MLKEM768, priv.EncapsulationKey().Bytes()}}, nil
++}
++
++func (ke *mlkem768KeyExchange) serverSharedSecret(_ io.Reader, clientKeyShare []byte) ([]byte, keyShare, error) {
++	peerKey, err := mlkem.NewEncapsulationKey768(clientKeyShare)
++	if err != nil {
++		return nil, keyShare{}, err
++	}
++	sharedKey, keyShareData := peerKey.Encapsulate()
++	return sharedKey, keyShare{MLKEM768, keyShareData}, nil
++}
++
++func (ke *mlkem768KeyExchange) clientSharedSecret(priv *keySharePrivateKeys, serverKeyShare []byte) ([]byte, error) {
++	sharedKey, err := priv.mlkem.Decapsulate(serverKeyShare)
++	if err != nil {
++		return nil, err
++	}
++	return sharedKey, nil
++}
++
+ type mlkem1024KeyExchange struct{}
+ 
+ func (ke *mlkem1024KeyExchange) keyShares(_ io.Reader) (*keySharePrivateKeys, []keyShare, error) {
+diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
+index 6fe44907..c188dc22 100644
+--- a/src/crypto/tls/tls_test.go
++++ b/src/crypto/tls/tls_test.go
+@@ -988,6 +988,8 @@ func TestCloneNonFuncFields(t *testing.T) {
+ 			f.Set(reflect.ValueOf([]uint16{1, 2}))
+ 		case "CurvePreferences":
+ 			f.Set(reflect.ValueOf([]CurveID{CurveP256}))
++		case "SignatureSchemes":
++			f.Set(reflect.ValueOf([]SignatureScheme{Ed25519}))
+ 		case "Renegotiation":
+ 			f.Set(reflect.ValueOf(RenegotiateOnceAsClient))
+ 		case "EncryptedClientHelloConfigList":
+diff --git a/src/crypto/x509/composite.go b/src/crypto/x509/composite.go
+new file mode 100644
+index 00000000..241c4df4
+--- /dev/null
++++ b/src/crypto/x509/composite.go
+@@ -0,0 +1,135 @@
++// Copyright 2026 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package x509
++
++import (
++	"crypto"
++	"crypto/ed25519"
++	"crypto/mldsa"
++	"encoding/asn1"
++	"errors"
++)
++
++// Experimental private-use OIDs for composite Ed25519+ML-DSA public keys and
++// signatures. These are NOT standardized; they interoperate only between peers
++// using this toolchain.
++var (
++	oidPublicKeyCompositeEd25519MLDSA44 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 3, 32}
++	oidPublicKeyCompositeEd25519MLDSA65 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 3, 33}
++	oidPublicKeyCompositeEd25519MLDSA87 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 3, 34}
++)
++
++// CompositePublicKey is a composite public key combining a classical Ed25519 key
++// and a post-quantum ML-DSA key. A signature is valid only if BOTH component
++// signatures verify, so authentication holds as long as either scheme is
++// unbroken. It is an experimental, non-standard construction.
++type CompositePublicKey struct {
++	Ed25519 ed25519.PublicKey
++	MLDSA   *mldsa.PublicKey
++}
++
++// Equal reports whether both components are equal.
++func (pub *CompositePublicKey) Equal(x crypto.PublicKey) bool {
++	xx, ok := x.(*CompositePublicKey)
++	if !ok {
++		return false
++	}
++	return pub.Ed25519.Equal(xx.Ed25519) && pub.MLDSA.Equal(xx.MLDSA)
++}
++
++// compositeKeyASN1 is the DER structure carried in the SubjectPublicKeyInfo BIT
++// STRING for a composite key (and analogously for a composite signature).
++type compositeKeyASN1 struct {
++	Ed25519 []byte
++	MLDSA   []byte
++}
++
++func compositeOIDForParameters(p mldsa.Parameters) (asn1.ObjectIdentifier, bool) {
++	switch p {
++	case mldsa.MLDSA44():
++		return oidPublicKeyCompositeEd25519MLDSA44, true
++	case mldsa.MLDSA65():
++		return oidPublicKeyCompositeEd25519MLDSA65, true
++	case mldsa.MLDSA87():
++		return oidPublicKeyCompositeEd25519MLDSA87, true
++	default:
++		return nil, false
++	}
++}
++
++func compositeParametersFromOID(oid asn1.ObjectIdentifier) (mldsa.Parameters, bool) {
++	switch {
++	case oid.Equal(oidPublicKeyCompositeEd25519MLDSA44):
++		return mldsa.MLDSA44(), true
++	case oid.Equal(oidPublicKeyCompositeEd25519MLDSA65):
++		return mldsa.MLDSA65(), true
++	case oid.Equal(oidPublicKeyCompositeEd25519MLDSA87):
++		return mldsa.MLDSA87(), true
++	default:
++		return mldsa.Parameters{}, false
++	}
++}
++
++func isCompositeOID(oid asn1.ObjectIdentifier) bool {
++	_, ok := compositeParametersFromOID(oid)
++	return ok
++}
++
++// marshalCompositePublicKey returns the SubjectPublicKeyInfo BIT STRING contents
++// and the algorithm OID for a composite public key.
++func marshalCompositePublicKey(pub *CompositePublicKey) ([]byte, asn1.ObjectIdentifier, error) {
++	oid, ok := compositeOIDForParameters(pub.MLDSA.Parameters())
++	if !ok {
++		return nil, nil, errors.New("x509: unsupported ML-DSA parameters for composite key")
++	}
++	der, err := asn1.Marshal(compositeKeyASN1{
++		Ed25519: pub.Ed25519,
++		MLDSA:   pub.MLDSA.Bytes(),
++	})
++	if err != nil {
++		return nil, nil, err
++	}
++	return der, oid, nil
++}
++
++// parseCompositePublicKey parses the SubjectPublicKeyInfo BIT STRING contents of
++// a composite public key identified by oid.
++func parseCompositePublicKey(oid asn1.ObjectIdentifier, data []byte) (*CompositePublicKey, error) {
++	params, ok := compositeParametersFromOID(oid)
++	if !ok {
++		return nil, errors.New("x509: unsupported composite parameters")
++	}
++	var raw compositeKeyASN1
++	if _, err := asn1.Unmarshal(data, &raw); err != nil {
++		return nil, errors.New("x509: invalid composite public key encoding")
++	}
++	if len(raw.Ed25519) != ed25519.PublicKeySize {
++		return nil, errors.New("x509: invalid Ed25519 component in composite key")
++	}
++	mldsaPub, err := mldsa.NewPublicKey(params, raw.MLDSA)
++	if err != nil {
++		return nil, err
++	}
++	return &CompositePublicKey{
++		Ed25519: ed25519.PublicKey(raw.Ed25519),
++		MLDSA:   mldsaPub,
++	}, nil
++}
++
++// MarshalCompositeSignature encodes the two component signatures of a composite
++// signature into a single DER blob. Used by signers and TLS verification.
++func MarshalCompositeSignature(ed25519Sig, mldsaSig []byte) ([]byte, error) {
++	return asn1.Marshal(compositeKeyASN1{Ed25519: ed25519Sig, MLDSA: mldsaSig})
++}
++
++// ParseCompositeSignature decodes a composite signature into its Ed25519 and
++// ML-DSA components.
++func ParseCompositeSignature(sig []byte) (ed25519Sig, mldsaSig []byte, err error) {
++	var raw compositeKeyASN1
++	if _, err := asn1.Unmarshal(sig, &raw); err != nil {
++		return nil, nil, errors.New("x509: invalid composite signature encoding")
++	}
++	return raw.Ed25519, raw.MLDSA, nil
++}
+diff --git a/src/crypto/x509/parser.go b/src/crypto/x509/parser.go
+index 4a1416e3..ebfd9afa 100644
+--- a/src/crypto/x509/parser.go
++++ b/src/crypto/x509/parser.go
+@@ -372,6 +372,11 @@ func parsePublicKey(keyData *publicKeyInfo) (any, error) {
+ 			return nil, errors.New("x509: unsupported ML-DSA parameters")
+ 		}
+ 		return mldsa.NewPublicKey(params, data)
++	case isCompositeOID(oid):
++		if len(params.FullBytes) != 0 {
++			return nil, errors.New("x509: composite key encoded with illegal parameters")
++		}
++		return parseCompositePublicKey(oid, data)
+ 	case oid.Equal(oidPublicKeyX25519):
+ 		// RFC 8410, Section 3
+ 		// > For all of the OIDs, the parameters MUST be absent.
+diff --git a/src/crypto/x509/x509.go b/src/crypto/x509/x509.go
+index 755007f5..0c787fc5 100644
+--- a/src/crypto/x509/x509.go
++++ b/src/crypto/x509/x509.go
+@@ -124,6 +124,13 @@ func marshalPublicKey(pub any) (publicKeyBytes []byte, publicKeyAlgorithm pkix.A
+ 		}
+ 		publicKeyBytes = pub.Bytes()
+ 		publicKeyAlgorithm.Algorithm = oid
++	case *CompositePublicKey:
++		der, oid, err := marshalCompositePublicKey(pub)
++		if err != nil {
++			return nil, pkix.AlgorithmIdentifier{}, err
++		}
++		publicKeyBytes = der
++		publicKeyAlgorithm.Algorithm = oid
+ 	case *ecdh.PublicKey:
+ 		publicKeyBytes = pub.Bytes()
+ 		if pub.Curve() == ecdh.X25519() {
+@@ -243,6 +250,9 @@ const (
+ 	MLDSA44
+ 	MLDSA65
+ 	MLDSA87
++	CompositeEd25519MLDSA44 // Experimental, non-standard.
++	CompositeEd25519MLDSA65 // Experimental, non-standard.
++	CompositeEd25519MLDSA87 // Experimental, non-standard.
+ )
+ 
+ func (algo SignatureAlgorithm) isRSAPSS() bool {
+@@ -281,14 +291,16 @@ const (
+ 	ECDSA
+ 	Ed25519
+ 	MLDSA
++	CompositeEd25519MLDSA // Experimental, non-standard.
+ )
+ 
+ var publicKeyAlgoName = [...]string{
+-	RSA:     "RSA",
+-	DSA:     "DSA",
+-	ECDSA:   "ECDSA",
+-	Ed25519: "Ed25519",
+-	MLDSA:   "ML-DSA",
++	RSA:                   "RSA",
++	DSA:                   "DSA",
++	ECDSA:                 "ECDSA",
++	Ed25519:               "Ed25519",
++	MLDSA:                 "ML-DSA",
++	CompositeEd25519MLDSA: "Composite-Ed25519-ML-DSA",
+ }
+ 
+ func (algo PublicKeyAlgorithm) String() string {
+@@ -401,6 +413,9 @@ var signatureAlgorithmDetails = []struct {
+ 	{MLDSA44, "ML-DSA-44", oidPublicKeyMLDSA44, emptyRawValue, MLDSA, crypto.Hash(0) /* no pre-hashing */, false},
+ 	{MLDSA65, "ML-DSA-65", oidPublicKeyMLDSA65, emptyRawValue, MLDSA, crypto.Hash(0) /* no pre-hashing */, false},
+ 	{MLDSA87, "ML-DSA-87", oidPublicKeyMLDSA87, emptyRawValue, MLDSA, crypto.Hash(0) /* no pre-hashing */, false},
++	{CompositeEd25519MLDSA44, "Composite-Ed25519-ML-DSA-44", oidPublicKeyCompositeEd25519MLDSA44, emptyRawValue, CompositeEd25519MLDSA, crypto.Hash(0) /* no pre-hashing */, false},
++	{CompositeEd25519MLDSA65, "Composite-Ed25519-ML-DSA-65", oidPublicKeyCompositeEd25519MLDSA65, emptyRawValue, CompositeEd25519MLDSA, crypto.Hash(0) /* no pre-hashing */, false},
++	{CompositeEd25519MLDSA87, "Composite-Ed25519-ML-DSA-87", oidPublicKeyCompositeEd25519MLDSA87, emptyRawValue, CompositeEd25519MLDSA, crypto.Hash(0) /* no pre-hashing */, false},
+ }
+ 
+ var emptyRawValue = asn1.RawValue{}
+@@ -553,6 +568,8 @@ func getPublicKeyAlgorithmFromOID(oid asn1.ObjectIdentifier) PublicKeyAlgorithm
+ 			return UnknownPublicKeyAlgorithm
+ 		}
+ 		return MLDSA
++	case isCompositeOID(oid):
++		return CompositeEd25519MLDSA
+ 	}
+ 	return UnknownPublicKeyAlgorithm
+ }
+@@ -1066,7 +1083,7 @@ func checkSignature(algo SignatureAlgorithm, signed, signature []byte, publicKey
+ 
+ 	switch hashType {
+ 	case crypto.Hash(0):
+-		if pubKeyAlgo != Ed25519 && pubKeyAlgo != MLDSA {
++		if pubKeyAlgo != Ed25519 && pubKeyAlgo != MLDSA && pubKeyAlgo != CompositeEd25519MLDSA {
+ 			return ErrUnsupportedAlgorithm
+ 		}
+ 	case crypto.MD5:
+@@ -1136,6 +1153,21 @@ func checkSignature(algo SignatureAlgorithm, signed, signature []byte, publicKey
+ 			return fmt.Errorf("x509: ML-DSA verification failure: %w", err)
+ 		}
+ 		return
++	case *CompositePublicKey:
++		if pubKeyAlgo != CompositeEd25519MLDSA {
++			return signaturePublicKeyAlgoMismatchError(pubKeyAlgo, pub)
++		}
++		edSig, mldsaSig, perr := ParseCompositeSignature(signature)
++		if perr != nil {
++			return perr
++		}
++		if !ed25519.Verify(pub.Ed25519, signed, edSig) {
++			return errors.New("x509: composite Ed25519 verification failure")
++		}
++		if verr := mldsa.Verify(pub.MLDSA, signed, mldsaSig, nil); verr != nil {
++			return fmt.Errorf("x509: composite ML-DSA verification failure: %w", verr)
++		}
++		return nil
+ 	}
+ 	return ErrUnsupportedAlgorithm
+ }
+@@ -1679,8 +1711,21 @@ func signingParamsForKey(key crypto.Signer, sigAlgo SignatureAlgorithm) (Signatu
+ 			return 0, ai, fmt.Errorf("x509: unsupported ML-DSA parameters: %s", pub.Parameters())
+ 		}
+ 
++	case *CompositePublicKey:
++		pubType = CompositeEd25519MLDSA
++		switch pub.MLDSA.Parameters() {
++		case mldsa.MLDSA44():
++			defaultAlgo = CompositeEd25519MLDSA44
++		case mldsa.MLDSA65():
++			defaultAlgo = CompositeEd25519MLDSA65
++		case mldsa.MLDSA87():
++			defaultAlgo = CompositeEd25519MLDSA87
++		default:
++			return 0, ai, fmt.Errorf("x509: unsupported composite ML-DSA parameters: %s", pub.MLDSA.Parameters())
++		}
++
+ 	default:
+-		return 0, ai, errors.New("x509: only RSA, ECDSA, ML-DSA and Ed25519 keys supported")
++		return 0, ai, errors.New("x509: only RSA, ECDSA, ML-DSA, Ed25519 and composite keys supported")
+ 	}
+ 
+ 	if sigAlgo == 0 {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/example/pqc_client/main.go
+++ b/example/pqc_client/main.go
@@ -1,0 +1,77 @@
+// Command pqc_client connects to pqc_server and echoes a message, selecting the
+// post-quantum key exchange purely through tls.Config.CurvePreferences.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/pqctls"
+)
+
+func main() {
+	addr := flag.String("addr", "localhost:4433", "server address")
+	mode := flag.String("mode", "mlkem768", "classical | mlkem768 | mlkem1024 | hybrid")
+	flag.Parse()
+
+	curve, err := clientCurve(*mode)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tlsConf := &tls.Config{
+		InsecureSkipVerify: true, // self-signed certificates in this demo
+		NextProtos:         []string{"pqc-echo"},
+		CurvePreferences:   []tls.CurveID{curve},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := quic.DialAddr(ctx, *addr, tlsConf, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.CloseWithError(0, "")
+
+	cs := conn.ConnectionState().TLS
+	fmt.Printf("connected: curve=0x%04x cipher=0x%04x\n", uint16(cs.CurveID), cs.CipherSuite)
+
+	str, err := conn.OpenStreamSync(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := str.Write([]byte("hello post-quantum world")); err != nil {
+		log.Fatal(err)
+	}
+	if err := str.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	echo, err := io.ReadAll(str)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("echo: %s\n", echo)
+}
+
+func clientCurve(mode string) (tls.CurveID, error) {
+	switch mode {
+	case "classical":
+		return tls.X25519, nil
+	case "mlkem768":
+		return pqctls.MLKEM768, nil
+	case "mlkem1024":
+		return pqctls.MLKEM1024, nil
+	case "hybrid":
+		return pqctls.X25519MLKEM768, nil
+	default:
+		return 0, fmt.Errorf("unknown mode %q", mode)
+	}
+}

--- a/example/pqc_server/main.go
+++ b/example/pqc_server/main.go
@@ -1,0 +1,127 @@
+// Command pqc_server is a minimal QUIC echo server demonstrating post-quantum
+// cryptography in quic-go, configured entirely through crypto/tls: ML-KEM key
+// exchange via CurvePreferences and ML-DSA authentication via a certificate from
+// the pqctls package. ML-KEM and ML-DSA are provided natively by the standard
+// library (pure ML-KEM-768 requires the project's patched Go toolchain).
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/pqctls"
+)
+
+func main() {
+	addr := flag.String("addr", "localhost:4433", "address to listen on")
+	mode := flag.String("mode", "mlkem768", "classical | mlkem768 | mlkem1024 | hybrid")
+	flag.Parse()
+
+	curve, cert, err := serverConfig(*mode)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tlsConf := &tls.Config{
+		Certificates:     []tls.Certificate{cert},
+		NextProtos:       []string{"pqc-echo"},
+		CurvePreferences: []tls.CurveID{curve},
+	}
+
+	ln, err := quic.ListenAddr(*addr, tlsConf, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ln.Close()
+	log.Printf("PQC echo server listening on %s (mode=%s, curve=0x%04x)", *addr, *mode, uint16(curve))
+
+	for {
+		conn, err := ln.Accept(context.Background())
+		if err != nil {
+			log.Fatal(err)
+		}
+		go handle(conn)
+	}
+}
+
+func handle(conn *quic.Conn) {
+	defer conn.CloseWithError(0, "")
+	cs := conn.ConnectionState().TLS
+	log.Printf("handshake complete: curve=0x%04x cipher=0x%04x", uint16(cs.CurveID), cs.CipherSuite)
+
+	str, err := conn.AcceptStream(context.Background())
+	if err != nil {
+		return
+	}
+	data, err := io.ReadAll(str)
+	if err != nil {
+		return
+	}
+	if _, err := str.Write(data); err != nil {
+		return
+	}
+	str.Close() // FIN so the client's ReadAll completes
+	<-conn.Context().Done()
+}
+
+func serverConfig(mode string) (tls.CurveID, tls.Certificate, error) {
+	switch mode {
+	case "classical":
+		cert, err := classicalCertificate()
+		return tls.X25519, cert, err
+	case "mlkem768":
+		cert, err := pqctls.GenerateMLDSACertificate(pqctls.MLDSA65, "quic-go PQC", []string{"localhost"}, 24*time.Hour)
+		return pqctls.MLKEM768, cert, err
+	case "mlkem1024":
+		cert, err := pqctls.GenerateMLDSACertificate(pqctls.MLDSA87, "quic-go PQC", []string{"localhost"}, 24*time.Hour)
+		return pqctls.MLKEM1024, cert, err
+	case "hybrid":
+		cert, err := pqctls.GenerateMLDSACertificate(pqctls.MLDSA65, "quic-go PQC", []string{"localhost"}, 24*time.Hour)
+		return pqctls.X25519MLKEM768, cert, err
+	default:
+		return 0, tls.Certificate{}, fmt.Errorf("unknown mode %q", mode)
+	}
+}
+
+func classicalCertificate() (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"quic-go Classical"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, key.Public(), key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/pqc_test.go
+++ b/pqc_test.go
@@ -1,0 +1,156 @@
+package quic
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/pqctls"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPQCHandshake verifies that QUIC establishes connections using the post-quantum
+// cryptography provided natively by the (patched) standard library, selected entirely
+// through tls.Config: ML-KEM key exchange via CurvePreferences and ML-DSA
+// authentication via Certificates. There are no PQC-specific fields on quic.Config.
+func TestPQCHandshake(t *testing.T) {
+	classicalCert := generateClassicalTestCertificate(t)
+	mldsa65Cert, err := pqctls.GenerateMLDSACertificate(pqctls.MLDSA65, "QUIC PQC Test", []string{"localhost"}, time.Hour)
+	require.NoError(t, err)
+	mldsa87Cert, err := pqctls.GenerateMLDSACertificate(pqctls.MLDSA87, "QUIC PQC Test", []string{"localhost"}, time.Hour)
+	require.NoError(t, err)
+	hybridCert, err := pqctls.GenerateHybridCertificate(pqctls.MLDSA65, "QUIC Hybrid Test", []string{"localhost"}, time.Hour)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name  string
+		curve tls.CurveID
+		cert  tls.Certificate
+		// sigScheme, when non-zero, is advertised by the client so a composite
+		// certificate can be selected and verified.
+		sigScheme tls.SignatureScheme
+	}{
+		{name: "Classical (X25519 + ECDSA)", curve: tls.X25519, cert: classicalCert},
+		{name: "Pure ML-KEM-768 + ML-DSA-65", curve: pqctls.MLKEM768, cert: mldsa65Cert},
+		{name: "Pure ML-KEM-1024 + ML-DSA-87", curve: pqctls.MLKEM1024, cert: mldsa87Cert},
+		{name: "Hybrid X25519+ML-KEM-768 + ML-DSA-65", curve: pqctls.X25519MLKEM768, cert: mldsa65Cert},
+		{name: "Hybrid KEX + Composite Ed25519+ML-DSA-65 cert", curve: pqctls.X25519MLKEM768, cert: hybridCert, sigScheme: pqctls.CompositeEd25519MLDSA65},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			serverTLSConf := &tls.Config{
+				Certificates:     []tls.Certificate{tc.cert},
+				NextProtos:       []string{"pqc-test"},
+				CurvePreferences: []tls.CurveID{tc.curve},
+			}
+			clientTLSConf := &tls.Config{
+				InsecureSkipVerify: true,
+				NextProtos:         []string{"pqc-test"},
+				CurvePreferences:   []tls.CurveID{tc.curve},
+			}
+			if tc.sigScheme != 0 {
+				// The client must advertise the composite scheme to accept a
+				// composite server certificate.
+				clientTLSConf.SignatureSchemes = []tls.SignatureScheme{tc.sigScheme}
+			}
+
+			serverTr := &Transport{Conn: newUDPConnLocalhost(t)}
+			defer serverTr.Close()
+			ln, err := serverTr.Listen(serverTLSConf, nil)
+			require.NoError(t, err)
+			defer ln.Close()
+
+			serverErr := make(chan error, 1)
+			go func() {
+				conn, err := ln.Accept(context.Background())
+				if err != nil {
+					serverErr <- err
+					return
+				}
+				str, err := conn.AcceptStream(context.Background())
+				if err != nil {
+					serverErr <- err
+					return
+				}
+				data, err := io.ReadAll(str)
+				if err != nil {
+					serverErr <- err
+					return
+				}
+				if _, err := str.Write(data); err != nil {
+					serverErr <- err
+					return
+				}
+				str.Close()
+				<-conn.Context().Done()
+				serverErr <- nil
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			clientTr := &Transport{Conn: newUDPConnLocalhost(t)}
+			defer clientTr.Close()
+			conn, err := clientTr.Dial(ctx, ln.Addr(), clientTLSConf, nil)
+			require.NoError(t, err)
+
+			negotiated := conn.ConnectionState().TLS.CurveID
+			t.Logf("negotiated curve: 0x%04x, cipher: 0x%04x", uint16(negotiated), conn.ConnectionState().TLS.CipherSuite)
+			require.Equal(t, tc.curve, negotiated, "negotiated curve must match the requested curve")
+
+			str, err := conn.OpenStreamSync(ctx)
+			require.NoError(t, err)
+			msg := []byte("hello post-quantum world")
+			_, err = str.Write(msg)
+			require.NoError(t, err)
+			require.NoError(t, str.Close())
+
+			echo, err := io.ReadAll(str)
+			require.NoError(t, err)
+			require.Equal(t, msg, echo)
+
+			conn.CloseWithError(0, "")
+			require.NoError(t, <-serverErr)
+		})
+	}
+}
+
+// generateClassicalTestCertificate creates a self-signed ECDSA certificate for the
+// classical baseline.
+func generateClassicalTestCertificate(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"QUIC Classical Test"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, key.Public(), key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+	return cert
+}

--- a/pqctls/hybrid.go
+++ b/pqctls/hybrid.go
@@ -1,0 +1,88 @@
+package pqctls
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/mldsa"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"time"
+)
+
+// compositeSigner is a crypto.Signer that produces composite Ed25519+ML-DSA
+// signatures (an experimental, non-standard construction). It is used both as the
+// TLS certificate private key and to self-sign the certificate.
+type compositeSigner struct {
+	ed    ed25519.PrivateKey
+	mldsa *mldsa.PrivateKey
+	pub   *x509.CompositePublicKey
+}
+
+func (s *compositeSigner) Public() crypto.PublicKey { return s.pub }
+
+// Sign signs the (already-final) message with both component keys and returns the
+// composite signature. The composite scheme uses direct signing (no pre-hash),
+// so opts.HashFunc() is expected to be zero.
+func (s *compositeSigner) Sign(rnd io.Reader, message []byte, opts crypto.SignerOpts) ([]byte, error) {
+	edSig := ed25519.Sign(s.ed, message)
+	mldsaSig, err := s.mldsa.Sign(rnd, message, crypto.Hash(0))
+	if err != nil {
+		return nil, err
+	}
+	return x509.MarshalCompositeSignature(edSig, mldsaSig)
+}
+
+// GenerateHybridCertificate returns a self-signed certificate whose key and
+// signature are a composite of Ed25519 and ML-DSA (at mldsaLevel 44, 65 or 87),
+// so authentication holds as long as either scheme remains unbroken. This is an
+// experimental, non-standard construction that requires the project's patched Go
+// toolchain and interoperates only between peers using it.
+func GenerateHybridCertificate(mldsaLevel int, organization string, dnsNames []string, validFor time.Duration) (tls.Certificate, error) {
+	params, ok := mldsaParameters(mldsaLevel)
+	if !ok {
+		return tls.Certificate{}, &invalidLevelError{mldsaLevel}
+	}
+	edPub, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	mldsaPriv, err := mldsa.GenerateKey(params)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	signer := &compositeSigner{
+		ed:    edPriv,
+		mldsa: mldsaPriv,
+		pub: &x509.CompositePublicKey{
+			Ed25519: edPub,
+			MLDSA:   mldsaPriv.PublicKey(),
+		},
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{organization}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(validFor),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              dnsNames,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, signer.Public(), signer)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  signer,
+		Leaf:        leaf,
+	}, nil
+}

--- a/pqctls/pqctls.go
+++ b/pqctls/pqctls.go
@@ -1,0 +1,120 @@
+// Package pqctls exposes the post-quantum capabilities of Go's standard
+// crypto/tls through helpers convenient for quic-go.
+//
+// Post-quantum behaviour is driven entirely by the *tls.Config passed to
+// quic-go; there are no PQC-specific fields on quic.Config. Callers select:
+//
+//   - ML-KEM key exchange by listing a curve ID from this package in
+//     tls.Config.CurvePreferences (e.g. pqctls.MLKEM768, pqctls.MLKEM1024 or the
+//     hybrid pqctls.X25519MLKEM768);
+//   - ML-DSA authentication by placing a certificate produced by
+//     GenerateMLDSACertificate in tls.Config.Certificates.
+//
+// ML-KEM and ML-DSA are provided natively by the standard library
+// (crypto/mlkem, crypto/mldsa, crypto/x509, crypto/tls). The pure ML-KEM-768
+// curve (codepoint 513) and composite Ed25519+ML-DSA certificates require the
+// project's patched Go toolchain; everything else builds on stock Go 1.27+.
+package pqctls
+
+import (
+	"crypto/mldsa"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"time"
+)
+
+// Post-quantum key-exchange curve IDs, usable directly in
+// tls.Config.CurvePreferences. Values match the standard crypto/tls CurveID
+// numbering, so they interoperate with stdlib curve constants.
+const (
+	// X25519MLKEM768 is the hybrid X25519 + ML-KEM-768 key exchange (RFC-standard).
+	X25519MLKEM768 tls.CurveID = 4588
+	// MLKEM768 is pure ML-KEM-768 key exchange (codepoint 513; requires the
+	// patched toolchain).
+	MLKEM768 tls.CurveID = 513
+	// MLKEM1024 is pure ML-KEM-1024 key exchange (codepoint 514).
+	MLKEM1024 tls.CurveID = 514
+)
+
+// ML-DSA security levels accepted by GenerateMLDSACertificate and
+// GenerateHybridCertificate.
+const (
+	MLDSA44 = 44 // ML-DSA-44 (NIST level 2)
+	MLDSA65 = 65 // ML-DSA-65 (NIST level 3, recommended)
+	MLDSA87 = 87 // ML-DSA-87 (NIST level 5)
+)
+
+// Composite Ed25519+ML-DSA TLS 1.3 signature schemes (experimental, non-standard
+// private-use codepoints; require the patched toolchain). To use a composite
+// certificate, the client must advertise the matching scheme by setting it in
+// tls.Config.SignatureSchemes.
+const (
+	CompositeEd25519MLDSA44 tls.SignatureScheme = 0xFE10
+	CompositeEd25519MLDSA65 tls.SignatureScheme = 0xFE11
+	CompositeEd25519MLDSA87 tls.SignatureScheme = 0xFE12
+)
+
+// mldsaParameters maps a level (44/65/87) to the crypto/mldsa parameter set.
+func mldsaParameters(level int) (mldsa.Parameters, bool) {
+	switch level {
+	case MLDSA44:
+		return mldsa.MLDSA44(), true
+	case MLDSA65:
+		return mldsa.MLDSA65(), true
+	case MLDSA87:
+		return mldsa.MLDSA87(), true
+	default:
+		return mldsa.Parameters{}, false
+	}
+}
+
+// GenerateMLDSACertificate returns a self-signed certificate whose key and
+// signature use ML-DSA at the given level (44, 65 or 87), built with the native
+// crypto/mldsa and crypto/x509 packages. The returned tls.Certificate can be
+// placed directly into tls.Config.Certificates.
+func GenerateMLDSACertificate(level int, organization string, dnsNames []string, validFor time.Duration) (tls.Certificate, error) {
+	params, ok := mldsaParameters(level)
+	if !ok {
+		return tls.Certificate{}, &invalidLevelError{level}
+	}
+	priv, err := mldsa.GenerateKey(params)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{organization}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(validFor),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              dnsNames,
+	}
+	// SignatureAlgorithm is left zero: x509.CreateCertificate derives the ML-DSA
+	// algorithm from the signer's public key.
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, priv.Public(), priv)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  priv,
+		Leaf:        leaf,
+	}, nil
+}
+
+type invalidLevelError struct{ level int }
+
+func (e *invalidLevelError) Error() string {
+	return "pqctls: invalid ML-DSA level (want 44, 65 or 87), got " + itoa(e.level)
+}
+
+func itoa(n int) string { return big.NewInt(int64(n)).String() }

--- a/pqctls/smoke_test.go
+++ b/pqctls/smoke_test.go
@@ -1,0 +1,124 @@
+package pqctls
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestCompositeQUICTLS drives a composite handshake through the tls.QUICServer /
+// tls.QUICClient API (the exact API quic-go uses), to isolate QUIC-TLS behaviour.
+func TestCompositeQUICTLS(t *testing.T) {
+	cert, err := GenerateHybridCertificate(MLDSA65, "smoke", []string{"localhost"}, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := tls.QUICServer(&tls.QUICConfig{EnableSessionEvents: true, TLSConfig: &tls.Config{
+		Certificates:     []tls.Certificate{cert},
+		NextProtos:       []string{"pqc-test"},
+		CurvePreferences: []tls.CurveID{X25519MLKEM768},
+	}})
+	client := tls.QUICClient(&tls.QUICConfig{EnableSessionEvents: true, TLSConfig: &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"pqc-test"},
+		CurvePreferences:   []tls.CurveID{X25519MLKEM768},
+		SignatureSchemes:   []tls.SignatureScheme{CompositeEd25519MLDSA65},
+	}})
+	ctx := context.Background()
+	client.SetTransportParameters([]byte("client-tp"))
+	server.SetTransportParameters([]byte("server-tp"))
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("client start: %v", err)
+	}
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("server start: %v", err)
+	}
+	pump := func(src, dst *tls.QUICConn) error {
+		for {
+			e := src.NextEvent()
+			switch e.Kind {
+			case tls.QUICNoEvent:
+				return nil
+			case tls.QUICWriteData:
+				if err := dst.HandleData(e.Level, e.Data); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	for i := 0; i < 12; i++ {
+		if err := pump(client, server); err != nil {
+			t.Fatalf("server rejected handshake: %v", err)
+		}
+		if err := pump(server, client); err != nil {
+			t.Fatalf("client rejected handshake: %v", err)
+		}
+		if client.ConnectionState().HandshakeComplete && server.ConnectionState().HandshakeComplete {
+			t.Logf("QUIC-TLS composite handshake complete after %d rounds", i+1)
+			return
+		}
+	}
+	t.Fatal("handshake did not complete")
+}
+
+// TestCompositeTLSHandshake exercises a composite Ed25519+ML-DSA certificate over
+// a plain crypto/tls connection (net.Pipe), isolating TLS behaviour from QUIC.
+func TestCompositeTLSHandshake(t *testing.T) {
+	cert, err := GenerateHybridCertificate(MLDSA65, "smoke", []string{"localhost"}, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverConf := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{"smoke"},
+	}
+	clientConf := &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS13,
+		NextProtos:         []string{"smoke"},
+		SignatureSchemes:   []tls.SignatureScheme{CompositeEd25519MLDSA65},
+	}
+
+	c, s := net.Pipe()
+	defer c.Close()
+	defer s.Close()
+
+	srvErr := make(chan error, 1)
+	go func() {
+		conn := tls.Server(s, serverConf)
+		if err := conn.Handshake(); err != nil {
+			srvErr <- err
+			return
+		}
+		buf := make([]byte, 5)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			srvErr <- err
+			return
+		}
+		_, err := conn.Write(buf)
+		srvErr <- err
+	}()
+
+	client := tls.Client(c, clientConf)
+	if err := client.Handshake(); err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+	t.Logf("client handshake OK; sig scheme verified, curve=%v", client.ConnectionState().CipherSuite)
+	if _, err := client.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(client, buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-srvErr; err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("server: %v", err)
+	}
+	t.Log("composite TLS handshake + echo OK")
+}


### PR DESCRIPTION
**Draft / experimental — not intended for merge.** This is part of a UnB TCC on post-quantum QUIC.

## Summary
Adopts upstream Go's **native** post-quantum support (ML-KEM, ML-DSA in `crypto/tls`, `crypto/mlkem`, `crypto/mldsa`, `crypto/x509`) instead of an embedded `crypto/tls` fork. The quic-go core is unchanged from upstream; all PQC lives in a thin `pqctls/` helper plus examples and tests.

PQC is selected entirely via `tls.Config`:
- key exchange via `CurvePreferences` (`pqctls.MLKEM768` / `MLKEM1024` / `X25519MLKEM768`)
- authentication via `tls.Config.Certificates` (`pqctls.GenerateMLDSACertificate`, `GenerateHybridCertificate`)

## Build requirement
Two features (pure ML-KEM-768 curve `513`, and experimental composite Ed25519+ML-DSA certs) require a small patch to the Go toolchain — see `docs/pqc-tls/` and the companion patch `docs/pqc-tls/crypto-tls-pqc.patch`. **CI on stock Go will not build those**; the standard modes (hybrid X25519MLKEM768, pure ML-KEM-1024, native single ML-DSA certs) build on stock Go 1.27.

## Tested (with the patched toolchain)
End-to-end QUIC handshakes for classical, pure ML-KEM-768/1024, hybrid, and composite-cert modes; `crypto/tls`/`crypto/x509`/`crypto/mldsa`/`crypto/mlkem` suites pass.

See `docs/pqc-tls/ARCHITECTURE.md` and `docs/pqc-tls/REPOSITORIES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add experimental post-quantum QUIC support via native crypto/tls with ML-KEM and ML-DSA
> - Adds a `pqctls` package exposing constants, `GenerateMLDSACertificate`, and `GenerateHybridCertificate` (composite Ed25519+ML-DSA) for use in `tls.Config`.
> - Adds end-to-end QUIC tests in [pqc_test.go](https://github.com/quic-go/quic-go/pull/5697/files#diff-9f0b49a6469512264f42015c09781eb2a4988ac2625b456bba6c54f1791ab216) covering classical X25519/ECDSA, pure ML-KEM-768/1024, hybrid X25519+ML-KEM-768, and composite certificate modes.
> - Adds example client and server binaries in [example/pqc_client](https://github.com/quic-go/quic-go/pull/5697/files#diff-17d2fed2d4bc6a92a9fd78eb978b5a3669f171e8a75d8b3c3620c9df49236c2a) and [example/pqc_server](https://github.com/quic-go/quic-go/pull/5697/files#diff-3a595347d802f4a62ec782ae2d0f5f170a590f9ea041dfa7dcdabcad36cb2687) with a `-mode` flag to select key exchange (classical | mlkem768 | mlkem1024 | hybrid).
> - Includes architecture docs and a `crypto/tls` patch in [docs/pqc-tls/](https://github.com/quic-go/quic-go/pull/5697/files#diff-5ad0ab3a9718771303776be16733e056fc9c63290a03eede378e8ee137c7409c) describing the two-layer design and how to reproduce the patched Go toolchain.
> - Risk: requires a patched Go toolchain (`crypto/tls` + `crypto/x509`) for ML-KEM and composite ML-DSA support; not usable with a standard Go release.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 17e6fc0. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->