### PR TITLE
simnet: fix flaky TestMTUEnforcement

### DIFF
--- a/testutils/simnet/simlink_test.go
+++ b/testutils/simnet/simlink_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -109,14 +110,10 @@ func TestMTUEnforcement(t *testing.T) {
 			MTU: MTU,
 		}
 
-		packetsReceived := 0
-		packetHandler := func(p Packet) {
-			packetsReceived++
-		}
-
+		var packetsReceived atomic.Uint32
 		router := &testRouter{
-			onSend: packetHandler,
-			onRecv: packetHandler,
+			onSend: func(p Packet) { packetsReceived.Add(1) },
+			onRecv: func(p Packet) { packetsReceived.Add(1) },
 		}
 		link := SimulatedLink{
 			UplinkSettings:   linkSettings,
@@ -149,8 +146,8 @@ func TestMTUEnforcement(t *testing.T) {
 		link.Close()
 
 		// Only packets within MTU should be received (2 packets: 1 from SendPacket, 1 from RecvPacket)
-		if packetsReceived != 2 {
-			t.Fatalf("expected 2 packets to be received, got %d", packetsReceived)
+		if packetsReceived.Load() != 2 {
+			t.Fatalf("expected 2 packets to be received, got %d", packetsReceived.Load())
 		}
 	})
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix flaky `TestMTUEnforcement` by using atomic packet counter
The `packetsReceived` counter in [simlink_test.go](https://github.com/quic-go/quic-go/pull/5719/files#diff-7e1f600b8a47a83fb19443d6312a1c2f5520a04bc223f1df976122683a2a045e) was incremented from concurrent router callbacks without synchronization, causing a data race and flaky test results. Replaces the plain `int` with an `atomic.Uint32`, using `.Add(1)` in callbacks and `.Load()` in the final assertion.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48943d8.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by making packet-count tracking safe for concurrent operations.
  * Updated MTU enforcement verification to consistently read the final packet count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->