### PR TITLE
handshake: simplify code by using bytes.CutPrefix

### DIFF
--- a/internal/handshake/session_ticket.go
+++ b/internal/handshake/session_ticket.go
@@ -47,10 +47,9 @@ func addSessionStateExtraPrefix(b []byte) []byte {
 func findSessionStateExtraData(extras [][]byte) []byte {
 	prefix := []byte(extraPrefix)
 	for _, extra := range extras {
-		if len(extra) < len(prefix) || !bytes.Equal(prefix, extra[:len(prefix)]) {
-			continue
+		if data, ok := bytes.CutPrefix(extra, prefix); ok {
+			return data
 		}
-		return extra[len(prefix):]
 	}
 	return nil
 }


### PR DESCRIPTION
No functional change expected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify `findSessionStateExtraData` prefix detection using `bytes.CutPrefix`
> Replaces a manual length check and `bytes.Equal` comparison in [session_ticket.go](https://github.com/quic-go/quic-go/pull/5732/files#diff-44cddc9d286b132f3b628794b912224014b52f1518bde0604e2695f6db25565f) with a single `bytes.CutPrefix` call to detect and strip `extraPrefix`. No behavioral change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b85355d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal session data prefix matching without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->