### PR TITLE
http3: implement a stricter API for capsule parsing

### DIFF
--- a/http3/capsule.go
+++ b/http3/capsule.go
@@ -34,11 +34,16 @@ func NewCapsuleParser(r io.Reader) *CapsuleParser {
 	return &CapsuleParser{r: quicvarint.NewReader(r)}
 }
 
+var (
+	errReaderInvalid      = errors.New("http3: capsule reader is no longer valid")
+	errCapsuleNotConsumed = errors.New("http3: previous capsule was not fully consumed")
+)
+
 // Next returns the type and contents of the next capsule.
 // The previous capsule's contents must be fully consumed or discarded before calling Next.
 func (p *CapsuleParser) Next() (CapsuleType, CapsuleReader, error) {
 	if p.remaining > 0 {
-		return 0, CapsuleReader{}, errors.New("http3: previous capsule was not fully consumed")
+		return 0, CapsuleReader{}, errCapsuleNotConsumed
 	}
 
 	r := &countingByteReader{Reader: p.r}
@@ -72,10 +77,17 @@ type CapsuleReader struct {
 	generation uint64
 }
 
+var _ quicvarint.Reader = CapsuleReader{}
+
+// valid reports whether the reader still refers to the parser's current capsule.
+func (r CapsuleReader) valid() bool {
+	return r.parser != nil && r.generation == r.parser.generation
+}
+
 // Read reads from the capsule contents.
 func (r CapsuleReader) Read(b []byte) (int, error) {
-	if r.parser == nil || r.generation != r.parser.generation {
-		return 0, errors.New("http3: capsule reader is no longer valid")
+	if !r.valid() {
+		return 0, errReaderInvalid
 	}
 	if r.parser.remaining == 0 {
 		return 0, io.EOF
@@ -93,8 +105,8 @@ func (r CapsuleReader) Read(b []byte) (int, error) {
 
 // ReadByte reads one byte from the capsule contents.
 func (r CapsuleReader) ReadByte() (byte, error) {
-	if r.generation != r.parser.generation {
-		return 0, errors.New("http3: capsule reader is no longer valid")
+	if !r.valid() {
+		return 0, errReaderInvalid
 	}
 	if r.parser.remaining == 0 {
 		return 0, io.EOF
@@ -111,7 +123,7 @@ func (r CapsuleReader) ReadByte() (byte, error) {
 
 // Remaining returns the number of bytes remaining in the capsule.
 func (r CapsuleReader) Remaining() int64 {
-	if r.generation != r.parser.generation {
+	if !r.valid() {
 		return 0
 	}
 	return int64(r.parser.remaining)

--- a/http3/capsule.go
+++ b/http3/capsule.go
@@ -1,6 +1,7 @@
 package http3
 
 import (
+	"errors"
 	"io"
 
 	"github.com/quic-go/quic-go/quicvarint"
@@ -12,40 +13,114 @@ type CapsuleType uint64
 // CapsuleProtocolHeader is the header value used to advertise support for the capsule protocol
 const CapsuleProtocolHeader = "Capsule-Protocol"
 
-type exactReader struct {
-	R io.LimitedReader
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
+
+// CapsuleParser parses a sequence of capsules.
+// A capsule's contents must be fully consumed or discarded before calling Next again.
+type CapsuleParser struct {
+	noCopy noCopy
+
+	r quicvarint.Reader
+
+	generation uint64
+	remaining  uint64
 }
 
-func (r *exactReader) Read(b []byte) (int, error) {
-	n, err := r.R.Read(b)
-	if err == io.EOF && r.R.N > 0 {
+// NewCapsuleParser creates a parser that reads capsules from r.
+func NewCapsuleParser(r io.Reader) *CapsuleParser {
+	return &CapsuleParser{r: quicvarint.NewReader(r)}
+}
+
+// Next returns the type and contents of the next capsule.
+// The previous capsule's contents must be fully consumed or discarded before calling Next.
+func (p *CapsuleParser) Next() (CapsuleType, CapsuleReader, error) {
+	if p.remaining > 0 {
+		return 0, CapsuleReader{}, errors.New("http3: previous capsule was not fully consumed")
+	}
+
+	r := &countingByteReader{Reader: p.r}
+	ct, err := quicvarint.Read(r)
+	if err != nil {
+		// If an io.EOF is returned without consuming any bytes, return it unmodified.
+		// Otherwise, return an io.ErrUnexpectedEOF.
+		if err == io.EOF && r.NumRead > 0 {
+			return 0, CapsuleReader{}, io.ErrUnexpectedEOF
+		}
+		return 0, CapsuleReader{}, err
+	}
+	r.Reset()
+	l, err := quicvarint.Read(r)
+	if err != nil {
+		if err == io.EOF {
+			return 0, CapsuleReader{}, io.ErrUnexpectedEOF
+		}
+		return 0, CapsuleReader{}, err
+	}
+
+	p.generation++
+	p.remaining = l
+	return CapsuleType(ct), CapsuleReader{parser: p, generation: p.generation}, nil
+}
+
+// CapsuleReader reads the contents of a capsule.
+// It becomes invalid when the parser advances to the next capsule.
+type CapsuleReader struct {
+	parser     *CapsuleParser
+	generation uint64
+}
+
+// Read reads from the capsule contents.
+func (r CapsuleReader) Read(b []byte) (int, error) {
+	if r.parser == nil || r.generation != r.parser.generation {
+		return 0, errors.New("http3: capsule reader is no longer valid")
+	}
+	if r.parser.remaining == 0 {
+		return 0, io.EOF
+	}
+	if uint64(len(b)) > r.parser.remaining {
+		b = b[:r.parser.remaining]
+	}
+	n, err := r.parser.r.Read(b)
+	r.parser.remaining -= uint64(n)
+	if err == io.EOF && r.parser.remaining > 0 {
 		return n, io.ErrUnexpectedEOF
 	}
 	return n, err
 }
 
-// ParseCapsule parses the header of a Capsule.
-// It returns an io.Reader that can be used to read the Capsule value.
-// The Capsule value must be read entirely (i.e. until the io.EOF) before using r again.
-func ParseCapsule(r quicvarint.Reader) (CapsuleType, io.Reader, error) {
-	cbr := countingByteReader{Reader: r}
-	ct, err := quicvarint.Read(&cbr)
-	if err != nil {
-		// If an io.EOF is returned without consuming any bytes, return it unmodified.
-		// Otherwise, return an io.ErrUnexpectedEOF.
-		if err == io.EOF && cbr.NumRead > 0 {
-			return 0, nil, io.ErrUnexpectedEOF
-		}
-		return 0, nil, err
+// ReadByte reads one byte from the capsule contents.
+func (r CapsuleReader) ReadByte() (byte, error) {
+	if r.generation != r.parser.generation {
+		return 0, errors.New("http3: capsule reader is no longer valid")
 	}
-	l, err := quicvarint.Read(r)
-	if err != nil {
-		if err == io.EOF {
-			return 0, nil, io.ErrUnexpectedEOF
-		}
-		return 0, nil, err
+	if r.parser.remaining == 0 {
+		return 0, io.EOF
 	}
-	return CapsuleType(ct), &exactReader{R: io.LimitedReader{R: r, N: int64(l)}}, nil
+	b, err := r.parser.r.ReadByte()
+	if err == io.EOF {
+		return 0, io.ErrUnexpectedEOF
+	}
+	if err == nil {
+		r.parser.remaining--
+	}
+	return b, err
+}
+
+// Remaining returns the number of bytes remaining in the capsule.
+func (r CapsuleReader) Remaining() int64 {
+	if r.generation != r.parser.generation {
+		return 0
+	}
+	return int64(r.parser.remaining)
+}
+
+// Discard consumes the remaining capsule contents.
+func (r CapsuleReader) Discard() error {
+	_, err := io.Copy(io.Discard, r)
+	return err
 }
 
 // WriteCapsule writes a capsule

--- a/http3/capsule_test.go
+++ b/http3/capsule_test.go
@@ -93,7 +93,7 @@ func TestCapsuleParserRequiresConsumption(t *testing.T) {
 	_, err = r.ReadByte()
 	require.NoError(t, err)
 	_, _, err = p.Next()
-	require.Error(t, err)
+	require.ErrorIs(t, err, errCapsuleNotConsumed)
 
 	require.NoError(t, r.Discard())
 	ct, next, err := p.Next()
@@ -104,7 +104,10 @@ func TestCapsuleParserRequiresConsumption(t *testing.T) {
 	require.Equal(t, []byte("second"), data)
 
 	_, err = r.ReadByte()
-	require.Error(t, err)
+	require.ErrorIs(t, err, errReaderInvalid)
+	_, err = r.Read(make([]byte, 1))
+	require.ErrorIs(t, err, errReaderInvalid)
+	require.ErrorIs(t, err, errReaderInvalid)
 }
 
 func TestCopiedCapsuleReadersShareProgress(t *testing.T) {

--- a/http3/capsule_test.go
+++ b/http3/capsule_test.go
@@ -15,17 +15,23 @@ func TestCapsuleParsing(t *testing.T) {
 	b = quicvarint.Append(b, 6)
 	b = append(b, []byte("foobar")...)
 
-	ct, r, err := ParseCapsule(bytes.NewReader(b))
+	p := NewCapsuleParser(bytes.NewReader(b))
+	ct, r, err := p.Next()
 	require.NoError(t, err)
 	require.Equal(t, CapsuleType(1337), ct)
+	require.Equal(t, int64(6), r.Remaining())
 	buf := make([]byte, 3)
 	n, err := r.Read(buf)
 	require.NoError(t, err)
 	require.Equal(t, 3, n)
 	require.Equal(t, []byte("foo"), buf)
+	require.Equal(t, int64(3), r.Remaining())
 	data, err := io.ReadAll(r) // reads until EOF
 	require.NoError(t, err)
 	require.Equal(t, []byte("bar"), data)
+	require.Zero(t, r.Remaining())
+	_, _, err = p.Next()
+	require.ErrorIs(t, err, io.EOF)
 }
 
 func TestEmptyCapsuleParsing(t *testing.T) {
@@ -33,7 +39,8 @@ func TestEmptyCapsuleParsing(t *testing.T) {
 	b = quicvarint.Append(b, 0)
 	// Capsule content is empty.
 
-	ct, r, err := ParseCapsule(bytes.NewReader(b))
+	p := NewCapsuleParser(bytes.NewReader(b))
+	ct, r, err := p.Next()
 	require.NoError(t, err)
 	require.Equal(t, CapsuleType(1337), ct)
 	data, err := io.ReadAll(r) // reads until EOF
@@ -59,7 +66,8 @@ func TestCapsuleTruncation(t *testing.T) {
 
 func testCapsuleTruncation(t *testing.T, b []byte) {
 	for i := range b {
-		ct, r, err := ParseCapsule(bytes.NewReader(b[:i]))
+		p := NewCapsuleParser(bytes.NewReader(b[:i]))
+		ct, r, err := p.Next()
 		if err != nil {
 			if i == 0 {
 				require.ErrorIs(t, err, io.EOF)
@@ -74,11 +82,56 @@ func testCapsuleTruncation(t *testing.T, b []byte) {
 	}
 }
 
+func TestCapsuleParserRequiresConsumption(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteCapsule(&buf, 1, []byte("first")))
+	require.NoError(t, WriteCapsule(&buf, 2, []byte("second")))
+
+	p := NewCapsuleParser(&buf)
+	_, r, err := p.Next()
+	require.NoError(t, err)
+	_, err = r.ReadByte()
+	require.NoError(t, err)
+	_, _, err = p.Next()
+	require.Error(t, err)
+
+	require.NoError(t, r.Discard())
+	ct, next, err := p.Next()
+	require.NoError(t, err)
+	require.Equal(t, CapsuleType(2), ct)
+	data, err := io.ReadAll(next)
+	require.NoError(t, err)
+	require.Equal(t, []byte("second"), data)
+
+	_, err = r.ReadByte()
+	require.Error(t, err)
+}
+
+func TestCopiedCapsuleReadersShareProgress(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteCapsule(&buf, 1, []byte("foobar")))
+
+	p := NewCapsuleParser(&buf)
+	_, r, err := p.Next()
+	require.NoError(t, err)
+	r2 := r
+
+	b, err := r.ReadByte()
+	require.NoError(t, err)
+	require.Equal(t, byte('f'), b)
+	require.Equal(t, int64(5), r2.Remaining())
+	data, err := io.ReadAll(r2)
+	require.NoError(t, err)
+	require.Equal(t, []byte("oobar"), data)
+	require.Zero(t, r.Remaining())
+}
+
 func TestCapsuleWriting(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, WriteCapsule(&buf, 1337, []byte("foobar")))
 
-	ct, r, err := ParseCapsule(&buf)
+	p := NewCapsuleParser(&buf)
+	ct, r, err := p.Next()
 	require.NoError(t, err)
 	require.Equal(t, CapsuleType(1337), ct)
 	val, err := io.ReadAll(r)
@@ -91,14 +144,15 @@ func TestCapsuleWriteEmpty(t *testing.T) {
 	require.NoError(t, WriteCapsule(&buf, 1337, []byte{}))
 	require.NoError(t, WriteCapsule(&buf, 1337, []byte{}))
 
-	ct, r, err := ParseCapsule(&buf)
+	p := NewCapsuleParser(&buf)
+	ct, r, err := p.Next()
 	require.NoError(t, err)
 	require.Equal(t, CapsuleType(1337), ct)
 	val, err := io.ReadAll(r)
 	require.NoError(t, err)
 	require.Empty(t, val)
 
-	ct, r, err = ParseCapsule(&buf)
+	ct, r, err = p.Next()
 	require.NoError(t, err)
 	require.Equal(t, CapsuleType(1337), ct)
 	val, err = io.ReadAll(r)

--- a/http3/capsule_test.go
+++ b/http3/capsule_test.go
@@ -107,7 +107,6 @@ func TestCapsuleParserRequiresConsumption(t *testing.T) {
 	require.ErrorIs(t, err, errReaderInvalid)
 	_, err = r.Read(make([]byte, 1))
 	require.ErrorIs(t, err, errReaderInvalid)
-	require.ErrorIs(t, err, errReaderInvalid)
 }
 
 func TestCopiedCapsuleReadersShareProgress(t *testing.T) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace `ParseCapsule` with a stateful `CapsuleParser` API in http3
- Removes `ParseCapsule` in favor of `CapsuleParser` with a `Next` method that returns a `CapsuleReader` per capsule, enforcing that each capsule is fully consumed or discarded before advancing.
- `CapsuleReader` tracks remaining bytes, converts premature `io.EOF` to `io.ErrUnexpectedEOF`, and becomes invalid once the parser advances to the next capsule.
- Copies of `CapsuleReader` share progress via a pointer to the parent parser's state.
- Risk: callers using `ParseCapsule` must migrate to the new `CapsuleParser.Next` API; the old function is removed.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a22003b.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stateful capsule parsing API to iterate through capsule data.
  * Added capsule reader support for reading payload bytes, checking remaining content, and discarding unread data.
* **Improvements**
  * Enhanced handling of truncated/incomplete capsule data with clearer EOF vs unexpected EOF behavior.
  * Added safeguards requiring full capsule consumption before advancing, and preventing reads from invalidated readers.
  * Preserved read progress when capsule readers are copied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->