### PR TITLE
fix flaky TestDatagramSizeLimitWithMTUDiscovery

### DIFF
--- a/integrationtests/self/datagram_test.go
+++ b/integrationtests/self/datagram_test.go
@@ -177,31 +177,12 @@ func TestDatagramSizeLimitWithMTUDiscovery(t *testing.T) {
 
 	data := bytes.Repeat([]byte("d"), 16*1024)
 	var discoveredMTU int
-	var checkedMTUUpdates int
-	var previousMaxPayloadSize int64
 	for discoveredMTU == 0 {
 		_, err = str.Write(data)
 		require.NoError(t, err)
 		events := eventRecorder.Events(qlog.MTUUpdated{})
-		for ; checkedMTUUpdates < len(events); checkedMTUUpdates++ {
-			update := events[checkedMTUUpdates].(qlog.MTUUpdated)
-			err = clientConn.SendDatagram(bytes.Repeat([]byte("x"), 2000))
-			var sizeErr *quic.DatagramTooLargeError
-			require.ErrorAs(t, err, &sizeErr)
-			maxPayloadSize := sizeErr.MaxDatagramPayloadSize
-			require.Greater(t, maxPayloadSize, int64(0))
-			require.Greater(t, maxPayloadSize, previousMaxPayloadSize)
-			require.Less(t, maxPayloadSize, int64(update.Value))
-			previousMaxPayloadSize = maxPayloadSize
-
-			datagramData := bytes.Repeat([]byte("z"), int(maxPayloadSize))
-			err = clientConn.SendDatagram(datagramData)
-			require.NoError(t, err)
-
-			datagram, err := serverConn.ReceiveDatagram(ctx)
-			require.NoError(t, err, "datagram should be deliverable when respecting MaxDatagramPayloadSize")
-			require.Equal(t, datagramData, datagram)
-
+		if len(events) > 0 {
+			update := events[len(events)-1].(qlog.MTUUpdated)
 			if update.Done {
 				discoveredMTU = update.Value
 			}
@@ -210,12 +191,26 @@ func TestDatagramSizeLimitWithMTUDiscovery(t *testing.T) {
 	}
 	require.NoError(t, str.Close())
 
+	// Receiving the stream FIN guarantees that the client applied the MTU update observed above.
 	select {
 	case err := <-serverErrChan:
 		require.NoError(t, err)
 	case <-ctx.Done():
 		require.NoError(t, ctx.Err())
 	}
+
+	err = clientConn.SendDatagram(bytes.Repeat([]byte("x"), 2000))
+	var sizeErr *quic.DatagramTooLargeError
+	require.ErrorAs(t, err, &sizeErr)
+	maxPayloadSize := sizeErr.MaxDatagramPayloadSize
+	require.Greater(t, maxPayloadSize, int64(protocol.MinInitialPacketSize), "MTU discovery should increase the datagram size limit")
+	require.Less(t, maxPayloadSize, int64(discoveredMTU), "datagram payload must leave room for packet overhead")
+
+	datagramData := bytes.Repeat([]byte("z"), int(maxPayloadSize))
+	require.NoError(t, clientConn.SendDatagram(datagramData))
+	datagram, err := serverConn.ReceiveDatagram(ctx)
+	require.NoError(t, err, "datagram should be deliverable when respecting MaxDatagramPayloadSize")
+	require.Equal(t, datagramData, datagram)
 }
 
 func TestDatagramLoss(t *testing.T) {


### PR DESCRIPTION
Wait for the stream FIN before checking the final datagram limit. This ensures the MTU update is applied without polling, eliminating the race between the qlog event and payload-size update.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky `TestDatagramSizeLimitWithMTUDiscovery` by consolidating MTU validation
> The test was flaky because it validated `MaxDatagramPayloadSize` on every MTU update event, which could race with the client applying the update. The fix waits for the server to read to EOF (stream FIN) before performing a single size-limit check and a single successful datagram delivery at `MaxDatagramPayloadSize`. The new assertions require `MaxDatagramPayloadSize > MinInitialPacketSize` and `< discoveredMTU` instead of checking monotonic increases at each step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14a73be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated MTU discovery coverage to verify datagram size limits more reliably.
  * Added validation that oversized datagrams are rejected while payloads within the discovered limit are delivered successfully.
  * Improved synchronization checks to ensure MTU updates are applied before datagram assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->