### PR TITLE
http3: avoid logging of invalid header values

### DIFF
--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -140,7 +140,7 @@ func (w *requestWriter) encodeHeaders(req *http.Request, addGzipHeader bool, tra
 		}
 		for _, v := range vv {
 			if !httpguts.ValidHeaderFieldValue(v) {
-				return nil, fmt.Errorf("invalid HTTP header value %q for header %q", v, k)
+				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
 			}
 		}
 	}

--- a/http3/request_writer_test.go
+++ b/http3/request_writer_test.go
@@ -96,6 +96,13 @@ func TestRequestWriterInvalidHostHeader(t *testing.T) {
 	)
 }
 
+func TestRequestWriterInvalidHeaderValue(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://quic-go.net", nil)
+	req.Header.Set("Authorization", "Bearer secret\x00")
+	err := newRequestWriter().WriteRequestHeader(&bytes.Buffer{}, req, false, 0, nil)
+	require.EqualError(t, err, `invalid HTTP header value for header "Authorization"`)
+}
+
 func TestRequestWriterConnect(t *testing.T) {
 	// httptest.NewRequest does not properly support the CONNECT method
 	req, err := http.NewRequest(http.MethodConnect, "https://quic-go.net/", nil)

--- a/http3/transport.go
+++ b/http3/transport.go
@@ -203,7 +203,7 @@ func (t *Transport) roundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
 		}
 		for _, v := range vv {
 			if !httpguts.ValidHeaderFieldValue(v) {
-				return nil, fmt.Errorf("http3: invalid http header field value %q for key %v", v, k)
+				return nil, fmt.Errorf("http3: invalid http header field value for key %q", k)
 			}
 		}
 	}

--- a/http3/transport_test.go
+++ b/http3/transport_test.go
@@ -100,10 +100,10 @@ func TestRequestValidation(t *testing.T) {
 			name: "invalid header value",
 			req: func() *http.Request {
 				r := httptest.NewRequest(http.MethodGet, "https://www.example.org/", nil)
-				r.Header.Add("foo", string([]byte{0x7}))
+				r.Header.Add("Authorization", "Bearer secret\x00")
 				return r
 			}(),
-			expectedErrContains: "http3: invalid http header field value",
+			expectedErr: `http3: invalid http header field value for key "Authorization"`,
 		},
 		{
 			name: "invalid method",


### PR DESCRIPTION
This could potentially leak credentials into log files.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit invalid header values from http3 error messages
> Error messages for invalid HTTP header values in the http3 package previously included the raw header value, which could leak sensitive data (e.g. tokens in `Authorization` headers) into logs. Both [`request_writer.go`](https://github.com/quic-go/quic-go/pull/5742/files#diff-26e7bb9b62686667822b50c4aaf21fd74417a19983a35d83408ac35d1de73bb9) and [`transport.go`](https://github.com/quic-go/quic-go/pull/5742/files#diff-7d32c594a607b2cfc28367b8feb1b2510d2514eacdd0d2f3f0ebd038b2ffb3c5) now report only the header name in the error string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5067dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for invalid HTTP header values by reporting the affected header name, without echoing the invalid value.
* **Tests**
  * Added a unit test to cover invalid `Authorization` header values (including embedded NUL bytes).
  * Updated request validation tests to assert the exact improved error message for invalid header values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->