### PR TITLE
add SendStream.WriteCreditAvailable to allow blocking on flow control

### DIFF
--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -14,11 +14,12 @@ import (
 type connectionFlowController struct {
 	receiveFlowController
 
-	// Protects send-side state, which TryWrite and TryWriteAll can access from application goroutines.
-	sendMutex     sync.Mutex
-	bytesSent     protocol.ByteCount
-	sendWindow    protocol.ByteCount
-	lastBlockedAt protocol.ByteCount
+	// Protects send-side state accessed from application goroutines.
+	sendMutex         sync.Mutex
+	bytesSent         protocol.ByteCount
+	sendWindow        protocol.ByteCount
+	lastBlockedAt     protocol.ByteCount
+	sendWindowUpdated chan struct{}
 }
 
 // newConnectionFlowController gets a new flow controller for the connection.
@@ -89,9 +90,24 @@ func (c *connectionFlowController) UpdateSendWindow(offset protocol.ByteCount) (
 
 	if offset > c.sendWindow {
 		c.sendWindow = offset
+		if c.sendWindowUpdated != nil {
+			close(c.sendWindowUpdated)
+			c.sendWindowUpdated = nil
+		}
 		return true
 	}
 	return false
+}
+
+// WriteCredit returns the current credit and the channel for the next update atomically.
+func (c *connectionFlowController) WriteCredit() (protocol.ByteCount, <-chan struct{}) {
+	c.sendMutex.Lock()
+	defer c.sendMutex.Unlock()
+
+	if c.sendWindowUpdated == nil {
+		c.sendWindowUpdated = make(chan struct{})
+	}
+	return max(0, c.sendWindow-c.bytesSent), c.sendWindowUpdated
 }
 
 func (c *connectionFlowController) SendWindowSize() protocol.ByteCount {

--- a/flow_controller_stream.go
+++ b/flow_controller_stream.go
@@ -12,9 +12,10 @@ import (
 type streamFlowController struct {
 	receiveFlowController
 
-	bytesSent     protocol.ByteCount
-	sendWindow    protocol.ByteCount
-	lastBlockedAt protocol.ByteCount
+	bytesSent         protocol.ByteCount
+	sendWindow        protocol.ByteCount
+	lastBlockedAt     protocol.ByteCount
+	sendWindowUpdated chan struct{}
 
 	streamID protocol.StreamID
 
@@ -122,6 +123,10 @@ func (c *streamFlowController) Abandon() {
 func (c *streamFlowController) UpdateSendWindow(offset protocol.ByteCount) (updated bool) {
 	if offset > c.sendWindow {
 		c.sendWindow = offset
+		if c.sendWindowUpdated != nil {
+			close(c.sendWindowUpdated)
+			c.sendWindowUpdated = nil
+		}
 		return true
 	}
 	return false
@@ -137,6 +142,25 @@ func (c *streamFlowController) ReserveBytesSent(minimum, maximum protocol.ByteCo
 
 func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
 	return min(c.sendWindow-c.bytesSent, c.connection.SendWindowSize())
+}
+
+// WriteCreditAvailable returns a channel that is closed when at least minimum bytes of send credit are available.
+// minimum includes credit for unreserved buffered STREAM data and one new byte.
+func (c *streamFlowController) WriteCreditAvailable(minimum protocol.ByteCount) <-chan struct{} {
+	streamCredit := c.sendWindow - c.bytesSent
+	connCredit, connUpdated := c.connection.WriteCredit()
+	if min(streamCredit, connCredit) >= minimum {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	if streamCredit <= connCredit {
+		if c.sendWindowUpdated == nil {
+			c.sendWindowUpdated = make(chan struct{})
+		}
+		return c.sendWindowUpdated
+	}
+	return connUpdated
 }
 
 func (c *streamFlowController) IsNewlyBlocked() bool {

--- a/integrationtests/self/stream_test.go
+++ b/integrationtests/self/stream_test.go
@@ -9,11 +9,73 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/quicvarint"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestTryWriteStreamFlowControl(t *testing.T) {
+	testTryWriteFlowControl(t, &quic.Config{
+		InitialStreamReceiveWindow:     100,
+		InitialConnectionReceiveWindow: quicvarint.Max,
+	})
+}
+
+func TestTryWriteConnectionFlowControl(t *testing.T) {
+	testTryWriteFlowControl(t, &quic.Config{
+		InitialStreamReceiveWindow:     quicvarint.Max,
+		InitialConnectionReceiveWindow: 100,
+	})
+}
+
+func testTryWriteFlowControl(t *testing.T, config *quic.Config) {
+	ln, err := quic.Listen(newUDPConnLocalhost(t), getTLSConfig(), getQuicConfig(config))
+	require.NoError(t, err)
+	defer ln.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	client, err := quic.Dial(ctx, newUDPConnLocalhost(t), ln.Addr(), getTLSClientConfig(), getQuicConfig(nil))
+	require.NoError(t, err)
+	defer client.CloseWithError(0, "")
+
+	server, err := ln.Accept(ctx)
+	require.NoError(t, err)
+	str, err := client.OpenUniStreamSync(ctx)
+	require.NoError(t, err)
+
+	data := GeneratePRData(101)
+	require.ErrorIs(t, str.TryWriteAll(data), quic.ErrWouldBlock)
+	n, err := str.TryWrite(data)
+	require.Equal(t, 100, n)
+	require.ErrorIs(t, err, quic.ErrWouldBlock)
+
+	credit := str.WriteCreditAvailable()
+	select {
+	case <-credit:
+		require.Fail(t, "write credit available before reading stream data")
+	default:
+	}
+
+	receiveStr, err := server.AcceptUniStream(ctx)
+	require.NoError(t, err)
+	received := make([]byte, n)
+	_, err = io.ReadFull(receiveStr, received)
+	require.NoError(t, err)
+	select {
+	case <-credit:
+	case <-ctx.Done():
+		require.Fail(t, "write credit not made available")
+	}
+
+	require.NoError(t, str.TryWriteAll(data[n:]))
+	require.NoError(t, str.Close())
+	rest, err := io.ReadAll(receiveStr)
+	require.NoError(t, err)
+	require.Equal(t, data, append(received, rest...))
+}
 
 func TestBidirectionalStreamMultiplexing(t *testing.T) {
 	const numStreams = 75

--- a/send_stream.go
+++ b/send_stream.go
@@ -112,6 +112,21 @@ func (s *SendStream) TryWrite(p []byte) (int, error) {
 	return s.writeNonblocking(p, true)
 }
 
+// WriteCreditAvailable returns a channel that's closed when [SendStream.TryWrite] can make flow-control progress.
+// The channel is already closed if flow-control credit is currently available.
+// Otherwise, it is closed when the limiting stream- or connection-level flow-control window increases.
+// It only signals flow-control availability. Callers must retry TryWrite and watch Context().Done() for cancellation.
+func (s *SendStream) WriteCreditAvailable() <-chan struct{} {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	minimum := protocol.ByteCount(1)
+	if s.nextFrame != nil && !s.nextFrameReserved {
+		minimum += s.nextFrame.DataLen()
+	}
+	return s.flowController.WriteCreditAvailable(minimum)
+}
+
 // TryWriteAll writes data to the stream if it can be queued immediately.
 // It doesn't block for flow control credit and doesn't respect the write deadline.
 // If the entire slice can't be queued immediately, it queues nothing and returns [ErrWouldBlock].

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -254,6 +254,87 @@ func TestSendStreamTryWriteFlowControlBlocked(t *testing.T) {
 	}
 }
 
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestSendStreamWriteCreditAvailable(t *testing.T) {
+	const streamID protocol.StreamID = 42
+
+	t.Run("stream-level blocking", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 3)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str).Times(2)
+		n, err := str.TryWrite([]byte("foobar"))
+		require.Equal(t, 3, n)
+		require.ErrorIs(t, err, ErrWouldBlock)
+		credit := str.WriteCreditAvailable()
+		require.False(t, isClosed(credit))
+
+		str.updateSendWindow(4)
+		require.True(t, isClosed(credit))
+	})
+
+	t.Run("connection-level blocking", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
+		mockFC.connection.sendWindow = 3
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str)
+		n, err := str.TryWrite([]byte("foobar"))
+		require.Equal(t, 3, n)
+		require.ErrorIs(t, err, ErrWouldBlock)
+		credit := str.WriteCreditAvailable()
+		require.False(t, isClosed(credit))
+
+		mockFC.connection.UpdateSendWindow(4)
+		require.True(t, isClosed(credit))
+	})
+
+	t.Run("already available", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 1)
+		str := newSendStream(context.Background(), streamID, NewMockStreamSender(mockCtrl), mockFC, false)
+
+		require.True(t, isClosed(str.WriteCreditAvailable()))
+	})
+
+	t.Run("update before call", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
+		mockFC.connection.sendWindow = 0
+		str := newSendStream(context.Background(), streamID, NewMockStreamSender(mockCtrl), mockFC, false)
+
+		_, err := str.TryWrite([]byte("foo"))
+		require.ErrorIs(t, err, ErrWouldBlock)
+		mockFC.connection.UpdateSendWindow(1)
+		require.True(t, isClosed(str.WriteCreditAvailable()))
+	})
+
+	t.Run("unreserved buffered data", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 3)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str)
+		n, err := str.Write([]byte("foo"))
+		require.Equal(t, 3, n)
+		require.NoError(t, err)
+		require.False(t, isClosed(str.WriteCreditAvailable()))
+	})
+}
+
 func TestSendStreamTryWriteAfterBufferedWrite(t *testing.T) {
 	const streamID protocol.StreamID = 42
 

--- a/stream.go
+++ b/stream.go
@@ -144,6 +144,12 @@ func (s *Stream) TryWrite(p []byte) (int, error) {
 	return s.sendStr.TryWrite(p)
 }
 
+// WriteCreditAvailable returns a channel that's closed when [Stream.TryWrite] can make flow-control progress.
+// See [SendStream.WriteCreditAvailable] for more details.
+func (s *Stream) WriteCreditAvailable() <-chan struct{} {
+	return s.sendStr.WriteCreditAvailable()
+}
+
 // SetReliableBoundary marks the data written to this stream so far as reliable.
 // It is valid to call this function multiple times, thereby increasing the reliable size.
 // It only has an effect if the peer enabled support for the RESET_STREAM_AT extension,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `WriteCreditAvailable` to `SendStream` to block on flow control
> - Adds `SendStream.WriteCreditAvailable()` (and a `Stream` wrapper) that returns a channel closed when `TryWrite` can make flow-control progress, avoiding busy-polling after a blocked write.
> - Adds `WriteCredit` to the connection flow controller and `WriteCreditAvailable` to the stream flow controller; both lazily initialize a one-shot channel that is closed whenever the respective send window increases.
> - The minimum credit threshold accounts for any unreserved buffered data in `nextFrame` plus one new byte, so the channel fires only when a meaningful write can proceed.
> - Integration tests in [stream_test.go](https://github.com/quic-go/quic-go/pull/5740/files#diff-dca0aebea1cbb77e3b65c2a52e92484331d8daf470a06e5778d4126d31c3ee80) cover stream-level and connection-level flow control scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccf603c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `WriteCreditAvailable()` to `Stream` and `SendStream`, returning a notification channel that closes when flow-control allows further `TryWrite` progress.
* **Tests**
  * Added integration coverage for stream-level and connection-level flow control, ensuring `TryWrite` blocks with the expected would-block behavior and resumes only after the peer reads.
  * Confirmed end-to-end payload integrity across partial writes and subsequent resumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->