### PR TITLE
fix flaky TestHTTPServerIdleTimeout

### DIFF
--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -608,8 +608,12 @@ func TestHTTPServerIdleTimeout(t *testing.T) {
 	t.Cleanup(func() { tr.Close() })
 	cl := &http.Client{Transport: tr}
 
-	_, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
+	resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
 	require.NoError(t, err)
+	// Wait for the server to close the request stream and start the idle timer.
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
 
 	var conn *quic.Conn
 	select {


### PR DESCRIPTION
Drain the response body before waiting for the connection to close, ensuring the server has finished the request stream and started its idle timer.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky `TestHTTPServerIdleTimeout` by draining and closing the HTTP response body
> The test was discarding the HTTP response, which left the response body open and caused a race between the open stream and the idle timeout check. The fix reads the response body into `io.Discard` and explicitly closes `resp.Body` before waiting for the QUIC connection to close.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d6dca5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved HTTP idle-timeout test coverage by explicitly completing and closing a request before validating connection shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->