### PR TITLE
replace receive stream final size wait with callback

### DIFF
--- a/receive_stream.go
+++ b/receive_stream.go
@@ -1,7 +1,6 @@
 package quic
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -22,9 +21,9 @@ type ReceiveStream struct {
 
 	sender streamSender
 
-	frameQueue    *frameSorter
-	finalOffset   protocol.ByteCount
-	finalSizeChan chan struct{} // closed when the final size is known
+	frameQueue               *frameSorter
+	finalOffset              protocol.ByteCount
+	receiveFinalSizeCallback func(int64)
 
 	currentFrame       []byte
 	currentFrameDone   func()
@@ -71,7 +70,6 @@ func newReceiveStream(
 		readChan:       make(chan struct{}, 1),
 		readOnce:       make(chan struct{}, 1),
 		finalOffset:    protocol.MaxByteCount,
-		finalSizeChan:  make(chan struct{}),
 	}
 }
 
@@ -80,30 +78,33 @@ func (s *ReceiveStream) StreamID() StreamID {
 	return s.streamID
 }
 
-// WaitForReceiveFinalSize waits until the receive stream's final size is known.
+// SetReceiveFinalSizeCallback sets a callback that is called when the receive stream's final size is known.
 // The final size is learned from a FIN or RESET_STREAM frame.
 // Most applications don't need this. It is mainly useful for protocol layers
 // that need exact stream final sizes, such as WebTransport flow control accounting.
-func (s *ReceiveStream) WaitForReceiveFinalSize(ctx context.Context) (int64, error) {
-	for {
-		s.mutex.Lock()
-		size := s.finalOffset
-		closeErr := s.closeForShutdownErr
-		finalSizeChan := s.finalSizeChan
-		s.mutex.Unlock()
+// If the final size is already known, the callback is called before this method returns.
+// When the final size is learned later, the callback is called from the connection's event loop and must not block.
+// The callback is not called if the connection is closed before the final size is known.
+// Setting a nil callback removes it if the final size is not yet known.
+func (s *ReceiveStream) SetReceiveFinalSizeCallback(callback func(int64)) {
+	s.mutex.Lock()
+	size := s.finalOffset
 
-		if size != protocol.MaxByteCount {
-			return int64(size), nil
+	// final size is already known
+	if size != protocol.MaxByteCount {
+		s.mutex.Unlock()
+		if callback != nil {
+			callback(int64(size))
 		}
-		if closeErr != nil {
-			return 0, closeErr
-		}
-		select {
-		case <-finalSizeChan:
-		case <-ctx.Done():
-			return 0, context.Cause(ctx)
-		}
+		return
 	}
+
+	if s.closeForShutdownErr != nil {
+		s.mutex.Unlock()
+		return
+	}
+	s.receiveFinalSizeCallback = callback
+	s.mutex.Unlock()
 }
 
 // Read reads data from the stream.
@@ -432,22 +433,29 @@ func (s *ReceiveStream) handleStreamFrame(frame *wire.StreamFrame, now monotime.
 	s.mutex.Lock()
 	err := s.handleStreamFrameImpl(frame, now)
 	completed := s.isNewlyCompleted()
+	size, callback := s.takeReceiveFinalSizeCallback()
 	s.mutex.Unlock()
 
 	if completed {
 		s.flowController.Abandon()
 		s.sender.onStreamCompleted(s.streamID)
 	}
+	if callback != nil {
+		callback(size)
+	}
 	return err
 }
 
 func (s *ReceiveStream) handleStreamFrameImpl(frame *wire.StreamFrame, now monotime.Time) error {
+	if s.closeForShutdownErr != nil {
+		return nil
+	}
 	maxOffset := frame.Offset + frame.DataLen()
 	if err := s.flowController.UpdateHighestReceived(maxOffset, frame.Fin, now); err != nil {
 		return err
 	}
 	if frame.Fin {
-		s.setFinalOffset(maxOffset)
+		s.finalOffset = maxOffset
 	}
 	if s.cancelledLocally {
 		return nil
@@ -463,10 +471,14 @@ func (s *ReceiveStream) handleResetStreamFrame(frame *wire.ResetStreamFrame, now
 	s.mutex.Lock()
 	err := s.handleResetStreamFrameImpl(frame, now)
 	completed := s.isNewlyCompleted()
+	size, callback := s.takeReceiveFinalSizeCallback()
 	s.mutex.Unlock()
 
 	if completed {
 		s.sender.onStreamCompleted(s.streamID)
+	}
+	if callback != nil {
+		callback(size)
 	}
 	return err
 }
@@ -478,7 +490,7 @@ func (s *ReceiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame,
 	if err := s.flowController.UpdateHighestReceived(frame.FinalSize, true, now); err != nil {
 		return err
 	}
-	s.setFinalOffset(frame.FinalSize)
+	s.finalOffset = frame.FinalSize
 
 	// senders are allowed to reduce the reliable size, but frames might have been reordered
 	if (!s.cancelledRemotely && s.reliableSize == 0) || frame.ReliableSize < s.reliableSize {
@@ -503,9 +515,13 @@ func (s *ReceiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame,
 	return nil
 }
 
-func (s *ReceiveStream) setFinalOffset(offset protocol.ByteCount) {
-	s.finalOffset = offset
-	s.closeFinalSizeChan()
+func (s *ReceiveStream) takeReceiveFinalSizeCallback() (int64, func(int64)) {
+	if s.finalOffset == protocol.MaxByteCount {
+		return 0, nil
+	}
+	callback := s.receiveFinalSizeCallback
+	s.receiveFinalSizeCallback = nil
+	return int64(s.finalOffset), callback
 }
 
 func (s *ReceiveStream) getControlFrame(now monotime.Time) (_ ackhandler.Frame, ok, hasMore bool) {
@@ -548,16 +564,9 @@ func (s *ReceiveStream) SetReadDeadline(t time.Time) error {
 func (s *ReceiveStream) closeForShutdown(err error) {
 	s.mutex.Lock()
 	s.closeForShutdownErr = err
-	s.closeFinalSizeChan()
+	s.receiveFinalSizeCallback = nil
 	s.mutex.Unlock()
 	s.signalRead()
-}
-
-func (s *ReceiveStream) closeFinalSizeChan() {
-	if s.finalSizeChan != nil {
-		close(s.finalSizeChan)
-		s.finalSizeChan = nil
-	}
 }
 
 // signalRead performs a non-blocking send on the readChan

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -1,7 +1,6 @@
 package quic
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -542,81 +541,53 @@ func TestReceiveStreamImmediateFINs(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 }
 
-func TestReceiveStreamWaitForReceiveFinalSizeAfterFIN(t *testing.T) {
+func TestReceiveStreamFinalSizeCallbackAfterFIN(t *testing.T) {
 	fc := newTestStreamFlowController(42)
 	str := newReceiveStream(42, nil, fc)
 
 	require.NoError(t, str.handleStreamFrame(&wire.StreamFrame{Data: []byte("foobar"), Fin: true}, monotime.Now()))
 
-	size, err := str.WaitForReceiveFinalSize(context.Background())
-	require.NoError(t, err)
+	var size int64
+	str.SetReceiveFinalSizeCallback(func(s int64) { size = s })
 	require.EqualValues(t, 6, size)
 
 	str.closeForShutdown(assert.AnError)
-	size, err = str.WaitForReceiveFinalSize(context.Background())
-	require.NoError(t, err)
+	str.SetReceiveFinalSizeCallback(func(s int64) { size = s })
 	require.EqualValues(t, 6, size)
 }
 
-func TestReceiveStreamWaitForReceiveFinalSizeAfterCancelRead(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		fc := newTestStreamFlowController(42)
-		mockSender := NewMockStreamSender(mockCtrl)
-		str := newReceiveStream(42, mockSender, fc)
+func TestReceiveStreamFinalSizeCallbackAfterCancelRead(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	fc := newTestStreamFlowController(42)
+	mockSender := NewMockStreamSender(mockCtrl)
+	str := newReceiveStream(42, mockSender, fc)
 
-		type result struct {
-			size int64
-			err  error
-		}
-		resultChan := make(chan result, 1)
-		go func() {
-			size, err := str.WaitForReceiveFinalSize(context.Background())
-			resultChan <- result{size: size, err: err}
-		}()
-
-		synctest.Wait()
-		select {
-		case result := <-resultChan:
-			t.Fatalf("WaitForReceiveFinalSize returned before the final size was known: %v", result.err)
-		default:
-		}
-
-		mockSender.EXPECT().onHasStreamControlFrame(str.StreamID(), str)
-		str.CancelRead(1234)
-
-		synctest.Wait()
-		select {
-		case result := <-resultChan:
-			t.Fatalf("WaitForReceiveFinalSize returned after CancelRead, before the final size was known: %v", result.err)
-		default:
-		}
-
-		mockSender.EXPECT().onStreamCompleted(protocol.StreamID(42))
-		require.NoError(t, str.handleResetStreamFrame(
-			&wire.ResetStreamFrame{StreamID: 42, ErrorCode: 4321, FinalSize: 42},
-			monotime.Now(),
-		))
-
-		synctest.Wait()
-		select {
-		case result := <-resultChan:
-			require.NoError(t, result.err)
-			require.EqualValues(t, 42, result.size)
-		default:
-			t.Fatal("WaitForReceiveFinalSize did not return")
-		}
+	var size int64
+	var called bool
+	str.SetReceiveFinalSizeCallback(func(s int64) {
+		size, called = s, true
 	})
+	require.False(t, called)
+
+	mockSender.EXPECT().onHasStreamControlFrame(str.StreamID(), str)
+	str.CancelRead(1234)
+	require.False(t, called)
+
+	mockSender.EXPECT().onStreamCompleted(protocol.StreamID(42))
+	require.NoError(t, str.handleResetStreamFrame(
+		&wire.ResetStreamFrame{StreamID: 42, ErrorCode: 4321, FinalSize: 42},
+		monotime.Now(),
+	))
+
+	require.True(t, called)
+	require.EqualValues(t, 42, size)
 }
 
-func TestReceiveStreamWaitForReceiveFinalSizeContextCanceled(t *testing.T) {
-	str := newReceiveStream(42, nil, nil)
-	ctx, cancel := context.WithCancelCause(context.Background())
-	cancel(assert.AnError)
-
-	size, err := str.WaitForReceiveFinalSize(ctx)
-	require.Zero(t, size)
-	require.ErrorIs(t, err, assert.AnError)
+func TestReceiveStreamFinalSizeCallbackRemoved(t *testing.T) {
+	str := newReceiveStream(42, nil, newTestStreamFlowController(42))
+	str.SetReceiveFinalSizeCallback(func(int64) { t.Fatal("callback called") })
+	str.SetReceiveFinalSizeCallback(nil)
+	require.NoError(t, str.handleStreamFrame(&wire.StreamFrame{Fin: true}, monotime.Now()))
 }
 
 func TestReceiveStreamCloseForShutdown(t *testing.T) {
@@ -652,9 +623,8 @@ func TestReceiveStreamCloseForShutdown(t *testing.T) {
 		str.closeForShutdown(assert.AnError)
 		synctest.Wait()
 
-		size, err := str.WaitForReceiveFinalSize(context.Background())
-		require.Zero(t, size)
-		require.ErrorIs(t, err, assert.AnError)
+		require.NoError(t, str.handleStreamFrame(&wire.StreamFrame{Fin: true}, monotime.Now()))
+		str.SetReceiveFinalSizeCallback(func(int64) { t.Fatal("callback called") })
 
 		select {
 		case err := <-readErrChan:

--- a/stream.go
+++ b/stream.go
@@ -158,12 +158,12 @@ func (s *Stream) CancelRead(errorCode StreamErrorCode) {
 	s.receiveStr.CancelRead(errorCode)
 }
 
-// WaitForReceiveFinalSize waits until the receive side's final size is known.
-// See [ReceiveStream.WaitForReceiveFinalSize] for more details.
+// SetReceiveFinalSizeCallback sets a callback that is called when the receive side's final size is known.
+// See [ReceiveStream.SetReceiveFinalSizeCallback] for more details.
 // Most applications don't need this. It is mainly useful for protocol layers
 // that need exact stream final sizes, such as WebTransport flow control accounting.
-func (s *Stream) WaitForReceiveFinalSize(ctx context.Context) (int64, error) {
-	return s.receiveStr.WaitForReceiveFinalSize(ctx)
+func (s *Stream) SetReceiveFinalSizeCallback(callback func(int64)) {
+	s.receiveStr.SetReceiveFinalSizeCallback(callback)
 }
 
 // The Context is canceled as soon as the write-side of the stream is closed.

--- a/stream_test.go
+++ b/stream_test.go
@@ -34,7 +34,7 @@ func TestStreamDeadlines(t *testing.T) {
 	require.Zero(t, n)
 }
 
-func TestStreamWaitForReceiveFinalSize(t *testing.T) {
+func TestStreamReceiveFinalSizeCallback(t *testing.T) {
 	const streamID protocol.StreamID = 1337
 	mockCtrl := gomock.NewController(t)
 	mockSender := NewMockStreamSender(mockCtrl)
@@ -43,8 +43,8 @@ func TestStreamWaitForReceiveFinalSize(t *testing.T) {
 
 	require.NoError(t, str.handleStreamFrame(&wire.StreamFrame{Data: []byte("foobar"), Fin: true}, monotime.Now()))
 
-	size, err := str.WaitForReceiveFinalSize(context.Background())
-	require.NoError(t, err)
+	var size int64
+	str.SetReceiveFinalSizeCallback(func(s int64) { size = s })
 	require.EqualValues(t, 6, size)
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `WaitForReceiveFinalSize` blocking API with `SetReceiveFinalSizeCallback` on receive streams
> - Replaces the channel-based `finalSizeChan` and blocking `WaitForReceiveFinalSize` method on `ReceiveStream` and `Stream` with a callback-based `SetReceiveFinalSizeCallback` method.
> - The callback is invoked immediately if the final size is already known, or later from the connection's event loop when a FIN or RESET_STREAM frame arrives.
> - Callbacks are cleared on shutdown and guaranteed to be invoked at most once via the new `takeReceiveFinalSizeCallback` helper.
> - Behavioral Change: callers that previously blocked on `WaitForReceiveFinalSize` must now register a callback; the callback will not be invoked if the connection shuts down before the final size is known.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c447898.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added callback-based notifications for when a stream’s receive-side final size becomes available.
  * Callbacks are invoked for final sizes learned through completed data or reset streams.
  * Callbacks can be registered, replaced, or cleared.

* **Breaking Changes**
  * Removed the blocking API for waiting on a receive-side final size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->