### PR TITLE
wire: speed up transport parameter parsing by using slices.Sort

### DIFF
--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -232,13 +232,8 @@ func (p *TransportParameters) unmarshal(b []byte, sentBy protocol.Perspective, f
 	}
 
 	// check that every transport parameter was sent at most once
-	slices.SortFunc(parameterIDs, func(a, b transportParameterID) int {
-		if a < b {
-			return -1
-		}
-		return 1
-	})
-	for i := 0; i < len(parameterIDs)-1; i++ {
+	slices.Sort(parameterIDs)
+	for i := range len(parameterIDs) - 1 {
 		if parameterIDs[i] == parameterIDs[i+1] {
 			return fmt.Errorf("received duplicate transport parameter %#x", parameterIDs[i])
 		}


### PR DESCRIPTION
```
name                                              old time/op    new time/op    delta
TransportParameters/without_preferred_address-16     314ns ± 2%     228ns ± 4%  -27.26%  (p=0.008 n=5+5)
TransportParameters/with_preferred_address-16        359ns ± 3%     258ns ± 1%  -28.25%  (p=0.008 n=5+5)

name                                              old alloc/op   new alloc/op   delta
TransportParameters/without_preferred_address-16     40.0B ± 0%     40.0B ± 0%     ~     (all equal)
TransportParameters/with_preferred_address-16         152B ± 0%      152B ± 0%     ~     (all equal)

name                                              old allocs/op  new allocs/op  delta
TransportParameters/without_preferred_address-16      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
TransportParameters/with_preferred_address-16         3.00 ± 0%      3.00 ± 0%     ~     (all equal)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up transport parameter parsing by using `slices.Sort` in `TransportParameters.unmarshal`
> Replaces `slices.SortFunc` (with a comparator that never returned 0 for equal elements) with `slices.Sort` in [transport_parameters.go](https://github.com/quic-go/quic-go/pull/5712/files#diff-39da89f9b997bcbb683fc9579f35c9b0e23d9256300909e15f2edcc64aa8bd00). This fixes duplicate parameter ID detection: equal IDs are now treated as equal, so duplicates are reliably adjacent and caught by the existing check. Also updates the iteration loop to Go 1.22 integer range style.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3174163.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of transport parameters to reliably detect duplicate entries.
  * Simplified duplicate-checking behavior while preserving clear error reporting for invalid parameter sets.
  * No changes to the public API or user-facing configuration formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->