### PR TITLE
protocol: avoid exposing methods on the StreamID

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2931,8 +2931,8 @@ func (c *Conn) OpenUniStreamSync(ctx context.Context) (*SendStream, error) {
 
 func (c *Conn) newFlowController(id protocol.StreamID) *streamFlowController {
 	initialSendWindow := c.peerParams.InitialMaxStreamDataUni
-	if id.Type() == protocol.StreamTypeBidi {
-		if id.InitiatedBy() == c.perspective {
+	if protocol.StreamTypeOf(id) == protocol.StreamTypeBidi {
+		if protocol.StreamInitiator(id) == c.perspective {
 			initialSendWindow = c.peerParams.InitialMaxStreamDataBidiRemote
 		} else {
 			initialSendWindow = c.peerParams.InitialMaxStreamDataBidiLocal

--- a/internal/protocol/stream.go
+++ b/internal/protocol/stream.go
@@ -79,17 +79,17 @@ func (s StreamNum) StreamID(stype StreamType, pers Perspective) StreamID {
 // A StreamID in QUIC
 type StreamID int64
 
-// InitiatedBy says if the stream was initiated by the client or by the server
-func (s StreamID) InitiatedBy() Perspective {
-	if s%2 == 0 {
+// StreamInitiator says if the stream was initiated by the client or by the server.
+func StreamInitiator(id StreamID) Perspective {
+	if id%2 == 0 {
 		return PerspectiveClient
 	}
 	return PerspectiveServer
 }
 
-// Type says if this is a unidirectional or bidirectional stream
-func (s StreamID) Type() StreamType {
-	if s%4 >= 2 {
+// StreamTypeOf says if this is a unidirectional or bidirectional stream.
+func StreamTypeOf(id StreamID) StreamType {
+	if id%4 >= 2 {
 		return StreamTypeUni
 	}
 	return StreamTypeBidi

--- a/internal/protocol/stream_test.go
+++ b/internal/protocol/stream_test.go
@@ -10,18 +10,18 @@ func TestInvalidStreamIDSmallerThanAllValidStreamIDs(t *testing.T) {
 	require.Less(t, InvalidStreamID, StreamID(0))
 }
 
-func TestStreamIDInitiatedBy(t *testing.T) {
-	require.Equal(t, PerspectiveClient, StreamID(4).InitiatedBy())
-	require.Equal(t, PerspectiveServer, StreamID(5).InitiatedBy())
-	require.Equal(t, PerspectiveClient, StreamID(6).InitiatedBy())
-	require.Equal(t, PerspectiveServer, StreamID(7).InitiatedBy())
+func TestStreamInitiator(t *testing.T) {
+	require.Equal(t, PerspectiveClient, StreamInitiator(4))
+	require.Equal(t, PerspectiveServer, StreamInitiator(5))
+	require.Equal(t, PerspectiveClient, StreamInitiator(6))
+	require.Equal(t, PerspectiveServer, StreamInitiator(7))
 }
 
-func TestStreamIDType(t *testing.T) {
-	require.Equal(t, StreamTypeBidi, StreamID(4).Type())
-	require.Equal(t, StreamTypeBidi, StreamID(5).Type())
-	require.Equal(t, StreamTypeUni, StreamID(6).Type())
-	require.Equal(t, StreamTypeUni, StreamID(7).Type())
+func TestStreamTypeOf(t *testing.T) {
+	require.Equal(t, StreamTypeBidi, StreamTypeOf(4))
+	require.Equal(t, StreamTypeBidi, StreamTypeOf(5))
+	require.Equal(t, StreamTypeUni, StreamTypeOf(6))
+	require.Equal(t, StreamTypeUni, StreamTypeOf(7))
 }
 
 func TestStreamIDStreamNum(t *testing.T) {

--- a/streams_map.go
+++ b/streams_map.go
@@ -164,14 +164,14 @@ func (m *streamsMap) AcceptUniStream(ctx context.Context) (*ReceiveStream, error
 }
 
 func (m *streamsMap) DeleteStream(id protocol.StreamID) error {
-	switch id.Type() {
+	switch protocol.StreamTypeOf(id) {
 	case protocol.StreamTypeUni:
-		if id.InitiatedBy() == m.perspective {
+		if protocol.StreamInitiator(id) == m.perspective {
 			return m.outgoingUniStreams.DeleteStream(id)
 		}
 		return m.incomingUniStreams.DeleteStream(id)
 	case protocol.StreamTypeBidi:
-		if id.InitiatedBy() == m.perspective {
+		if protocol.StreamInitiator(id) == m.perspective {
 			return m.outgoingBidiStreams.DeleteStream(id)
 		}
 		return m.incomingBidiStreams.DeleteStream(id)
@@ -194,9 +194,9 @@ type sendStreamFrameHandler interface {
 }
 
 func (m *streamsMap) getSendStream(id protocol.StreamID) (sendStreamFrameHandler, error) {
-	switch id.Type() {
+	switch protocol.StreamTypeOf(id) {
 	case protocol.StreamTypeUni:
-		if id.InitiatedBy() != m.perspective {
+		if protocol.StreamInitiator(id) != m.perspective {
 			// an outgoing unidirectional stream is a send stream, not a receive stream
 			return nil, &qerr.TransportError{
 				ErrorCode:    qerr.StreamStateError,
@@ -209,7 +209,7 @@ func (m *streamsMap) getSendStream(id protocol.StreamID) (sendStreamFrameHandler
 		}
 		return str, nil
 	case protocol.StreamTypeBidi:
-		if id.InitiatedBy() == m.perspective {
+		if protocol.StreamInitiator(id) == m.perspective {
 			str, err := m.outgoingBidiStreams.GetStream(id)
 			if str == nil || err != nil {
 				return nil, err
@@ -255,10 +255,10 @@ type receiveStreamFrameHandler interface {
 }
 
 func (m *streamsMap) getReceiveStream(id protocol.StreamID) (receiveStreamFrameHandler, error) {
-	switch id.Type() {
+	switch protocol.StreamTypeOf(id) {
 	case protocol.StreamTypeUni:
 		// an outgoing unidirectional stream is a send stream, not a receive stream
-		if id.InitiatedBy() == m.perspective {
+		if protocol.StreamInitiator(id) == m.perspective {
 			return nil, &qerr.TransportError{
 				ErrorCode:    qerr.StreamStateError,
 				ErrorMessage: fmt.Sprintf("invalid frame for receive stream %d", id),
@@ -272,7 +272,7 @@ func (m *streamsMap) getReceiveStream(id protocol.StreamID) (receiveStreamFrameH
 	case protocol.StreamTypeBidi:
 		var str *Stream
 		var err error
-		if id.InitiatedBy() == m.perspective {
+		if protocol.StreamInitiator(id) == m.perspective {
 			str, err = m.outgoingBidiStreams.GetStream(id)
 		} else {
 			str, err = m.incomingBidiStreams.GetOrOpenStream(id)


### PR DESCRIPTION
The `StreamID` is exported in the `quic` package, therefore it should avoid exposing methods that use internal types.

Closes #5585.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `StreamID` methods with top-level protocol helpers for stream type and initiator
> Removes `Type()` and `InitiatedBy()` methods from `StreamID`, replacing them with package-level functions `protocol.StreamTypeOf(id)` and `protocol.StreamInitiator(id)` in [internal/protocol/stream.go](https://github.com/quic-go/quic-go/pull/5744/files#diff-4ce2387fa696adc992f06ea8e7685b64250c3134d1fa2f279cd2d32b10da8bde). Call sites in [connection.go](https://github.com/quic-go/quic-go/pull/5744/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7) and [streams_map.go](https://github.com/quic-go/quic-go/pull/5744/files#diff-666bc646e87db500ba5ef77f336c8fb175703c97cf0b6485012fd65bad83b382) are updated accordingly. Logic is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0def90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal stream classification handling while preserving existing stream direction, initiation, routing, and flow-control behavior.
  * Maintained existing error handling for invalid stream configurations.

* **Tests**
  * Updated stream classification tests to verify client/server initiation and bidirectional/unidirectional stream behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->