### PR TITLE
clear stream control frames on 0-RTT rejection

### DIFF
--- a/framer.go
+++ b/framer.go
@@ -279,6 +279,7 @@ func (f *framer) Handle0RTTRejection() {
 	for id := range f.activeStreams {
 		delete(f.activeStreams, id)
 	}
+	clear(f.streamsWithControlFrames)
 	var j int
 	for i, frame := range f.controlFrames {
 		switch frame.(type) {

--- a/framer_test.go
+++ b/framer_test.go
@@ -464,6 +464,7 @@ func TestFramer0RTTRejection(t *testing.T) {
 	framer.QueueControlFrame(pc)
 
 	framer.AddActiveStream(10, NewMockStreamFrameGetter(gomock.NewController(t)))
+	framer.AddStreamWithControlFrames(10, NewMockStreamControlFrameGetter(gomock.NewController(t)))
 
 	framer.Handle0RTTRejection()
 	controlFrames, streamFrames, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)


### PR DESCRIPTION
Drop streams queued for control-frame generation when 0-RTT is rejected, matching the existing cleanup of active streams.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear stream control frames on 0-RTT rejection in `framer.Handle0RTTRejection`
> Adds a call to `clear(f.streamsWithControlFrames)` in [`framer.go`](https://github.com/quic-go/quic-go/pull/5717/files#diff-a97a2544cb1bf86661368aeb59921e0629ab259d2728c61715e856a7ab5c1f6f) so that streams registered with control frames are reset alongside the stream queue and active streams when 0-RTT is rejected. Without this, stale stream control frames from the pre-rejection state could be emitted after rejection. The test in [`framer_test.go`](https://github.com/quic-go/quic-go/pull/5717/files#diff-44d4e5f3567272c5d38adad20085dc713b183d678b6d1832bd455ea97bf88d25) is updated to register a stream with control frames before invoking `Handle0RTTRejection` to cover this case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb71174.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 0-RTT rejection handling by clearing pending stream-related control frames.
  * Prevented stale control frames from being retained after a rejected 0-RTT connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->