### PR TITLE
fix RESET_STREAM_AT negotiation after 0-RTT for existing streams

### DIFF
--- a/streams_map.go
+++ b/streams_map.go
@@ -318,8 +318,10 @@ func (m *streamsMap) HandleStreamFrame(f *wire.StreamFrame, rcvTime monotime.Tim
 
 func (m *streamsMap) HandleTransportParameters(p *wire.TransportParameters) {
 	m.supportsResetStreamAt = p.EnableResetStreamAt
-	m.outgoingBidiStreams.EnableResetStreamAt()
-	m.outgoingUniStreams.EnableResetStreamAt()
+	if p.EnableResetStreamAt {
+		m.outgoingBidiStreams.EnableResetStreamAt()
+		m.outgoingUniStreams.EnableResetStreamAt()
+	}
 	m.outgoingBidiStreams.UpdateSendWindow(p.InitialMaxStreamDataBidiRemote)
 	m.outgoingBidiStreams.SetMaxStream(p.MaxBidiStreamNum.StreamID(protocol.StreamTypeBidi, m.perspective))
 	m.outgoingUniStreams.UpdateSendWindow(p.InitialMaxStreamDataUni)

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -543,6 +543,36 @@ func TestStreamsMap0RTT(t *testing.T) {
 	require.Equal(t, protocol.ByteCount(4321), fcs[1].SendWindowSize())
 }
 
+func TestStreamsMap0RTTResetStreamAt(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enabled: %t", enabled), func(t *testing.T) {
+			mockSender := NewMockStreamSender(gomock.NewController(t))
+			mockSender.EXPECT().onHasStreamData(gomock.Any(), gomock.Any()).AnyTimes()
+			mockSender.EXPECT().onHasStreamControlFrame(gomock.Any(), gomock.Any()).AnyTimes()
+			m := newStreamsMap(
+				context.Background(),
+				mockSender,
+				func(wire.Frame) {},
+				func(id protocol.StreamID) *streamFlowController {
+					return newTestStreamFlowControllerWithSendWindow(id, 1)
+				},
+				1,
+				1,
+				protocol.PerspectiveClient,
+			)
+			m.HandleTransportParameters(&wire.TransportParameters{MaxBidiStreamNum: 1, MaxUniStreamNum: 1})
+			str, err := m.OpenStream()
+			require.NoError(t, err)
+			uniStr, err := m.OpenUniStream()
+			require.NoError(t, err)
+
+			m.HandleTransportParameters(&wire.TransportParameters{EnableResetStreamAt: enabled})
+			require.Equal(t, enabled, supportsResetStreamAt(t, str))
+			require.Equal(t, enabled, sendStreamSupportsResetStreamAt(t, uniStr))
+		})
+	}
+}
+
 func TestStreamsMap0RTTRejection(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockSender := NewMockStreamSender(mockCtrl)
@@ -574,4 +604,30 @@ func TestStreamsMap0RTTRejection(t *testing.T) {
 	_, err = m.OpenStream()
 	require.Error(t, err)
 	require.ErrorIs(t, err, &StreamLimitReachedError{})
+}
+
+func supportsResetStreamAt(t *testing.T, str *Stream) bool {
+	t.Helper()
+	_, err := str.Write([]byte{0})
+	require.NoError(t, err)
+	str.SetReliableBoundary()
+	str.CancelWrite(0)
+	frame, ok, _ := str.getControlFrame(monotime.Now())
+	require.True(t, ok)
+	reset, ok := frame.Frame.(*wire.ResetStreamFrame)
+	require.True(t, ok)
+	return reset.ReliableSize > 0
+}
+
+func sendStreamSupportsResetStreamAt(t *testing.T, str *SendStream) bool {
+	t.Helper()
+	_, err := str.Write([]byte{0})
+	require.NoError(t, err)
+	str.SetReliableBoundary()
+	str.CancelWrite(0)
+	frame, ok, _ := str.getControlFrame(monotime.Now())
+	require.True(t, ok)
+	reset, ok := frame.Frame.(*wire.ResetStreamFrame)
+	require.True(t, ok)
+	return reset.ReliableSize > 0
 }


### PR DESCRIPTION
Only enable RESET_STREAM_AT when advertised by the peer, and propagate support to streams created before transport parameters are processed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RESET_STREAM_AT` negotiation for existing streams after 0-RTT
> - In [`streams_map.go`](https://github.com/quic-go/quic-go/pull/5715/files#diff-666bc646e87db500ba5ef77f336c8fb175703c97cf0b6485012fd65bad83b382), `EnableResetStreamAt()` is now called on outgoing bidi and uni stream managers only when `TransportParameters.EnableResetStreamAt` is true; previously it was unconditionally enabled during `HandleTransportParameters`.
> - Adds a regression test `TestStreamsMap0RTTResetStreamAt` that opens streams under initial transport parameters, reapplies them with the flag toggled, and verifies the resulting `ResetStreamFrame.ReliableSize` reflects the correct state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b48429.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reset-stream support is now enabled only when the corresponding transport setting is active.
  * Corrected reset-stream behavior during 0-RTT connections for bidirectional and unidirectional streams.

* **Tests**
  * Added coverage to verify reset-stream support toggles correctly as transport settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->