### PR TITLE
fix flaky TestHTTPSettings

### DIFF
--- a/integrationtests/self/http_datagram_test.go
+++ b/integrationtests/self/http_datagram_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"testing"
@@ -24,9 +25,10 @@ func TestHTTPSettings(t *testing.T) {
 	t.Run("server settings", func(t *testing.T) {
 		tlsConf := tlsClientConfigWithoutServerName.Clone()
 		tlsConf.NextProtos = []string{http3.NextProtoH3}
-		conn, err := quic.DialAddr(
+		conn, err := quic.Dial(
 			context.Background(),
-			fmt.Sprintf("localhost:%d", port),
+			newUDPConnLocalhost(t),
+			&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
 			tlsConf,
 			getQuicConfig(nil),
 		)
@@ -63,6 +65,7 @@ func TestHTTPSettings(t *testing.T) {
 			EnableDatagrams:    true,
 			AdditionalSettings: map[uint64]uint64{1337: 42},
 		}
+		addDialCallback(t, tr)
 		defer tr.Close()
 		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/settings", port), nil)
 		require.NoError(t, err)
@@ -99,7 +102,15 @@ func dialAndOpenHTTPDatagramStream(t *testing.T, addr string) *http3.RequestStre
 	tlsConf.NextProtos = []string{http3.NextProtoH3}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	conn, err := quic.DialAddr(ctx, u.Host, tlsConf, getQuicConfig(&quic.Config{EnableDatagrams: true}))
+	serverAddr, err := net.ResolveUDPAddr("udp4", u.Host)
+	require.NoError(t, err)
+	conn, err := quic.Dial(
+		ctx,
+		newUDPConnLocalhost(t),
+		serverAddr,
+		tlsConf,
+		getQuicConfig(&quic.Config{EnableDatagrams: true}),
+	)
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.CloseWithError(0, "") })
 


### PR DESCRIPTION
This was caused by the well-known macOS dual-stack UDP socket bug (https://github.com/golang/go/issues/67226).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky `TestHTTPSettings` by using explicit UDP connections for QUIC dialing
> Replaces `quic.DialAddr` with `quic.Dial` in both `TestHTTPSettings` and `dialAndOpenHTTPDatagramStream` in [http_datagram_test.go](https://github.com/quic-go/quic-go/pull/5727/files#diff-89f8bafc5603e1e8981164eeb6021da0cb6559a4fe25bf009bd292adb8a9e7b7). Each call now creates an explicit localhost-bound `UDPConn` via `newUDPConnLocalhost` and resolves the server address to a `*net.UDPAddr`, avoiding the implicit address resolution that caused flakiness. `TestHTTPSettings` also registers a dial callback on the `http3.Transport` after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a029bf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated HTTP/3 integration coverage to establish QUIC connections with explicit UDP transport details.
  * Enabled dial-time behavior in HTTP settings tests.
  * Improved HTTP datagram stream connection testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->