### PR TITLE
protocol: remove unused AtomicByteCount type

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"fmt"
-	"sync/atomic"
 	"time"
 )
 
@@ -95,8 +94,6 @@ func (e ECN) String() string {
 
 // A ByteCount in QUIC
 type ByteCount int64
-
-type AtomicByteCount atomic.Int64
 
 // MaxByteCount is the maximum value of a ByteCount
 const MaxByteCount = ByteCount(1<<62 - 1)


### PR DESCRIPTION
No functional change expected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `AtomicByteCount` type from `internal/protocol`
> Removes the `AtomicByteCount` type alias and its associated `sync/atomic` import from [protocol.go](https://github.com/quic-go/quic-go/pull/5703/files#diff-fe481f02a2cbffa775d15f7581bb3f25bed55efc2cb8697b878a2f13016c3a81). The type was unused and left over code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4791dc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal byte-count handling by removing an unused legacy type.
  * No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->