### PR TITLE
remove unneeded underflow checks in the flow controller

### DIFF
--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -97,9 +97,6 @@ func (c *connectionFlowController) SendWindowSize() protocol.ByteCount {
 	c.sendMutex.Lock()
 	defer c.sendMutex.Unlock()
 
-	if c.bytesSent > c.sendWindow {
-		return 0
-	}
 	return c.sendWindow - c.bytesSent
 }
 

--- a/flow_controller_stream.go
+++ b/flow_controller_stream.go
@@ -139,10 +139,6 @@ func (c *streamFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
 }
 
 func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
-	// this only happens during connection establishment, when data is sent before we receive the peer's transport parameters
-	if c.bytesSent > c.sendWindow {
-		return 0
-	}
 	return min(c.sendWindow-c.bytesSent, c.connection.SendWindowSize())
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send-window calculations during connection establishment and stream transmission.
  * Flow control now consistently reports the calculated available capacity, including temporary states where data has been sent before transport parameters are available.
  * This helps maintain more accurate transmission behavior in edge cases involving connection and stream flow control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove underflow checks in flow controller `SendWindowSize` methods
> The underflow guards in `connectionFlowController.SendWindowSize` and `streamFlowController.SendWindowSize` that returned `0` when `bytesSent` exceeded `sendWindow` are removed. Both methods now compute the window size directly without the special-case branch, relying on the invariant that `bytesSent` never exceeds `sendWindow`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37b3f88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->