### PR TITLE
rename ReceiveStream.WaitForFinalSize to WaitForReceiveFinalSize

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -80,11 +80,11 @@ func (s *ReceiveStream) StreamID() StreamID {
 	return s.streamID
 }
 
-// WaitForFinalSize waits until the receive stream's final size is known.
+// WaitForReceiveFinalSize waits until the receive stream's final size is known.
 // The final size is learned from a FIN or RESET_STREAM frame.
 // Most applications don't need this. It is mainly useful for protocol layers
 // that need exact stream final sizes, such as WebTransport flow control accounting.
-func (s *ReceiveStream) WaitForFinalSize(ctx context.Context) (int64, error) {
+func (s *ReceiveStream) WaitForReceiveFinalSize(ctx context.Context) (int64, error) {
 	for {
 		s.mutex.Lock()
 		size := s.finalOffset

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -542,23 +542,23 @@ func TestReceiveStreamImmediateFINs(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 }
 
-func TestReceiveStreamWaitForFinalSizeAfterFIN(t *testing.T) {
+func TestReceiveStreamWaitForReceiveFinalSizeAfterFIN(t *testing.T) {
 	fc := newTestStreamFlowController(42)
 	str := newReceiveStream(42, nil, fc)
 
 	require.NoError(t, str.handleStreamFrame(&wire.StreamFrame{Data: []byte("foobar"), Fin: true}, monotime.Now()))
 
-	size, err := str.WaitForFinalSize(context.Background())
+	size, err := str.WaitForReceiveFinalSize(context.Background())
 	require.NoError(t, err)
 	require.EqualValues(t, 6, size)
 
 	str.closeForShutdown(assert.AnError)
-	size, err = str.WaitForFinalSize(context.Background())
+	size, err = str.WaitForReceiveFinalSize(context.Background())
 	require.NoError(t, err)
 	require.EqualValues(t, 6, size)
 }
 
-func TestReceiveStreamWaitForFinalSizeAfterCancelRead(t *testing.T) {
+func TestReceiveStreamWaitForReceiveFinalSizeAfterCancelRead(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		fc := newTestStreamFlowController(42)
@@ -571,14 +571,14 @@ func TestReceiveStreamWaitForFinalSizeAfterCancelRead(t *testing.T) {
 		}
 		resultChan := make(chan result, 1)
 		go func() {
-			size, err := str.WaitForFinalSize(context.Background())
+			size, err := str.WaitForReceiveFinalSize(context.Background())
 			resultChan <- result{size: size, err: err}
 		}()
 
 		synctest.Wait()
 		select {
 		case result := <-resultChan:
-			t.Fatalf("WaitForFinalSize returned before the final size was known: %v", result.err)
+			t.Fatalf("WaitForReceiveFinalSize returned before the final size was known: %v", result.err)
 		default:
 		}
 
@@ -588,7 +588,7 @@ func TestReceiveStreamWaitForFinalSizeAfterCancelRead(t *testing.T) {
 		synctest.Wait()
 		select {
 		case result := <-resultChan:
-			t.Fatalf("WaitForFinalSize returned after CancelRead, before the final size was known: %v", result.err)
+			t.Fatalf("WaitForReceiveFinalSize returned after CancelRead, before the final size was known: %v", result.err)
 		default:
 		}
 
@@ -604,17 +604,17 @@ func TestReceiveStreamWaitForFinalSizeAfterCancelRead(t *testing.T) {
 			require.NoError(t, result.err)
 			require.EqualValues(t, 42, result.size)
 		default:
-			t.Fatal("WaitForFinalSize did not return")
+			t.Fatal("WaitForReceiveFinalSize did not return")
 		}
 	})
 }
 
-func TestReceiveStreamWaitForFinalSizeContextCanceled(t *testing.T) {
+func TestReceiveStreamWaitForReceiveFinalSizeContextCanceled(t *testing.T) {
 	str := newReceiveStream(42, nil, nil)
 	ctx, cancel := context.WithCancelCause(context.Background())
 	cancel(assert.AnError)
 
-	size, err := str.WaitForFinalSize(ctx)
+	size, err := str.WaitForReceiveFinalSize(ctx)
 	require.Zero(t, size)
 	require.ErrorIs(t, err, assert.AnError)
 }
@@ -652,7 +652,7 @@ func TestReceiveStreamCloseForShutdown(t *testing.T) {
 		str.closeForShutdown(assert.AnError)
 		synctest.Wait()
 
-		size, err := str.WaitForFinalSize(context.Background())
+		size, err := str.WaitForReceiveFinalSize(context.Background())
 		require.Zero(t, size)
 		require.ErrorIs(t, err, assert.AnError)
 

--- a/stream.go
+++ b/stream.go
@@ -159,11 +159,11 @@ func (s *Stream) CancelRead(errorCode StreamErrorCode) {
 }
 
 // WaitForReceiveFinalSize waits until the receive side's final size is known.
-// See [ReceiveStream.WaitForFinalSize] for more details.
+// See [ReceiveStream.WaitForReceiveFinalSize] for more details.
 // Most applications don't need this. It is mainly useful for protocol layers
 // that need exact stream final sizes, such as WebTransport flow control accounting.
 func (s *Stream) WaitForReceiveFinalSize(ctx context.Context) (int64, error) {
-	return s.receiveStr.WaitForFinalSize(ctx)
+	return s.receiveStr.WaitForReceiveFinalSize(ctx)
 }
 
 // The Context is canceled as soon as the write-side of the stream is closed.


### PR DESCRIPTION
Using the same method name on `Stream` and `ReceiveStream` simplifies usage.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `ReceiveStream.WaitForFinalSize` to `WaitForReceiveFinalSize`
> Pure rename with no behavioral changes. Updates the method name in [receive_stream.go](https://github.com/quic-go/quic-go/pull/5750/files#diff-64d427149d1560f49d2c53dcd126759f078d0bd308a251ed5ab965a2c5e5dc1d) and [stream.go](https://github.com/quic-go/quic-go/pull/5750/files#diff-4f588cddf63cad8c5e4fc9685c5b200fb4daacf14be2bece09a8296d4e266d90), along with all call sites and test functions in [receive_stream_test.go](https://github.com/quic-go/quic-go/pull/5750/files#diff-97b3aeb7e32c0db6ee2be1095aaeb85c292713cb093a5fa3a90274967dba6e0e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14f9ea2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Renamed the receive-stream final-size waiting method to `WaitForReceiveFinalSize` for clearer API naming.
  * Updated stream-level references and documentation to use the new method name.

* **Compatibility**
  * Behavior remains unchanged, including handling of completion, shutdown, and context cancellation.
  * Updated validation coverage to reflect the renamed API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->