### PR TITLE
reset RESET_STREAM_AT support after 0-RTT rejection

### DIFF
--- a/streams_map.go
+++ b/streams_map.go
@@ -345,6 +345,7 @@ func (m *streamsMap) ResetFor0RTT() {
 	defer m.mutex.Unlock()
 	m.reset = true
 	m.CloseWithError(Err0RTTRejected)
+	m.supportsResetStreamAt = false
 	m.initMaps()
 }
 

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -606,6 +606,47 @@ func TestStreamsMap0RTTRejection(t *testing.T) {
 	require.ErrorIs(t, err, &StreamLimitReachedError{})
 }
 
+func TestStreamsMap0RTTRejectionResetStreamAt(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enabled: %t", enabled), func(t *testing.T) {
+			testStreamsMap0RTTRejectionResetStreamAt(t, enabled)
+		})
+	}
+}
+
+func testStreamsMap0RTTRejectionResetStreamAt(t *testing.T, enabled bool) {
+	mockSender := NewMockStreamSender(gomock.NewController(t))
+	mockSender.EXPECT().onHasStreamData(gomock.Any(), gomock.Any()).AnyTimes()
+	mockSender.EXPECT().onHasStreamControlFrame(gomock.Any(), gomock.Any()).AnyTimes()
+	m := newStreamsMap(
+		context.Background(),
+		mockSender,
+		func(wire.Frame) {},
+		func(id protocol.StreamID) *streamFlowController {
+			return newTestStreamFlowControllerWithSendWindow(id, 1)
+		},
+		2,
+		1,
+		protocol.PerspectiveClient,
+	)
+	m.HandleTransportParameters(&wire.TransportParameters{EnableResetStreamAt: true})
+	m.ResetFor0RTT()
+
+	// The server can send 0.5-RTT data before the handshake completes.
+	require.NoError(t, m.HandleStreamFrame(&wire.StreamFrame{StreamID: 1}, monotime.Now()))
+	m.UseResetMaps()
+
+	str, err := m.AcceptStream(context.Background())
+	require.NoError(t, err)
+	require.False(t, supportsResetStreamAt(t, str))
+
+	m.HandleTransportParameters(&wire.TransportParameters{EnableResetStreamAt: enabled})
+	require.NoError(t, m.HandleStreamFrame(&wire.StreamFrame{StreamID: 5}, monotime.Now()))
+	str, err = m.AcceptStream(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, enabled, supportsResetStreamAt(t, str))
+}
+
 func supportsResetStreamAt(t *testing.T, str *Stream) bool {
 	t.Helper()
 	_, err := str.Write([]byte{0})


### PR DESCRIPTION
Clear the restored setting when rebuilding the stream maps so new streams use the transport parameters negotiated for the current connection.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RESET_STREAM_AT` support flag after 0-RTT rejection in `streamsMap`
> During 0-RTT rejection, `streamsMap.ResetFor0RTT` now sets `supportsResetStreamAt` to `false` before reinitializing the maps. This ensures the flag reflects the correct disabled state until new transport parameters re-enable it. A table-driven test in [streams_map_test.go](https://github.com/quic-go/quic-go/pull/5716/files#diff-6ad19f424ce497af8104804ea49a4f10ac87e88bfd616d0ac5e76426f1b5fffd) verifies the flag is disabled after rejection and correctly reflects the new transport parameters once they are applied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de8d1a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stream reset capability handling after a rejected 0-RTT connection.
  * Ensured stream reset support is disabled during the 0-RTT rejection/reset path, then resumes based on the latest transport settings.

* **Tests**
  * Added coverage verifying `EnableResetStreamAt` does not apply during the 0-RTT rejection/reset flow, and that behavior updates correctly after transport parameters are refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->