### PR TITLE
ci: don’t cancel interop Docker image builds on master

### DIFF
--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref != 'refs/heads/master' }}
 
 jobs:
   interop:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Prevent cancellation of in-progress interop Docker image builds on master
Updates the `cancel-in-progress` concurrency setting in [build-interop-docker.yml](.github/workflows/build-interop-docker.yml) to exclude pushes to the `master` branch. Previously, any push event would cancel in-progress runs; now only pushes to non-master refs trigger cancellation.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized df8cbf1. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow concurrency behavior to preserve in-progress runs on the master branch while canceling superseded runs for other pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->