### PR TITLE
validate RESET_STREAM_AT across 0-RTT resumption

### DIFF
--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -657,6 +657,7 @@ func TestTransportParametersValidFor0RTT(t *testing.T) {
 		MaxUniStreamNum:                6,
 		ActiveConnectionIDLimit:        7,
 		MaxDatagramFrameSize:           1000,
+		EnableResetStreamAt:            true,
 	}
 
 	tests := []struct {
@@ -668,6 +669,11 @@ func TestTransportParametersValidFor0RTT(t *testing.T) {
 			name:   "No Changes",
 			modify: func(p *TransportParameters) {},
 			valid:  true,
+		},
+		{
+			name:   "ResetStreamAt disabled",
+			modify: func(p *TransportParameters) { p.EnableResetStreamAt = false },
+			valid:  false,
 		},
 		{
 			name: "InitialMaxStreamDataBidiLocal reduced",
@@ -761,6 +767,12 @@ func TestTransportParametersValidFor0RTT(t *testing.T) {
 			require.Equal(t, tt.valid, p.ValidFor0RTT(saved))
 		})
 	}
+	t.Run("ResetStreamAt enabled", func(t *testing.T) {
+		p := *saved
+		withoutResetStreamAt := *saved
+		withoutResetStreamAt.EnableResetStreamAt = false
+		require.True(t, p.ValidFor0RTT(&withoutResetStreamAt))
+	})
 }
 
 func TestTransportParametersValidAfter0RTT(t *testing.T) {
@@ -773,6 +785,7 @@ func TestTransportParametersValidAfter0RTT(t *testing.T) {
 		MaxUniStreamNum:                6,
 		ActiveConnectionIDLimit:        7,
 		MaxDatagramFrameSize:           1000,
+		EnableResetStreamAt:            true,
 	}
 
 	tests := []struct {
@@ -784,6 +797,11 @@ func TestTransportParametersValidAfter0RTT(t *testing.T) {
 			name:   "no changes",
 			modify: func(p *TransportParameters) {},
 			reject: false,
+		},
+		{
+			name:   "ResetStreamAt disabled",
+			modify: func(p *TransportParameters) { p.EnableResetStreamAt = false },
+			reject: true,
 		},
 		{
 			name: "InitialMaxStreamDataBidiLocal reduced",
@@ -886,6 +904,12 @@ func TestTransportParametersValidAfter0RTT(t *testing.T) {
 			}
 		})
 	}
+	t.Run("ResetStreamAt enabled", func(t *testing.T) {
+		p := *saved
+		withoutResetStreamAt := *saved
+		withoutResetStreamAt.EnableResetStreamAt = false
+		require.True(t, p.ValidForUpdate(&withoutResetStreamAt))
+	})
 }
 
 func BenchmarkTransportParameters(b *testing.B) {

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -530,6 +530,9 @@ func (p *TransportParameters) ValidFor0RTT(saved *TransportParameters) bool {
 	if saved.MaxDatagramFrameSize != protocol.InvalidByteCount && (p.MaxDatagramFrameSize == protocol.InvalidByteCount || p.MaxDatagramFrameSize < saved.MaxDatagramFrameSize) {
 		return false
 	}
+	if saved.EnableResetStreamAt && !p.EnableResetStreamAt {
+		return false
+	}
 	return p.InitialMaxStreamDataBidiLocal >= saved.InitialMaxStreamDataBidiLocal &&
 		p.InitialMaxStreamDataBidiRemote >= saved.InitialMaxStreamDataBidiRemote &&
 		p.InitialMaxStreamDataUni >= saved.InitialMaxStreamDataUni &&
@@ -543,6 +546,9 @@ func (p *TransportParameters) ValidFor0RTT(saved *TransportParameters) bool {
 // It is only used on the client side.
 func (p *TransportParameters) ValidForUpdate(saved *TransportParameters) bool {
 	if saved.MaxDatagramFrameSize != protocol.InvalidByteCount && (p.MaxDatagramFrameSize == protocol.InvalidByteCount || p.MaxDatagramFrameSize < saved.MaxDatagramFrameSize) {
+		return false
+	}
+	if saved.EnableResetStreamAt && !p.EnableResetStreamAt {
 		return false
 	}
 	return p.ActiveConnectionIDLimit >= saved.ActiveConnectionIDLimit &&


### PR DESCRIPTION
Reject 0-RTT when remembered RESET_STREAM_AT support is no longer available.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate `EnableResetStreamAt` in `ValidFor0RTT` and `ValidForUpdate` across 0-RTT resumption
> Both `ValidFor0RTT` and `ValidForUpdate` in [transport_parameters.go](https://github.com/quic-go/quic-go/pull/5722/files#diff-39da89f9b997bcbb683fc9579f35c9b0e23d9256300909e15f2edcc64aa8bd00) now reject when the saved transport parameters have `EnableResetStreamAt` enabled but the current parameters have it disabled. This mirrors the existing handling of `MaxDatagramFrameSize` and connection limit fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e7b232.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session resumption validation to ensure the stream reset setting remains enabled when it was enabled in the saved session.
  * Prevented 0-RTT and post-0-RTT updates from being accepted when this setting is unexpectedly disabled.
  * Added coverage for the updated validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->