### PR TITLE
implement a method on the SendStream to send data immediately

### DIFF
--- a/flow_controller_base.go
+++ b/flow_controller_base.go
@@ -9,13 +9,7 @@ import (
 	"github.com/quic-go/quic-go/internal/utils"
 )
 
-type baseFlowController struct {
-	// for sending data
-	bytesSent     protocol.ByteCount
-	sendWindow    protocol.ByteCount
-	lastBlockedAt protocol.ByteCount
-
-	// for receiving data
+type receiveFlowController struct {
 	//nolint:structcheck // The mutex is used both by the stream and the connection flow controller
 	mutex                sync.Mutex
 	bytesRead            protocol.ByteCount
@@ -33,44 +27,12 @@ type baseFlowController struct {
 	logger utils.Logger
 }
 
-// IsNewlyBlocked says if it is newly blocked by flow control.
-// For every offset, it only returns true once.
-// If it is blocked, the offset is returned.
-func (c *baseFlowController) IsNewlyBlocked() (bool, protocol.ByteCount) {
-	if c.SendWindowSize() != 0 || c.sendWindow == c.lastBlockedAt {
-		return false, 0
-	}
-	c.lastBlockedAt = c.sendWindow
-	return true, c.sendWindow
-}
-
-func (c *baseFlowController) AddBytesSent(n protocol.ByteCount) {
-	c.bytesSent += n
-}
-
-// UpdateSendWindow is called after receiving a MAX_{STREAM_}DATA frame.
-func (c *baseFlowController) UpdateSendWindow(offset protocol.ByteCount) (updated bool) {
-	if offset > c.sendWindow {
-		c.sendWindow = offset
-		return true
-	}
-	return false
-}
-
-func (c *baseFlowController) SendWindowSize() protocol.ByteCount {
-	// this only happens during connection establishment, when data is sent before we receive the peer's transport parameters
-	if c.bytesSent > c.sendWindow {
-		return 0
-	}
-	return c.sendWindow - c.bytesSent
-}
-
 // needs to be called with locked mutex
-func (c *baseFlowController) addBytesRead(n protocol.ByteCount) {
+func (c *receiveFlowController) addBytesRead(n protocol.ByteCount) {
 	c.bytesRead += n
 }
 
-func (c *baseFlowController) hasWindowUpdate() bool {
+func (c *receiveFlowController) hasWindowUpdate() bool {
 	bytesRemaining := c.receiveWindow - c.bytesRead
 	// update the window when more than the threshold was consumed
 	return bytesRemaining <= protocol.ByteCount(float64(c.receiveWindowSize)*(1-protocol.WindowUpdateThreshold))
@@ -78,7 +40,7 @@ func (c *baseFlowController) hasWindowUpdate() bool {
 
 // getWindowUpdate updates the receive window, if necessary
 // it returns the new offset
-func (c *baseFlowController) getWindowUpdate(now monotime.Time) protocol.ByteCount {
+func (c *receiveFlowController) getWindowUpdate(now monotime.Time) protocol.ByteCount {
 	if !c.hasWindowUpdate() {
 		return 0
 	}
@@ -90,7 +52,7 @@ func (c *baseFlowController) getWindowUpdate(now monotime.Time) protocol.ByteCou
 
 // maybeAdjustWindowSize increases the receiveWindowSize if we're sending updates too often.
 // For details about auto-tuning, see https://docs.google.com/document/d/1SExkMmGiz8VYzV3s9E35JQlJ73vhzCekKkDi85F1qCE/edit?usp=sharing.
-func (c *baseFlowController) maybeAdjustWindowSize(now monotime.Time) {
+func (c *receiveFlowController) maybeAdjustWindowSize(now monotime.Time) {
 	bytesReadInEpoch := c.bytesRead - c.epochStartOffset
 	// don't do anything if less than half the window has been consumed
 	if bytesReadInEpoch <= c.receiveWindowSize/2 {
@@ -112,11 +74,11 @@ func (c *baseFlowController) maybeAdjustWindowSize(now monotime.Time) {
 	c.startNewAutoTuningEpoch(now)
 }
 
-func (c *baseFlowController) startNewAutoTuningEpoch(now monotime.Time) {
+func (c *receiveFlowController) startNewAutoTuningEpoch(now monotime.Time) {
 	c.epochStartTime = now
 	c.epochStartOffset = c.bytesRead
 }
 
-func (c *baseFlowController) checkFlowControlViolation() bool {
+func (c *receiveFlowController) checkFlowControlViolation() bool {
 	return c.highestReceived > c.receiveWindow
 }

--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -70,12 +70,6 @@ func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) (hasWindow
 	return c.hasWindowUpdate()
 }
 
-func (c *connectionFlowController) AddBytesSent(n protocol.ByteCount) {
-	c.sendMutex.Lock()
-	c.bytesSent += n
-	c.sendMutex.Unlock()
-}
-
 func (c *connectionFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
 	c.sendMutex.Lock()
 	defer c.sendMutex.Unlock()

--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -3,6 +3,7 @@ package quic
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -13,6 +14,8 @@ import (
 type connectionFlowController struct {
 	receiveFlowController
 
+	// Protects send-side state, which WriteImmediately can access from application goroutines.
+	sendMutex     sync.Mutex
 	bytesSent     protocol.ByteCount
 	sendWindow    protocol.ByteCount
 	lastBlockedAt protocol.ByteCount
@@ -68,10 +71,27 @@ func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) (hasWindow
 }
 
 func (c *connectionFlowController) AddBytesSent(n protocol.ByteCount) {
+	c.sendMutex.Lock()
 	c.bytesSent += n
+	c.sendMutex.Unlock()
 }
 
+func (c *connectionFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
+	c.sendMutex.Lock()
+	defer c.sendMutex.Unlock()
+
+	if c.bytesSent > c.sendWindow || n > c.sendWindow-c.bytesSent {
+		return false
+	}
+	c.bytesSent += n
+	return true
+}
+
+// UpdateSendWindow is called after receiving a MAX_DATA frame.
 func (c *connectionFlowController) UpdateSendWindow(offset protocol.ByteCount) (updated bool) {
+	c.sendMutex.Lock()
+	defer c.sendMutex.Unlock()
+
 	if offset > c.sendWindow {
 		c.sendWindow = offset
 		return true
@@ -80,7 +100,9 @@ func (c *connectionFlowController) UpdateSendWindow(offset protocol.ByteCount) (
 }
 
 func (c *connectionFlowController) SendWindowSize() protocol.ByteCount {
-	// this only happens during connection establishment, when data is sent before we receive the peer's transport parameters
+	c.sendMutex.Lock()
+	defer c.sendMutex.Unlock()
+
 	if c.bytesSent > c.sendWindow {
 		return 0
 	}
@@ -91,7 +113,10 @@ func (c *connectionFlowController) SendWindowSize() protocol.ByteCount {
 // For every offset, it only returns true once.
 // If it is blocked, the offset is returned.
 func (c *connectionFlowController) IsNewlyBlocked() (bool, protocol.ByteCount) {
-	if c.SendWindowSize() != 0 || c.sendWindow == c.lastBlockedAt {
+	c.sendMutex.Lock()
+	defer c.sendMutex.Unlock()
+
+	if c.bytesSent < c.sendWindow || c.sendWindow == c.lastBlockedAt {
 		return false, 0
 	}
 	c.lastBlockedAt = c.sendWindow
@@ -139,6 +164,9 @@ func (c *connectionFlowController) Reset() error {
 	if c.bytesRead > 0 || c.highestReceived > 0 || !c.epochStartTime.IsZero() {
 		return errors.New("flow controller reset after reading data")
 	}
+	c.sendMutex.Lock()
+	defer c.sendMutex.Unlock()
+
 	c.bytesSent = 0
 	c.lastBlockedAt = 0
 	c.sendWindow = 0

--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -11,7 +11,11 @@ import (
 )
 
 type connectionFlowController struct {
-	baseFlowController
+	receiveFlowController
+
+	bytesSent     protocol.ByteCount
+	sendWindow    protocol.ByteCount
+	lastBlockedAt protocol.ByteCount
 }
 
 // newConnectionFlowController gets a new flow controller for the connection.
@@ -24,7 +28,7 @@ func newConnectionFlowController(
 	logger utils.Logger,
 ) *connectionFlowController {
 	return &connectionFlowController{
-		baseFlowController: baseFlowController{
+		receiveFlowController: receiveFlowController{
 			rttStats:             rttStats,
 			receiveWindow:        receiveWindow,
 			receiveWindowSize:    receiveWindow,
@@ -61,6 +65,37 @@ func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) (hasWindow
 
 	c.addBytesRead(n)
 	return c.hasWindowUpdate()
+}
+
+func (c *connectionFlowController) AddBytesSent(n protocol.ByteCount) {
+	c.bytesSent += n
+}
+
+func (c *connectionFlowController) UpdateSendWindow(offset protocol.ByteCount) (updated bool) {
+	if offset > c.sendWindow {
+		c.sendWindow = offset
+		return true
+	}
+	return false
+}
+
+func (c *connectionFlowController) SendWindowSize() protocol.ByteCount {
+	// this only happens during connection establishment, when data is sent before we receive the peer's transport parameters
+	if c.bytesSent > c.sendWindow {
+		return 0
+	}
+	return c.sendWindow - c.bytesSent
+}
+
+// IsNewlyBlocked says if it is newly blocked by connection flow control.
+// For every offset, it only returns true once.
+// If it is blocked, the offset is returned.
+func (c *connectionFlowController) IsNewlyBlocked() (bool, protocol.ByteCount) {
+	if c.SendWindowSize() != 0 || c.sendWindow == c.lastBlockedAt {
+		return false, 0
+	}
+	c.lastBlockedAt = c.sendWindow
+	return true, c.sendWindow
 }
 
 func (c *connectionFlowController) GetWindowUpdate(now monotime.Time) protocol.ByteCount {

--- a/flow_controller_connection_test.go
+++ b/flow_controller_connection_test.go
@@ -64,7 +64,7 @@ func TestConnectionFlowControlViolation(t *testing.T) {
 func TestConnectionFlowControllerReset(t *testing.T) {
 	fc := newConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
 	fc.UpdateSendWindow(100)
-	fc.AddBytesSent(10)
+	require.True(t, fc.TryAddBytesSent(10))
 	require.Equal(t, protocol.ByteCount(90), fc.SendWindowSize())
 	require.NoError(t, fc.Reset())
 	require.Zero(t, fc.SendWindowSize())

--- a/flow_controller_stream.go
+++ b/flow_controller_stream.go
@@ -10,7 +10,11 @@ import (
 )
 
 type streamFlowController struct {
-	baseFlowController
+	receiveFlowController
+
+	bytesSent     protocol.ByteCount
+	sendWindow    protocol.ByteCount
+	lastBlockedAt protocol.ByteCount
 
 	streamID protocol.StreamID
 
@@ -32,12 +36,12 @@ func newStreamFlowController(
 	return &streamFlowController{
 		streamID:   streamID,
 		connection: cfc,
-		baseFlowController: baseFlowController{
+		sendWindow: initialSendWindow,
+		receiveFlowController: receiveFlowController{
 			rttStats:             rttStats,
 			receiveWindow:        receiveWindow,
 			receiveWindowSize:    receiveWindow,
 			maxReceiveWindowSize: maxReceiveWindow,
-			sendWindow:           initialSendWindow,
 			logger:               logger,
 		},
 	}
@@ -116,17 +120,32 @@ func (c *streamFlowController) Abandon() {
 }
 
 func (c *streamFlowController) AddBytesSent(n protocol.ByteCount) {
-	c.baseFlowController.AddBytesSent(n)
+	c.bytesSent += n
 	c.connection.AddBytesSent(n)
 }
 
+func (c *streamFlowController) UpdateSendWindow(offset protocol.ByteCount) (updated bool) {
+	if offset > c.sendWindow {
+		c.sendWindow = offset
+		return true
+	}
+	return false
+}
+
 func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
-	return min(c.baseFlowController.SendWindowSize(), c.connection.SendWindowSize())
+	// this only happens during connection establishment, when data is sent before we receive the peer's transport parameters
+	if c.bytesSent > c.sendWindow {
+		return 0
+	}
+	return min(c.sendWindow-c.bytesSent, c.connection.SendWindowSize())
 }
 
 func (c *streamFlowController) IsNewlyBlocked() bool {
-	blocked, _ := c.baseFlowController.IsNewlyBlocked()
-	return blocked
+	if c.bytesSent < c.sendWindow || c.sendWindow == c.lastBlockedAt {
+		return false
+	}
+	c.lastBlockedAt = c.sendWindow
+	return true
 }
 
 func (c *streamFlowController) shouldQueueWindowUpdate() bool {

--- a/flow_controller_stream.go
+++ b/flow_controller_stream.go
@@ -132,6 +132,17 @@ func (c *streamFlowController) UpdateSendWindow(offset protocol.ByteCount) (upda
 	return false
 }
 
+func (c *streamFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
+	if c.bytesSent > c.sendWindow || n > c.sendWindow-c.bytesSent {
+		return false
+	}
+	if !c.connection.TryAddBytesSent(n) {
+		return false
+	}
+	c.bytesSent += n
+	return true
+}
+
 func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
 	// this only happens during connection establishment, when data is sent before we receive the peer's transport parameters
 	if c.bytesSent > c.sendWindow {
@@ -141,11 +152,16 @@ func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
 }
 
 func (c *streamFlowController) IsNewlyBlocked() bool {
+	blocked, _ := c.isNewlyBlocked()
+	return blocked
+}
+
+func (c *streamFlowController) isNewlyBlocked() (bool, protocol.ByteCount) {
 	if c.bytesSent < c.sendWindow || c.sendWindow == c.lastBlockedAt {
-		return false
+		return false, 0
 	}
 	c.lastBlockedAt = c.sendWindow
-	return true
+	return true, c.sendWindow
 }
 
 func (c *streamFlowController) shouldQueueWindowUpdate() bool {

--- a/flow_controller_stream.go
+++ b/flow_controller_stream.go
@@ -119,11 +119,6 @@ func (c *streamFlowController) Abandon() {
 	}
 }
 
-func (c *streamFlowController) AddBytesSent(n protocol.ByteCount) {
-	c.bytesSent += n
-	c.connection.AddBytesSent(n)
-}
-
 func (c *streamFlowController) UpdateSendWindow(offset protocol.ByteCount) (updated bool) {
 	if offset > c.sendWindow {
 		c.sendWindow = offset

--- a/flow_controller_stream_test.go
+++ b/flow_controller_stream_test.go
@@ -176,6 +176,30 @@ func TestStreamSendWindow(t *testing.T) {
 	require.False(t, fc.IsNewlyBlocked()) // we're blocked, but not on stream flow control
 }
 
+func TestStreamFlowControllerTryAddBytesSent(t *testing.T) {
+	connFC := newConnectionFlowController(
+		protocol.MaxByteCount,
+		protocol.MaxByteCount,
+		nil,
+		utils.NewRTTStats(),
+		utils.DefaultLogger,
+	)
+	require.True(t, connFC.UpdateSendWindow(10))
+	fc := newStreamFlowController(
+		42,
+		connFC,
+		protocol.MaxByteCount,
+		protocol.MaxByteCount,
+		100,
+		utils.NewRTTStats(),
+		utils.DefaultLogger,
+	)
+
+	require.True(t, fc.TryAddBytesSent(6))
+	require.False(t, fc.TryAddBytesSent(5))
+	require.Equal(t, protocol.ByteCount(4), connFC.SendWindowSize())
+}
+
 func TestStreamWindowUpdate(t *testing.T) {
 	fc := newStreamFlowController(
 		42,

--- a/flow_controller_stream_test.go
+++ b/flow_controller_stream_test.go
@@ -155,10 +155,10 @@ func TestStreamSendWindow(t *testing.T) {
 	)
 	// first, we're limited by the stream flow controller
 	require.Equal(t, protocol.ByteCount(100), fc.SendWindowSize())
-	fc.AddBytesSent(50)
+	require.True(t, fc.TryAddBytesSent(50))
 	require.False(t, fc.IsNewlyBlocked())
 	require.Equal(t, protocol.ByteCount(50), fc.SendWindowSize())
-	fc.AddBytesSent(50)
+	require.True(t, fc.TryAddBytesSent(50))
 	require.True(t, fc.IsNewlyBlocked())
 	require.Zero(t, fc.SendWindowSize())
 	require.False(t, fc.IsNewlyBlocked()) // we're still blocked, but it's not new
@@ -171,7 +171,7 @@ func TestStreamSendWindow(t *testing.T) {
 
 	require.False(t, fc.IsNewlyBlocked()) // we're not blocked anymore
 	require.Equal(t, protocol.ByteCount(200), fc.SendWindowSize())
-	fc.AddBytesSent(200)
+	require.True(t, fc.TryAddBytesSent(200))
 	require.Zero(t, fc.SendWindowSize())
 	require.False(t, fc.IsNewlyBlocked()) // we're blocked, but not on stream flow control
 }

--- a/framer_test.go
+++ b/framer_test.go
@@ -172,7 +172,7 @@ func testFramerDataBlocked(t *testing.T, fits bool) {
 
 	fc := newConnectionFlowController(0, 0, nil, nil, nil)
 	fc.UpdateSendWindow(offset)
-	fc.AddBytesSent(offset)
+	require.True(t, fc.TryAddBytesSent(offset))
 
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
 	framer := newFramer(fc)

--- a/interface.go
+++ b/interface.go
@@ -58,6 +58,9 @@ type TokenStore interface {
 // when the server rejects a 0-RTT connection attempt.
 var Err0RTTRejected = errors.New("0-RTT rejected")
 
+// ErrWouldBlock is returned by [SendStream.WriteImmediately] if the entire slice can't be queued immediately.
+var ErrWouldBlock = errors.New("operation would block")
+
 // QUICVersionContextKey can be used to find out the QUIC version of a TLS handshake from the
 // context returned by tls.Config.ClientInfo.Context.
 var QUICVersionContextKey = handshake.QUICVersionContextKey

--- a/send_stream.go
+++ b/send_stream.go
@@ -380,10 +380,7 @@ func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 	if !s.nextFrameReserved && !s.flowController.TryAddBytesSent(maxDataLen) {
 		return nil, nil, true
 	}
-	f, hasMoreData := s.popNewStreamFrame(maxBytes, maxDataLen, v)
-	if f == nil {
-		return nil, nil, hasMoreData
-	}
+	f, hasMoreData := s.popNewStreamFrame(maxDataLen)
 	if f.DataLen() > 0 {
 		s.writeOffset += f.DataLen()
 	}
@@ -405,12 +402,8 @@ func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 
 // popNewStreamFrame returns a new STREAM frame to send for this stream
 // hasMoreData says if there's more data to send, *not* taking into account the reliable size
-func (s *SendStream) popNewStreamFrame(maxBytes, maxDataLen protocol.ByteCount, v protocol.Version) (_ *wire.StreamFrame, hasMoreData bool) {
+func (s *SendStream) popNewStreamFrame(maxDataLen protocol.ByteCount) (_ *wire.StreamFrame, hasMoreData bool) {
 	if s.nextFrame != nil {
-		maxDataLen := min(maxDataLen, s.nextFrame.MaxDataLen(maxBytes, v))
-		if maxDataLen == 0 {
-			return nil, true
-		}
 		nextFrame := s.nextFrame
 		nextFrameReserved := s.nextFrameReserved
 		s.nextFrame = nil
@@ -443,22 +436,8 @@ func (s *SendStream) popNewStreamFrame(maxBytes, maxDataLen protocol.ByteCount, 
 	f.DataLenPresent = true
 	f.Data = f.Data[:0]
 
-	hasMoreData = s.popNewStreamFrameWithoutBuffer(f, maxBytes, maxDataLen, v)
-	if len(f.Data) == 0 && !f.Fin {
-		f.PutBack()
-		return nil, hasMoreData
-	}
-	return f, hasMoreData
-}
-
-func (s *SendStream) popNewStreamFrameWithoutBuffer(f *wire.StreamFrame, maxBytes, sendWindow protocol.ByteCount, v protocol.Version) bool {
-	maxDataLen := f.MaxDataLen(maxBytes, v)
-	if maxDataLen == 0 { // a STREAM frame must have at least one byte of data
-		return s.dataForWriting != nil || s.nextFrame != nil || s.finishedWriting
-	}
-	s.getDataForWriting(f, min(maxDataLen, sendWindow))
-
-	return s.dataForWriting != nil || s.nextFrame != nil || s.finishedWriting
+	s.getDataForWriting(f, maxDataLen)
+	return f, s.dataForWriting != nil || s.nextFrame != nil || s.finishedWriting
 }
 
 func (s *SendStream) maybeGetRetransmission(maxBytes protocol.ByteCount, v protocol.Version) (*wire.StreamFrame, bool /* has more retransmissions */) {

--- a/send_stream.go
+++ b/send_stream.go
@@ -37,6 +37,11 @@ type SendStream struct {
 	resetErr               *StreamError
 	queuedResetStreamFrame *wire.ResetStreamFrame
 
+	dataForWriting []byte // during a Write() call, this slice is the part of p that still needs to be sent out
+	nextFrame      *wire.StreamFrame
+	// set if flow control credit for nextFrame was already consumed
+	nextFrameReserved bool
+
 	supportsResetStreamAt bool
 	finishedWriting       bool // set once Close() is called
 	finSent               bool // set when a STREAM_FRAME with FIN bit has been sent
@@ -45,9 +50,6 @@ type SendStream struct {
 	// or because Write returned the error (for remote cancellations).
 	cancellationFlagged bool
 	completed           bool // set when this stream has been reported to the streamSender as completed
-
-	dataForWriting []byte // during a Write() call, this slice is the part of p that still needs to be sent out
-	nextFrame      *wire.StreamFrame
 
 	writeChan chan struct{}
 	writeOnce chan struct{}
@@ -101,6 +103,82 @@ func (s *SendStream) Write(p []byte) (int, error) {
 		s.sender.onStreamCompleted(s.streamID)
 	}
 	return n, err
+}
+
+// WriteImmediately writes data to the stream if it can be queued immediately.
+// It doesn't block for flow control credit and doesn't respect the write deadline.
+// If the entire slice can't be queued immediately, it queues nothing and returns [ErrWouldBlock].
+func (s *SendStream) WriteImmediately(p []byte) error {
+	select {
+	case s.writeOnce <- struct{}{}:
+		defer func() { <-s.writeOnce }()
+	default:
+		return ErrWouldBlock
+	}
+
+	isNewlyCompleted, hasData, err := s.writeImmediately(p)
+	if isNewlyCompleted {
+		s.sender.onStreamCompleted(s.streamID)
+	}
+	if hasData {
+		s.sender.onHasStreamData(s.streamID, s)
+	}
+	return err
+}
+
+func (s *SendStream) writeImmediately(p []byte) (bool /* is newly completed */, bool /* has data */, error) {
+	// This might wait briefly while a packet is dequeuing stream data.
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.resetErr != nil {
+		s.cancellationFlagged = true
+		return s.isNewlyCompleted(), false, s.resetErr
+	}
+	if s.shutdownErr != nil {
+		return false, false, s.shutdownErr
+	}
+	if s.finishedWriting {
+		return false, false, fmt.Errorf("write on closed stream %d", s.streamID)
+	}
+	if len(p) == 0 {
+		return false, false, nil
+	}
+
+	bytesToReserve := protocol.ByteCount(len(p))
+	if s.nextFrame != nil && !s.nextFrameReserved {
+		bytesToReserve += s.nextFrame.DataLen()
+	}
+	if !s.flowController.TryAddBytesSent(bytesToReserve) {
+		return false, false, ErrWouldBlock
+	}
+
+	if s.nextFrame == nil {
+		s.nextFrame = wire.GetStreamFrame()
+		s.nextFrame.Offset = s.writeOffset
+		s.nextFrame.StreamID = s.streamID
+		s.nextFrame.DataLenPresent = true
+		s.nextFrame.Data = s.nextFrame.Data[:0]
+	}
+	l := len(s.nextFrame.Data)
+	if l+len(p) > cap(s.nextFrame.Data) {
+		// Pooled STREAM frames must keep their packet-sized buffer.
+		// Use a non-pooled frame when the queued data grows beyond that.
+		nextFrame := &wire.StreamFrame{
+			StreamID:       s.streamID,
+			Offset:         s.nextFrame.Offset,
+			DataLenPresent: true,
+			Data:           make([]byte, l+len(p)),
+		}
+		copy(nextFrame.Data, s.nextFrame.Data)
+		s.nextFrame.PutBack()
+		s.nextFrame = nextFrame
+	} else {
+		s.nextFrame.Data = s.nextFrame.Data[:l+len(p)]
+	}
+	copy(s.nextFrame.Data[l:], p)
+	s.nextFrameReserved = true
+	return false, true, nil
 }
 
 func (s *SendStream) write(p []byte) (bool /* is newly completed */, int, error) {
@@ -210,6 +288,9 @@ func (s *SendStream) write(p []byte) (bool /* is newly completed */, int, error)
 }
 
 func (s *SendStream) canBufferStreamFrame() bool {
+	if s.nextFrameReserved {
+		return false
+	}
 	var l protocol.ByteCount
 	if s.nextFrame != nil {
 		l = s.nextFrame.DataLen()
@@ -272,15 +353,32 @@ func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 		return nil, nil, false
 	}
 
-	maxDataLen := s.flowController.SendWindowSize()
+	// if the stream is canceled, only data up to the reliable size needs to be sent
+	reliableOffset := s.reliableOffset()
+	var maxDataLen protocol.ByteCount
+	if s.nextFrameReserved {
+		maxDataLen = s.nextFrame.DataLen()
+	} else {
+		maxDataLen = s.flowController.SendWindowSize()
+	}
+	if s.resetErr != nil && reliableOffset > 0 {
+		maxDataLen = min(maxDataLen, reliableOffset-s.writeOffset)
+	}
+	if s.nextFrame != nil {
+		maxDataLen = min(maxDataLen, s.nextFrame.MaxDataLen(maxBytes, v), s.nextFrame.DataLen())
+	} else {
+		f := wire.StreamFrame{
+			StreamID:       s.streamID,
+			Offset:         s.writeOffset,
+			DataLenPresent: true,
+		}
+		maxDataLen = min(maxDataLen, f.MaxDataLen(maxBytes, v), protocol.ByteCount(len(s.dataForWriting)))
+	}
 	if maxDataLen == 0 {
 		return nil, nil, true
 	}
-
-	// if the stream is canceled, only data up to the reliable size needs to be sent
-	reliableOffset := s.reliableOffset()
-	if s.resetErr != nil && reliableOffset > 0 {
-		maxDataLen = min(maxDataLen, reliableOffset-s.writeOffset)
+	if !s.nextFrameReserved && !s.flowController.TryAddBytesSent(maxDataLen) {
+		return nil, nil, true
 	}
 	f, hasMoreData := s.popNewStreamFrame(maxBytes, maxDataLen, v)
 	if f == nil {
@@ -288,16 +386,15 @@ func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 	}
 	if f.DataLen() > 0 {
 		s.writeOffset += f.DataLen()
-		s.flowController.AddBytesSent(f.DataLen())
 	}
 	if s.resetErr != nil && s.writeOffset >= reliableOffset {
 		hasMoreData = false
 	}
 	var blocked *wire.StreamDataBlockedFrame
-	// If the entire send window is used, the stream might have become blocked on stream-level flow control.
-	// This is not guaranteed though, because the stream might also have been blocked on connection-level flow control.
-	if f.DataLen() == maxDataLen && s.flowController.IsNewlyBlocked() {
-		blocked = &wire.StreamDataBlockedFrame{StreamID: s.streamID, MaximumStreamData: s.writeOffset}
+	if f.DataLen() > 0 {
+		if isBlocked, offset := s.flowController.isNewlyBlocked(); isBlocked {
+			blocked = &wire.StreamDataBlockedFrame{StreamID: s.streamID, MaximumStreamData: offset}
+		}
 	}
 	f.Fin = s.finishedWriting && s.dataForWriting == nil && s.nextFrame == nil && !s.finSent
 	if f.Fin {
@@ -315,15 +412,24 @@ func (s *SendStream) popNewStreamFrame(maxBytes, maxDataLen protocol.ByteCount, 
 			return nil, true
 		}
 		nextFrame := s.nextFrame
+		nextFrameReserved := s.nextFrameReserved
 		s.nextFrame = nil
+		s.nextFrameReserved = false
 		if nextFrame.DataLen() > maxDataLen {
-			s.nextFrame = wire.GetStreamFrame()
+			if nextFrame.DataLen()-maxDataLen > protocol.MaxPacketBufferSize {
+				s.nextFrame = &wire.StreamFrame{
+					Data: make([]byte, nextFrame.DataLen()-maxDataLen),
+				}
+			} else {
+				s.nextFrame = wire.GetStreamFrame()
+				s.nextFrame.Data = s.nextFrame.Data[:nextFrame.DataLen()-maxDataLen]
+			}
 			s.nextFrame.StreamID = s.streamID
 			s.nextFrame.Offset = s.writeOffset + maxDataLen
-			s.nextFrame.Data = s.nextFrame.Data[:nextFrame.DataLen()-maxDataLen]
 			s.nextFrame.DataLenPresent = true
 			copy(s.nextFrame.Data, nextFrame.Data[maxDataLen:])
 			nextFrame.Data = nextFrame.Data[:maxDataLen]
+			s.nextFrameReserved = nextFrameReserved
 		} else {
 			s.signalWrite()
 		}
@@ -464,6 +570,7 @@ func (s *SendStream) returnFramesToPool() {
 		s.nextFrame.PutBack()
 		s.nextFrame = nil
 	}
+	s.nextFrameReserved = false
 }
 
 // CancelWrite aborts sending on this stream.
@@ -495,13 +602,17 @@ func (s *SendStream) CancelWrite(errorCode StreamErrorCode) {
 	s.ctxCancel(s.resetErr)
 
 	reliableOffset := s.reliableOffset()
+	finalSize := max(s.writeOffset, reliableOffset)
+	if s.nextFrameReserved && s.nextFrame != nil {
+		finalSize = max(finalSize, s.nextFrame.Offset+s.nextFrame.DataLen())
+	}
 	if reliableOffset == 0 {
 		s.numOutstandingFrames = 0
 		s.returnFramesToPool()
 	}
 	s.queuedResetStreamFrame = &wire.ResetStreamFrame{
 		StreamID:  s.streamID,
-		FinalSize: max(s.writeOffset, reliableOffset),
+		FinalSize: finalSize,
 		ErrorCode: errorCode,
 		// if the peer doesn't support the extension, the reliable offset will always be 0
 		ReliableSize: reliableOffset,
@@ -511,6 +622,7 @@ func (s *SendStream) CancelWrite(errorCode StreamErrorCode) {
 			if s.nextFrame.Offset >= reliableOffset {
 				s.nextFrame.PutBack()
 				s.nextFrame = nil
+				s.nextFrameReserved = false
 			} else if s.nextFrame.Offset+s.nextFrame.DataLen() > reliableOffset {
 				s.nextFrame.Data = s.nextFrame.Data[:reliableOffset-s.nextFrame.Offset]
 			}
@@ -545,11 +657,12 @@ func (s *SendStream) enableResetStreamAt() {
 }
 
 func (s *SendStream) updateSendWindow(limit protocol.ByteCount) {
+	s.mutex.Lock()
 	updated := s.flowController.UpdateSendWindow(limit)
 	if !updated { // duplicate or reordered MAX_STREAM_DATA frame
+		s.mutex.Unlock()
 		return
 	}
-	s.mutex.Lock()
 	hasStreamData := s.dataForWriting != nil || s.nextFrame != nil
 	s.mutex.Unlock()
 	if hasStreamData {
@@ -573,6 +686,10 @@ func (s *SendStream) handleStopSendingFrame(f *wire.StopSendingFrame) {
 	// if the peer stopped reading from the stream, there's no need to transmit any data reliably
 	s.reliableSize = 0
 	s.numOutstandingFrames = 0
+	finalSize := s.writeOffset
+	if s.nextFrameReserved && s.nextFrame != nil {
+		finalSize = max(finalSize, s.nextFrame.Offset+s.nextFrame.DataLen())
+	}
 	s.returnFramesToPool()
 	if s.resetErr == nil {
 		s.resetErr = &StreamError{StreamID: s.streamID, ErrorCode: f.ErrorCode, Remote: true}
@@ -580,7 +697,7 @@ func (s *SendStream) handleStopSendingFrame(f *wire.StopSendingFrame) {
 	}
 	s.queuedResetStreamFrame = &wire.ResetStreamFrame{
 		StreamID:  s.streamID,
-		FinalSize: s.writeOffset,
+		FinalSize: finalSize,
 		ErrorCode: s.resetErr.ErrorCode,
 	}
 	s.mutex.Unlock()

--- a/send_stream.go
+++ b/send_stream.go
@@ -553,9 +553,10 @@ func (s *SendStream) SetReliableBoundary() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	s.reliableSize = s.writeOffset
 	if s.nextFrame != nil {
-		s.reliableSize += s.nextFrame.DataLen()
+		s.reliableSize = max(s.reliableSize, s.writeOffset+s.nextFrame.DataLen())
+	} else {
+		s.reliableSize = max(s.reliableSize, s.writeOffset)
 	}
 }
 

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -142,6 +142,9 @@ func TestSendStreamWriteImmediately(t *testing.T) {
 	mockSender := NewMockStreamSender(mockCtrl)
 	str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
+	require.NoError(t, str.WriteImmediately(nil))
+	require.NoError(t, str.WriteImmediately([]byte{}))
+
 	mockSender.EXPECT().onHasStreamData(streamID, str)
 	data := []byte("foobar")
 	require.NoError(t, str.WriteImmediately(data))
@@ -168,6 +171,16 @@ func TestSendStreamWriteImmediatelyFlowControlBlocked(t *testing.T) {
 	frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 	require.Nil(t, frame.Frame)
 	require.False(t, hasMore)
+
+	mockSender.EXPECT().onHasStreamData(streamID, str)
+	require.NoError(t, str.WriteImmediately([]byte("foo")))
+	frame, blocked, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	require.False(t, hasMore)
+	require.EqualExportedValues(t,
+		&wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true},
+		frame.Frame,
+	)
+	require.Equal(t, &wire.StreamDataBlockedFrame{StreamID: streamID, MaximumStreamData: 3}, blocked)
 }
 
 func TestSendStreamWriteImmediatelyAfterBufferedWrite(t *testing.T) {
@@ -660,6 +673,7 @@ func TestSendStreamClose(t *testing.T) {
 	// further calls to Write return an error
 	_, err = strWithTimeout.Write([]byte("foobar"))
 	require.ErrorContains(t, err, "write on closed stream 1234")
+	require.ErrorContains(t, str.WriteImmediately([]byte("foobar")), "write on closed stream 1234")
 	frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 	require.Nil(t, frame.Frame)
 	require.False(t, hasMore)
@@ -873,6 +887,8 @@ func TestSendStreamCancellation(t *testing.T) {
 
 		// future calls to Write should return an error
 		_, err = strWithTimeout.Write([]byte("foo"))
+		require.ErrorIs(t, err, &StreamError{StreamID: streamID, ErrorCode: 1234, Remote: false})
+		err = str.WriteImmediately([]byte("foo"))
 		require.ErrorIs(t, err, &StreamError{StreamID: streamID, ErrorCode: 1234, Remote: false})
 		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 		require.Nil(t, frame.Frame)

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -334,6 +334,35 @@ func TestSendStreamResetFinalSizeIncludesReservedData(t *testing.T) {
 	}
 }
 
+func TestSendStreamSetReliableBoundaryAfterWriteImmediately(t *testing.T) {
+	const streamID protocol.StreamID = 42
+	mockCtrl := gomock.NewController(t)
+	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 100)
+	mockSender := NewMockStreamSender(mockCtrl)
+	str := newSendStream(context.Background(), streamID, mockSender, mockFC, true)
+
+	mockSender.EXPECT().onHasStreamData(streamID, str)
+	require.NoError(t, str.WriteImmediately(make([]byte, 100)))
+
+	frame, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, 0)+40, protocol.Version1)
+	require.True(t, hasMore)
+	require.Equal(t, protocol.ByteCount(40), frame.Frame.DataLen())
+
+	str.SetReliableBoundary()
+
+	mockSender.EXPECT().onHasStreamControlFrame(streamID, str)
+	str.CancelWrite(42)
+	cf, ok, hasMore := str.getControlFrame(monotime.Now())
+	require.True(t, ok)
+	require.False(t, hasMore)
+	require.Equal(t, &wire.ResetStreamFrame{StreamID: streamID, FinalSize: 100, ErrorCode: 42, ReliableSize: 100}, cf.Frame)
+
+	frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	require.False(t, hasMore)
+	require.Equal(t, protocol.ByteCount(40), frame.Frame.Offset)
+	require.Equal(t, protocol.ByteCount(60), frame.Frame.DataLen())
+}
+
 func TestSendStreamLargeWrites(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const streamID protocol.StreamID = 1337

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -135,6 +135,205 @@ func TestSendStreamWriteData(t *testing.T) {
 	)
 }
 
+func TestSendStreamWriteImmediately(t *testing.T) {
+	const streamID protocol.StreamID = 42
+	mockCtrl := gomock.NewController(t)
+	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
+	mockSender := NewMockStreamSender(mockCtrl)
+	str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+	mockSender.EXPECT().onHasStreamData(streamID, str)
+	data := []byte("foobar")
+	require.NoError(t, str.WriteImmediately(data))
+	data[0] = 'x' // make sure the data was copied
+
+	frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	require.False(t, hasMore)
+	require.EqualExportedValues(t,
+		&wire.StreamFrame{StreamID: streamID, Data: []byte("foobar"), DataLenPresent: true},
+		frame.Frame,
+	)
+}
+
+func TestSendStreamWriteImmediatelyFlowControlBlocked(t *testing.T) {
+	const streamID protocol.StreamID = 42
+	mockCtrl := gomock.NewController(t)
+	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 3)
+	mockSender := NewMockStreamSender(mockCtrl)
+	str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+	require.ErrorIs(t, str.WriteImmediately([]byte("foobar")), ErrWouldBlock)
+	require.Equal(t, protocol.ByteCount(3), mockFC.SendWindowSize())
+
+	frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	require.Nil(t, frame.Frame)
+	require.False(t, hasMore)
+}
+
+func TestSendStreamWriteImmediatelyAfterBufferedWrite(t *testing.T) {
+	const streamID protocol.StreamID = 42
+
+	t.Run("enough credit", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 6)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str).Times(2)
+		n, err := str.Write([]byte("foo"))
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
+		require.NoError(t, str.WriteImmediately([]byte("bar")))
+
+		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.False(t, hasMore)
+		require.EqualExportedValues(t,
+			&wire.StreamFrame{StreamID: streamID, Data: []byte("foobar"), DataLenPresent: true},
+			frame.Frame,
+		)
+		require.Zero(t, mockFC.SendWindowSize())
+	})
+
+	t.Run("not enough credit", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 5)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str)
+		n, err := str.Write([]byte("foo"))
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
+		require.ErrorIs(t, str.WriteImmediately([]byte("bar")), ErrWouldBlock)
+
+		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.False(t, hasMore)
+		require.EqualExportedValues(t,
+			&wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true},
+			frame.Frame,
+		)
+		require.Equal(t, protocol.ByteCount(2), mockFC.SendWindowSize())
+	})
+}
+
+func TestSendStreamWriteAfterWriteImmediately(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const streamID protocol.StreamID = 42
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str).Times(2)
+		require.NoError(t, str.WriteImmediately([]byte("foo")))
+
+		errChan := make(chan error, 1)
+		go func() {
+			n, err := str.Write([]byte("bar"))
+			if n != 3 {
+				errChan <- fmt.Errorf("expected to write 3 bytes, wrote %d", n)
+				return
+			}
+			errChan <- err
+		}()
+		synctest.Wait()
+		select {
+		case err := <-errChan:
+			t.Fatalf("Write should not have returned yet: %v", err)
+		default:
+		}
+
+		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.True(t, hasMore)
+		require.EqualExportedValues(t,
+			&wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true},
+			frame.Frame,
+		)
+
+		synctest.Wait()
+		select {
+		case err := <-errChan:
+			require.NoError(t, err)
+		default:
+			t.Fatal("Write should have returned")
+		}
+
+		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.False(t, hasMore)
+		require.EqualExportedValues(t,
+			&wire.StreamFrame{StreamID: streamID, Offset: 3, Data: []byte("bar"), DataLenPresent: true},
+			frame.Frame,
+		)
+	})
+}
+
+func TestSendStreamLargeWriteImmediately(t *testing.T) {
+	const streamID protocol.StreamID = 42
+	mockCtrl := gomock.NewController(t)
+	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
+	mockSender := NewMockStreamSender(mockCtrl)
+	str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+	data := make([]byte, 10*protocol.MaxPacketBufferSize)
+	for i := range data {
+		data[i] = byte(i)
+	}
+
+	mockSender.EXPECT().onHasStreamData(streamID, str)
+	require.NoError(t, str.WriteImmediately(data))
+
+	var offset protocol.ByteCount
+	for offset < protocol.ByteCount(len(data)) {
+		frame, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, offset)+40, protocol.Version1)
+		require.NotNil(t, frame.Frame)
+		require.Equal(t, offset, frame.Frame.Offset)
+		require.Equal(t, data[offset:offset+40], frame.Frame.Data)
+		offset += 40
+		require.Equal(t, offset < protocol.ByteCount(len(data)), hasMore)
+	}
+}
+
+func TestSendStreamResetFinalSizeIncludesReservedData(t *testing.T) {
+	const streamID protocol.StreamID = 42
+
+	for _, tc := range []struct {
+		name  string
+		reset func(*SendStream)
+	}{
+		{
+			name:  "CancelWrite",
+			reset: func(str *SendStream) { str.CancelWrite(42) },
+		},
+		{
+			name: "STOP_SENDING",
+			reset: func(str *SendStream) {
+				str.handleStopSendingFrame(&wire.StopSendingFrame{StreamID: streamID, ErrorCode: 42})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 100)
+			mockSender := NewMockStreamSender(mockCtrl)
+			str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+			mockSender.EXPECT().onHasStreamData(streamID, str)
+			require.NoError(t, str.WriteImmediately(make([]byte, 100)))
+
+			frame, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, 0)+40, protocol.Version1)
+			require.True(t, hasMore)
+			require.Equal(t, protocol.ByteCount(40), frame.Frame.DataLen())
+
+			mockSender.EXPECT().onHasStreamControlFrame(streamID, str)
+			tc.reset(str)
+			cf, ok, hasMore := str.getControlFrame(monotime.Now())
+			require.True(t, ok)
+			require.False(t, hasMore)
+			require.Equal(t, &wire.ResetStreamFrame{StreamID: streamID, FinalSize: 100, ErrorCode: 42}, cf.Frame)
+		})
+	}
+}
+
 func TestSendStreamLargeWrites(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const streamID protocol.StreamID = 1337

--- a/stream.go
+++ b/stream.go
@@ -132,6 +132,12 @@ func (s *Stream) Write(p []byte) (int, error) {
 	return s.sendStr.Write(p)
 }
 
+// WriteImmediately writes data to the stream if it can be queued immediately.
+// See [SendStream.WriteImmediately] for more details.
+func (s *Stream) WriteImmediately(p []byte) error {
+	return s.sendStr.WriteImmediately(p)
+}
+
 // SetReliableBoundary marks the data written to this stream so far as reliable.
 // It is valid to call this function multiple times, thereby increasing the reliable size.
 // It only has an effect if the peer enabled support for the RESET_STREAM_AT extension,


### PR DESCRIPTION
Fixes #5575.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `WriteImmediately` to `SendStream` for non-blocking writes
> - Adds `SendStream.WriteImmediately` (and `Stream.WriteImmediately`) that queues an entire byte slice without blocking on flow control or write deadlines. Returns `ErrWouldBlock` if there is insufficient flow control credit, with no partial queueing.
> - Introduces `TryAddBytesSent` on both stream and connection flow controllers to atomically reserve send credit at queue time, so later framing skips credit checks for reserved frames.
> - Refactors `baseFlowController` into a receive-only `receiveFlowController`, moving send-side state into dedicated fields with their own mutex on each controller for safe concurrent access.
> - `popNewOrRetransmittedStreamFrame` honors pre-reserved credit and emits `STREAM_DATA_BLOCKED` with the precise offset from the flow controller.
> - Risk: `CancelWrite` and `STOP_SENDING` handling now include reserved-but-unframed bytes in `FinalSize`; existing code that inspects final size may see larger values than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d56f3ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `WriteImmediately(p []byte)` for `Stream`/`SendStream` to queue data synchronously when send-window credit is available.
  * Added `ErrWouldBlock` to indicate the operation can’t be queued immediately due to flow control.
* **Bug Fixes**
  * Refined send-window credit handling and blocking detection.
  * Corrected reset/cancel and reliable-boundary sizing behavior when using `WriteImmediately`.
* **Tests**
  * Expanded coverage for `WriteImmediately`, flow-control blocking, frame splitting, and reset/reliable-boundary edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->