### PR TITLE
http3: avoid race initializing server idle timer

### DIFF
--- a/http3/server_conn.go
+++ b/http3/server_conn.go
@@ -54,7 +54,9 @@ func newRawServerConn(
 	}
 	c.rawConn = *newRawConn(conn, enableDatagrams, c.onStreamsEmpty, nil, qlogger, logger)
 	if idleTimeout > 0 {
-		c.idleTimer = time.AfterFunc(idleTimeout, c.onIdleTimer)
+		c.idleTimer = time.AfterFunc(idleTimeout, func() {
+			conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "idle timeout")
+		})
 	}
 	return c
 }
@@ -63,10 +65,6 @@ func (c *RawServerConn) onStreamsEmpty() {
 	if c.idleTimeout > 0 {
 		c.idleTimer.Reset(c.idleTimeout)
 	}
-}
-
-func (c *RawServerConn) onIdleTimer() {
-	c.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "idle timeout")
 }
 
 // CloseWithError closes the connection with the given error code and message.


### PR DESCRIPTION
Capture the QUIC connection in the timer callback, avoiding a concurrent read of `idleTimer` before `time.AfterFunc` assigns it to `RawServerConn`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix race condition when initializing idle timer in `http3.newRawServerConn`
> In [server_conn.go](https://github.com/quic-go/quic-go/pull/5725/files#diff-1f6b117a2ea0aa678aae54139e07ae729d9580f0f3014517c0a4d094c1ef52a2), the idle timeout callback previously referenced `c.onIdleTimer`, a method on `RawServerConn`, which could race during construction before `c` was fully initialized. The fix replaces it with an inline closure that captures `conn` directly and calls `conn.CloseWithError` without going through the receiver.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdf604f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of idle connections by ensuring timed-out QUIC connections close reliably.
  * Preserved idle-timeout resets when stream activity resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->