### PR TITLE
http3: unblock pending calls to OpenStreamSync on GOAWAY

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -70,7 +70,8 @@ type ClientConn struct {
 
 	streamMx     sync.Mutex
 	maxStreamID  quic.StreamID // set once a GOAWAY frame is received
-	lastStreamID quic.StreamID // the highest stream ID that was opened
+	goAwayCtx    context.Context
+	goAwayCancel context.CancelFunc
 
 	qlogger qlogwriter.Recorder
 	logger  *slog.Logger
@@ -97,11 +98,11 @@ func newClientConn(
 		additionalSettings: additionalSettings,
 		disableCompression: disableCompression,
 		maxStreamID:        invalidStreamID,
-		lastStreamID:       invalidStreamID,
 		logger:             logger,
 		qlogger:            qlogger,
 		decoder:            qpack.NewDecoder(),
 	}
+	c.goAwayCtx, c.goAwayCancel = context.WithCancel(context.Background())
 	if maxResponseHeaderBytes <= 0 {
 		c.maxResponseHeaderBytes = defaultMaxResponseHeaderBytes
 	} else {
@@ -146,38 +147,27 @@ func (c *ClientConn) openRequestStream(
 	disableCompression bool,
 	maxHeaderBytes int,
 ) (*RequestStream, error) {
-	c.streamMx.Lock()
-	maxStreamID := c.maxStreamID
-	var nextStreamID quic.StreamID
-	if c.lastStreamID == invalidStreamID {
-		nextStreamID = 0
-	} else {
-		nextStreamID = c.lastStreamID + 4
-	}
-	c.streamMx.Unlock()
-	// Streams with stream ID equal to or greater than the stream ID carried in the GOAWAY frame
-	// will be rejected, see section 5.2 of RFC 9114.
-	if maxStreamID != invalidStreamID && nextStreamID >= maxStreamID {
+	// RFC 9114 Section 5.2 prohibits opening any new request streams after GOAWAY.
+	// The stream ID only identifies requests that were already in flight and might still be processed.
+	if c.goAwayCtx.Err() != nil {
 		return nil, errGoAway
 	}
 
-	str, err := c.conn.OpenStreamSync(ctx)
+	openCtx, cancel := context.WithCancelCause(ctx)
+	// A request blocked in OpenStreamSync has no request stream yet, so it is not in flight.
+	stop := context.AfterFunc(c.goAwayCtx, func() { cancel(errGoAway) })
+	str, err := c.conn.OpenStreamSync(openCtx)
+	stop()
+	cancel(nil)
 	if err != nil {
+		if context.Cause(openCtx) == errGoAway {
+			return nil, errGoAway
+		}
 		return nil, err
 	}
 
-	c.streamMx.Lock()
-	// take the maximum here, as multiple OpenStreamSync calls might have returned concurrently
-	if c.lastStreamID == invalidStreamID {
-		c.lastStreamID = str.StreamID()
-	} else {
-		c.lastStreamID = max(c.lastStreamID, str.StreamID())
-	}
-	// check again, in case a (or another) GOAWAY frame was received
-	maxStreamID = c.maxStreamID
-	c.streamMx.Unlock()
-
-	if maxStreamID != invalidStreamID && str.StreamID() >= maxStreamID {
+	// Check again in case GOAWAY raced with OpenStreamSync.
+	if c.goAwayCtx.Err() != nil {
 		str.CancelRead(quic.StreamErrorCode(ErrCodeRequestCanceled))
 		str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestCanceled))
 		return nil, errGoAway
@@ -240,6 +230,7 @@ func (c *ClientConn) handleControlStream(str *quic.ReceiveStream, fp *frameParse
 			return
 		}
 		c.maxStreamID = goaway.StreamID
+		c.goAwayCancel()
 		c.streamMx.Unlock()
 
 		hasActiveStreams := c.rawConn.hasActiveStreams()

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -615,16 +615,7 @@ func testClientConnGoAway(t *testing.T, withStream bool) {
 		case <-time.After(scaleDuration(10 * time.Millisecond)):
 		}
 
-		// the stream ID in the GOAWAY frame is 8, so it's possible to open stream 4
-		str2, err := cc.OpenRequestStream(context.Background())
-		require.NoError(t, err)
-		str2.Close()
-		str2.CancelRead(1337)
-
-		// it's not possible to open stream 8
-		_, err = cc.OpenRequestStream(context.Background())
-		require.ErrorIs(t, err, errGoAway)
-
+		// GOAWAY allows the request that was already open to finish.
 		str.Close()
 		str.CancelRead(1337)
 	}
@@ -652,8 +643,8 @@ func testClientConnGoAway(t *testing.T, withStream bool) {
 	)
 }
 
-func TestClientConnGoConcurrent(t *testing.T) {
-	clientConn, serverConn := newConnPair(t, withServerBidiStreamLimit(1)) // allows streams 0
+func TestClientConnGoawayConcurrent(t *testing.T) {
+	clientConn, serverConn := newConnPair(t, withServerBidiStreamLimit(2)) // allows streams 0 and 4
 
 	cc := (&Transport{}).NewClientConn(clientConn)
 
@@ -671,8 +662,24 @@ func TestClientConnGoConcurrent(t *testing.T) {
 	case <-time.After(scaleDuration(10 * time.Millisecond)):
 	}
 
-	// of these 2 OpenStreamSync calls, one will succeed, the other one will block
-	errChan := make(chan error, 3)
+	// Consume both streams the server allows, but keep their receive sides open.
+	for range 2 {
+		str, err := cc.OpenRequestStream(context.Background())
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	sstr0, err := serverConn.AcceptStream(ctx)
+	require.NoError(t, err)
+	require.Equal(t, quic.StreamID(0), sstr0.StreamID())
+	sstr4, err := serverConn.AcceptStream(ctx)
+	require.NoError(t, err)
+	require.Equal(t, quic.StreamID(4), sstr4.StreamID())
+
+	// Both of these calls will block in OpenStreamSync.
+	errChan := make(chan error, 2)
 	for range 2 {
 		go func() {
 			str, err := cc.OpenRequestStream(context.Background())
@@ -683,48 +690,51 @@ func TestClientConnGoConcurrent(t *testing.T) {
 		}()
 	}
 
-	// wait until all Goroutines have started
-	time.Sleep(scaleDuration(10 * time.Millisecond))
-
-	select {
-	case err := <-errChan:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
-	// the second stream is still blocked
 	select {
 	case <-errChan:
-		t.Fatal("second OpenStreamSync should have blocked")
+		t.Fatal("OpenStreamSync calls should have blocked")
 	case <-time.After(scaleDuration(10 * time.Millisecond)):
 	}
 
-	// send the GOAWAY frame
-	b = (&goAwayFrame{StreamID: 4}).Append(nil)
+	// Send a GOAWAY with a stream ID higher than the next stream ID.
+	b = (&goAwayFrame{StreamID: 12}).Append(nil)
 	_, err = controlStr.Write(b)
 	require.NoError(t, err)
 
-	// accepting and closing the stream allows the client to open another stream
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	sstr, err := serverConn.AcceptStream(ctx)
-	require.NoError(t, err)
-	sstr.Close()
-	sstr.CancelRead(1337)
-
-	// The second stream is opened by the client,
-	// and immediately closed with a H3_REQUEST_CANCELED error.
-	select {
-	case err := <-errChan:
-		require.ErrorIs(t, err, errGoAway)
-	case <-time.After(scaleDuration(10 * time.Millisecond)):
-		t.Fatal("timeout")
+	// The GOAWAY stream ID only applies to requests already in flight. Even though
+	// stream 8 would be below the limit, no new request stream may be opened.
+	for range 2 {
+		select {
+		case err := <-errChan:
+			require.ErrorIs(t, err, errGoAway)
+		case <-time.After(time.Second):
+			t.Fatal("timeout")
+		}
 	}
 
-	sstr, err = serverConn.AcceptStream(ctx)
-	require.NoError(t, err)
-	_, err = sstr.Read([]byte{0})
-	require.ErrorIs(t, err, &quic.StreamError{StreamID: 4, ErrorCode: quic.StreamErrorCode(ErrCodeRequestCanceled), Remote: true})
+	// The streams opened before GOAWAY are not canceled.
+	buf := make([]byte, 1)
+	_, err = sstr0.Read(buf)
+	require.ErrorIs(t, err, io.EOF)
+	_, err = sstr4.Read(buf)
+	require.ErrorIs(t, err, io.EOF)
+
+	// Complete stream 0 to free stream credit, while stream 4 keeps the connection alive.
+	require.NoError(t, sstr0.Close())
+
+	// Calls made after receiving GOAWAY fail even when stream credit is available.
+	openCtx, openCancel := context.WithTimeout(context.Background(), time.Second)
+	defer openCancel()
+	_, err = cc.OpenRequestStream(openCtx)
+	require.ErrorIs(t, err, errGoAway)
+
+	// In particular, the client didn't open and cancel stream 8 behind the caller's back.
+	noStreamCtx, noStreamCancel := context.WithTimeout(context.Background(), scaleDuration(10*time.Millisecond))
+	defer noStreamCancel()
+	_, err = serverConn.AcceptStream(noStreamCtx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	require.NoError(t, sstr4.Close())
 }
 
 func TestClientConnGoAwayFailures(t *testing.T) {

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -643,7 +643,7 @@ func testClientConnGoAway(t *testing.T, withStream bool) {
 	)
 }
 
-func TestClientConnGoawayConcurrent(t *testing.T) {
+func TestClientConnGoAwayConcurrent(t *testing.T) {
 	clientConn, serverConn := newConnPair(t, withServerBidiStreamLimit(2)) // allows streams 0 and 4
 
 	cc := (&Transport{}).NewClientConn(clientConn)


### PR DESCRIPTION
According to RFC 9114 Section 5.2, no new streams must be opened after receiving a GOAWAY frame, regardless of the stream ID carried in that frame.

This stream ID only specifies which in-flight requests the client can expect will still be processed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unblock pending `OpenStreamSync` calls on HTTP/3 GOAWAY receipt
> - Replaces `lastStreamID`-based GOAWAY tracking in `ClientConn` with a `goAwayCtx`/`goAwayCancel` pair that broadcasts GOAWAY state to all waiters.
> - Calls blocked in `OpenStreamSync` at the time GOAWAY arrives are now cancelled with `errGoAway` via `context.AfterFunc`; previously they would block indefinitely.
> - A pre-check and post-open check in `openRequestStream` ensure no new streams are opened after GOAWAY, regardless of stream ID ordering.
> - Behavioral Change: any GOAWAY now prevents all new stream opens (not just streams above `maxStreamID`), which is stricter than the previous behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cad570c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/3 GOAWAY handling so new request streams are rejected once shutdown begins.
  * Requests already opened before GOAWAY can complete normally.
  * Concurrent attempts to open new streams now fail consistently when GOAWAY is processed.
  * The connection stays available for in-flight work until those streams finish.
* **Tests**
  * Updated and extended GOAWAY-related client test coverage to reflect the revised behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->