### PR TITLE
add SendStream.WriteWithLimit for higher-level flow control

### DIFF
--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -70,6 +70,7 @@ func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) (hasWindow
 	return c.hasWindowUpdate()
 }
 
+// TryAddBytesSent adds n bytes if sufficient connection-level send credit is available.
 func (c *connectionFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
 	c.sendMutex.Lock()
 	defer c.sendMutex.Unlock()
@@ -79,6 +80,26 @@ func (c *connectionFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
 	}
 	c.bytesSent += n
 	return true
+}
+
+// AddBytesSentWithLimiter adds the limiter-approved portion of the available connection-level send credit.
+func (c *connectionFlowController) AddBytesSentWithLimiter(
+	n protocol.ByteCount,
+	limiter func(int) int,
+) (protocol.ByteCount, bool) {
+	c.sendMutex.Lock()
+	defer c.sendMutex.Unlock()
+
+	if c.bytesSent >= c.sendWindow {
+		return 0, false
+	}
+	n = min(n, c.sendWindow-c.bytesSent)
+	added := min(
+		max(protocol.ByteCount(limiter(int(n))), 0),
+		n,
+	)
+	c.bytesSent += added
+	return added, added < n
 }
 
 // UpdateSendWindow is called after receiving a MAX_DATA frame.

--- a/flow_controller_stream.go
+++ b/flow_controller_stream.go
@@ -127,6 +127,7 @@ func (c *streamFlowController) UpdateSendWindow(offset protocol.ByteCount) (upda
 	return false
 }
 
+// TryAddBytesSent adds n bytes if sufficient stream- and connection-level send credit is available.
 func (c *streamFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
 	if c.bytesSent > c.sendWindow || n > c.sendWindow-c.bytesSent {
 		return false
@@ -136,6 +137,20 @@ func (c *streamFlowController) TryAddBytesSent(n protocol.ByteCount) bool {
 	}
 	c.bytesSent += n
 	return true
+}
+
+// AddBytesSentWithLimiter adds the limiter-approved portion of the available stream- and connection-level send credit.
+func (c *streamFlowController) AddBytesSentWithLimiter(
+	n protocol.ByteCount,
+	limiter func(int) int,
+) (protocol.ByteCount, bool) {
+	if c.bytesSent >= c.sendWindow {
+		return 0, false
+	}
+	n = min(n, c.sendWindow-c.bytesSent)
+	added, limited := c.connection.AddBytesSentWithLimiter(n, limiter)
+	c.bytesSent += added
+	return added, limited
 }
 
 func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
@@ -172,7 +187,10 @@ func (c *streamFlowController) GetWindowUpdate(now monotime.Time) protocol.ByteC
 	offset := c.getWindowUpdate(now)
 	if c.receiveWindowSize > oldWindowSize { // auto-tuning enlarged the window size
 		c.logger.Debugf("Increasing receive flow control window for stream %d to %d", c.streamID, c.receiveWindowSize)
-		c.connection.EnsureMinimumWindowSize(protocol.ByteCount(float64(c.receiveWindowSize)*protocol.ConnectionFlowControlMultiplier), now)
+		c.connection.EnsureMinimumWindowSize(
+			protocol.ByteCount(float64(c.receiveWindowSize)*protocol.ConnectionFlowControlMultiplier),
+			now,
+		)
 	}
 	return offset
 }

--- a/integrationtests/self/stream_test.go
+++ b/integrationtests/self/stream_test.go
@@ -9,11 +9,69 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/quicvarint"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestWriteWithLimitStreamFlowControl(t *testing.T) {
+	testWriteWithLimitFlowControl(t, &quic.Config{
+		InitialStreamReceiveWindow:     100,
+		InitialConnectionReceiveWindow: quicvarint.Max,
+	})
+}
+
+func TestWriteWithLimitConnectionFlowControl(t *testing.T) {
+	testWriteWithLimitFlowControl(t, &quic.Config{
+		InitialStreamReceiveWindow:     quicvarint.Max,
+		InitialConnectionReceiveWindow: 100,
+	})
+}
+
+func testWriteWithLimitFlowControl(t *testing.T, config *quic.Config) {
+	ln, err := quic.Listen(newUDPConnLocalhost(t), getTLSConfig(), getQuicConfig(config))
+	require.NoError(t, err)
+	defer ln.Close()
+
+	deadline := time.Now().Add(time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	client, err := quic.Dial(ctx, newUDPConnLocalhost(t), ln.Addr(), getTLSClientConfig(), getQuicConfig(nil))
+	require.NoError(t, err)
+	defer client.CloseWithError(0, "")
+
+	server, err := ln.Accept(ctx)
+	require.NoError(t, err)
+	str, err := client.OpenUniStreamSync(ctx)
+	require.NoError(t, err)
+	require.NoError(t, str.SetWriteDeadline(deadline))
+
+	data := GeneratePRData(101)
+	n, err := str.WriteWithLimit(data, func(maxBytes int) int {
+		return min(maxBytes, 25)
+	})
+	require.Equal(t, 25, n)
+	require.ErrorIs(t, err, quic.ErrWriteLimitReached)
+
+	receiveStr, err := server.AcceptUniStream(ctx)
+	require.NoError(t, err)
+	require.NoError(t, receiveStr.SetReadDeadline(deadline))
+	received := make([]byte, n)
+	_, err = io.ReadFull(receiveStr, received)
+	require.NoError(t, err)
+	require.Equal(t, data[:n], received)
+
+	written, err := str.WriteWithLimit(data[n:], func(maxBytes int) int { return maxBytes })
+	require.Equal(t, len(data)-n, written)
+	require.NoError(t, err)
+
+	require.NoError(t, str.Close())
+	rest, err := io.ReadAll(receiveStr)
+	require.NoError(t, err)
+	require.Equal(t, data, append(received, rest...))
+}
 
 func TestBidirectionalStreamMultiplexing(t *testing.T) {
 	const numStreams = 75

--- a/interface.go
+++ b/interface.go
@@ -61,6 +61,9 @@ var Err0RTTRejected = errors.New("0-RTT rejected")
 // ErrWouldBlock is returned by [SendStream.TryWriteAll] if the entire slice can't be queued immediately.
 var ErrWouldBlock = errors.New("operation would block")
 
+// ErrWriteLimitReached is returned by [SendStream.WriteWithLimit] when its limiter prevents accepting the entire slice.
+var ErrWriteLimitReached = errors.New("write limit reached")
+
 // QUICVersionContextKey can be used to find out the QUIC version of a TLS handshake from the
 // context returned by tls.Config.ClientInfo.Context.
 var QUICVersionContextKey = handshake.QUICVersionContextKey

--- a/send_stream.go
+++ b/send_stream.go
@@ -40,8 +40,8 @@ type SendStream struct {
 	dataForWriting []byte // during a Write() call, this slice is the part of p that still needs to be sent out
 
 	writeLimiter func(int) int
-	// Set by the packetizer when writeLimiter shortens a reservation. It makes the blocked
-	// WriteWithLimit return ErrWouldBlock and prevents another dequeue before it wakes up.
+	// Set by the packetizer when writeLimiter reduces the allowed byte count. It makes the blocked
+	// WriteWithLimit return ErrWriteLimitReached and prevents another dequeue before it wakes up.
 	writeLimited bool
 
 	nextFrame *wire.StreamFrame
@@ -104,7 +104,7 @@ func (s *SendStream) Write(p []byte) (int, error) {
 // WriteWithLimit writes data to the stream, subject to an additional send limit.
 // During packetization, limiter receives the bytes allowed for the next STREAM frame after
 // QUIC flow control and returns how many may be sent. Values outside [0, maxBytes] are clamped.
-// A short result returns the accepted prefix and [ErrWouldBlock]; the caller can wait
+// A short result returns the accepted prefix and [ErrWriteLimitReached]; the caller can wait
 // for external credit and retry the suffix. QUIC blocking behaves like [SendStream.Write].
 // limiter can run multiple times on another goroutine while QUIC send flow-control accounting
 // is locked. It must be concurrency-safe and must not block or call QUIC methods.
@@ -314,7 +314,7 @@ func (s *SendStream) write(p []byte, limiter func(int) int) (bool /* is newly co
 		return s.isNewlyCompleted(), bytesWritten, s.resetErr
 	}
 	if s.writeLimited {
-		return false, bytesWritten, ErrWouldBlock
+		return false, bytesWritten, ErrWriteLimitReached
 	}
 	return false, bytesWritten, nil
 }

--- a/send_stream.go
+++ b/send_stream.go
@@ -103,7 +103,9 @@ func (s *SendStream) Write(p []byte) (int, error) {
 
 // WriteWithLimit writes data to the stream, subject to an additional send limit.
 // During packetization, limiter receives the bytes allowed for the next STREAM frame after
-// QUIC flow control and returns how many may be sent. Values outside [0, maxBytes] are clamped.
+// QUIC flow control and returns how many may be sent. Returning n in [0, maxBytes] commits
+// n bytes of limiter credit; the limiter is not called again when those bytes are retransmitted.
+// Values outside [0, maxBytes] are clamped.
 // A short result returns the accepted prefix and [ErrWriteLimitReached]; the caller can wait
 // for external credit and retry the suffix. QUIC blocking behaves like [SendStream.Write].
 // limiter can run multiple times on another goroutine while QUIC send flow-control accounting

--- a/send_stream.go
+++ b/send_stream.go
@@ -38,7 +38,13 @@ type SendStream struct {
 	queuedResetStreamFrame *wire.ResetStreamFrame
 
 	dataForWriting []byte // during a Write() call, this slice is the part of p that still needs to be sent out
-	nextFrame      *wire.StreamFrame
+
+	writeLimiter func(int) int
+	// Set by the packetizer when writeLimiter shortens a reservation. It makes the blocked
+	// WriteWithLimit return ErrWouldBlock and prevents another dequeue before it wakes up.
+	writeLimited bool
+
+	nextFrame *wire.StreamFrame
 	// set if flow control credit for nextFrame was already consumed
 	nextFrameReserved bool
 
@@ -92,13 +98,25 @@ func (s *SendStream) StreamID() StreamID {
 // Write can be made to time out using [SendStream.SetWriteDeadline].
 // If the stream was canceled, the error is a [StreamError].
 func (s *SendStream) Write(p []byte) (int, error) {
+	return s.WriteWithLimit(p, nil)
+}
+
+// WriteWithLimit writes data to the stream, subject to an additional send limit.
+// During packetization, limiter receives the bytes allowed for the next STREAM frame after
+// QUIC flow control and returns how many may be sent. Values outside [0, maxBytes] are clamped.
+// A short result returns the accepted prefix and [ErrWouldBlock]; the caller can wait
+// for external credit and retry the suffix. QUIC blocking behaves like [SendStream.Write].
+// limiter can run multiple times on another goroutine while QUIC send flow-control accounting
+// is locked. It must be concurrency-safe and must not block or call QUIC methods.
+// A nil limiter behaves like [SendStream.Write].
+func (s *SendStream) WriteWithLimit(p []byte, limiter func(maxBytes int) int) (int, error) {
 	// Concurrent use of Write is not permitted (and doesn't make any sense),
 	// but sometimes people do it anyway.
 	// Make sure that we only execute one call at any given time to avoid hard to debug failures.
 	s.writeOnce <- struct{}{}
 	defer func() { <-s.writeOnce }()
 
-	isNewlyCompleted, n, err := s.write(p)
+	isNewlyCompleted, n, err := s.write(p, limiter)
 	if isNewlyCompleted {
 		s.sender.onStreamCompleted(s.streamID)
 	}
@@ -181,9 +199,15 @@ func (s *SendStream) tryWriteAll(p []byte) (bool /* is newly completed */, bool 
 	return false, true, nil
 }
 
-func (s *SendStream) write(p []byte) (bool /* is newly completed */, int, error) {
+func (s *SendStream) write(p []byte, limiter func(int) int) (bool /* is newly completed */, int, error) {
 	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	s.writeLimiter = limiter
+	s.writeLimited = false
+	defer func() {
+		s.writeLimiter = nil
+		s.writeLimited = false
+		s.mutex.Unlock()
+	}()
 
 	if s.resetErr != nil {
 		s.cancellationFlagged = true
@@ -210,6 +234,11 @@ func (s *SendStream) write(p []byte) (bool /* is newly completed */, int, error)
 		notifiedSender bool
 	)
 	for {
+		if s.writeLimited {
+			bytesWritten = len(p) - len(s.dataForWriting)
+			s.dataForWriting = nil
+			break
+		}
 		var copied bool
 		var deadline monotime.Time
 		// As soon as dataForWriting becomes smaller than a certain size x, we copy all the data to a STREAM frame (s.nextFrame),
@@ -284,11 +313,14 @@ func (s *SendStream) write(p []byte) (bool /* is newly completed */, int, error)
 		s.cancellationFlagged = true
 		return s.isNewlyCompleted(), bytesWritten, s.resetErr
 	}
+	if s.writeLimited {
+		return false, bytesWritten, ErrWouldBlock
+	}
 	return false, bytesWritten, nil
 }
 
 func (s *SendStream) canBufferStreamFrame() bool {
-	if s.nextFrameReserved {
+	if s.writeLimiter != nil || s.nextFrameReserved {
 		return false
 	}
 	var l protocol.ByteCount
@@ -339,6 +371,9 @@ func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 			return f, nil, true
 		}
 	}
+	if s.writeLimited {
+		return nil, nil, false
+	}
 
 	if len(s.dataForWriting) == 0 && s.nextFrame == nil {
 		if s.finishedWriting && !s.finSent {
@@ -355,6 +390,7 @@ func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 
 	// if the stream is canceled, only data up to the reliable size needs to be sent
 	reliableOffset := s.reliableOffset()
+	limitedWrite := s.writeLimiter != nil && s.nextFrame == nil
 	var maxDataLen protocol.ByteCount
 	if s.nextFrameReserved {
 		maxDataLen = s.nextFrame.DataLen()
@@ -377,7 +413,17 @@ func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 	if maxDataLen == 0 {
 		return nil, nil, true
 	}
-	if !s.nextFrameReserved && !s.flowController.TryAddBytesSent(maxDataLen) {
+	if limitedWrite {
+		added, limited := s.flowController.AddBytesSentWithLimiter(maxDataLen, s.writeLimiter)
+		if limited {
+			s.writeLimited = true
+			s.signalWrite()
+		}
+		maxDataLen = added
+		if maxDataLen == 0 {
+			return nil, nil, !limited
+		}
+	} else if !s.nextFrameReserved && !s.flowController.TryAddBytesSent(maxDataLen) {
 		return nil, nil, true
 	}
 	f, hasMoreData := s.popNewStreamFrame(maxDataLen)
@@ -385,6 +431,9 @@ func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 		s.writeOffset += f.DataLen()
 	}
 	if s.resetErr != nil && s.writeOffset >= reliableOffset {
+		hasMoreData = false
+	}
+	if s.writeLimited {
 		hasMoreData = false
 	}
 	var blocked *wire.StreamDataBlockedFrame

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -135,6 +135,79 @@ func TestSendStreamWriteData(t *testing.T) {
 	)
 }
 
+func TestSendStreamWriteWithLimit(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const streamID protocol.StreamID = 42
+		mockCtrl := gomock.NewController(t)
+		mockFC := newTestStreamFlowControllerWithSendWindow(streamID, 56)
+		mockSender := NewMockStreamSender(mockCtrl)
+		str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
+
+		mockSender.EXPECT().onHasStreamData(streamID, str).Times(4)
+		_, err := str.Write([]byte("header"))
+		require.NoError(t, err)
+
+		type result struct {
+			n   int
+			err error
+		}
+		results := make(chan result, 1)
+		data := make([]byte, 51)
+		calls := 0
+		go func() {
+			n, err := str.WriteWithLimit(data, func(maxBytes int) int {
+				calls++
+				return min(maxBytes, 25)
+			})
+			results <- result{n: n, err: err}
+		}()
+
+		synctest.Wait()
+		frame, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.True(t, hasMore)
+		require.Equal(t, []byte("header"), frame.Frame.Data)
+		require.Zero(t, calls)
+
+		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.False(t, hasMore)
+		require.Equal(t, data[:25], frame.Frame.Data)
+		synctest.Wait()
+		writeResult := <-results
+		require.Equal(t, 25, writeResult.n)
+		require.ErrorIs(t, writeResult.err, ErrWouldBlock)
+		require.Equal(t, 1, calls)
+
+		go func() {
+			n, err := str.WriteWithLimit(data[25:], func(maxBytes int) int {
+				calls++
+				return maxBytes
+			})
+			results <- result{n: n, err: err}
+		}()
+		synctest.Wait()
+
+		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.True(t, hasMore)
+		require.Equal(t, data[25:50], frame.Frame.Data)
+		require.Equal(t, 2, calls)
+
+		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.Nil(t, frame.Frame)
+		require.True(t, hasMore)
+		require.Equal(t, 2, calls)
+
+		str.updateSendWindow(57)
+		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		require.False(t, hasMore)
+		require.Equal(t, data[50:], frame.Frame.Data)
+		synctest.Wait()
+		writeResult = <-results
+		require.Equal(t, 26, writeResult.n)
+		require.NoError(t, writeResult.err)
+		require.Equal(t, 3, calls)
+	})
+}
+
 func TestSendStreamTryWriteAll(t *testing.T) {
 	const streamID protocol.StreamID = 42
 	mockCtrl := gomock.NewController(t)

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -174,7 +174,7 @@ func TestSendStreamWriteWithLimit(t *testing.T) {
 		synctest.Wait()
 		writeResult := <-results
 		require.Equal(t, 25, writeResult.n)
-		require.ErrorIs(t, writeResult.err, ErrWouldBlock)
+		require.ErrorIs(t, writeResult.err, ErrWriteLimitReached)
 		require.Equal(t, 1, calls)
 
 		go func() {

--- a/stream.go
+++ b/stream.go
@@ -132,6 +132,12 @@ func (s *Stream) Write(p []byte) (int, error) {
 	return s.sendStr.Write(p)
 }
 
+// WriteWithLimit writes data to the stream, subject to an additional send limit.
+// See [SendStream.WriteWithLimit] for more details.
+func (s *Stream) WriteWithLimit(p []byte, limiter func(maxBytes int) int) (int, error) {
+	return s.sendStr.WriteWithLimit(p, limiter)
+}
+
 // TryWriteAll writes data to the stream if it can be queued immediately.
 // See [SendStream.TryWriteAll] for more details.
 func (s *Stream) TryWriteAll(p []byte) error {


### PR DESCRIPTION
Closes #5736. Closes #5740.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SendStream.WriteWithLimit` for limiter-driven partial writes
> - Adds `SendStream.WriteWithLimit` (and `Stream.WriteWithLimit`) accepting a caller-provided limiter function that caps how many bytes are consumed per packetization cycle; returns `ErrWriteLimitReached` when the limiter prevents the full write.
> - Extends flow controllers with `AddBytesSentWithLimiter` at both stream and connection level to slice send credit according to the limiter and signal when a write was partially accepted.
> - Replaces the blocking `WaitForReceiveFinalSize` API on `ReceiveStream` with `SetReceiveFinalSizeCallback`, which invokes the callback immediately if the final size is already known or on the first FIN/RESET_STREAM frame.
> - `SendStream.Write` is unchanged in behavior, delegating to `WriteWithLimit` with a nil limiter.
> - Risk: `canBufferStreamFrame` now returns false during any limited write, which changes pre-buffering behavior for concurrent writers using the new API.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #5753 opened
>
> - Updated `SendStream.WriteWithLimit` method documentation to clarify limiter semantics [ab8adc9]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa20b46.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `WriteWithLimit` to `SendStream` and the higher-level `Stream` API to cap per-call enqueued data.
  * Added `ErrWriteLimitReached` when the limiter prevents the full payload from being accepted.
* **Behavior Improvements**
  * When limiting is hit, `WriteWithLimit` returns `ErrWriteLimitReached` while still reporting the number of bytes successfully queued/written.
  * Existing `Write` behavior remains unchanged when no limiter is provided.
* **Tests**
  * Added unit and integration coverage for stream and connection flow-control scenarios involving `WriteWithLimit`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->