### PR TITLE
add support for RESET_STREAM_AT draft-09

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In addition to these base RFCs, it also implements the following RFCs:
 * Datagram Packetization Layer Path MTU Discovery (DPLPMTUD, [RFC 8899](https://datatracker.ietf.org/doc/html/rfc8899))
 * QUIC Version 2 ([RFC 9369](https://datatracker.ietf.org/doc/html/rfc9369))
 * QUIC Event Logging using qlog ([draft-ietf-quic-qlog-main-schema](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-main-schema/) and [draft-ietf-quic-qlog-quic-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-quic-events/))
-* QUIC Stream Resets with Partial Delivery ([draft-ietf-quic-reliable-stream-reset](https://datatracker.ietf.org/doc/html/draft-ietf-quic-reliable-stream-reset-07))
+* QUIC Stream Resets with Partial Delivery ([draft-ietf-quic-reliable-stream-reset-07](https://datatracker.ietf.org/doc/html/draft-ietf-quic-reliable-stream-reset-07) and [draft-ietf-quic-reliable-stream-reset-09](https://datatracker.ietf.org/doc/html/draft-ietf-quic-reliable-stream-reset-09))
 
 Support for WebTransport over HTTP/3 ([draft-ietf-webtrans-http3](https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/)) is implemented in [webtransport-go](https://github.com/quic-go/webtransport-go).
 

--- a/interface.go
+++ b/interface.go
@@ -176,7 +176,7 @@ type Config struct {
 	// Enable QUIC datagram support (RFC 9221).
 	EnableDatagrams bool
 	// Enable QUIC Stream Resets with Partial Delivery.
-	// See https://datatracker.ietf.org/doc/html/draft-ietf-quic-reliable-stream-reset-07.
+	// See https://datatracker.ietf.org/doc/html/draft-ietf-quic-reliable-stream-reset-09.
 	EnableStreamResetPartialDelivery bool
 
 	Tracer func(ctx context.Context, isClient bool, connID ConnectionID) qlogwriter.Trace

--- a/internal/wire/frame_parser_test.go
+++ b/internal/wire/frame_parser_test.go
@@ -452,6 +452,15 @@ func TestFrameAllowedAtEncLevel(t *testing.T) {
 			allowedZeroRTT:   true,
 			allowedOneRTT:    true,
 		},
+		{
+			name:             "RESET_STREAM_AT",
+			frameType:        FrameTypeResetStreamAt,
+			frame:            &ResetStreamFrame{StreamID: 1, FinalSize: 1, ReliableSize: 1},
+			allowedInitial:   false,
+			allowedHandshake: false,
+			allowedZeroRTT:   true,
+			allowedOneRTT:    true,
+		},
 	} {
 		for _, encLevel := range []protocol.EncryptionLevel{
 			protocol.EncryptionInitial,

--- a/internal/wire/frame_type.go
+++ b/internal/wire/frame_type.go
@@ -30,7 +30,7 @@ const (
 	FrameTypeConnectionClose    FrameType = 0x1c
 	FrameTypeApplicationClose   FrameType = 0x1d
 	FrameTypeHandshakeDone      FrameType = 0x1e
-	// https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/07/
+	// https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/09/
 	FrameTypeResetStreamAt FrameType = 0x24
 	// https://datatracker.ietf.org/doc/draft-ietf-quic-ack-frequency/11/
 	FrameTypeAckFrequency FrameType = 0xaf

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -130,6 +130,30 @@ func TestMarshalAndUnmarshalTransportParameters(t *testing.T) {
 	require.Equal(t, minAckDelay, *p.MinAckDelay)
 }
 
+func TestResetStreamAtTransportParameterCodepoints(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ids  []transportParameterID
+	}{
+		{name: "current", ids: []transportParameterID{resetStreamAtParameterID}},
+		{name: "legacy", ids: []transportParameterID{legacyResetStreamAtParameterID}},
+		{name: "both", ids: []transportParameterID{resetStreamAtParameterID, legacyResetStreamAtParameterID}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var data []byte
+			for _, id := range tc.ids {
+				data = quicvarint.Append(data, uint64(id))
+				data = quicvarint.Append(data, 0)
+			}
+			data = appendInitialSourceConnectionID(data)
+
+			var p TransportParameters
+			require.NoError(t, p.Unmarshal(data, protocol.PerspectiveClient))
+			require.True(t, p.EnableResetStreamAt)
+		})
+	}
+}
+
 func TestMarshalAdditionalTransportParameters(t *testing.T) {
 	origAdditionalTransportParametersClient := AdditionalTransportParametersClient
 	t.Cleanup(func() {
@@ -394,6 +418,17 @@ func TestTransportParameterErrors(t *testing.T) {
 			expectedErrMsg: "wrong length for reset_stream_at: 1 (expected empty)",
 		},
 		{
+			name: "invalid value for legacy reset_stream_at",
+			data: func() []byte {
+				b := quicvarint.Append(nil, uint64(legacyResetStreamAtParameterID))
+				b = quicvarint.Append(b, 1)
+				b = quicvarint.Append(b, 1)
+				return appendInitialSourceConnectionID(b)
+			}(),
+			perspective:    protocol.PerspectiveClient,
+			expectedErrMsg: "wrong length for reset_stream_at: 1 (expected empty)",
+		},
+		{
 			name: "min ack delay is greater than max ack delay",
 			data: func() []byte {
 				b := quicvarint.Append(nil, uint64(minAckDelayParameterID))
@@ -636,6 +671,16 @@ func TestTransportParametersFromSessionTicket(t *testing.T) {
 func TestSessionTicketInvalidTransportParameters(t *testing.T) {
 	var p TransportParameters
 	require.Error(t, p.UnmarshalFromSessionTicket([]byte("foobar")))
+}
+
+func TestSessionTicketLegacyResetStreamAtTransportParameter(t *testing.T) {
+	b := quicvarint.Append(nil, transportParameterMarshalingVersion)
+	b = quicvarint.Append(b, uint64(legacyResetStreamAtParameterID))
+	b = quicvarint.Append(b, 0)
+
+	var p TransportParameters
+	require.NoError(t, p.UnmarshalFromSessionTicket(b))
+	require.True(t, p.EnableResetStreamAt)
 }
 
 func TestSessionTicketTransportParameterVersionMismatch(t *testing.T) {

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -46,8 +46,12 @@ const (
 	retrySourceConnectionIDParameterID         transportParameterID = 0x10
 	// RFC 9221
 	maxDatagramFrameSizeParameterID transportParameterID = 0x20
-	// https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/06/
-	resetStreamAtParameterID transportParameterID = 0x17f7586d2cb571
+	// https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/09/
+	resetStreamAtParameterID transportParameterID = 0x1d
+	// https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/07/
+	// When removing support for this codepoint, increment transportParameterMarshalingVersion
+	// to prevent 0-RTT resumption with tickets that remember it.
+	legacyResetStreamAtParameterID transportParameterID = 0x17f7586d2cb571
 	// https://datatracker.ietf.org/doc/draft-ietf-quic-ack-frequency/11/
 	minAckDelayParameterID transportParameterID = 0xff04de1b
 )
@@ -88,7 +92,7 @@ type TransportParameters struct {
 	ActiveConnectionIDLimit uint64
 
 	MaxDatagramFrameSize protocol.ByteCount // RFC 9221
-	EnableResetStreamAt  bool               // https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/06/
+	EnableResetStreamAt  bool               // https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/09/
 	MinAckDelay          *time.Duration
 }
 
@@ -205,7 +209,7 @@ func (p *TransportParameters) unmarshal(b []byte, sentBy protocol.Perspective, f
 			connID := protocol.ParseConnectionID(b[:paramLen])
 			b = b[paramLen:]
 			p.RetrySourceConnectionID = &connID
-		case resetStreamAtParameterID:
+		case resetStreamAtParameterID, legacyResetStreamAtParameterID:
 			if paramLen != 0 {
 				return fmt.Errorf("wrong length for reset_stream_at: %d (expected empty)", paramLen)
 			}


### PR DESCRIPTION
Only the transport parameter code point changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add support for RESET_STREAM_AT draft-09 transport parameter codepoint
> - Updates `resetStreamAtParameterID` to the new codepoint `0x1d` per draft-09, while retaining `legacyResetStreamAtParameterID` (`0x17f7586d2cb571`) from draft-07 for backwards compatibility.
> - The transport parameter parser now accepts either codepoint and sets `EnableResetStreamAt = true`; non-empty values for either codepoint are rejected with an error.
> - Updates references in [README.md](https://github.com/quic-go/quic-go/pull/5724/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [interface.go](https://github.com/quic-go/quic-go/pull/5724/files#diff-189ad68e1729b49c973b8a4baa0ac4a7058d274d5b52abe852ac21a28accf8cf), and [internal/wire/frame_type.go](https://github.com/quic-go/quic-go/pull/5724/files#diff-688f0c9ddabb88083d0aa4f0ffa61d73899ccc87eb8916b7c958d3d5d5805727) from draft-07 to draft-09.
> - Behavioral Change: removing the legacy codepoint in the future will require incrementing `transportParameterMarshalingVersion`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93ca361.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for both the current and legacy `reset_stream_at` QUIC transport parameter codepoints, including for session-ticket-based transport parameters.
  - Stream reset is enabled when either recognized `reset_stream_at` parameter is present.
- **Bug Fixes**
  - Improved validation of `RESET_STREAM_AT` frame acceptance by encryption level and enforced correct handling of empty transport-parameter values.
- **Documentation**
  - Updated QUIC reliable stream reset draft references to the latest `/09` version across user-facing materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->