### PR TITLE
ci: only run Codspeed benchmarks for the integration tests

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -24,4 +24,4 @@ jobs:
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
         with:
           mode: walltime
-          run: go test -run=^$ -bench=. ./...
+          run: go test -run=^$ -bench=. ./integrationtests/self


### PR DESCRIPTION
Running the benchmark on parsers doesn't seem that valuable since we're not making a lot of changes to parsers, and if we do, we can just run those benchmarks independently. Benchmarking higher level functions though might allow us to catch regressions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict CodSpeed benchmarks to the `integrationtests/self` package
> Updates [codspeed.yml](.github/workflows/codspeed.yml) to run `go test -bench` only against `./integrationtests/self` instead of all packages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f5538e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the benchmark workflow to run against a narrower test target, helping benchmark runs focus on the intended integration test suite.
  * Benchmark execution settings and timing mode remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->