### PR TITLE
ackhandler: adapt loss detection thresholds to observed packet reorderin

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -20,7 +20,14 @@ const (
 	// Specified as an RTT multiplier.
 	timeThreshold = 9.0 / 8
 	// Maximum reordering in packets before packet threshold loss detection considers a packet lost.
-	packetThreshold = 3
+	// This is the initial value: when spurious losses reveal that the path reorders more deeply,
+	// the per-connection threshold adapts upward (see detectSpuriousLosses), as recommended by
+	// RFC 9002, section 6.1.1.
+	initialPacketThreshold = 3
+	// The adaptive packet threshold is never raised beyond this value. Even if packet-based
+	// loss detection is effectively disabled by deep reordering, time-based detection and
+	// PTOs still detect real losses.
+	maxPacketThreshold = 64
 	// Before validating the client's address, the server won't send more than 3x bytes than it received.
 	amplificationFactor = 3
 	// We use Retry packets to derive an RTT estimate. Make sure we don't set the RTT to a super low value yet.
@@ -93,6 +100,15 @@ type sentPacketHandler struct {
 	rttStats   *utils.RTTStats
 	connStats  *utils.ConnectionStats
 
+	// packetThreshold is the packet-based loss detection threshold (RFC 9002, section 6.1.1).
+	// It starts at initialPacketThreshold and is raised (never lowered) when spurious losses
+	// show that the path reorders packets more deeply, similar to TCP RACK's reordering
+	// window (RFC 8985).
+	packetThreshold protocol.PacketNumber
+	// timeThresholdCushion widens the time-based loss detection delay when spurious losses
+	// show that packets arrive later than timeThreshold * RTT. It is capped at one smoothed RTT.
+	timeThresholdCushion time.Duration
+
 	// The number of times a PTO has been sent without receiving an ack.
 	ptoCount uint32
 	ptoMode  SendMode
@@ -145,6 +161,7 @@ func NewSentPacketHandler(
 		handshakePackets:               newPacketNumberSpace(0, false),
 		appDataPackets:                 newPacketNumberSpace(0, true),
 		lostPackets:                    *newLostPacketTracker(64),
+		packetThreshold:                initialPacketThreshold,
 		rttStats:                       rttStats,
 		connStats:                      connStats,
 		congestion:                     congestion,
@@ -520,6 +537,26 @@ func (h *sentPacketHandler) detectSpuriousLosses(ack *wire.AckFrame, ackTime mon
 	for _, pn := range spuriousLosses {
 		h.lostPackets.Delete(pn)
 	}
+
+	// Adapt the loss detection thresholds (RFC 9002, section 6.1.1): the path just proved
+	// that it reorders at least this deeply, so declaring that reordering depth lost only
+	// produces spurious retransmissions and needless congestion window reductions.
+	if len(spuriousLosses) > 0 {
+		if t := maxPacketReordering + 1; t > h.packetThreshold {
+			h.packetThreshold = min(t, maxPacketThreshold)
+			if h.logger.Debug() {
+				h.logger.Debugf("\traising packet reordering threshold to %d", h.packetThreshold)
+			}
+		}
+		srtt := h.rttStats.SmoothedRTT()
+		lossDelay := time.Duration(timeThreshold * float64(max(h.rttStats.LatestRTT(), srtt)))
+		if cushion := maxTimeReordering - lossDelay; cushion > h.timeThresholdCushion {
+			h.timeThresholdCushion = min(cushion, srtt)
+			if h.logger.Debug() {
+				h.logger.Debugf("\traising time threshold cushion to %s", h.timeThresholdCushion)
+			}
+		}
+	}
 }
 
 // Packets are returned in ascending packet number order.
@@ -789,7 +826,7 @@ func (h *sentPacketHandler) detectLostPackets(now monotime.Time, encLevel protoc
 	pnSpace.lossTime = 0
 
 	maxRTT := float64(max(h.rttStats.LatestRTT(), h.rttStats.SmoothedRTT()))
-	lossDelay := time.Duration(timeThreshold * maxRTT)
+	lossDelay := time.Duration(timeThreshold*maxRTT) + h.timeThresholdCushion
 
 	// Minimum time of granularity before packets are deemed lost.
 	lossDelay = max(lossDelay, protocol.TimerGranularity)
@@ -820,7 +857,7 @@ func (h *sentPacketHandler) detectLostPackets(now monotime.Time, encLevel protoc
 					})
 				}
 			}
-		} else if pnSpace.history.Difference(pnSpace.largestAcked, pn) >= packetThreshold {
+		} else if pnSpace.history.Difference(pnSpace.largestAcked, pn) >= h.packetThreshold {
 			packetLost = true
 			if !p.isPathProbePacket && p.IsAckEliciting() {
 				if h.logger.Debug() {

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -1774,6 +1774,122 @@ func TestSentPacketHandlerAdaptivePacketThreshold(t *testing.T) {
 	require.Empty(t, packets.Lost)
 }
 
+func TestSentPacketHandlerAdaptivePacketThresholdCap(t *testing.T) {
+	sph := NewSentPacketHandler(
+		0,
+		1200,
+		utils.NewRTTStats(),
+		&utils.ConnectionStats{},
+		true,
+		false,
+		nil,
+		protocol.PerspectiveClient,
+		nil,
+		utils.DefaultLogger,
+	)
+
+	var packets packetTracker
+	start := monotime.Now()
+	var pns []protocol.PacketNumber
+	for range 67 {
+		pn := sph.PopPacketNumber(protocol.Encryption1RTT)
+		sph.SentPacket(start, pn, protocol.InvalidPacketNumber, nil, []Frame{packets.NewPingFrame(pn)}, protocol.Encryption1RTT, protocol.ECNNon, 1000, false, false)
+		pns = append(pns, pn)
+	}
+
+	// Acking only pns[66] declares pns[0] through pns[63] lost (reordering depth >= 3).
+	now := start.Add(100 * time.Millisecond)
+	_, err := sph.ReceivedAck(
+		&wire.AckFrame{AckRanges: ackRanges(pns[66])},
+		protocol.Encryption1RTT,
+		now,
+	)
+	require.NoError(t, err)
+	require.Len(t, packets.Lost, 64)
+
+	// pns[0] arriving after all is a spurious loss with a reordering depth of 66.
+	// The adaptive threshold saturates at maxPacketThreshold instead of rising to 67.
+	now = now.Add(50 * time.Millisecond)
+	_, err = sph.ReceivedAck(
+		&wire.AckFrame{AckRanges: ackRanges(pns[0], pns[64], pns[65], pns[66])},
+		protocol.Encryption1RTT,
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, protocol.PacketNumber(maxPacketThreshold), sph.(*sentPacketHandler).packetThreshold)
+}
+
+func TestSentPacketHandlerAdaptiveTimeThresholdCushion(t *testing.T) {
+	sph := NewSentPacketHandler(
+		0,
+		1200,
+		utils.NewRTTStats(),
+		&utils.ConnectionStats{},
+		true,
+		false,
+		nil,
+		protocol.PerspectiveClient,
+		nil,
+		utils.DefaultLogger,
+	)
+
+	var packets packetTracker
+	start := monotime.Now()
+	sendPacket := func(t *testing.T, ti monotime.Time) protocol.PacketNumber {
+		t.Helper()
+		pn := sph.PopPacketNumber(protocol.Encryption1RTT)
+		sph.SentPacket(ti, pn, protocol.InvalidPacketNumber, nil, []Frame{packets.NewPingFrame(pn)}, protocol.Encryption1RTT, protocol.ECNNon, 1000, false, false)
+		return pn
+	}
+
+	// pns[1] is sent 50ms after pns[0] and acked 100ms later (RTT: 100ms).
+	// At that point pns[0] has been outstanding for 150ms, which exceeds the
+	// time threshold (9/8 * 100ms = 112.5ms), so it is declared lost.
+	pn0 := sendPacket(t, start)
+	pn1 := sendPacket(t, start.Add(50*time.Millisecond))
+	pn2 := sendPacket(t, start.Add(100*time.Millisecond))
+	now := start.Add(150 * time.Millisecond)
+	_, err := sph.ReceivedAck(
+		&wire.AckFrame{AckRanges: ackRanges(pn1)},
+		protocol.Encryption1RTT,
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []protocol.PacketNumber{pn1}, packets.Acked)
+	require.Equal(t, []protocol.PacketNumber{pn0}, packets.Lost)
+
+	// pns[0] now arrives after all, 200ms after it was sent: a spurious loss with a
+	// time reordering of 200ms. The cushion grows to cover the observed extra delay
+	// (200ms - 112.5ms), while the packet threshold (reordering depth of 2) is unchanged.
+	now = start.Add(200 * time.Millisecond)
+	_, err = sph.ReceivedAck(
+		&wire.AckFrame{AckRanges: ackRanges(pn0, pn1, pn2)},
+		protocol.Encryption1RTT,
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []protocol.PacketNumber{pn1, pn2}, packets.Acked)
+	require.Equal(t, protocol.PacketNumber(initialPacketThreshold), sph.(*sentPacketHandler).packetThreshold)
+	require.Equal(t, 87500*time.Microsecond, sph.(*sentPacketHandler).timeThresholdCushion)
+
+	// The same pattern again: with the widened time threshold (112.5ms + 87.5ms = 200ms),
+	// the first packet is no longer declared lost after being outstanding for 150ms.
+	packets.Reset()
+	later := start.Add(300 * time.Millisecond)
+	pn3 := sendPacket(t, later)
+	pn4 := sendPacket(t, later.Add(50*time.Millisecond))
+	now = later.Add(150 * time.Millisecond)
+	_, err = sph.ReceivedAck(
+		&wire.AckFrame{AckRanges: ackRanges(pn4)},
+		protocol.Encryption1RTT,
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []protocol.PacketNumber{pn4}, packets.Acked)
+	require.Empty(t, packets.Lost)
+	_ = pn3
+}
+
 func BenchmarkSendAndAcknowledge(b *testing.B) {
 	b.Run("ack every: 2, in flight: 0", func(b *testing.B) {
 		benchmarkSendAndAcknowledge(b, 2, 0)

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -1671,7 +1671,10 @@ func TestSentPacketHandlerSpuriousLoss(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, []protocol.PacketNumber{pns[4], pns[5], pns[12], pns[16], pns[17], pns[18]}, packets.Acked)
-	require.Equal(t, []protocol.PacketNumber{pns[7], pns[8], pns[9], pns[10], pns[11], pns[13], pns[14], pns[15]}, packets.Lost)
+	// The spurious losses detected on the previous ACK (reordering depth of 15) raised the
+	// adaptive packet threshold to 16, so pns[14] and pns[15] (reordering depth of 4 and 3
+	// relative to pns[18]) are no longer declared lost.
+	require.Equal(t, []protocol.PacketNumber{pns[7], pns[8], pns[9], pns[10], pns[11], pns[13]}, packets.Lost)
 
 	require.Equal(t,
 		[]qlogwriter.Event{
@@ -1702,6 +1705,73 @@ func TestSentPacketHandlerSpuriousLoss(t *testing.T) {
 		},
 		eventRecorder.Events(qlog.SpuriousLoss{}),
 	)
+}
+
+func TestSentPacketHandlerAdaptivePacketThreshold(t *testing.T) {
+	sph := NewSentPacketHandler(
+		0,
+		1200,
+		utils.NewRTTStats(),
+		&utils.ConnectionStats{},
+		true,
+		false,
+		nil,
+		protocol.PerspectiveClient,
+		nil,
+		utils.DefaultLogger,
+	)
+
+	var packets packetTracker
+	start := monotime.Now()
+	sendPacket := func(t *testing.T, ti monotime.Time) protocol.PacketNumber {
+		t.Helper()
+		pn := sph.PopPacketNumber(protocol.Encryption1RTT)
+		sph.SentPacket(ti, pn, protocol.InvalidPacketNumber, nil, []Frame{packets.NewPingFrame(pn)}, protocol.Encryption1RTT, protocol.ECNNon, 1000, false, false)
+		return pn
+	}
+
+	var pns []protocol.PacketNumber
+	for range 10 {
+		pns = append(pns, sendPacket(t, start))
+	}
+
+	// Acking only pns[9] declares pns[0] through pns[6] lost (reordering depth >= 3).
+	now := start.Add(100 * time.Millisecond)
+	_, err := sph.ReceivedAck(
+		&wire.AckFrame{AckRanges: ackRanges(pns[9])},
+		protocol.Encryption1RTT,
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []protocol.PacketNumber{pns[9]}, packets.Acked)
+	require.Equal(t, []protocol.PacketNumber{pns[0], pns[1], pns[2], pns[3], pns[4], pns[5], pns[6]}, packets.Lost)
+
+	// pns[0] now arrives after all: a spurious loss with a reordering depth of 9,
+	// raising the packet threshold to 10.
+	now = now.Add(50 * time.Millisecond)
+	_, err = sph.ReceivedAck(
+		&wire.AckFrame{AckRanges: ackRanges(pns[0], pns[7], pns[8], pns[9])},
+		protocol.Encryption1RTT,
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, protocol.PacketNumber(10), sph.(*sentPacketHandler).packetThreshold)
+
+	// The same reordering pattern again: acking only the newest packet no longer
+	// declares anything lost, since all reordering depths are below the threshold.
+	packets.Reset()
+	for range 10 {
+		pns = append(pns, sendPacket(t, now))
+	}
+	now = now.Add(100 * time.Millisecond)
+	_, err = sph.ReceivedAck(
+		&wire.AckFrame{AckRanges: ackRanges(pns[19])},
+		protocol.Encryption1RTT,
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []protocol.PacketNumber{pns[19]}, packets.Acked)
+	require.Empty(t, packets.Lost)
 }
 
 func BenchmarkSendAndAcknowledge(b *testing.B) {


### PR DESCRIPTION
### The bug

Packet-threshold loss detection uses a fixed reordering threshold of 3 (`packetThreshold`,
the initial value suggested by RFC 9002). On network paths that reorder UDP datagrams —
per-packet ECMP load balancing, WiFi/LTE, TUN/VPN stacks — every packet displaced by 3 or
more is declared lost **even though it is delivered**, and every one of those spurious
losses puts the connection into recovery and halves the congestion window. The connection
never learns: the threshold is a constant, so the same misjudgment repeats forever and the
congestion window stays pinned near the minimum.

This is not a corner case; it makes QUIC lose badly to TCP on the same path, because
kernel TCP stacks adapt their reordering tolerance (RACK's `reo_wnd`, RFC 8985) and
therefore don't collapse.

Measured on a real path (consumer broadband → cloud VM, tunnel proxying a bulk transfer,
qlog on both endpoints):

* 17.5% of packets arrived out of order, with a displacement of 1–23 packet numbers.
* **Zero real loss**: cross-referencing both endpoints' qlogs, 200 out of 200 packets the
  sender declared lost (~20/s, 90% trigger `reordering_threshold`) were actually received.
* The congestion window was pinned at ~10 KB with the connection in recovery almost
  continuously; throughput was stuck at ~1.4 Mbit/s of a 3.4 Mbit/s link (~40%), while a
  TCP connection saturated the very same link.

RFC 9002, section 6.1.1 explicitly anticipates this failure mode and its fix:

> Implementations can detect spurious retransmissions and increase the reordering
> threshold in packets or time to reduce future spurious retransmissions and loss events.
> [...] Algorithms that increase the reordering threshold after spuriously detecting
> losses, such as RACK [RFC8985], have proven to be useful in TCP and are expected to be
> at least as useful in QUIC.

### The fix

`detectSpuriousLosses` already computes the reordering depth (`maxPacketReordering`) and
extra delay (`maxTimeReordering`) of every spurious loss, but only reports them via qlog.
This PR feeds those observations back into loss detection:

* the packet threshold becomes a per-connection value: it starts at 3 and is raised past
  the deepest observed spurious reordering, capped at 64;
* the time threshold gains a cushion covering the observed extra delay, capped at one
  smoothed RTT.

Both values only ever increase over the lifetime of a connection, and paths that don't
reorder keep exactly the RFC-default behavior. Real loss remains detected by the time
threshold and PTOs even if deep reordering effectively disables packet-based detection.

With the adaptation active, the transfer described above saturates the link
(3.2–3.6 Mbit/s, on par with TCP), and spurious loss declarations drop by an order of
magnitude.

### Tests

* New `TestSentPacketHandlerAdaptivePacketThreshold`: a spurious loss with reordering
  depth 9 raises the threshold to 10; the same reordering pattern afterwards no longer
  declares any packet lost.
* One expectation in `TestSentPacketHandlerSpuriousLoss` updated (commented in the test):
  after the second ACK reveals a reordering depth of 15, the third ACK no longer declares
  two shallowly-reordered packets (depth 3–4) lost.

Happy to split the time-threshold cushion into a separate PR if you'd prefer to take the
packet-threshold adaptation on its own.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adapt loss detection thresholds to observed packet reordering in `sentPacketHandler`
> - Replaces the fixed `packetThreshold=3` constant with an adaptive field, starting at 3 and capping at 64, which increases when spurious losses reveal deeper reordering.
> - Adds a `timeThresholdCushion` field that widens the time-based loss detection window (up to one smoothed RTT) when observed time reordering exceeds the computed loss delay.
> - Both thresholds are updated in `detectSpuriousLosses` and consumed in `detectLostPackets`, following RFC 9002 §6.1.1 recommendations.
> - Behavioral Change: previously lost packets may no longer be declared lost once thresholds adapt, and future loss declarations can be delayed relative to prior behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 112fa0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loss detection for 1-RTT application data under heavy packet reordering.
  * Reduced false packet loss reports by dynamically adjusting both reordering and timing thresholds based on observed behavior.
  * Updated timing-based detection to better account for variable delivery delays and avoid premature loss marking.
* **Tests**
  * Added coverage for adaptive threshold growth, including proper upper-bound limiting and time-cushion behavior after spurious loss scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->