### PR TITLE
chore: fix some function names in comment

### DIFF
--- a/http3/stream.go
+++ b/http3/stream.go
@@ -263,7 +263,7 @@ func (s *RequestStream) SetDeadline(t time.Time) error {
 	return s.str.SetDeadline(t)
 }
 
-// SendDatagrams send a new HTTP Datagram (RFC 9297).
+// SendDatagram send a new HTTP Datagram (RFC 9297).
 //
 // It is only possible to send datagrams if the server enabled support for this extension.
 // It is recommended (though not required) to send the request before calling this method,

--- a/stateless_reset.go
+++ b/stateless_reset.go
@@ -15,7 +15,7 @@ type statelessResetter struct {
 	h  hash.Hash
 }
 
-// newStatelessRetter creates a new stateless reset generator.
+// newStatelessResetter creates a new stateless reset generator.
 // It is valid to use a nil key. In that case, a random key will be used.
 // This makes is impossible for on-path attackers to shut down established connections.
 func newStatelessResetter(key *StatelessResetKey) *statelessResetter {


### PR DESCRIPTION
 fix some function names in comment

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix doc comment typos for `SendDatagram` and `newStatelessResetter`
> Corrects two misspelled function names in doc comments: `SendDatagrams` → `SendDatagram` in [stream.go](https://github.com/quic-go/quic-go/pull/5699/files#diff-78b9dd15996d79e5718e0b1a031fd73b67983fceb406305fb50ec797dbb558de) and `newStatelessRetter` → `newStatelessResetter` in [stateless_reset.go](https://github.com/quic-go/quic-go/pull/5699/files#diff-9a25abed70c953c53fbe2d112d7ac5c4f8afd9737063ae74df2e9ca4012b127d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a8a9c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->