### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/internal/ackhandler/received_packet_history.go
+++ b/internal/ackhandler/received_packet_history.go
@@ -50,28 +50,28 @@ func (h *receivedPacketHistory) addToRanges(p protocol.PacketNumber) bool /* is 
 		return true
 	}
 
-	for i := len(h.ranges) - 1; i >= 0; i-- {
+	for i, v := range slices.Backward(h.ranges) {
 		// p already included in an existing range. Nothing to do here
-		if p >= h.ranges[i].Start && p <= h.ranges[i].End {
+		if p >= v.Start && p <= v.End {
 			return false
 		}
 
-		if h.ranges[i].End == p-1 { // extend a range at the end
-			h.ranges[i].End = p
+		if v.End == p-1 { // extend a range at the end
+			v.End = p
 			return true
 		}
-		if h.ranges[i].Start == p+1 { // extend a range at the beginning
-			h.ranges[i].Start = p
+		if v.Start == p+1 { // extend a range at the beginning
+			v.Start = p
 
-			if i > 0 && h.ranges[i-1].End+1 == h.ranges[i].Start { // merge two ranges
-				h.ranges[i-1].End = h.ranges[i].End
+			if i > 0 && h.ranges[i-1].End+1 == v.Start { // merge two ranges
+				h.ranges[i-1].End = v.End
 				h.ranges = slices.Delete(h.ranges, i, i+1)
 			}
 			return true
 		}
 
 		// create a new range after the current one
-		if p > h.ranges[i].End {
+		if p > v.End {
 			h.ranges = slices.Insert(h.ranges, i+1, interval{Start: p, End: p})
 			return true
 		}
@@ -112,8 +112,8 @@ func (h *receivedPacketHistory) DeleteBelow(p protocol.PacketNumber) {
 // Backward returns an iterator over the ranges in reverse order
 func (h *receivedPacketHistory) Backward() iter.Seq[interval] {
 	return func(yield func(interval) bool) {
-		for i := len(h.ranges) - 1; i >= 0; i-- {
-			if !yield(h.ranges[i]) {
+		for _, v := range slices.Backward(h.ranges) {
+			if !yield(v) {
 				return
 			}
 		}
@@ -125,8 +125,8 @@ func (h *receivedPacketHistory) HighestMissingUpTo(p protocol.PacketNumber) prot
 		return protocol.InvalidPacketNumber
 	}
 	p = min(h.ranges[len(h.ranges)-1].End, p)
-	for i := len(h.ranges) - 1; i >= 0; i-- {
-		r := h.ranges[i]
+	for i, r := range slices.Backward(h.ranges) {
+
 		if p >= r.Start && p <= r.End { // p is contained in this range
 			highest := r.Start - 1 // highest packet in the gap before this range
 			if h.deletedBelow != protocol.InvalidPacketNumber && highest < h.deletedBelow {
@@ -147,11 +147,11 @@ func (h *receivedPacketHistory) IsPotentiallyDuplicate(p protocol.PacketNumber) 
 		return true
 	}
 	// Iterating over the slices is faster than using a binary search (using slices.BinarySearchFunc).
-	for i := len(h.ranges) - 1; i >= 0; i-- {
-		if p > h.ranges[i].End {
+	for _, v := range slices.Backward(h.ranges) {
+		if p > v.End {
 			return false
 		}
-		if p <= h.ranges[i].End && p >= h.ranges[i].Start {
+		if p <= v.End && p >= v.Start {
 			return true
 		}
 	}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor reverse loops in `receivedPacketHistory` to use `slices.Backward`
> Replaces manual reverse index loops in [received_packet_history.go](https://github.com/quic-go/quic-go/pull/5698/files#diff-6db1cd68b5559aef435ee1024896bcc079554e056bc4bd04712658bfc0528820) with `for i, v := range slices.Backward(...)` to reduce boilerplate.
>
> - Risk: `addToRanges` now assigns to the local copy `v` instead of `h.ranges[i]`, so range extensions (Start/End updates) are silently dropped — the underlying slice is not mutated.
> - Risk: `HighestMissingUpTo` uses `i` from the reversed iterator to reference `h.ranges[i-1]`, which no longer refers to the adjacent range in original order, corrupting gap detection and the returned missing packet number.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 85a6f64. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->