### PR TITLE
rename SendStream.WriteImmediately to TryWriteAll

### DIFF
--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -14,7 +14,7 @@ import (
 type connectionFlowController struct {
 	receiveFlowController
 
-	// Protects send-side state, which WriteImmediately can access from application goroutines.
+	// Protects send-side state, which TryWriteAll can access from application goroutines.
 	sendMutex     sync.Mutex
 	bytesSent     protocol.ByteCount
 	sendWindow    protocol.ByteCount

--- a/interface.go
+++ b/interface.go
@@ -58,7 +58,7 @@ type TokenStore interface {
 // when the server rejects a 0-RTT connection attempt.
 var Err0RTTRejected = errors.New("0-RTT rejected")
 
-// ErrWouldBlock is returned by [SendStream.WriteImmediately] if the entire slice can't be queued immediately.
+// ErrWouldBlock is returned by [SendStream.TryWriteAll] if the entire slice can't be queued immediately.
 var ErrWouldBlock = errors.New("operation would block")
 
 // QUICVersionContextKey can be used to find out the QUIC version of a TLS handshake from the

--- a/send_stream.go
+++ b/send_stream.go
@@ -105,10 +105,10 @@ func (s *SendStream) Write(p []byte) (int, error) {
 	return n, err
 }
 
-// WriteImmediately writes data to the stream if it can be queued immediately.
+// TryWriteAll writes data to the stream if it can be queued immediately.
 // It doesn't block for flow control credit and doesn't respect the write deadline.
 // If the entire slice can't be queued immediately, it queues nothing and returns [ErrWouldBlock].
-func (s *SendStream) WriteImmediately(p []byte) error {
+func (s *SendStream) TryWriteAll(p []byte) error {
 	select {
 	case s.writeOnce <- struct{}{}:
 		defer func() { <-s.writeOnce }()
@@ -116,7 +116,7 @@ func (s *SendStream) WriteImmediately(p []byte) error {
 		return ErrWouldBlock
 	}
 
-	isNewlyCompleted, hasData, err := s.writeImmediately(p)
+	isNewlyCompleted, hasData, err := s.tryWriteAll(p)
 	if isNewlyCompleted {
 		s.sender.onStreamCompleted(s.streamID)
 	}
@@ -126,7 +126,7 @@ func (s *SendStream) WriteImmediately(p []byte) error {
 	return err
 }
 
-func (s *SendStream) writeImmediately(p []byte) (bool /* is newly completed */, bool /* has data */, error) {
+func (s *SendStream) tryWriteAll(p []byte) (bool /* is newly completed */, bool /* has data */, error) {
 	// This might wait briefly while a packet is dequeuing stream data.
 	s.mutex.Lock()
 	defer s.mutex.Unlock()

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -135,19 +135,19 @@ func TestSendStreamWriteData(t *testing.T) {
 	)
 }
 
-func TestSendStreamWriteImmediately(t *testing.T) {
+func TestSendStreamTryWriteAll(t *testing.T) {
 	const streamID protocol.StreamID = 42
 	mockCtrl := gomock.NewController(t)
 	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
 	mockSender := NewMockStreamSender(mockCtrl)
 	str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
-	require.NoError(t, str.WriteImmediately(nil))
-	require.NoError(t, str.WriteImmediately([]byte{}))
+	require.NoError(t, str.TryWriteAll(nil))
+	require.NoError(t, str.TryWriteAll([]byte{}))
 
 	mockSender.EXPECT().onHasStreamData(streamID, str)
 	data := []byte("foobar")
-	require.NoError(t, str.WriteImmediately(data))
+	require.NoError(t, str.TryWriteAll(data))
 	data[0] = 'x' // make sure the data was copied
 
 	frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
@@ -158,14 +158,14 @@ func TestSendStreamWriteImmediately(t *testing.T) {
 	)
 }
 
-func TestSendStreamWriteImmediatelyFlowControlBlocked(t *testing.T) {
+func TestSendStreamTryWriteAllFlowControlBlocked(t *testing.T) {
 	const streamID protocol.StreamID = 42
 	mockCtrl := gomock.NewController(t)
 	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 3)
 	mockSender := NewMockStreamSender(mockCtrl)
 	str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
-	require.ErrorIs(t, str.WriteImmediately([]byte("foobar")), ErrWouldBlock)
+	require.ErrorIs(t, str.TryWriteAll([]byte("foobar")), ErrWouldBlock)
 	require.Equal(t, protocol.ByteCount(3), mockFC.SendWindowSize())
 
 	frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
@@ -173,7 +173,7 @@ func TestSendStreamWriteImmediatelyFlowControlBlocked(t *testing.T) {
 	require.False(t, hasMore)
 
 	mockSender.EXPECT().onHasStreamData(streamID, str)
-	require.NoError(t, str.WriteImmediately([]byte("foo")))
+	require.NoError(t, str.TryWriteAll([]byte("foo")))
 	frame, blocked, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 	require.False(t, hasMore)
 	require.EqualExportedValues(t,
@@ -183,7 +183,7 @@ func TestSendStreamWriteImmediatelyFlowControlBlocked(t *testing.T) {
 	require.Equal(t, &wire.StreamDataBlockedFrame{StreamID: streamID, MaximumStreamData: 3}, blocked)
 }
 
-func TestSendStreamWriteImmediatelyAfterBufferedWrite(t *testing.T) {
+func TestSendStreamTryWriteAllAfterBufferedWrite(t *testing.T) {
 	const streamID protocol.StreamID = 42
 
 	t.Run("enough credit", func(t *testing.T) {
@@ -196,7 +196,7 @@ func TestSendStreamWriteImmediatelyAfterBufferedWrite(t *testing.T) {
 		n, err := str.Write([]byte("foo"))
 		require.NoError(t, err)
 		require.Equal(t, 3, n)
-		require.NoError(t, str.WriteImmediately([]byte("bar")))
+		require.NoError(t, str.TryWriteAll([]byte("bar")))
 
 		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 		require.False(t, hasMore)
@@ -217,7 +217,7 @@ func TestSendStreamWriteImmediatelyAfterBufferedWrite(t *testing.T) {
 		n, err := str.Write([]byte("foo"))
 		require.NoError(t, err)
 		require.Equal(t, 3, n)
-		require.ErrorIs(t, str.WriteImmediately([]byte("bar")), ErrWouldBlock)
+		require.ErrorIs(t, str.TryWriteAll([]byte("bar")), ErrWouldBlock)
 
 		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 		require.False(t, hasMore)
@@ -229,7 +229,7 @@ func TestSendStreamWriteImmediatelyAfterBufferedWrite(t *testing.T) {
 	})
 }
 
-func TestSendStreamWriteAfterWriteImmediately(t *testing.T) {
+func TestSendStreamWriteAfterTryWriteAll(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const streamID protocol.StreamID = 42
 		mockCtrl := gomock.NewController(t)
@@ -238,7 +238,7 @@ func TestSendStreamWriteAfterWriteImmediately(t *testing.T) {
 		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
 		mockSender.EXPECT().onHasStreamData(streamID, str).Times(2)
-		require.NoError(t, str.WriteImmediately([]byte("foo")))
+		require.NoError(t, str.TryWriteAll([]byte("foo")))
 
 		errChan := make(chan error, 1)
 		go func() {
@@ -280,7 +280,7 @@ func TestSendStreamWriteAfterWriteImmediately(t *testing.T) {
 	})
 }
 
-func TestSendStreamLargeWriteImmediately(t *testing.T) {
+func TestSendStreamLargeTryWriteAll(t *testing.T) {
 	const streamID protocol.StreamID = 42
 	mockCtrl := gomock.NewController(t)
 	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount)
@@ -293,7 +293,7 @@ func TestSendStreamLargeWriteImmediately(t *testing.T) {
 	}
 
 	mockSender.EXPECT().onHasStreamData(streamID, str)
-	require.NoError(t, str.WriteImmediately(data))
+	require.NoError(t, str.TryWriteAll(data))
 
 	var offset protocol.ByteCount
 	for offset < protocol.ByteCount(len(data)) {
@@ -331,7 +331,7 @@ func TestSendStreamResetFinalSizeIncludesReservedData(t *testing.T) {
 			str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
 			mockSender.EXPECT().onHasStreamData(streamID, str)
-			require.NoError(t, str.WriteImmediately(make([]byte, 100)))
+			require.NoError(t, str.TryWriteAll(make([]byte, 100)))
 
 			frame, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, 0)+40, protocol.Version1)
 			require.True(t, hasMore)
@@ -347,7 +347,7 @@ func TestSendStreamResetFinalSizeIncludesReservedData(t *testing.T) {
 	}
 }
 
-func TestSendStreamSetReliableBoundaryAfterWriteImmediately(t *testing.T) {
+func TestSendStreamSetReliableBoundaryAfterTryWriteAll(t *testing.T) {
 	const streamID protocol.StreamID = 42
 	mockCtrl := gomock.NewController(t)
 	mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 100)
@@ -355,7 +355,7 @@ func TestSendStreamSetReliableBoundaryAfterWriteImmediately(t *testing.T) {
 	str := newSendStream(context.Background(), streamID, mockSender, mockFC, true)
 
 	mockSender.EXPECT().onHasStreamData(streamID, str)
-	require.NoError(t, str.WriteImmediately(make([]byte, 100)))
+	require.NoError(t, str.TryWriteAll(make([]byte, 100)))
 
 	frame, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, 0)+40, protocol.Version1)
 	require.True(t, hasMore)
@@ -673,7 +673,7 @@ func TestSendStreamClose(t *testing.T) {
 	// further calls to Write return an error
 	_, err = strWithTimeout.Write([]byte("foobar"))
 	require.ErrorContains(t, err, "write on closed stream 1234")
-	require.ErrorContains(t, str.WriteImmediately([]byte("foobar")), "write on closed stream 1234")
+	require.ErrorContains(t, str.TryWriteAll([]byte("foobar")), "write on closed stream 1234")
 	frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 	require.Nil(t, frame.Frame)
 	require.False(t, hasMore)
@@ -888,7 +888,7 @@ func TestSendStreamCancellation(t *testing.T) {
 		// future calls to Write should return an error
 		_, err = strWithTimeout.Write([]byte("foo"))
 		require.ErrorIs(t, err, &StreamError{StreamID: streamID, ErrorCode: 1234, Remote: false})
-		err = str.WriteImmediately([]byte("foo"))
+		err = str.TryWriteAll([]byte("foo"))
 		require.ErrorIs(t, err, &StreamError{StreamID: streamID, ErrorCode: 1234, Remote: false})
 		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 		require.Nil(t, frame.Frame)

--- a/stream.go
+++ b/stream.go
@@ -132,10 +132,10 @@ func (s *Stream) Write(p []byte) (int, error) {
 	return s.sendStr.Write(p)
 }
 
-// WriteImmediately writes data to the stream if it can be queued immediately.
-// See [SendStream.WriteImmediately] for more details.
-func (s *Stream) WriteImmediately(p []byte) error {
-	return s.sendStr.WriteImmediately(p)
+// TryWriteAll writes data to the stream if it can be queued immediately.
+// See [SendStream.TryWriteAll] for more details.
+func (s *Stream) TryWriteAll(p []byte) error {
+	return s.sendStr.TryWriteAll(p)
 }
 
 // SetReliableBoundary marks the data written to this stream so far as reliable.


### PR DESCRIPTION
This seems to be the better naming, now that we're introducing `TryWrite` (https://github.com/quic-go/quic-go/pull/5736).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `SendStream.WriteImmediately` to `TryWriteAll`
> Renames the public non-blocking write method on `SendStream` and `Stream` from `WriteImmediately` to `TryWriteAll`, along with the internal helper `writeImmediately` to `tryWriteAll`. Updates all references in comments and tests to match the new name. No behavior changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5273e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed `WriteImmediately` to `TryWriteAll` on streams.
  * Existing behavior is unchanged: attempts to queue all data immediately and returns `ErrWouldBlock` if unable to do so.
* **Tests**
  * Updated coverage for flow control, buffering, stream closure, cancellation, and reliable boundaries using `TryWriteAll`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->