### PR TITLE
add SendStream.TryWrite for non-blocking partial writes

### DIFF
--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -14,7 +14,7 @@ import (
 type connectionFlowController struct {
 	receiveFlowController
 
-	// Protects send-side state, which TryWriteAll can access from application goroutines.
+	// Protects send-side state, which TryWrite and TryWriteAll can access from application goroutines.
 	sendMutex     sync.Mutex
 	bytesSent     protocol.ByteCount
 	sendWindow    protocol.ByteCount
@@ -70,15 +70,16 @@ func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) (hasWindow
 	return c.hasWindowUpdate()
 }
 
-func (c *connectionFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
+func (c *connectionFlowController) ReserveBytesSent(minimum, maximum protocol.ByteCount) protocol.ByteCount {
 	c.sendMutex.Lock()
 	defer c.sendMutex.Unlock()
 
-	if c.bytesSent > c.sendWindow || n > c.sendWindow-c.bytesSent {
-		return false
+	n := min(maximum, max(0, c.sendWindow-c.bytesSent))
+	if n < minimum {
+		return 0
 	}
 	c.bytesSent += n
-	return true
+	return n
 }
 
 // UpdateSendWindow is called after receiving a MAX_DATA frame.

--- a/flow_controller_connection_test.go
+++ b/flow_controller_connection_test.go
@@ -64,10 +64,18 @@ func TestConnectionFlowControlViolation(t *testing.T) {
 func TestConnectionFlowControllerReset(t *testing.T) {
 	fc := newConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
 	fc.UpdateSendWindow(100)
-	require.True(t, fc.TryAddBytesSent(10))
+	require.Equal(t, protocol.ByteCount(10), fc.ReserveBytesSent(10, 10))
 	require.Equal(t, protocol.ByteCount(90), fc.SendWindowSize())
 	require.NoError(t, fc.Reset())
 	require.Zero(t, fc.SendWindowSize())
+}
+
+func TestConnectionFlowControllerReserveBytesSent(t *testing.T) {
+	fc := newConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
+	fc.UpdateSendWindow(10)
+	require.Equal(t, protocol.ByteCount(8), fc.ReserveBytesSent(6, 8))
+	require.Zero(t, fc.ReserveBytesSent(3, 5))
+	require.Equal(t, protocol.ByteCount(2), fc.SendWindowSize())
 }
 
 func TestConnectionFlowControllerResetAfterReading(t *testing.T) {

--- a/flow_controller_stream.go
+++ b/flow_controller_stream.go
@@ -127,15 +127,12 @@ func (c *streamFlowController) UpdateSendWindow(offset protocol.ByteCount) (upda
 	return false
 }
 
-func (c *streamFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
-	if c.bytesSent > c.sendWindow || n > c.sendWindow-c.bytesSent {
-		return false
-	}
-	if !c.connection.TryAddBytesSent(n) {
-		return false
-	}
+// ReserveBytesSent reserves the largest amount allowed by stream and connection flow control,
+// but reserves nothing unless at least minimum bytes are available.
+func (c *streamFlowController) ReserveBytesSent(minimum, maximum protocol.ByteCount) protocol.ByteCount {
+	n := c.connection.ReserveBytesSent(minimum, min(maximum, c.sendWindow-c.bytesSent))
 	c.bytesSent += n
-	return true
+	return n
 }
 
 func (c *streamFlowController) SendWindowSize() protocol.ByteCount {

--- a/flow_controller_stream_test.go
+++ b/flow_controller_stream_test.go
@@ -155,10 +155,10 @@ func TestStreamSendWindow(t *testing.T) {
 	)
 	// first, we're limited by the stream flow controller
 	require.Equal(t, protocol.ByteCount(100), fc.SendWindowSize())
-	require.True(t, fc.TryAddBytesSent(50))
+	require.Equal(t, protocol.ByteCount(50), fc.ReserveBytesSent(50, 50))
 	require.False(t, fc.IsNewlyBlocked())
 	require.Equal(t, protocol.ByteCount(50), fc.SendWindowSize())
-	require.True(t, fc.TryAddBytesSent(50))
+	require.Equal(t, protocol.ByteCount(50), fc.ReserveBytesSent(50, 50))
 	require.True(t, fc.IsNewlyBlocked())
 	require.Zero(t, fc.SendWindowSize())
 	require.False(t, fc.IsNewlyBlocked()) // we're still blocked, but it's not new
@@ -171,12 +171,12 @@ func TestStreamSendWindow(t *testing.T) {
 
 	require.False(t, fc.IsNewlyBlocked()) // we're not blocked anymore
 	require.Equal(t, protocol.ByteCount(200), fc.SendWindowSize())
-	require.True(t, fc.TryAddBytesSent(200))
+	require.Equal(t, protocol.ByteCount(200), fc.ReserveBytesSent(200, 200))
 	require.Zero(t, fc.SendWindowSize())
 	require.False(t, fc.IsNewlyBlocked()) // we're blocked, but not on stream flow control
 }
 
-func TestStreamFlowControllerTryAddBytesSent(t *testing.T) {
+func TestStreamFlowControllerReserveBytesSent(t *testing.T) {
 	connFC := newConnectionFlowController(
 		protocol.MaxByteCount,
 		protocol.MaxByteCount,
@@ -195,9 +195,12 @@ func TestStreamFlowControllerTryAddBytesSent(t *testing.T) {
 		utils.DefaultLogger,
 	)
 
-	require.True(t, fc.TryAddBytesSent(6))
-	require.False(t, fc.TryAddBytesSent(5))
+	require.Equal(t, protocol.ByteCount(6), fc.ReserveBytesSent(6, 6))
+	require.Zero(t, fc.ReserveBytesSent(5, 5))
 	require.Equal(t, protocol.ByteCount(4), connFC.SendWindowSize())
+	require.Equal(t, protocol.ByteCount(4), fc.ReserveBytesSent(3, 5))
+	require.Zero(t, fc.SendWindowSize())
+	require.Zero(t, connFC.SendWindowSize())
 }
 
 func TestStreamWindowUpdate(t *testing.T) {

--- a/framer_test.go
+++ b/framer_test.go
@@ -172,7 +172,7 @@ func testFramerDataBlocked(t *testing.T, fits bool) {
 
 	fc := newConnectionFlowController(0, 0, nil, nil, nil)
 	fc.UpdateSendWindow(offset)
-	require.True(t, fc.TryAddBytesSent(offset))
+	require.Equal(t, protocol.ByteCount(offset), fc.ReserveBytesSent(offset, offset))
 
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
 	framer := newFramer(fc)

--- a/interface.go
+++ b/interface.go
@@ -58,7 +58,8 @@ type TokenStore interface {
 // when the server rejects a 0-RTT connection attempt.
 var Err0RTTRejected = errors.New("0-RTT rejected")
 
-// ErrWouldBlock is returned by [SendStream.TryWriteAll] if the entire slice can't be queued immediately.
+// ErrWouldBlock is returned by [SendStream.TryWriteAll] and [SendStream.TryWrite]
+// when they would need to wait for flow-control credit or another write to finish.
 var ErrWouldBlock = errors.New("operation would block")
 
 // QUICVersionContextKey can be used to find out the QUIC version of a TLS handshake from the

--- a/send_stream.go
+++ b/send_stream.go
@@ -105,53 +105,76 @@ func (s *SendStream) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// TryWrite writes as much data as possible without blocking.
+// It doesn't block for flow control credit or concurrent Write calls, and doesn't respect the write deadline.
+// If the entire slice can't be queued immediately, it returns the number of bytes queued and [ErrWouldBlock].
+func (s *SendStream) TryWrite(p []byte) (int, error) {
+	return s.writeNonblocking(p, true)
+}
+
 // TryWriteAll writes data to the stream if it can be queued immediately.
 // It doesn't block for flow control credit and doesn't respect the write deadline.
 // If the entire slice can't be queued immediately, it queues nothing and returns [ErrWouldBlock].
 func (s *SendStream) TryWriteAll(p []byte) error {
+	_, err := s.writeNonblocking(p, false)
+	return err
+}
+
+func (s *SendStream) writeNonblocking(p []byte, partial bool) (int, error) {
+	if partial && len(p) == 0 {
+		return 0, nil
+	}
 	select {
 	case s.writeOnce <- struct{}{}:
 		defer func() { <-s.writeOnce }()
 	default:
-		return ErrWouldBlock
+		return 0, ErrWouldBlock
 	}
 
-	isNewlyCompleted, hasData, err := s.tryWriteAll(p)
+	isNewlyCompleted, n, hasData, err := s.tryWrite(p, partial)
 	if isNewlyCompleted {
 		s.sender.onStreamCompleted(s.streamID)
 	}
 	if hasData {
 		s.sender.onHasStreamData(s.streamID, s)
 	}
-	return err
+	return n, err
 }
 
-func (s *SendStream) tryWriteAll(p []byte) (bool /* is newly completed */, bool /* has data */, error) {
+func (s *SendStream) tryWrite(p []byte, partial bool) (bool /* is newly completed */, int, bool /* has data */, error) {
 	// This might wait briefly while a packet is dequeuing stream data.
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
 	if s.resetErr != nil {
 		s.cancellationFlagged = true
-		return s.isNewlyCompleted(), false, s.resetErr
+		return s.isNewlyCompleted(), 0, false, s.resetErr
 	}
 	if s.shutdownErr != nil {
-		return false, false, s.shutdownErr
+		return false, 0, false, s.shutdownErr
 	}
 	if s.finishedWriting {
-		return false, false, fmt.Errorf("write on closed stream %d", s.streamID)
+		return false, 0, false, fmt.Errorf("write on closed stream %d", s.streamID)
 	}
 	if len(p) == 0 {
-		return false, false, nil
+		return false, 0, false, nil
 	}
 
-	bytesToReserve := protocol.ByteCount(len(p))
+	maximum := protocol.ByteCount(len(p))
+	var unreserved protocol.ByteCount
 	if s.nextFrame != nil && !s.nextFrameReserved {
-		bytesToReserve += s.nextFrame.DataLen()
+		unreserved = s.nextFrame.DataLen()
+		maximum += unreserved
 	}
-	if !s.flowController.TryAddBytesSent(bytesToReserve) {
-		return false, false, ErrWouldBlock
+	minimum := maximum
+	if partial {
+		minimum = max(1, unreserved)
 	}
+	reserved := s.flowController.ReserveBytesSent(minimum, maximum)
+	if reserved == 0 {
+		return false, 0, false, ErrWouldBlock
+	}
+	n := int(reserved - unreserved)
 
 	if s.nextFrame == nil {
 		s.nextFrame = wire.GetStreamFrame()
@@ -161,24 +184,27 @@ func (s *SendStream) tryWriteAll(p []byte) (bool /* is newly completed */, bool 
 		s.nextFrame.Data = s.nextFrame.Data[:0]
 	}
 	l := len(s.nextFrame.Data)
-	if l+len(p) > cap(s.nextFrame.Data) {
+	if l+n > cap(s.nextFrame.Data) {
 		// Pooled STREAM frames must keep their packet-sized buffer.
 		// Use a non-pooled frame when the queued data grows beyond that.
 		nextFrame := &wire.StreamFrame{
 			StreamID:       s.streamID,
 			Offset:         s.nextFrame.Offset,
 			DataLenPresent: true,
-			Data:           make([]byte, l+len(p)),
+			Data:           make([]byte, l+n),
 		}
 		copy(nextFrame.Data, s.nextFrame.Data)
 		s.nextFrame.PutBack()
 		s.nextFrame = nextFrame
 	} else {
-		s.nextFrame.Data = s.nextFrame.Data[:l+len(p)]
+		s.nextFrame.Data = s.nextFrame.Data[:l+n]
 	}
-	copy(s.nextFrame.Data[l:], p)
+	copy(s.nextFrame.Data[l:], p[:n])
 	s.nextFrameReserved = true
-	return false, true, nil
+	if n < len(p) {
+		return false, n, true, ErrWouldBlock
+	}
+	return false, n, true, nil
 }
 
 func (s *SendStream) write(p []byte) (bool /* is newly completed */, int, error) {
@@ -377,7 +403,7 @@ func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 	if maxDataLen == 0 {
 		return nil, nil, true
 	}
-	if !s.nextFrameReserved && !s.flowController.TryAddBytesSent(maxDataLen) {
+	if !s.nextFrameReserved && s.flowController.ReserveBytesSent(maxDataLen, maxDataLen) != maxDataLen {
 		return nil, nil, true
 	}
 	f, hasMoreData := s.popNewStreamFrame(maxDataLen)

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -135,19 +135,28 @@ func TestSendStreamWriteData(t *testing.T) {
 	)
 }
 
-func TestSendStreamTryWriteAll(t *testing.T) {
+func TestSendStreamTryWrite(t *testing.T) {
 	const streamID protocol.StreamID = 42
 	mockCtrl := gomock.NewController(t)
 	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
 	mockSender := NewMockStreamSender(mockCtrl)
 	str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
-	require.NoError(t, str.TryWriteAll(nil))
-	require.NoError(t, str.TryWriteAll([]byte{}))
+	n, err := str.TryWrite(nil)
+	require.NoError(t, err)
+	require.Zero(t, n)
+	n, err = str.TryWrite([]byte{})
+	require.NoError(t, err)
+	require.Zero(t, n)
+
+	// deadlines are ignored for TryWrite
+	require.NoError(t, str.SetWriteDeadline(time.Now().Add(-time.Second)))
 
 	mockSender.EXPECT().onHasStreamData(streamID, str)
 	data := []byte("foobar")
-	require.NoError(t, str.TryWriteAll(data))
+	n, err = str.TryWrite(data)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
 	data[0] = 'x' // make sure the data was copied
 
 	frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
@@ -158,32 +167,94 @@ func TestSendStreamTryWriteAll(t *testing.T) {
 	)
 }
 
-func TestSendStreamTryWriteAllFlowControlBlocked(t *testing.T) {
+func TestSendStreamTryWriteAll(t *testing.T) {
 	const streamID protocol.StreamID = 42
-	mockCtrl := gomock.NewController(t)
-	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 3)
-	mockSender := NewMockStreamSender(mockCtrl)
-	str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
-	require.ErrorIs(t, str.TryWriteAll([]byte("foobar")), ErrWouldBlock)
-	require.Equal(t, protocol.ByteCount(3), mockFC.SendWindowSize())
+	t.Run("all or nothing", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 3)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
-	frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
-	require.Nil(t, frame.Frame)
-	require.False(t, hasMore)
+		require.ErrorIs(t, str.TryWriteAll([]byte("foobar")), ErrWouldBlock)
+		require.Equal(t, protocol.ByteCount(3), mockFC.SendWindowSize())
+		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.Nil(t, frame.Frame)
+		require.False(t, hasMore)
 
-	mockSender.EXPECT().onHasStreamData(streamID, str)
-	require.NoError(t, str.TryWriteAll([]byte("foo")))
-	frame, blocked, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
-	require.False(t, hasMore)
-	require.EqualExportedValues(t,
-		&wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true},
-		frame.Frame,
-	)
-	require.Equal(t, &wire.StreamDataBlockedFrame{StreamID: streamID, MaximumStreamData: 3}, blocked)
+		mockSender.EXPECT().onHasStreamData(streamID, str)
+		require.NoError(t, str.TryWriteAll([]byte("foo")))
+		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.False(t, hasMore)
+		require.Equal(t, []byte("foo"), frame.Frame.Data)
+	})
+
+	t.Run("after buffered Write", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 5)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str)
+		n, err := str.Write([]byte("foo"))
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
+		require.ErrorIs(t, str.TryWriteAll([]byte("bar")), ErrWouldBlock)
+		require.False(t, str.nextFrameReserved)
+		require.Equal(t, protocol.ByteCount(5), mockFC.SendWindowSize())
+	})
 }
 
-func TestSendStreamTryWriteAllAfterBufferedWrite(t *testing.T) {
+func TestSendStreamTryWriteFlowControlBlocked(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		connectionLimited bool
+	}{
+		{name: "stream"},
+		{name: "connection", connectionLimited: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const streamID protocol.StreamID = 42
+			mockCtrl := gomock.NewController(t)
+			streamWindow := protocol.ByteCount(3)
+			if tc.connectionLimited {
+				streamWindow = protocol.MaxByteCount
+			}
+			mockFC := newTestStreamFlowControllerWithSendWindow(streamID, streamWindow)
+			if tc.connectionLimited {
+				mockFC.connection.sendWindow = 3
+			}
+			mockSender := NewMockStreamSender(mockCtrl)
+			str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+			mockSender.EXPECT().onHasStreamData(streamID, str)
+			data := []byte("foobar")
+			n, err := str.TryWrite(data)
+			require.ErrorIs(t, err, ErrWouldBlock)
+			require.Equal(t, 3, n)
+			require.Zero(t, mockFC.SendWindowSize())
+			data[0] = 'x'
+
+			n, err = str.TryWrite([]byte("baz"))
+			require.ErrorIs(t, err, ErrWouldBlock)
+			require.Zero(t, n)
+
+			frame, blocked, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+			require.False(t, hasMore)
+			require.EqualExportedValues(t,
+				&wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true},
+				frame.Frame,
+			)
+			if tc.connectionLimited {
+				require.Nil(t, blocked)
+			} else {
+				require.Equal(t, &wire.StreamDataBlockedFrame{StreamID: streamID, MaximumStreamData: 3}, blocked)
+			}
+		})
+	}
+}
+
+func TestSendStreamTryWriteAfterBufferedWrite(t *testing.T) {
 	const streamID protocol.StreamID = 42
 
 	t.Run("enough credit", func(t *testing.T) {
@@ -196,7 +267,9 @@ func TestSendStreamTryWriteAllAfterBufferedWrite(t *testing.T) {
 		n, err := str.Write([]byte("foo"))
 		require.NoError(t, err)
 		require.Equal(t, 3, n)
-		require.NoError(t, str.TryWriteAll([]byte("bar")))
+		n, err = str.TryWrite([]byte("bar"))
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
 
 		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 		require.False(t, hasMore)
@@ -207,9 +280,52 @@ func TestSendStreamTryWriteAllAfterBufferedWrite(t *testing.T) {
 		require.Zero(t, mockFC.SendWindowSize())
 	})
 
-	t.Run("not enough credit", func(t *testing.T) {
+	t.Run("partial credit", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 5)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str).Times(2)
+		n, err := str.Write([]byte("foo"))
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
+		n, err = str.TryWrite([]byte("bar"))
+		require.ErrorIs(t, err, ErrWouldBlock)
+		require.Equal(t, 2, n)
+
+		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.False(t, hasMore)
+		require.EqualExportedValues(t,
+			&wire.StreamFrame{StreamID: streamID, Data: []byte("fooba"), DataLenPresent: true},
+			frame.Frame,
+		)
+		require.Zero(t, mockFC.SendWindowSize())
+	})
+
+	t.Run("only buffered data fits", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 3)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str).Times(2)
+		n, err := str.Write([]byte("foo"))
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
+		n, err = str.TryWrite([]byte("bar"))
+		require.ErrorIs(t, err, ErrWouldBlock)
+		require.Zero(t, n)
+
+		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.False(t, hasMore)
+		require.Equal(t, []byte("foo"), frame.Frame.Data)
+		require.Zero(t, mockFC.SendWindowSize())
+	})
+
+	t.Run("not enough credit for buffered data", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 2)
 		mockSender := NewMockStreamSender(mockCtrl)
 		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
@@ -217,19 +333,16 @@ func TestSendStreamTryWriteAllAfterBufferedWrite(t *testing.T) {
 		n, err := str.Write([]byte("foo"))
 		require.NoError(t, err)
 		require.Equal(t, 3, n)
-		require.ErrorIs(t, str.TryWriteAll([]byte("bar")), ErrWouldBlock)
-
-		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
-		require.False(t, hasMore)
-		require.EqualExportedValues(t,
-			&wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true},
-			frame.Frame,
-		)
+		n, err = str.TryWrite([]byte("bar"))
+		require.ErrorIs(t, err, ErrWouldBlock)
+		require.Zero(t, n)
+		require.False(t, str.nextFrameReserved)
 		require.Equal(t, protocol.ByteCount(2), mockFC.SendWindowSize())
+		require.Equal(t, protocol.MaxByteCount, mockFC.connection.SendWindowSize())
 	})
 }
 
-func TestSendStreamWriteAfterTryWriteAll(t *testing.T) {
+func TestSendStreamWriteAfterTryWrite(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const streamID protocol.StreamID = 42
 		mockCtrl := gomock.NewController(t)
@@ -238,7 +351,9 @@ func TestSendStreamWriteAfterTryWriteAll(t *testing.T) {
 		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
 		mockSender.EXPECT().onHasStreamData(streamID, str).Times(2)
-		require.NoError(t, str.TryWriteAll([]byte("foo")))
+		n, err := str.TryWrite([]byte("foo"))
+		require.NoError(t, err)
+		require.Equal(t, 3, n)
 
 		errChan := make(chan error, 1)
 		go func() {
@@ -280,7 +395,36 @@ func TestSendStreamWriteAfterTryWriteAll(t *testing.T) {
 	})
 }
 
-func TestSendStreamLargeTryWriteAll(t *testing.T) {
+func TestSendStreamTryWriteDuringWrite(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const streamID protocol.StreamID = 42
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str)
+		errChan := make(chan error, 1)
+		go func() {
+			_, err := str.Write(make([]byte, protocol.MaxPacketBufferSize+1))
+			errChan <- err
+		}()
+		synctest.Wait()
+
+		n, err := str.TryWrite(nil)
+		require.NoError(t, err)
+		require.Zero(t, n)
+		n, err = str.TryWrite([]byte("foo"))
+		require.ErrorIs(t, err, ErrWouldBlock)
+		require.Zero(t, n)
+
+		str.closeForShutdown(assert.AnError)
+		synctest.Wait()
+		require.ErrorIs(t, <-errChan, assert.AnError)
+	})
+}
+
+func TestSendStreamLargeTryWrite(t *testing.T) {
 	const streamID protocol.StreamID = 42
 	mockCtrl := gomock.NewController(t)
 	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
@@ -293,7 +437,9 @@ func TestSendStreamLargeTryWriteAll(t *testing.T) {
 	}
 
 	mockSender.EXPECT().onHasStreamData(streamID, str)
-	require.NoError(t, str.TryWriteAll(data))
+	n, err := str.TryWrite(data)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
 
 	var offset protocol.ByteCount
 	for offset < protocol.ByteCount(len(data)) {
@@ -306,7 +452,7 @@ func TestSendStreamLargeTryWriteAll(t *testing.T) {
 	}
 }
 
-func TestSendStreamResetFinalSizeIncludesReservedData(t *testing.T) {
+func TestSendStreamResetFinalSizeIncludesTryWriteData(t *testing.T) {
 	const streamID protocol.StreamID = 42
 
 	for _, tc := range []struct {
@@ -331,7 +477,9 @@ func TestSendStreamResetFinalSizeIncludesReservedData(t *testing.T) {
 			str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
 			mockSender.EXPECT().onHasStreamData(streamID, str)
-			require.NoError(t, str.TryWriteAll(make([]byte, 100)))
+			n, err := str.TryWrite(make([]byte, 150))
+			require.ErrorIs(t, err, ErrWouldBlock)
+			require.Equal(t, 100, n)
 
 			frame, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, 0)+40, protocol.Version1)
 			require.True(t, hasMore)
@@ -347,7 +495,7 @@ func TestSendStreamResetFinalSizeIncludesReservedData(t *testing.T) {
 	}
 }
 
-func TestSendStreamSetReliableBoundaryAfterTryWriteAll(t *testing.T) {
+func TestSendStreamSetReliableBoundaryAfterTryWrite(t *testing.T) {
 	const streamID protocol.StreamID = 42
 	mockCtrl := gomock.NewController(t)
 	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 100)
@@ -355,7 +503,9 @@ func TestSendStreamSetReliableBoundaryAfterTryWriteAll(t *testing.T) {
 	str := newSendStream(context.Background(), streamID, mockSender, mockFC, true)
 
 	mockSender.EXPECT().onHasStreamData(streamID, str)
-	require.NoError(t, str.TryWriteAll(make([]byte, 100)))
+	n, err := str.TryWrite(make([]byte, 150))
+	require.ErrorIs(t, err, ErrWouldBlock)
+	require.Equal(t, 100, n)
 
 	frame, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, 0)+40, protocol.Version1)
 	require.True(t, hasMore)
@@ -674,6 +824,8 @@ func TestSendStreamClose(t *testing.T) {
 	_, err = strWithTimeout.Write([]byte("foobar"))
 	require.ErrorContains(t, err, "write on closed stream 1234")
 	require.ErrorContains(t, str.TryWriteAll([]byte("foobar")), "write on closed stream 1234")
+	_, err = str.TryWrite([]byte("foobar"))
+	require.ErrorContains(t, err, "write on closed stream 1234")
 	frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 	require.Nil(t, frame.Frame)
 	require.False(t, hasMore)
@@ -889,6 +1041,8 @@ func TestSendStreamCancellation(t *testing.T) {
 		_, err = strWithTimeout.Write([]byte("foo"))
 		require.ErrorIs(t, err, &StreamError{StreamID: streamID, ErrorCode: 1234, Remote: false})
 		err = str.TryWriteAll([]byte("foo"))
+		require.ErrorIs(t, err, &StreamError{StreamID: streamID, ErrorCode: 1234, Remote: false})
+		_, err = str.TryWrite([]byte("foo"))
 		require.ErrorIs(t, err, &StreamError{StreamID: streamID, ErrorCode: 1234, Remote: false})
 		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 		require.Nil(t, frame.Frame)

--- a/stream.go
+++ b/stream.go
@@ -138,6 +138,12 @@ func (s *Stream) TryWriteAll(p []byte) error {
 	return s.sendStr.TryWriteAll(p)
 }
 
+// TryWrite writes as much data as possible without blocking.
+// See [SendStream.TryWrite] for more details.
+func (s *Stream) TryWrite(p []byte) (int, error) {
+	return s.sendStr.TryWrite(p)
+}
+
 // SetReliableBoundary marks the data written to this stream so far as reliable.
 // It is valid to call this function multiple times, thereby increasing the reliable size.
 // It only has an effect if the peer enabled support for the RESET_STREAM_AT extension,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `TryWrite` for non-blocking writes on both `Stream` and `SendStream`, with immediate return semantics and support for partial queuing when flow control permits.
* **Documentation**
  * Expanded `ErrWouldBlock` docs to clarify it can occur when writes must wait for flow-control credit or another write to finish.
* **Bug Fixes**
  * Improved send-window flow control with reservation-based accounting for more correct behavior under stream- vs connection-limited conditions.
* **Tests**
  * Updated and extended flow-control and send/write tests to validate `TryWrite` results and reservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SendStream.TryWrite` for non-blocking partial writes
> - Adds `SendStream.TryWrite` and `Stream.TryWrite` methods that queue as many bytes as flow control allows without blocking, returning the count queued and `ErrWouldBlock` if not all bytes fit.
> - Refactors `TryWriteAll` to share the new `writeNonblocking` helper, preserving its all-or-nothing semantics.
> - Replaces `TryAddBytesSent` with `ReserveBytesSent(minimum, maximum)` in both stream and connection flow controllers to support partial reservations with a minimum threshold.
> - Behavioral Change: `ErrWouldBlock` can now be returned alongside a positive byte count when using `TryWrite`, whereas `TryWriteAll` continues to return zero bytes on `ErrWouldBlock`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9029dfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->