### PR TITLE
wire: reject unknown transport params on session ticket restore

### DIFF
--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -462,6 +462,20 @@ func TestTransportParameterUnknownParameters(t *testing.T) {
 	require.Equal(t, protocol.ByteCount(0x42), p.InitialMaxStreamDataBidiRemote)
 }
 
+func TestSessionTicketTransportParameterRejectsUnknownParameter(t *testing.T) {
+	b := (&TransportParameters{
+		ActiveConnectionIDLimit: 2,
+		MaxDatagramFrameSize:    protocol.InvalidByteCount,
+	}).MarshalForSessionTicket(nil)
+	b = quicvarint.Append(b, 0x42)
+	b = quicvarint.Append(b, 6)
+	b = append(b, []byte("foobar")...)
+
+	var p TransportParameters
+	err := p.UnmarshalFromSessionTicket(b)
+	require.EqualError(t, err, "unknown transport parameter 0x42 in session ticket")
+}
+
 func TestTransportParameterRejectsDuplicateParameters(t *testing.T) {
 	// write first parameter
 	b := quicvarint.Append(nil, uint64(initialMaxStreamDataBidiLocalParameterID))

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -211,6 +211,11 @@ func (p *TransportParameters) unmarshal(b []byte, sentBy protocol.Perspective, f
 			}
 			p.EnableResetStreamAt = true
 		default:
+			if fromSessionTicket {
+				// A ticket might contain a parameter for an extension supported by an older
+				// version of this endpoint. If we can't parse it, don't resume with it.
+				return fmt.Errorf("unknown transport parameter %#x in session ticket", paramID)
+			}
 			b = b[paramLen:]
 		}
 	}


### PR DESCRIPTION
Session tickets should only be accepted when all saved transport parameters can be parsed. Unknown parameters might belong to an extension supported by an older version of this endpoint, so resuming with them incorrectly allow 0-RTT resumption.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject unknown transport parameters when restoring session tickets
> When parsing transport parameters from a session ticket, unknown parameters are now rejected with an error instead of being silently skipped. This is implemented in the `unmarshal` method in [transport_parameters.go](https://github.com/quic-go/quic-go/pull/5714/files#diff-39da89f9b997bcbb683fc9579f35c9b0e23d9256300909e15f2edcc64aa8bd00) by checking the `fromSessionTicket` flag in the default switch case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33e6c4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session-ticket restoration now fails clearly and immediately when unsupported transport parameters are present.
  - Improved error reporting identifies the unknown parameter that caused restoration to fail.

- **Tests**
  - Added coverage to verify that session tickets containing unknown transport parameters are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->