### PR TITLE
use the StreamID alias on Stream.StreamID and ReceiveStream.StreamID

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -76,7 +76,7 @@ func newReceiveStream(
 }
 
 // StreamID returns the stream ID.
-func (s *ReceiveStream) StreamID() protocol.StreamID {
+func (s *ReceiveStream) StreamID() StreamID {
 	return s.streamID
 }
 

--- a/stream.go
+++ b/stream.go
@@ -104,7 +104,7 @@ func newStream(
 }
 
 // StreamID returns the stream ID.
-func (s *Stream) StreamID() protocol.StreamID {
+func (s *Stream) StreamID() StreamID {
 	// the result is same for receiveStream and sendStream
 	return s.sendStr.StreamID()
 }


### PR DESCRIPTION
This is a purely cosmetic change, as `quic.StreamID` is an alias of `protocol.StreamID`, but it will make the documentation look nicer.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `StreamID` type alias for return types of `Stream.StreamID` and `ReceiveStream.StreamID`
> Updates the return type declarations of `StreamID()` in [stream.go](https://github.com/quic-go/quic-go/pull/5745/files#diff-4f588cddf63cad8c5e4fc9685c5b200fb4daacf14be2bece09a8296d4e266d90) and [receive_stream.go](https://github.com/quic-go/quic-go/pull/5745/files#diff-64d427149d1560f49d2c53dcd126759f078d0bd308a251ed5ab965a2c5e5dc1d) from `protocol.StreamID` to the local `StreamID` alias. The underlying returned values are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 064708e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized stream ID method return types across stream interfaces.
  * No behavioral changes to stream handling or ID retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->