### PR TITLE
QMux

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -210,6 +210,7 @@ type Conn struct {
 	pacingDeadline monotime.Time
 
 	peerParams *wire.TransportParameters
+	qmux       *qmuxState
 
 	timer *time.Timer
 	// keepAlivePingSent stores whether a keep alive PING is in flight.
@@ -519,6 +520,9 @@ func (c *Conn) preSetup() {
 		c.config.EnableStreamResetPartialDelivery,
 		false, // ACK_FREQUENCY is not supported yet
 	)
+	if c.qmux != nil {
+		c.frameParser.SetSupportsQMux(true)
+	}
 	c.rttStats = utils.NewRTTStats()
 	c.connFlowController = newConnectionFlowController(
 		protocol.ByteCount(c.config.InitialConnectionReceiveWindow),
@@ -576,6 +580,10 @@ func (c *Conn) run() (err error) {
 	}()
 
 	c.timer = time.NewTimer(monotime.Until(c.idleTimeoutStartTime().Add(c.config.HandshakeIdleTimeout)))
+	var qmuxWrittenFrameBatchesAvailable <-chan struct{}
+	if c.qmux != nil {
+		qmuxWrittenFrameBatchesAvailable = c.qmux.writtenFrameBatchesAvailable
+	}
 
 	if err := c.cryptoStreamHandler.StartHandshake(c.ctx); err != nil {
 		return err
@@ -659,6 +667,8 @@ runLoop:
 			case <-c.timer.C:
 			case <-c.sendingScheduled:
 			case <-sendQueueAvailable:
+			case <-qmuxWrittenFrameBatchesAvailable:
+				c.handleQMuxWrittenFrameBatches()
 			case <-c.notifyReceivedPacket:
 				wasProcessed, err := c.handlePackets()
 				if err != nil {
@@ -685,7 +695,12 @@ runLoop:
 		if keepAliveTime := c.nextKeepAliveTime(); !keepAliveTime.IsZero() && !now.Before(keepAliveTime) {
 			// send a PING frame since there is no activity in the connection
 			c.logger.Debugf("Sending a keep-alive PING to keep the connection alive.")
-			c.framer.QueueControlFrame(&wire.PingFrame{})
+			if c.qmux != nil {
+				// QMux prohibits PING frames; use a QX_PING frame instead.
+				c.framer.QueueControlFrame(&wire.QXPingFrame{SequenceNumber: c.qmux.nextPingRequest()})
+			} else {
+				c.framer.QueueControlFrame(&wire.PingFrame{})
+			}
 			c.keepAlivePingSent = true
 		} else if !c.handshakeComplete && now.Sub(c.creationTime) >= c.config.handshakeTimeout() {
 			c.destroyImpl(qerr.ErrHandshakeTimeout)
@@ -1000,6 +1015,9 @@ func (c *Conn) handleHandshakeConfirmed(now monotime.Time) error {
 const maxPacketsToProcess = 32
 
 func (c *Conn) handlePackets() (wasProcessed bool, _ error) {
+	if c.qmux != nil {
+		return c.handleQMuxRecords()
+	}
 	// Process packets from the receivedPackets queue.
 	// Limit the number of packets to process to maxPacketsToProcess,
 	// so we eventually get a chance to send out an ACK when receiving a lot of packets.
@@ -1046,6 +1064,103 @@ func (c *Conn) handlePackets() (wasProcessed bool, _ error) {
 		}
 	}
 	return wasProcessed, nil
+}
+
+func (c *Conn) handleQMuxRecords() (wasProcessed bool, _ error) {
+	c.receivedPacketMx.Lock()
+
+	if c.receivedPackets.Empty() {
+		c.receivedPacketMx.Unlock()
+		return false, nil
+	}
+
+	var remaining int
+	for range maxPacketsToProcess {
+		p := c.receivedPackets.PopFront()
+		c.receivedPacketMx.Unlock()
+
+		processed, err := c.handleOneQMuxRecord(p)
+		p.buffer.Release()
+		if err != nil {
+			return false, err
+		}
+		if processed {
+			wasProcessed = true
+		}
+		c.receivedPacketMx.Lock()
+		remaining = c.receivedPackets.Len()
+		if remaining == 0 {
+			break
+		}
+	}
+	c.receivedPacketMx.Unlock()
+
+	// Unblock the read loop if it paused because the receive queue was full.
+	if remaining < protocol.MaxConnUnprocessedPackets {
+		select {
+		case c.qmux.recordQueueSpace <- struct{}{}:
+		default:
+		}
+	}
+	if remaining > 0 {
+		select {
+		case c.notifyReceivedPacket <- struct{}{}:
+		default:
+		}
+	}
+	return wasProcessed, nil
+}
+
+// queuedQMuxRecordCount returns the number of records queued for processing.
+func (c *Conn) queuedQMuxRecordCount() int {
+	c.receivedPacketMx.Lock()
+	defer c.receivedPacketMx.Unlock()
+	return c.receivedPackets.Len()
+}
+
+func (c *Conn) handleOneQMuxRecord(p receivedPacket) (bool, error) {
+	c.sentPacketHandler.ReceivedBytes(p.Size(), p.rcvTime)
+
+	var log func([]qlog.Frame)
+	if c.qlogger != nil {
+		log = func(frames []qlog.Frame) {
+			c.qlogger.RecordEvent(qlog.PacketReceived{
+				Header: qlog.PacketHeader{
+					PacketType:       qlog.PacketType1RTT,
+					PacketNumber:     protocol.InvalidPacketNumber,
+					DestConnectionID: protocol.ConnectionID{},
+					KeyPhaseBit:      protocol.KeyPhaseZero,
+				},
+				Raw: qlog.RawInfo{
+					Length:        int(p.Size()),
+					PayloadLength: int(p.Size()),
+				},
+				Frames: frames,
+				ECN:    toQlogECN(p.ecn),
+			})
+		}
+	}
+
+	_, _, err := c.handleUnpackedQMuxRecord(p.data, p.rcvTime, log)
+	if err != nil {
+		return false, err
+	}
+	c.blocked = blockModeNone
+	return true, nil
+}
+
+func (c *Conn) handleQMuxWrittenFrameBatches() bool {
+	if c.qmux == nil {
+		return false
+	}
+	packets := c.qmux.popWrittenFrameBatches()
+	if len(packets) == 0 {
+		return false
+	}
+	for _, p := range packets {
+		acknowledgeWrittenFrames(p)
+	}
+	return true
 }
 
 func (c *Conn) handleOnePacket(rp receivedPacket, datagramID qlog.DatagramID) (wasProcessed bool, _ error) {
@@ -1765,6 +1880,22 @@ func (c *Conn) handleUnpackedShortHeaderPacket(
 	return isNonProbing, pathChallenge, nil
 }
 
+func (c *Conn) handleUnpackedQMuxRecord(
+	data []byte,
+	rcvTime monotime.Time,
+	log func([]qlog.Frame),
+) (isNonProbing bool, pathChallenge *wire.PathChallengeFrame, _ error) {
+	c.lastPacketReceivedTime = rcvTime
+	c.firstAckElicitingPacketAfterIdleSentTime = 0
+
+	_, isNonProbing, pathChallenge, err := c.handleFrames(data, protocol.ConnectionID{}, protocol.Encryption1RTT, log, rcvTime)
+	if err != nil {
+		return false, nil, err
+	}
+	c.sentPacketHandler.ReceivedPacket(protocol.Encryption1RTT, rcvTime)
+	return isNonProbing, pathChallenge, nil
+}
+
 // handleFrames parses the frames, one after the other, and handles them.
 // It returns the last PATH_CHALLENGE frame contained in the packet, if any.
 func (c *Conn) handleFrames(
@@ -1820,7 +1951,12 @@ func (c *Conn) handleFrames(
 				continue
 			}
 			wire.LogFrame(c.logger, streamFrame, false)
-			handleErr = c.streamsMap.HandleStreamFrame(streamFrame, rcvTime)
+			if c.qmux != nil {
+				handleErr = c.qmux.checkStreamFrameOrdering(streamFrame)
+			}
+			if handleErr == nil {
+				handleErr = c.streamsMap.HandleStreamFrame(streamFrame, rcvTime)
+			}
 		} else if frameType.IsAckFrameType() {
 			ackFrame, l, err := c.frameParser.ParseAckFrame(frameType, data, encLevel, c.version)
 			if err != nil {
@@ -1929,6 +2065,29 @@ func (c *Conn) handleFrame(
 	case *wire.StopSendingFrame:
 		err = c.streamsMap.HandleStopSendingFrame(frame)
 	case *wire.PingFrame:
+	case *wire.QXPingFrame:
+		if c.qmux == nil {
+			err = &qerr.TransportError{
+				ErrorCode:    qerr.FrameEncodingError,
+				ErrorMessage: "received QX_PING on non-QMux connection",
+			}
+			break
+		}
+		if frame.IsResponse {
+			var matched bool
+			matched, err = c.qmux.receivedPingResponse(frame.SequenceNumber)
+			if matched {
+				c.keepAlivePingSent = false
+			}
+		} else {
+			c.qmux.queuePingResponse(frame.SequenceNumber)
+			c.scheduleSending()
+		}
+	case *wire.QXTransportParametersFrame:
+		err = &qerr.TransportError{
+			ErrorCode:    qerr.TransportParameterError,
+			ErrorMessage: "received QX_TRANSPORT_PARAMETERS after connection setup",
+		}
 	case *wire.PathChallengeFrame:
 		c.handlePathChallengeFrame(frame)
 		pathChallenge = frame
@@ -1968,6 +2127,17 @@ func (c *Conn) handlePacket(p receivedPacket) {
 		c.receivedPacketMx.Unlock()
 		return
 	}
+	c.receivedPackets.PushBack(p)
+	c.receivedPacketMx.Unlock()
+
+	select {
+	case c.notifyReceivedPacket <- struct{}{}:
+	default:
+	}
+}
+
+func (c *Conn) queueQMuxRecord(p receivedPacket) {
+	c.receivedPacketMx.Lock()
 	c.receivedPackets.PushBack(p)
 	c.receivedPacketMx.Unlock()
 
@@ -2421,6 +2591,11 @@ func (c *Conn) applyTransportParameters() {
 	}
 	c.keepAliveInterval = min(c.config.KeepAlivePeriod, c.idleTimeout/2)
 	c.streamsMap.HandleTransportParameters(params)
+	if c.qmux != nil {
+		c.connFlowController.UpdateSendWindow(params.InitialMaxData)
+		c.maxPayloadSizeEstimate.Store(uint32(params.MaxRecordSize))
+		return
+	}
 	c.frameParser.SetAckDelayExponent(params.AckDelayExponent)
 	c.connFlowController.UpdateSendWindow(params.InitialMaxData)
 	c.rttStats.SetMaxAckDelay(params.MaxAckDelay)
@@ -2558,17 +2733,33 @@ func (c *Conn) sendPackets(now monotime.Time) error {
 
 func (c *Conn) sendPacketsWithoutGSO(now monotime.Time) error {
 	for {
-		buf := getPacketBuffer()
-		ecn := c.sentPacketHandler.ECNMode(true)
-		if _, err := c.appendOneShortHeaderPacket(buf, c.maxPacketSize(), ecn, now); err != nil {
-			if err == errNothingToPack {
-				buf.Release()
-				return nil
-			}
-			return err
+		var buf *packetBuffer
+		if c.qmux != nil {
+			buf = getLargePacketBuffer()
+		} else {
+			buf = getPacketBuffer()
 		}
-
-		c.sendQueue.Send(buf, 0, ecn)
+		ecn := c.sentPacketHandler.ECNMode(true)
+		if c.qmux != nil {
+			completion, err := c.appendOneQMuxRecord(buf, c.maxPacketSize(), ecn, now)
+			if err != nil {
+				if err == errNothingToPack {
+					buf.Release()
+					return nil
+				}
+				return err
+			}
+			c.sendQueue.(*qmuxSender).sendRecord(qmuxOutboundRecord{buf: buf, ecn: ecn, completion: completion})
+		} else {
+			if _, err := c.appendOneShortHeaderPacket(buf, c.maxPacketSize(), ecn, now); err != nil {
+				if err == errNothingToPack {
+					buf.Release()
+					return nil
+				}
+				return err
+			}
+			c.sendQueue.Send(buf, 0, ecn)
+		}
 
 		if c.sendQueue.WouldBlock() {
 			return nil
@@ -2744,6 +2935,18 @@ func (c *Conn) appendOneShortHeaderPacket(buf *packetBuffer, maxSize protocol.By
 	return size, nil
 }
 
+func (c *Conn) appendOneQMuxRecord(buf *packetBuffer, maxSize protocol.ByteCount, ecn protocol.ECN, now monotime.Time) (qmuxWrittenFrameBatch, error) {
+	startLen := buf.Len()
+	p, err := c.packer.AppendPacket(buf, maxSize, now, c.version)
+	if err != nil {
+		return qmuxWrittenFrameBatch{}, err
+	}
+	size := buf.Len() - startLen
+	c.logShortHeaderPacket(p, ecn, size)
+	c.registerPackedShortHeaderPacket(p, ecn, now)
+	return qmuxWrittenFrameBatch{frames: p.Frames, streamFrames: p.StreamFrames}, nil
+}
+
 func (c *Conn) registerPackedShortHeaderPacket(p shortHeaderPacket, ecn protocol.ECN, now monotime.Time) {
 	if p.IsPathProbePacket {
 		c.sentPacketHandler.SentPacket(
@@ -2858,12 +3061,31 @@ func (c *Conn) sendConnectionClose(e error) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if c.qmux != nil {
+		// Ordinary QUIC retains these bytes in ReplaceWithClosed. QMux writes the close
+		// directly and its no-op replacement doesn't retain them, so release this buffer here.
+		defer packet.buffer.Release()
+	}
 	ecn := c.sentPacketHandler.ECNMode(packet.IsOnlyShortHeaderPacket())
 	c.logCoalescedPacket(packet, ecn)
-	return packet.buffer.Data, c.conn.Write(packet.buffer.Data, 0, ecn)
+	// Unlike UDP writes, writes to a QMux transport can block. Sending the CONNECTION_CLOSE
+	// is best-effort: use a short write deadline so a peer that stopped reading can't block
+	// connection teardown. The transport is closed right after the run loop returns.
+	if qconn, ok := c.conn.(*qmuxSendConn); ok {
+		_ = qconn.setWriteDeadline(time.Now().Add(time.Second))
+	}
+	err = c.conn.Write(packet.buffer.Data, 0, ecn)
+	if c.qmux != nil {
+		// QMux has no closed-connection handler to retransmit CONNECTION_CLOSE.
+		return nil, err
+	}
+	return packet.buffer.Data, err
 }
 
 func (c *Conn) maxPacketSize() protocol.ByteCount {
+	if c.qmux != nil {
+		return c.qmux.maxRecordSize
+	}
 	if c.mtuDiscoverer == nil {
 		// Use the configured packet size on the client side.
 		// If the server sends a max_udp_payload_size that's smaller than this size, we can ignore this:
@@ -3014,6 +3236,9 @@ func (c *Conn) onStreamCompleted(id protocol.StreamID) {
 		c.closeLocal(err)
 	}
 	c.framer.RemoveActiveStream(id)
+	if c.qmux != nil {
+		c.qmux.removeStreamOffset(id)
+	}
 }
 
 // SendDatagram sends a message using a QUIC datagram, as specified in RFC 9221,
@@ -3080,6 +3305,9 @@ func (c *Conn) getPathManager() *pathManagerOutgoing {
 }
 
 func (c *Conn) AddPath(t *Transport) (*Path, error) {
+	if c.qmux != nil {
+		return nil, errors.New("QMux connections don't support connection migration")
+	}
 	if c.perspective == protocol.PerspectiveServer {
 		return nil, errors.New("server cannot initiate connection migration")
 	}

--- a/connection.go
+++ b/connection.go
@@ -2593,7 +2593,10 @@ func (c *Conn) applyTransportParameters() {
 	c.streamsMap.HandleTransportParameters(params)
 	if c.qmux != nil {
 		c.connFlowController.UpdateSendWindow(params.InitialMaxData)
-		c.maxPayloadSizeEstimate.Store(uint32(params.MaxRecordSize))
+		// Use the effective record size (capped to the packet buffer size), not the peer's
+		// raw max_record_size, and account for the DATAGRAM frame header, so that every
+		// datagram accepted by SendDatagram fits into a record.
+		c.maxPayloadSizeEstimate.Store(uint32(c.qmux.maxDatagramPayloadSize()))
 		return
 	}
 	c.frameParser.SetAckDelayExponent(params.AckDelayExponent)

--- a/integrationtests/self/http_qmux_test.go
+++ b/integrationtests/self/http_qmux_test.go
@@ -1,0 +1,82 @@
+package self_test
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPOverQMux(t *testing.T) {
+	clientPipe, serverPipe := net.Pipe()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tlsConf := getTLSConfig()
+	tlsConf.NextProtos = []string{http3.NextProtoH3}
+	clientTLSConf := getTLSClientConfig()
+	clientTLSConf.NextProtos = []string{http3.NextProtoH3}
+
+	serverConnChan := make(chan struct {
+		conn *quic.Conn
+		err  error
+	}, 1)
+	go func() {
+		conn, err := quic.AcceptQMux(ctx, serverPipe, tlsConf, getQuicConfig(nil))
+		serverConnChan <- struct {
+			conn *quic.Conn
+			err  error
+		}{conn: conn, err: err}
+	}()
+	clientConn, err := quic.DialQMux(ctx, clientPipe, clientTLSConf, getQuicConfig(nil))
+	require.NoError(t, err)
+	serverResult := <-serverConnChan
+	require.NoError(t, serverResult.err)
+	serverConn := serverResult.conn
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		_, err = w.Write([]byte("hello over qmux: " + string(body)))
+		require.NoError(t, err)
+	})
+	server := &http3.Server{
+		TLSConfig:  tlsConf,
+		QUICConfig: getQuicConfig(nil),
+		Handler:    mux,
+	}
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- server.ServeQUICConn(serverConn) }()
+
+	client := (&http3.Transport{}).NewClientConn(clientConn)
+	select {
+	case <-client.ReceivedSettings():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for HTTP/3 settings over QMux")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://localhost/hello", strings.NewReader("request body"))
+	require.NoError(t, err)
+	rsp, err := client.RoundTrip(req)
+	require.NoError(t, err)
+	defer rsp.Body.Close()
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	body, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello over qmux: request body", string(body))
+
+	require.NoError(t, clientConn.CloseWithError(0, ""))
+	select {
+	case <-serverErr:
+	case <-time.After(time.Second):
+		t.Fatal("server didn't stop after closing QMux client connection")
+	}
+}

--- a/internal/wire/frame_parser.go
+++ b/internal/wire/frame_parser.go
@@ -18,6 +18,7 @@ type FrameParser struct {
 	supportsDatagrams     bool
 	supportsResetStreamAt bool
 	supportsAckFrequency  bool
+	supportsQMux          bool
 
 	// To avoid allocating when parsing, keep a single ACK frame struct.
 	// It is used over and over again.
@@ -55,12 +56,20 @@ func (p *FrameParser) ParseType(b []byte, encLevel protocol.EncryptionLevel) (Fr
 		valid := ft.isValidRFC9000() ||
 			(p.supportsDatagrams && ft.IsDatagramFrameType()) ||
 			(p.supportsResetStreamAt && ft == FrameTypeResetStreamAt) ||
-			(p.supportsAckFrequency && (ft == FrameTypeAckFrequency || ft == FrameTypeImmediateAck))
+			(p.supportsAckFrequency && (ft == FrameTypeAckFrequency || ft == FrameTypeImmediateAck)) ||
+			(p.supportsQMux && (ft.IsQXPingFrameType() || ft == FrameTypeQXTransportParametersFrame))
 		if !valid {
 			return 0, parsed, &qerr.TransportError{
 				ErrorCode:    qerr.FrameEncodingError,
 				FrameType:    typ,
 				ErrorMessage: errUnknownFrameType.Error(),
+			}
+		}
+		if p.supportsQMux && !p.isAllowedInQMux(ft) {
+			return 0, parsed, &qerr.TransportError{
+				ErrorCode:    qerr.FrameEncodingError,
+				FrameType:    typ,
+				ErrorMessage: fmt.Sprintf("%d not allowed in QMux", ft),
 			}
 		}
 		if !ft.isAllowedAtEncLevel(encLevel) {
@@ -73,6 +82,33 @@ func (p *FrameParser) ParseType(b []byte, encLevel protocol.EncryptionLevel) (Fr
 		return ft, parsed, nil
 	}
 	return 0, parsed, io.EOF
+}
+
+func (p *FrameParser) isAllowedInQMux(ft FrameType) bool {
+	if ft.IsStreamFrameType() || ft.IsQXPingFrameType() || ft == FrameTypeQXTransportParametersFrame {
+		return true
+	}
+	if p.supportsDatagrams && ft.IsDatagramFrameType() {
+		return true
+	}
+	//nolint:exhaustive // QMux only allows the frame types listed below.
+	switch ft {
+	case FrameTypeResetStream,
+		FrameTypeStopSending,
+		FrameTypeMaxData,
+		FrameTypeMaxStreamData,
+		FrameTypeBidiMaxStreams,
+		FrameTypeUniMaxStreams,
+		FrameTypeDataBlocked,
+		FrameTypeStreamDataBlocked,
+		FrameTypeBidiStreamBlocked,
+		FrameTypeUniStreamBlocked,
+		FrameTypeConnectionClose,
+		FrameTypeApplicationClose:
+		return true
+	default:
+		return false
+	}
 }
 
 func (p *FrameParser) ParseStreamFrame(frameType FrameType, data []byte, v protocol.Version) (*StreamFrame, int, error) {
@@ -165,6 +201,10 @@ func (p *FrameParser) ParseLessCommonFrame(frameType FrameType, data []byte, v p
 		frame, l, err = parseAckFrequencyFrame(data, v)
 	case FrameTypeImmediateAck:
 		frame = &ImmediateAckFrame{}
+	case FrameTypeQXPingRequest, FrameTypeQXPingResponse:
+		frame, l, err = parseQXPingFrame(frameType, data, v)
+	case FrameTypeQXTransportParametersFrame:
+		frame, l, err = parseQXTransportParametersFrame(data, v)
 	default:
 		err = errUnknownFrameType
 	}
@@ -182,6 +222,10 @@ func (p *FrameParser) ParseLessCommonFrame(frameType FrameType, data []byte, v p
 // This value is used to scale the ACK Delay field in the ACK frame.
 func (p *FrameParser) SetAckDelayExponent(exp uint8) {
 	p.ackDelayExponent = exp
+}
+
+func (p *FrameParser) SetSupportsQMux(supportsQMux bool) {
+	p.supportsQMux = supportsQMux
 }
 
 func replaceUnexpectedEOF(e error) error {

--- a/internal/wire/frame_type.go
+++ b/internal/wire/frame_type.go
@@ -38,6 +38,11 @@ const (
 
 	FrameTypeDatagramNoLength   FrameType = 0x30
 	FrameTypeDatagramWithLength FrameType = 0x31
+
+	// https://datatracker.ietf.org/doc/draft-ietf-quic-qmux/01/
+	FrameTypeQXPingRequest              FrameType = 0x348c67529ef8c7bd
+	FrameTypeQXPingResponse             FrameType = 0x348c67529ef8c7be
+	FrameTypeQXTransportParametersFrame FrameType = 0x3f5153300d0a0d0a
 )
 
 func (t FrameType) IsStreamFrameType() bool {
@@ -54,6 +59,10 @@ func (t FrameType) IsAckFrameType() bool {
 
 func (t FrameType) IsDatagramFrameType() bool {
 	return t == FrameTypeDatagramNoLength || t == FrameTypeDatagramWithLength
+}
+
+func (t FrameType) IsQXPingFrameType() bool {
+	return t == FrameTypeQXPingRequest || t == FrameTypeQXPingResponse
 }
 
 func (t FrameType) isAllowedAtEncLevel(encLevel protocol.EncryptionLevel) bool {

--- a/internal/wire/pool.go
+++ b/internal/wire/pool.go
@@ -6,7 +6,10 @@ import (
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
-var pool sync.Pool
+// STREAM frames are pooled in two buffer sizes:
+// protocol.MaxPacketBufferSize for frames that fit into a QUIC packet,
+// and protocol.MaxLargePacketBufferSize for the larger frames permitted in QMux records.
+var pool, largePool sync.Pool
 
 func init() {
 	pool.New = func() any {
@@ -15,19 +18,37 @@ func init() {
 			fromPool: true,
 		}
 	}
+	largePool.New = func() any {
+		return &StreamFrame{
+			Data:     make([]byte, 0, protocol.MaxLargePacketBufferSize),
+			fromPool: true,
+		}
+	}
 }
 
-func GetStreamFrame() *StreamFrame {
-	f := pool.Get().(*StreamFrame)
-	return f
+// GetStreamFrame gets a StreamFrame whose Data buffer has a capacity of at least size bytes.
+func GetStreamFrame(size protocol.ByteCount) *StreamFrame {
+	switch {
+	case size <= protocol.MaxPacketBufferSize:
+		return pool.Get().(*StreamFrame)
+	case size <= protocol.MaxLargePacketBufferSize:
+		return largePool.Get().(*StreamFrame)
+	default:
+		// This should never happen: frames are limited by the packet / record size.
+		return &StreamFrame{Data: make([]byte, 0, size)}
+	}
 }
 
 func putStreamFrame(f *StreamFrame) {
 	if !f.fromPool {
 		return
 	}
-	if protocol.ByteCount(cap(f.Data)) != protocol.MaxPacketBufferSize {
+	switch protocol.ByteCount(cap(f.Data)) {
+	case protocol.MaxPacketBufferSize:
+		pool.Put(f)
+	case protocol.MaxLargePacketBufferSize:
+		largePool.Put(f)
+	default:
 		panic("wire.PutStreamFrame called with packet of wrong size!")
 	}
-	pool.Put(f)
 }

--- a/internal/wire/pool_test.go
+++ b/internal/wire/pool_test.go
@@ -3,16 +3,32 @@ package wire
 import (
 	"testing"
 
+	"github.com/quic-go/quic-go/internal/protocol"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetAndPutStreamFrames(t *testing.T) {
-	f := GetStreamFrame()
+	f := GetStreamFrame(protocol.MaxPacketBufferSize)
+	require.Equal(t, protocol.MaxPacketBufferSize, cap(f.Data))
 	putStreamFrame(f)
 }
 
+func TestGetAndPutLargeStreamFrames(t *testing.T) {
+	f := GetStreamFrame(protocol.MaxPacketBufferSize + 1)
+	require.Equal(t, protocol.MaxLargePacketBufferSize, cap(f.Data))
+	putStreamFrame(f)
+}
+
+func TestGetStreamFrameExceedingPooledSizes(t *testing.T) {
+	f := GetStreamFrame(protocol.MaxLargePacketBufferSize + 1)
+	require.GreaterOrEqual(t, cap(f.Data), protocol.MaxLargePacketBufferSize+1)
+	require.False(t, f.fromPool)
+	putStreamFrame(f) // must not panic, and must not be pooled
+}
+
 func TestPanicOnPuttingStreamFrameWithWrongCapacity(t *testing.T) {
-	f := GetStreamFrame()
+	f := GetStreamFrame(protocol.MaxPacketBufferSize)
 	f.Data = []byte("foobar")
 	require.Panics(t, func() { putStreamFrame(f) })
 }

--- a/internal/wire/qx_frame_test.go
+++ b/internal/wire/qx_frame_test.go
@@ -1,0 +1,65 @@
+package wire
+
+import (
+	"testing"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/quicvarint"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQXPingFrame(t *testing.T) {
+	for _, isResponse := range []bool{false, true} {
+		f := &QXPingFrame{SequenceNumber: 0xdecafbad, IsResponse: isResponse}
+		b, err := f.Append(nil, protocol.Version1)
+		require.NoError(t, err)
+		require.Equal(t, f.Length(protocol.Version1), protocol.ByteCount(len(b)))
+
+		expectedType := FrameTypeQXPingRequest
+		if isResponse {
+			expectedType = FrameTypeQXPingResponse
+		}
+
+		parser := NewFrameParser(true, true, true)
+		parser.SetSupportsQMux(true)
+		frameType, l, err := parser.ParseType(b, protocol.Encryption1RTT)
+		require.NoError(t, err)
+		require.Equal(t, expectedType, frameType)
+		require.Equal(t, quicvarint.Len(uint64(expectedType)), l)
+
+		parsed, n, err := parser.ParseLessCommonFrame(frameType, b[l:], protocol.Version1)
+		require.NoError(t, err)
+		require.Equal(t, f, parsed)
+		require.Equal(t, len(b)-l, n)
+	}
+}
+
+func TestQXTransportParametersFrame(t *testing.T) {
+	f := &QXTransportParametersFrame{TransportParameters: []byte("transport-parameters")}
+	b, err := f.Append(nil, protocol.Version1)
+	require.NoError(t, err)
+	require.Equal(t, f.Length(protocol.Version1), protocol.ByteCount(len(b)))
+
+	parser := NewFrameParser(true, true, true)
+	parser.SetSupportsQMux(true)
+	frameType, l, err := parser.ParseType(b, protocol.Encryption1RTT)
+	require.NoError(t, err)
+	require.Equal(t, FrameTypeQXTransportParametersFrame, frameType)
+	require.Equal(t, quicvarint.Len(uint64(FrameTypeQXTransportParametersFrame)), l)
+
+	parsed, n, err := parser.ParseLessCommonFrame(frameType, b[l:], protocol.Version1)
+	require.NoError(t, err)
+	require.Equal(t, f, parsed)
+	require.Equal(t, len(b)-l, n)
+}
+
+func TestFrameParserQMuxUnsupported(t *testing.T) {
+	f := &QXPingFrame{SequenceNumber: 1}
+	b, err := f.Append(nil, protocol.Version1)
+	require.NoError(t, err)
+
+	parser := NewFrameParser(true, true, true)
+	_, _, err = parser.ParseType(b, protocol.Encryption1RTT)
+	checkFrameUnsupported(t, err, uint64(FrameTypeQXPingRequest))
+}

--- a/internal/wire/qx_ping_frame.go
+++ b/internal/wire/qx_ping_frame.go
@@ -1,0 +1,39 @@
+package wire
+
+import (
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+type QXPingFrame struct {
+	SequenceNumber uint64
+	IsResponse     bool
+}
+
+func parseQXPingFrame(frameType FrameType, b []byte, _ protocol.Version) (*QXPingFrame, int, error) {
+	seq, l, err := quicvarint.Parse(b)
+	if err != nil {
+		return nil, 0, replaceUnexpectedEOF(err)
+	}
+	return &QXPingFrame{
+		SequenceNumber: seq,
+		IsResponse:     frameType == FrameTypeQXPingResponse,
+	}, l, nil
+}
+
+func (f *QXPingFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
+	frameType := FrameTypeQXPingRequest
+	if f.IsResponse {
+		frameType = FrameTypeQXPingResponse
+	}
+	b = quicvarint.Append(b, uint64(frameType))
+	return quicvarint.Append(b, f.SequenceNumber), nil
+}
+
+func (f *QXPingFrame) Length(_ protocol.Version) protocol.ByteCount {
+	frameType := FrameTypeQXPingRequest
+	if f.IsResponse {
+		frameType = FrameTypeQXPingResponse
+	}
+	return protocol.ByteCount(quicvarint.Len(uint64(frameType)) + quicvarint.Len(f.SequenceNumber))
+}

--- a/internal/wire/qx_transport_parameters_frame.go
+++ b/internal/wire/qx_transport_parameters_frame.go
@@ -1,0 +1,45 @@
+package wire
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+type QXTransportParametersFrame struct {
+	TransportParameters []byte
+}
+
+func parseQXTransportParametersFrame(b []byte, _ protocol.Version) (*QXTransportParametersFrame, int, error) {
+	length, l, err := quicvarint.Parse(b)
+	if err != nil {
+		return nil, 0, replaceUnexpectedEOF(err)
+	}
+	b = b[l:]
+	if uint64(len(b)) < length {
+		return nil, 0, io.EOF
+	}
+	if length == 0 {
+		return nil, 0, fmt.Errorf("transport parameters must not be empty")
+	}
+	params := make([]byte, int(length))
+	copy(params, b[:length])
+	return &QXTransportParametersFrame{TransportParameters: params}, l + int(length), nil
+}
+
+func (f *QXTransportParametersFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
+	b = quicvarint.Append(b, uint64(FrameTypeQXTransportParametersFrame))
+	b = quicvarint.Append(b, uint64(len(f.TransportParameters)))
+	b = append(b, f.TransportParameters...)
+	return b, nil
+}
+
+func (f *QXTransportParametersFrame) Length(_ protocol.Version) protocol.ByteCount {
+	return protocol.ByteCount(
+		quicvarint.Len(uint64(FrameTypeQXTransportParametersFrame)) +
+			quicvarint.Len(uint64(len(f.TransportParameters))) +
+			len(f.TransportParameters),
+	)
+}

--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -63,12 +63,9 @@ func ParseStreamFrame(b []byte, typ FrameType, _ protocol.Version) (*StreamFrame
 			frame.Data = make([]byte, dataLen)
 		}
 	} else {
-		frame = GetStreamFrame()
-		// The STREAM frame can't be larger than the StreamFrame we obtained from the buffer,
-		// since those StreamFrames have a buffer length of the maximum packet size.
-		if dataLen > uint64(cap(frame.Data)) {
-			return nil, 0, io.EOF
-		}
+		// dataLen was checked against len(b), so the frame is known to fit into the packet
+		// (or, for QMux, the record) it was received in, bounding the buffer size.
+		frame = GetStreamFrame(protocol.ByteCount(dataLen))
 		frame.Data = frame.Data[:dataLen]
 	}
 
@@ -168,7 +165,9 @@ func (f *StreamFrame) MaybeSplitOffFrame(maxSize protocol.ByteCount, version pro
 		return nil, true
 	}
 
-	new := GetStreamFrame()
+	// The frames swap data buffers below: f keeps the remaining f.DataLen() - n bytes,
+	// so the buffer obtained here needs to be large enough for them.
+	new := GetStreamFrame(f.DataLen() - n)
 	new.StreamID = f.StreamID
 	new.Offset = f.Offset
 	new.Fin = false

--- a/internal/wire/stream_frame_test.go
+++ b/internal/wire/stream_frame_test.go
@@ -68,12 +68,44 @@ func TestParseStreamFrameRejectsOverflow(t *testing.T) {
 	require.EqualError(t, err, "stream data overflows maximum offset")
 }
 
-func TestParseStreamFrameRejectsLongFrames(t *testing.T) {
-	data := encodeVarInt(0x12345)                                                // stream ID
-	data = append(data, encodeVarInt(uint64(protocol.MaxPacketBufferSize)+1)...) // data length
-	data = append(data, make([]byte, protocol.MaxPacketBufferSize+1)...)
-	_, _, err := ParseStreamFrame(data, 0x8^0x2, protocol.Version1)
-	require.Equal(t, io.EOF, err)
+func TestParseStreamFrameLargerThanPacketBuffer(t *testing.T) {
+	// Frames with more data than protocol.MaxPacketBufferSize are only possible in QMux
+	// records; QUIC packets are never larger. They use the large frame buffer pool.
+	payload := make([]byte, protocol.MaxPacketBufferSize+1)
+	payload[0] = 'f'
+	payload[len(payload)-1] = 'r'
+	data := encodeVarInt(0x12345)                              // stream ID
+	data = append(data, encodeVarInt(uint64(len(payload)))...) // data length
+	data = append(data, payload...)
+	frame, l, err := ParseStreamFrame(data, 0x8^0x2, protocol.Version1)
+	require.NoError(t, err)
+	require.Equal(t, len(data), l)
+	require.Equal(t, payload, frame.Data)
+	require.Equal(t, protocol.MaxLargePacketBufferSize, cap(frame.Data))
+	require.NotPanics(t, frame.PutBack)
+}
+
+func TestStreamFrameSplittingLargeFrame(t *testing.T) {
+	// Splitting a frame larger than protocol.MaxPacketBufferSize must obtain a buffer
+	// large enough for the remaining data.
+	payload := make([]byte, 4*protocol.MaxPacketBufferSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	f := &StreamFrame{
+		StreamID:       0x1337,
+		Offset:         0x42,
+		Data:           append([]byte{}, payload...),
+		DataLenPresent: true,
+	}
+	frame, needsSplit := f.MaybeSplitOffFrame(500, protocol.Version1)
+	require.True(t, needsSplit)
+	require.NotNil(t, frame)
+	require.Equal(t, protocol.ByteCount(0x42), frame.Offset)
+	require.Equal(t, protocol.ByteCount(0x42)+frame.DataLen(), f.Offset)
+	require.Equal(t, payload, append(append([]byte{}, frame.Data...), f.Data...))
+	require.NotPanics(t, frame.PutBack)
+	require.NotPanics(t, f.PutBack)
 }
 
 func TestParseStreamFrameRejectsFramesExceedingRemainingSize(t *testing.T) {

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -154,6 +154,73 @@ func TestResetStreamAtTransportParameterCodepoints(t *testing.T) {
 	}
 }
 
+func TestTransportParametersDefaultMaxRecordSize(t *testing.T) {
+	data := (&TransportParameters{
+		StatelessResetToken:     &protocol.StatelessResetToken{},
+		ActiveConnectionIDLimit: protocol.DefaultActiveConnectionIDLimit,
+	}).Marshal(protocol.PerspectiveServer)
+	var p TransportParameters
+	require.NoError(t, p.Unmarshal(data, protocol.PerspectiveServer))
+	require.Equal(t, DefaultMaxRecordSize, p.MaxRecordSize)
+}
+
+func TestTransportParameterMaxRecordSizeQMuxMarshalOnly(t *testing.T) {
+	params := &TransportParameters{
+		StatelessResetToken:     &protocol.StatelessResetToken{},
+		ActiveConnectionIDLimit: protocol.DefaultActiveConnectionIDLimit,
+		MaxRecordSize:           DefaultMaxRecordSize + 42,
+	}
+	var p TransportParameters
+	require.NoError(t, p.Unmarshal(params.Marshal(protocol.PerspectiveServer), protocol.PerspectiveServer))
+	require.Equal(t, DefaultMaxRecordSize, p.MaxRecordSize)
+
+	p = TransportParameters{}
+	require.NoError(t, p.UnmarshalQMux(params.MarshalQMux()))
+	require.Equal(t, DefaultMaxRecordSize+42, p.MaxRecordSize)
+}
+
+func TestTransportParameterMaxRecordSizeIgnoredByQUICUnmarshal(t *testing.T) {
+	// RFC 9000, section 7.4.2: transport parameters an endpoint doesn't support must be
+	// ignored. max_record_size is only defined for QMux, so a regular QUIC connection
+	// treats it as an unknown transport parameter.
+	b := quicvarint.Append(nil, uint64(maxRecordSizeParameterID))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(uint64(DefaultMaxRecordSize+42))))
+	b = quicvarint.Append(b, uint64(DefaultMaxRecordSize+42))
+	data := appendInitialSourceConnectionID(b)
+
+	var p TransportParameters
+	require.NoError(t, p.Unmarshal(data, protocol.PerspectiveClient))
+	require.Equal(t, DefaultMaxRecordSize, p.MaxRecordSize)
+}
+
+func TestTransportParameterQMuxIgnoresExtensionParameters(t *testing.T) {
+	// Section 5.1 of draft-ietf-quic-qmux: only transport parameters defined in QUIC
+	// version 1 are prohibited. Extension transport parameters without a QMux mapping
+	// (like reset_stream_at and min_ack_delay) are ignored.
+	b := quicvarint.Append(nil, uint64(resetStreamAtParameterID))
+	b = quicvarint.Append(b, 0)
+	b = quicvarint.Append(b, uint64(minAckDelayParameterID))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(1000)))
+	b = quicvarint.Append(b, 1000)
+
+	var p TransportParameters
+	require.NoError(t, p.UnmarshalQMux(b))
+	require.False(t, p.EnableResetStreamAt)
+	require.Nil(t, p.MinAckDelay)
+}
+
+func TestTransportParameterQMuxMaxRecordSizeTooSmall(t *testing.T) {
+	b := quicvarint.Append(nil, uint64(maxRecordSizeParameterID))
+	b = quicvarint.Append(b, uint64(quicvarint.Len(uint64(DefaultMaxRecordSize-1))))
+	b = quicvarint.Append(b, uint64(DefaultMaxRecordSize-1))
+
+	err := (&TransportParameters{}).UnmarshalQMux(b)
+	require.Error(t, err)
+	transportErr, ok := err.(*qerr.TransportError)
+	require.True(t, ok)
+	require.Equal(t, qerr.TransportParameterError, transportErr.ErrorCode)
+	require.Equal(t, "invalid value for max_record_size: 16381 (minimum 16382)", transportErr.ErrorMessage)
+}
 func TestMarshalAdditionalTransportParameters(t *testing.T) {
 	origAdditionalTransportParametersClient := AdditionalTransportParametersClient
 	t.Cleanup(func() {

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -24,6 +24,8 @@ var AdditionalTransportParametersClient map[uint64][]byte
 
 const transportParameterMarshalingVersion = 1
 
+const DefaultMaxRecordSize protocol.ByteCount = 16382
+
 type transportParameterID uint64
 
 const (
@@ -46,6 +48,8 @@ const (
 	retrySourceConnectionIDParameterID         transportParameterID = 0x10
 	// RFC 9221
 	maxDatagramFrameSizeParameterID transportParameterID = 0x20
+	// https://datatracker.ietf.org/doc/draft-ietf-quic-qmux/01/
+	maxRecordSizeParameterID transportParameterID = 0x0571c59429cd0845
 	// https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/09/
 	resetStreamAtParameterID transportParameterID = 0x1d
 	// https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/07/
@@ -94,6 +98,7 @@ type TransportParameters struct {
 	MaxDatagramFrameSize protocol.ByteCount // RFC 9221
 	EnableResetStreamAt  bool               // https://datatracker.ietf.org/doc/draft-ietf-quic-reliable-stream-reset/09/
 	MinAckDelay          *time.Duration
+	MaxRecordSize        protocol.ByteCount // https://datatracker.ietf.org/doc/draft-ietf-quic-qmux/01/
 }
 
 // Unmarshal the transport parameters
@@ -102,6 +107,86 @@ func (p *TransportParameters) Unmarshal(data []byte, sentBy protocol.Perspective
 		return &qerr.TransportError{
 			ErrorCode:    qerr.TransportParameterError,
 			ErrorMessage: err.Error(),
+		}
+	}
+	return nil
+}
+
+func (p *TransportParameters) UnmarshalQMux(data []byte) error {
+	if err := p.unmarshalQMux(data); err != nil {
+		return &qerr.TransportError{
+			ErrorCode:    qerr.TransportParameterError,
+			ErrorMessage: err.Error(),
+		}
+	}
+	return nil
+}
+
+func (p *TransportParameters) unmarshalQMux(b []byte) error {
+	parameterIDs := make([]transportParameterID, 0, 16)
+	p.AckDelayExponent = protocol.DefaultAckDelayExponent
+	p.MaxAckDelay = protocol.DefaultMaxAckDelay
+	p.MaxDatagramFrameSize = protocol.InvalidByteCount
+	p.MaxRecordSize = DefaultMaxRecordSize
+
+	for len(b) > 0 {
+		paramIDInt, l, err := quicvarint.Parse(b)
+		if err != nil {
+			return err
+		}
+		paramID := transportParameterID(paramIDInt)
+		b = b[l:]
+		paramLen, l, err := quicvarint.Parse(b)
+		if err != nil {
+			return err
+		}
+		b = b[l:]
+		if uint64(len(b)) < paramLen {
+			return fmt.Errorf("remaining length (%d) smaller than parameter length (%d)", len(b), paramLen)
+		}
+		parameterIDs = append(parameterIDs, paramID)
+		switch paramID {
+		case maxIdleTimeoutParameterID,
+			initialMaxDataParameterID,
+			initialMaxStreamDataBidiLocalParameterID,
+			initialMaxStreamDataBidiRemoteParameterID,
+			initialMaxStreamDataUniParameterID,
+			initialMaxStreamsBidiParameterID,
+			initialMaxStreamsUniParameterID,
+			maxDatagramFrameSizeParameterID,
+			maxRecordSizeParameterID:
+			if err := p.readNumericTransportParameter(b, paramID, int(paramLen)); err != nil {
+				return err
+			}
+		// Section 5.1 of draft-ietf-quic-qmux: only transport parameters defined in
+		// QUIC version 1 are prohibited. Extension transport parameters (e.g.
+		// reset_stream_at, min_ack_delay) are ignored, unless they are specified to be
+		// usable on QMux.
+		case originalDestinationConnectionIDParameterID,
+			statelessResetTokenParameterID,
+			maxUDPPayloadSizeParameterID,
+			ackDelayExponentParameterID,
+			maxAckDelayParameterID,
+			disableActiveMigrationParameterID,
+			preferredAddressParameterID,
+			activeConnectionIDLimitParameterID,
+			initialSourceConnectionIDParameterID,
+			retrySourceConnectionIDParameterID:
+			return fmt.Errorf("transport parameter %#x is prohibited by QMux", paramID)
+		default:
+		}
+		b = b[paramLen:]
+	}
+
+	slices.SortFunc(parameterIDs, func(a, b transportParameterID) int {
+		if a < b {
+			return -1
+		}
+		return 1
+	})
+	for i := 0; i < len(parameterIDs)-1; i++ {
+		if parameterIDs[i] == parameterIDs[i+1] {
+			return fmt.Errorf("received duplicate transport parameter %#x", parameterIDs[i])
 		}
 	}
 	return nil
@@ -120,6 +205,7 @@ func (p *TransportParameters) unmarshal(b []byte, sentBy protocol.Perspective, f
 	p.MaxAckDelay = protocol.DefaultMaxAckDelay
 	p.MaxDatagramFrameSize = protocol.InvalidByteCount
 	p.ActiveConnectionIDLimit = protocol.DefaultActiveConnectionIDLimit
+	p.MaxRecordSize = DefaultMaxRecordSize
 
 	for len(b) > 0 {
 		paramIDInt, l, err := quicvarint.Parse(b)
@@ -348,6 +434,11 @@ func (p *TransportParameters) readNumericTransportParameter(b []byte, paramID tr
 			mad = math.MaxInt64
 		}
 		p.MinAckDelay = &mad
+	case maxRecordSizeParameterID:
+		if val < uint64(DefaultMaxRecordSize) {
+			return fmt.Errorf("invalid value for max_record_size: %d (minimum %d)", val, DefaultMaxRecordSize)
+		}
+		p.MaxRecordSize = protocol.ByteCount(val)
 	default:
 		return fmt.Errorf("TransportParameter BUG: transport parameter %d not found", paramID)
 	}
@@ -474,6 +565,24 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 	return b
 }
 
+func (p *TransportParameters) MarshalQMux() []byte {
+	b := make([]byte, 0, 128)
+	b = p.marshalVarintParam(b, initialMaxStreamDataBidiLocalParameterID, uint64(p.InitialMaxStreamDataBidiLocal))
+	b = p.marshalVarintParam(b, initialMaxStreamDataBidiRemoteParameterID, uint64(p.InitialMaxStreamDataBidiRemote))
+	b = p.marshalVarintParam(b, initialMaxStreamDataUniParameterID, uint64(p.InitialMaxStreamDataUni))
+	b = p.marshalVarintParam(b, initialMaxDataParameterID, uint64(p.InitialMaxData))
+	b = p.marshalVarintParam(b, initialMaxStreamsBidiParameterID, uint64(p.MaxBidiStreamNum))
+	b = p.marshalVarintParam(b, initialMaxStreamsUniParameterID, uint64(p.MaxUniStreamNum))
+	b = p.marshalVarintParam(b, maxIdleTimeoutParameterID, uint64(p.MaxIdleTimeout/time.Millisecond))
+	if p.MaxDatagramFrameSize != protocol.InvalidByteCount {
+		b = p.marshalVarintParam(b, maxDatagramFrameSizeParameterID, uint64(p.MaxDatagramFrameSize))
+	}
+	if p.MaxRecordSize != 0 && p.MaxRecordSize != DefaultMaxRecordSize {
+		b = p.marshalVarintParam(b, maxRecordSizeParameterID, uint64(p.MaxRecordSize))
+	}
+	return b
+}
+
 func (p *TransportParameters) marshalVarintParam(b []byte, id transportParameterID, val uint64) []byte {
 	b = quicvarint.Append(b, uint64(id))
 	b = quicvarint.Append(b, uint64(quicvarint.Len(val)))
@@ -587,6 +696,10 @@ func (p *TransportParameters) String() string {
 	if p.MinAckDelay != nil {
 		logString += ", MinAckDelay: %s"
 		logParams = append(logParams, *p.MinAckDelay)
+	}
+	if p.MaxRecordSize != 0 && p.MaxRecordSize != DefaultMaxRecordSize {
+		logString += ", MaxRecordSize: %d"
+		logParams = append(logParams, p.MaxRecordSize)
 	}
 	logString += "}"
 	return fmt.Sprintf(logString, logParams...)

--- a/qmux.go
+++ b/qmux.go
@@ -132,7 +132,7 @@ func newQMuxConnection(ctx context.Context, conn net.Conn, perspective protocol.
 		c.queueControlFrame,
 		zeroLengthConnectionIDGenerator{},
 	)
-	c.packer = &qmuxPacker{state: state, framer: c.framer}
+	c.packer = &qmuxPacker{state: state, framer: c.framer, datagramQueue: c.datagramQueue}
 	c.peerParams = peerParams
 	c.applyTransportParameters()
 	close(c.handshakeCompleteChan)
@@ -172,6 +172,15 @@ func effectiveQMuxMaxRecordSize(peerMaxRecordSize protocol.ByteCount) protocol.B
 	return min(peerMaxRecordSize, maxSize)
 }
 
+// maxDatagramPayloadSize returns the largest DATAGRAM frame payload that is guaranteed to fit
+// into a record: the effective record size minus the frame's type byte and the worst-case
+// length encoding. Using this as the payload size estimate ensures that any datagram accepted
+// by SendDatagram can actually be packed (QMux runs over a reliable transport, so a datagram
+// that can never be sent would otherwise be dropped silently).
+func (s *qmuxState) maxDatagramPayloadSize() protocol.ByteCount {
+	return s.maxRecordSize - 1 /* frame type */ - protocol.ByteCount(quicvarint.Len(uint64(s.maxRecordSize)))
+}
+
 func newQMuxTransportParameters(conf *Config) *wire.TransportParameters {
 	params := &wire.TransportParameters{
 		InitialMaxStreamDataBidiLocal:  protocol.ByteCount(conf.InitialStreamReceiveWindow),
@@ -183,6 +192,9 @@ func newQMuxTransportParameters(conf *Config) *wire.TransportParameters {
 		MaxUniStreamNum:                protocol.StreamNum(conf.MaxIncomingUniStreams),
 		MaxDatagramFrameSize:           protocol.InvalidByteCount,
 		MaxRecordSize:                  wire.DefaultMaxRecordSize,
+	}
+	if conf.EnableDatagrams {
+		params.MaxDatagramFrameSize = wire.MaxDatagramSize
 	}
 	return params
 }

--- a/qmux.go
+++ b/qmux.go
@@ -1,0 +1,365 @@
+package quic
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/monotime"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/qerr"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+// DialQMux establishes a QMux connection over conn and returns it as a regular quic-go Conn.
+func DialQMux(ctx context.Context, conn net.Conn, tlsConf *tls.Config, conf *Config) (*Conn, error) {
+	if tlsConf == nil {
+		return nil, errors.New("quic: tls.Config not set")
+	}
+	if err := validateConfig(conf); err != nil {
+		return nil, err
+	}
+	tlsConn := tls.Client(conn, tlsConf.Clone())
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if err := checkQMuxALPN(tlsConf, tlsConn.ConnectionState()); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return newQMuxConnection(ctx, tlsConn, protocol.PerspectiveClient, tlsConn.ConnectionState(), populateConfig(conf))
+}
+
+// AcceptQMux accepts a QMux connection over conn and returns it as a regular quic-go Conn.
+func AcceptQMux(ctx context.Context, conn net.Conn, tlsConf *tls.Config, conf *Config) (*Conn, error) {
+	if tlsConf == nil {
+		return nil, errors.New("quic: tls.Config not set")
+	}
+	if err := validateConfig(conf); err != nil {
+		return nil, err
+	}
+	tlsConn := tls.Server(conn, tlsConf.Clone())
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if err := checkQMuxALPN(tlsConf, tlsConn.ConnectionState()); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return newQMuxConnection(ctx, tlsConn, protocol.PerspectiveServer, tlsConn.ConnectionState(), populateConfig(conf))
+}
+
+// checkQMuxALPN enforces that an application protocol was negotiated via ALPN.
+// As required by Section 8.1 of draft-ietf-quic-qmux, both clients and servers MUST abort
+// when ALPN negotiation fails. Enforcement only applies when the endpoint configured ALPN
+// identifiers; otherwise an out-of-band mechanism for agreeing on the application protocol is assumed.
+//
+// Deviation from Section 8.1: the draft asks for a no_application_protocol TLS alert when
+// aborting. crypto/tls sends this alert itself in most failure cases (e.g. no protocol overlap),
+// but doesn't allow sending alerts after the handshake completed, so the case caught here
+// (the peer didn't negotiate ALPN at all) closes the connection without an alert.
+func checkQMuxALPN(tlsConf *tls.Config, state tls.ConnectionState) error {
+	if len(tlsConf.NextProtos) > 0 && state.NegotiatedProtocol == "" {
+		return errors.New("quic: ALPN application protocol not negotiated")
+	}
+	return nil
+}
+
+func newQMuxConnection(ctx context.Context, conn net.Conn, perspective protocol.Perspective, tlsState tls.ConnectionState, conf *Config) (*Conn, error) {
+	localParams := newQMuxTransportParameters(conf)
+	peerParams, leftover, err := exchangeQMuxTransportParameters(ctx, conn, localParams)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	// The ctx passed to DialQMux / AcceptQMux only bounds connection setup.
+	// It must not cancel the established connection (cf. Transport.dial).
+	ctx, ctxCancel := context.WithCancelCause(context.WithoutCancel(ctx))
+	state := &qmuxState{
+		maxRecordSize:                effectiveQMuxMaxRecordSize(peerParams.MaxRecordSize),
+		recordQueueSpace:             make(chan struct{}, 1),
+		writtenFrameBatchesAvailable: make(chan struct{}, 1),
+	}
+	qconn := &qmuxSendConn{conn: conn}
+	c := &Conn{
+		ctx:                 ctx,
+		ctxCancel:           ctxCancel,
+		conn:                qconn,
+		config:              conf,
+		perspective:         perspective,
+		logger:              utils.DefaultLogger,
+		version:             protocol.Version1,
+		qmux:                state,
+		handshakeComplete:   true,
+		handshakeConfirmed:  true,
+		sentFirstPacket:     true,
+		versionNegotiated:   true,
+		receivedFirstPacket: true,
+	}
+	c.logID = fmt.Sprintf("qmux-%s", conn.RemoteAddr())
+	if conf.Tracer != nil {
+		c.qlogTrace = conf.Tracer(ctx, perspective == protocol.PerspectiveClient, protocol.ConnectionID{})
+		if c.qlogTrace != nil {
+			c.qlogger = c.qlogTrace.AddProducer()
+		}
+	}
+	c.preSetup()
+	c.sendQueue = newQMuxSender(qconn, state)
+	c.cryptoStreamHandler = newQMuxCryptoStreamHandler(tlsState)
+	c.cryptoStreamManager = newCryptoStreamManager(c.initialStream, c.handshakeStream, newCryptoStream())
+	c.sentPacketHandler = &qmuxSentPacketHandler{connStats: &c.connStats}
+	runner := noopConnRunner{}
+	c.connIDManager = newConnIDManager(protocol.ConnectionID{}, func(protocol.StatelessResetToken) {}, func(protocol.StatelessResetToken) {}, c.queueControlFrame)
+	c.connIDManager.SetHandshakeComplete()
+	c.connIDGenerator = newConnIDGenerator(
+		runner,
+		protocol.ConnectionID{},
+		nil,
+		nil,
+		connRunnerCallbacks{
+			AddConnectionID:    func(protocol.ConnectionID) {},
+			RemoveConnectionID: func(protocol.ConnectionID) {},
+			ReplaceWithClosed:  func([]protocol.ConnectionID, []byte, time.Duration) {},
+		},
+		c.queueControlFrame,
+		zeroLengthConnectionIDGenerator{},
+	)
+	c.packer = &qmuxPacker{state: state, framer: c.framer}
+	c.peerParams = peerParams
+	c.applyTransportParameters()
+	close(c.handshakeCompleteChan)
+	close(c.earlyConnReadyChan)
+
+	// Process any frames the peer coalesced after QX_TRANSPORT_PARAMETERS in the first record.
+	if len(leftover) > 0 {
+		buf := getLargePacketBuffer()
+		buf.Data = append(buf.Data[:0], leftover...)
+		c.queueQMuxRecord(receivedPacket{
+			buffer:     buf,
+			remoteAddr: conn.RemoteAddr(),
+			rcvTime:    monotime.Now(),
+			data:       buf.Data,
+			ecn:        protocol.ECNUnsupported,
+		})
+	}
+
+	go readQMuxRecords(c, conn, localParams.MaxRecordSize)
+	go func() {
+		c.run()
+		// QMux owns the underlying transport for this connection. Close it once the run loop
+		// exits so the transport is released immediately (Section 7) and the readQMuxRecords
+		// goroutine, blocked on conn.Read, unblocks.
+		conn.Close()
+	}()
+	return c, nil
+}
+
+func effectiveQMuxMaxRecordSize(peerMaxRecordSize protocol.ByteCount) protocol.ByteCount {
+	// A QMux record consists of the Size prefix followed by the Frames payload.
+	// We pack records into a large packet buffer, so the prefix and the payload combined
+	// must fit into protocol.MaxLargePacketBufferSize. Reserve space for the Size prefix,
+	// which is encoded as a variable-length integer sized for the maximum record size.
+	maxSize := protocol.ByteCount(protocol.MaxLargePacketBufferSize)
+	maxSize -= protocol.ByteCount(quicvarint.Len(uint64(maxSize)))
+	return min(peerMaxRecordSize, maxSize)
+}
+
+func newQMuxTransportParameters(conf *Config) *wire.TransportParameters {
+	params := &wire.TransportParameters{
+		InitialMaxStreamDataBidiLocal:  protocol.ByteCount(conf.InitialStreamReceiveWindow),
+		InitialMaxStreamDataBidiRemote: protocol.ByteCount(conf.InitialStreamReceiveWindow),
+		InitialMaxStreamDataUni:        protocol.ByteCount(conf.InitialStreamReceiveWindow),
+		InitialMaxData:                 protocol.ByteCount(conf.InitialConnectionReceiveWindow),
+		MaxIdleTimeout:                 conf.MaxIdleTimeout,
+		MaxBidiStreamNum:               protocol.StreamNum(conf.MaxIncomingStreams),
+		MaxUniStreamNum:                protocol.StreamNum(conf.MaxIncomingUniStreams),
+		MaxDatagramFrameSize:           protocol.InvalidByteCount,
+		MaxRecordSize:                  wire.DefaultMaxRecordSize,
+	}
+	return params
+}
+
+// exchangeQMuxTransportParameters sends the local QX_TRANSPORT_PARAMETERS frame and reads the
+// peer's first record, which must start with a QX_TRANSPORT_PARAMETERS frame. Any frames the peer
+// coalesced after it in the same record are returned so they can be processed by the connection.
+// If a QMux protocol violation is detected, a CONNECTION_CLOSE frame conveying the error is sent
+// to the peer before returning.
+func exchangeQMuxTransportParameters(ctx context.Context, conn net.Conn, local *wire.TransportParameters) (*wire.TransportParameters, []byte, error) {
+	params, leftover, err := negotiateQMuxTransportParameters(ctx, conn, local)
+	if err != nil {
+		// A typed transport error means we detected a protocol violation after our own
+		// transport parameters were written, so it is safe to send a CONNECTION_CLOSE.
+		var transportErr *qerr.TransportError
+		if errors.As(err, &transportErr) {
+			writeQMuxConnectionClose(conn, transportErr)
+		}
+	}
+	return params, leftover, err
+}
+
+// writeQMuxConnectionClose sends a CONNECTION_CLOSE frame conveying transportErr to the peer.
+// It is best-effort and uses a short write deadline so a non-reading peer can't block teardown.
+func writeQMuxConnectionClose(conn net.Conn, transportErr *qerr.TransportError) {
+	ccf := &wire.ConnectionCloseFrame{
+		ErrorCode:    uint64(transportErr.ErrorCode),
+		FrameType:    transportErr.FrameType,
+		ReasonPhrase: transportErr.ErrorMessage,
+	}
+	payload, err := ccf.Append(nil, protocol.Version1)
+	if err != nil {
+		return
+	}
+	record, err := appendQMuxRecord(nil, payload, wire.DefaultMaxRecordSize)
+	if err != nil {
+		return
+	}
+	_ = conn.SetWriteDeadline(time.Now().Add(time.Second))
+	_, _ = conn.Write(record)
+}
+
+func negotiateQMuxTransportParameters(ctx context.Context, conn net.Conn, local *wire.TransportParameters) (params *wire.TransportParameters, leftover []byte, retErr error) {
+	deadlineSet := make(chan struct{})
+	stopCancellation := context.AfterFunc(ctx, func() {
+		_ = conn.SetDeadline(time.Now())
+		close(deadlineSet)
+	})
+	exchangeSucceeded := false
+	defer func() {
+		// If cancellation raced with completion, wait for the watcher before clearing its
+		// deadline. This prevents a late callback from poisoning an established connection.
+		if !stopCancellation() {
+			<-deadlineSet
+		}
+		if exchangeSucceeded {
+			if err := conn.SetDeadline(time.Time{}); retErr == nil && err != nil {
+				retErr = err
+			}
+		}
+	}()
+
+	localFrame := &wire.QXTransportParametersFrame{TransportParameters: local.MarshalQMux()}
+	payload, err := localFrame.Append(nil, protocol.Version1)
+	if err != nil {
+		return nil, nil, err
+	}
+	record, err := appendQMuxRecord(nil, payload, wire.DefaultMaxRecordSize)
+	if err != nil {
+		return nil, nil, err
+	}
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := conn.Write(record)
+		writeErr <- err
+	}()
+
+	peerRecord, err := readQMuxRecord(conn, local.MaxRecordSize, make([]byte, 0, int(local.MaxRecordSize)))
+	if err != nil {
+		// Unblock and join the concurrent write before returning. In particular, this keeps
+		// cancellation and an unresponsive peer from leaking the writer goroutine.
+		_ = conn.SetDeadline(time.Now())
+		<-writeErr
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, nil, ctxErr
+		}
+		return nil, nil, err
+	}
+	if err := <-writeErr; err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, nil, ctxErr
+		}
+		return nil, nil, err
+	}
+	parser := wire.NewFrameParser(false, false, false)
+	parser.SetSupportsQMux(true)
+	frameType, l, err := parser.ParseType(peerRecord, protocol.Encryption1RTT)
+	if err != nil {
+		return nil, nil, err
+	}
+	if frameType != wire.FrameTypeQXTransportParametersFrame {
+		// Section 4.2: if the first frame received is not a QX_TRANSPORT_PARAMETERS frame,
+		// the endpoint MUST close the connection with a TRANSPORT_PARAMETER_ERROR.
+		return nil, nil, &qerr.TransportError{
+			ErrorCode:    qerr.TransportParameterError,
+			ErrorMessage: fmt.Sprintf("expected QX_TRANSPORT_PARAMETERS as the first frame, got %#x", frameType),
+		}
+	}
+	frame, n, err := parser.ParseLessCommonFrame(frameType, peerRecord[l:], protocol.Version1)
+	if err != nil {
+		return nil, nil, err
+	}
+	params = &wire.TransportParameters{}
+	if err := params.UnmarshalQMux(frame.(*wire.QXTransportParametersFrame).TransportParameters); err != nil {
+		return nil, nil, err
+	}
+	// The peer is allowed to coalesce additional frames after QX_TRANSPORT_PARAMETERS in the
+	// first record (e.g. to start sending stream data immediately). Return them for processing.
+	if rest := peerRecord[l+n:]; len(rest) > 0 {
+		leftover = append(leftover, rest...)
+	}
+	exchangeSucceeded = true
+	return params, leftover, nil
+}
+
+func readQMuxRecords(c *Conn, conn net.Conn, maxRecordSize protocol.ByteCount) {
+	for {
+		// Records can't be dropped: the transport is reliable and ordered. Instead, apply
+		// backpressure by pausing reads while the connection's receive queue is full, so a
+		// peer flooding cheap frames can't grow the queue without bound (Section 12 of
+		// draft-ietf-quic-qmux). The transport's flow control then throttles the peer.
+		for c.queuedQMuxRecordCount() >= protocol.MaxConnUnprocessedPackets {
+			select {
+			case <-c.qmux.recordQueueSpace:
+			case <-c.ctx.Done():
+				return
+			}
+		}
+		buf := getLargePacketBuffer()
+		record, err := readQMuxRecord(conn, maxRecordSize, buf.Data)
+		if err != nil {
+			buf.Release()
+			// Protocol violations detected at the record layer (e.g. a record exceeding
+			// max_record_size) must be conveyed to the peer with a CONNECTION_CLOSE frame.
+			// Transport-level read errors (EOF, closed connection) tear down immediately.
+			var transportErr *qerr.TransportError
+			if errors.As(err, &transportErr) {
+				c.closeLocal(err)
+			} else {
+				c.destroyImpl(err)
+			}
+			return
+		}
+		buf.Data = record
+		c.queueQMuxRecord(receivedPacket{
+			buffer:     buf,
+			remoteAddr: conn.RemoteAddr(),
+			rcvTime:    monotime.Now(),
+			data:       buf.Data,
+			ecn:        protocol.ECNUnsupported,
+		})
+	}
+}
+
+type noopConnRunner struct{}
+
+func (noopConnRunner) Add(protocol.ConnectionID, packetHandler) bool { return true }
+func (noopConnRunner) Remove(protocol.ConnectionID)                  {}
+func (noopConnRunner) ReplaceWithClosed([]protocol.ConnectionID, []byte, time.Duration) {
+}
+func (noopConnRunner) AddResetToken(protocol.StatelessResetToken, packetHandler) {}
+func (noopConnRunner) RemoveResetToken(protocol.StatelessResetToken)             {}
+
+type zeroLengthConnectionIDGenerator struct{}
+
+func (zeroLengthConnectionIDGenerator) GenerateConnectionID() (protocol.ConnectionID, error) {
+	return protocol.ConnectionID{}, nil
+}
+
+func (zeroLengthConnectionIDGenerator) ConnectionIDLen() int { return 0 }

--- a/qmux_ackhandler.go
+++ b/qmux_ackhandler.go
@@ -1,0 +1,77 @@
+package quic
+
+import (
+	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/monotime"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/internal/wire"
+)
+
+type qmuxSentPacketHandler struct {
+	connStats *utils.ConnectionStats
+}
+
+var _ ackhandler.SentPacketHandler = &qmuxSentPacketHandler{}
+
+func (h *qmuxSentPacketHandler) SentPacket(
+	_ monotime.Time,
+	_, _ protocol.PacketNumber,
+	_ []ackhandler.StreamFrame,
+	_ []ackhandler.Frame,
+	_ protocol.EncryptionLevel,
+	_ protocol.ECN,
+	size protocol.ByteCount,
+	_, _ bool,
+) {
+	if h.connStats != nil {
+		h.connStats.BytesSent.Add(uint64(size))
+		h.connStats.PacketsSent.Add(1)
+	}
+}
+
+func (h *qmuxSentPacketHandler) ReceivedAck(*wire.AckFrame, protocol.EncryptionLevel, monotime.Time) (bool, error) {
+	return false, nil
+}
+
+func (h *qmuxSentPacketHandler) ReceivedPacket(protocol.EncryptionLevel, monotime.Time) {
+	if h.connStats != nil {
+		h.connStats.PacketsReceived.Add(1)
+	}
+}
+
+func (h *qmuxSentPacketHandler) ReceivedBytes(size protocol.ByteCount, _ monotime.Time) {
+	if h.connStats != nil {
+		h.connStats.BytesReceived.Add(uint64(size))
+	}
+}
+
+func (h *qmuxSentPacketHandler) DropPackets(protocol.EncryptionLevel, monotime.Time) {}
+
+func (h *qmuxSentPacketHandler) ResetForRetry(monotime.Time) {}
+
+func (h *qmuxSentPacketHandler) SendMode(monotime.Time) ackhandler.SendMode {
+	return ackhandler.SendAny
+}
+
+func (h *qmuxSentPacketHandler) TimeUntilSend() monotime.Time { return 0 }
+
+func (h *qmuxSentPacketHandler) SetMaxDatagramSize(protocol.ByteCount) {}
+
+func (h *qmuxSentPacketHandler) QueueProbePacket(protocol.EncryptionLevel) bool { return false }
+
+func (h *qmuxSentPacketHandler) ECNMode(bool) protocol.ECN { return protocol.ECNUnsupported }
+
+func (h *qmuxSentPacketHandler) PeekPacketNumber(protocol.EncryptionLevel) (protocol.PacketNumber, protocol.PacketNumberLen) {
+	return 0, protocol.PacketNumberLen1
+}
+
+func (h *qmuxSentPacketHandler) PopPacketNumber(protocol.EncryptionLevel) protocol.PacketNumber {
+	return 0
+}
+
+func (h *qmuxSentPacketHandler) GetLossDetectionTimeout() monotime.Time { return 0 }
+
+func (h *qmuxSentPacketHandler) OnLossDetectionTimeout(monotime.Time) error { return nil }
+
+func (h *qmuxSentPacketHandler) MigratedPath(monotime.Time, protocol.ByteCount) {}

--- a/qmux_crypto.go
+++ b/qmux_crypto.go
@@ -1,0 +1,41 @@
+package quic
+
+import (
+	"context"
+	"crypto/tls"
+
+	"github.com/quic-go/quic-go/internal/handshake"
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+type qmuxCryptoStreamHandler struct {
+	state handshake.ConnectionState
+}
+
+var _ cryptoStreamHandler = &qmuxCryptoStreamHandler{}
+
+func newQMuxCryptoStreamHandler(cs tls.ConnectionState) *qmuxCryptoStreamHandler {
+	return &qmuxCryptoStreamHandler{state: handshake.ConnectionState{ConnectionState: cs}}
+}
+
+func (h *qmuxCryptoStreamHandler) StartHandshake(context.Context) error { return nil }
+
+func (h *qmuxCryptoStreamHandler) ChangeConnectionID(protocol.ConnectionID) {}
+
+func (h *qmuxCryptoStreamHandler) SetLargest1RTTAcked(protocol.PacketNumber) error { return nil }
+
+func (h *qmuxCryptoStreamHandler) SetHandshakeConfirmed() {}
+
+func (h *qmuxCryptoStreamHandler) GetSessionTicket() ([]byte, error) { return nil, nil }
+
+func (h *qmuxCryptoStreamHandler) NextEvent() handshake.Event {
+	return handshake.Event{Kind: handshake.EventNoEvent}
+}
+
+func (h *qmuxCryptoStreamHandler) DiscardInitialKeys() {}
+
+func (h *qmuxCryptoStreamHandler) HandleMessage([]byte, protocol.EncryptionLevel) error { return nil }
+
+func (h *qmuxCryptoStreamHandler) Close() error { return nil }
+
+func (h *qmuxCryptoStreamHandler) ConnectionState() handshake.ConnectionState { return h.state }

--- a/qmux_packer.go
+++ b/qmux_packer.go
@@ -9,8 +9,9 @@ import (
 )
 
 type qmuxPacker struct {
-	state  *qmuxState
-	framer *framer
+	state         *qmuxState
+	framer        *framer
+	datagramQueue *datagramQueue
 }
 
 var _ packer = &qmuxPacker{}
@@ -38,6 +39,26 @@ func (p *qmuxPacker) AppendPacket(buf *packetBuffer, maxSize protocol.ByteCount,
 		buf.Data, err = f.Append(buf.Data, v)
 		if err != nil {
 			return shortHeaderPacket{}, err
+		}
+	}
+
+	if p.datagramQueue != nil {
+		if f := p.datagramQueue.Peek(); f != nil {
+			// Pack DATAGRAM before STREAM frames. A final STREAM frame can omit its length and then consumes
+			// the rest of the record by definition.
+			payloadLen := protocol.ByteCount(len(buf.Data) - recordStart - prefixLen)
+			if payloadLen+f.Length(v) <= maxRecordSize {
+				frames = append(frames, ackhandler.Frame{Frame: f})
+				var err error
+				buf.Data, err = f.Append(buf.Data, v)
+				if err != nil {
+					return shortHeaderPacket{}, err
+				}
+				p.datagramQueue.Pop()
+			} else if payloadLen == 0 {
+				// This should not happen, since SendDatagram checks that the DATAGRAM fits before admitting it to the queue.
+				p.datagramQueue.Pop()
+			}
 		}
 	}
 

--- a/qmux_packer.go
+++ b/qmux_packer.go
@@ -1,0 +1,132 @@
+package quic
+
+import (
+	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/monotime"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/qerr"
+	"github.com/quic-go/quic-go/internal/wire"
+)
+
+type qmuxPacker struct {
+	state  *qmuxState
+	framer *framer
+}
+
+var _ packer = &qmuxPacker{}
+
+func (p *qmuxPacker) PackCoalescedPacket(bool, protocol.ByteCount, monotime.Time, protocol.Version) (*coalescedPacket, error) {
+	return nil, nil
+}
+
+func (p *qmuxPacker) PackAckOnlyPacket(protocol.ByteCount, monotime.Time, protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+	return shortHeaderPacket{}, nil, errNothingToPack
+}
+
+func (p *qmuxPacker) AppendPacket(buf *packetBuffer, maxSize protocol.ByteCount, now monotime.Time, v protocol.Version) (shortHeaderPacket, error) {
+	maxRecordSize := min(p.state.maxRecordSize, maxSize)
+	var frames []ackhandler.Frame
+	var streamFrames []ackhandler.StreamFrame
+	startLen := buf.Len()
+	var recordStart, prefixLen int
+	buf.Data, recordStart, prefixLen = appendQMuxRecordPrefix(buf.Data, maxRecordSize)
+
+	if seq, ok := p.state.popPingResponse(); ok {
+		f := &wire.QXPingFrame{SequenceNumber: seq, IsResponse: true}
+		frames = append(frames, ackhandler.Frame{Frame: f})
+		var err error
+		buf.Data, err = f.Append(buf.Data, v)
+		if err != nil {
+			return shortHeaderPacket{}, err
+		}
+	}
+
+	if p.framer.HasData() {
+		payloadLen := protocol.ByteCount(len(buf.Data) - recordStart - prefixLen)
+		remaining := maxRecordSize - payloadLen
+		startLen := len(frames)
+		frames, streamFrames, _ = p.framer.Append(frames, streamFrames, remaining, now, v)
+		for _, f := range frames[startLen:] {
+			var err error
+			buf.Data, err = f.Frame.Append(buf.Data, v)
+			if err != nil {
+				return shortHeaderPacket{}, err
+			}
+		}
+		for _, sf := range streamFrames {
+			var err error
+			buf.Data, err = sf.Frame.Append(buf.Data, v)
+			if err != nil {
+				return shortHeaderPacket{}, err
+			}
+		}
+	}
+
+	data, err := finishQMuxRecord(buf.Data, recordStart, maxRecordSize)
+	if err != nil {
+		return shortHeaderPacket{}, err
+	}
+	buf.Data = data
+	return shortHeaderPacket{
+		PacketNumber:      0,
+		PacketNumberLen:   protocol.PacketNumberLen1,
+		Frames:            frames,
+		StreamFrames:      streamFrames,
+		Length:            buf.Len() - startLen,
+		DestConnID:        protocol.ConnectionID{},
+		KeyPhase:          protocol.KeyPhaseZero,
+		IsPathProbePacket: false,
+	}, nil
+}
+
+func (p *qmuxPacker) PackPTOProbePacket(protocol.EncryptionLevel, protocol.ByteCount, bool, monotime.Time, protocol.Version) (*coalescedPacket, error) {
+	return nil, nil
+}
+
+func (p *qmuxPacker) PackConnectionClose(e *qerr.TransportError, _ protocol.ByteCount, v protocol.Version) (*coalescedPacket, error) {
+	return p.packClose(&wire.ConnectionCloseFrame{
+		ErrorCode:    uint64(e.ErrorCode),
+		FrameType:    e.FrameType,
+		ReasonPhrase: e.ErrorMessage,
+	}, v)
+}
+
+func (p *qmuxPacker) PackApplicationClose(e *qerr.ApplicationError, _ protocol.ByteCount, v protocol.Version) (*coalescedPacket, error) {
+	return p.packClose(&wire.ConnectionCloseFrame{
+		IsApplicationError: true,
+		ErrorCode:          uint64(e.ErrorCode),
+		ReasonPhrase:       e.ErrorMessage,
+	}, v)
+}
+
+func (p *qmuxPacker) packClose(f *wire.ConnectionCloseFrame, v protocol.Version) (*coalescedPacket, error) {
+	payload, err := f.Append(nil, v)
+	if err != nil {
+		return nil, err
+	}
+	buf := getPacketBuffer()
+	buf.Data, err = appendQMuxRecord(buf.Data, payload, p.state.maxRecordSize)
+	if err != nil {
+		buf.Release()
+		return nil, err
+	}
+	return &coalescedPacket{
+		buffer: buf,
+		shortHdrPacket: &shortHeaderPacket{
+			PacketNumber:    0,
+			PacketNumberLen: protocol.PacketNumberLen1,
+			Frames:          []ackhandler.Frame{{Frame: f}},
+			Length:          buf.Len(),
+		},
+	}, nil
+}
+
+func (p *qmuxPacker) PackPathProbePacket(protocol.ConnectionID, []ackhandler.Frame, protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+	return shortHeaderPacket{}, nil, errNothingToPack
+}
+
+func (p *qmuxPacker) PackMTUProbePacket(ackhandler.Frame, protocol.ByteCount, protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+	return shortHeaderPacket{}, nil, errNothingToPack
+}
+
+func (p *qmuxPacker) SetToken([]byte) {}

--- a/qmux_record.go
+++ b/qmux_record.go
@@ -1,0 +1,71 @@
+package quic
+
+import (
+	"fmt"
+	"io"
+	"slices"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/qerr"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+func appendQMuxRecord(b, frames []byte, maxRecordSize protocol.ByteCount) ([]byte, error) {
+	if len(frames) == 0 {
+		return nil, errNothingToPack
+	}
+	if protocol.ByteCount(len(frames)) > maxRecordSize {
+		return nil, fmt.Errorf("qmux record size %d exceeds peer max_record_size %d", len(frames), maxRecordSize)
+	}
+	b = quicvarint.Append(b, uint64(len(frames)))
+	return append(b, frames...), nil
+}
+
+func appendQMuxRecordPrefix(b []byte, maxRecordSize protocol.ByteCount) ([]byte, int, int) {
+	recordStart := len(b)
+	prefixLen := quicvarint.Len(uint64(maxRecordSize))
+	return slices.Grow(b, prefixLen)[:recordStart+prefixLen], recordStart, prefixLen
+}
+
+func finishQMuxRecord(b []byte, recordStart int, maxRecordSize protocol.ByteCount) ([]byte, error) {
+	prefixLen := quicvarint.Len(uint64(maxRecordSize))
+	payloadStart := recordStart + prefixLen
+	payloadLen := len(b) - payloadStart
+	if payloadLen == 0 {
+		return b[:recordStart], errNothingToPack
+	}
+	if protocol.ByteCount(payloadLen) > maxRecordSize {
+		return nil, fmt.Errorf("qmux record size %d exceeds peer max_record_size %d", payloadLen, maxRecordSize)
+	}
+	quicvarint.AppendWithLen(b[recordStart:recordStart], uint64(payloadLen), prefixLen)
+	return b, nil
+}
+
+func readQMuxRecord(r io.Reader, maxRecordSize protocol.ByteCount, b []byte) ([]byte, error) {
+	if protocol.ByteCount(cap(b)) < maxRecordSize {
+		return nil, fmt.Errorf("qmux read buffer capacity %d is smaller than max_record_size %d", cap(b), maxRecordSize)
+	}
+	qr := quicvarint.NewReader(r)
+	size, err := quicvarint.Read(qr)
+	if err != nil {
+		return nil, err
+	}
+	// Section 5.2 of draft-ietf-quic-qmux: records exceeding the declared maximum MUST be
+	// treated as a connection error of type FRAME_ENCODING_ERROR.
+	if protocol.ByteCount(size) > maxRecordSize {
+		return nil, &qerr.TransportError{
+			ErrorCode:    qerr.FrameEncodingError,
+			ErrorMessage: fmt.Sprintf("qmux record size %d exceeds max_record_size %d", size, maxRecordSize),
+		}
+	}
+	// Section 3.2: the Frames field contains one or more QUIC frames, so an empty record is malformed.
+	if size == 0 {
+		return nil, &qerr.TransportError{
+			ErrorCode:    qerr.FrameEncodingError,
+			ErrorMessage: "qmux record must contain at least one frame",
+		}
+	}
+	b = b[:int(size)]
+	_, err = io.ReadFull(qr, b)
+	return b, err
+}

--- a/qmux_send_conn.go
+++ b/qmux_send_conn.go
@@ -1,0 +1,44 @@
+package quic
+
+import (
+	"io"
+	"net"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+type qmuxSendConn struct {
+	conn net.Conn
+}
+
+var _ sendConn = &qmuxSendConn{}
+
+func (c *qmuxSendConn) Write(b []byte, _ uint16, _ protocol.ECN) error {
+	n, err := c.conn.Write(b)
+	if err != nil {
+		return err
+	}
+	if n != len(b) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func (c *qmuxSendConn) WriteTo(b []byte, _ net.Addr, _ packetInfo) error {
+	return c.Write(b, 0, protocol.ECNUnsupported)
+}
+
+func (c *qmuxSendConn) Close() error { return c.conn.Close() }
+
+// setWriteDeadline bounds writes to the underlying transport. It is used during connection
+// teardown, so that a peer that stopped reading can't block closing indefinitely.
+func (c *qmuxSendConn) setWriteDeadline(t time.Time) error { return c.conn.SetWriteDeadline(t) }
+
+func (c *qmuxSendConn) LocalAddr() net.Addr { return c.conn.LocalAddr() }
+
+func (c *qmuxSendConn) RemoteAddr() net.Addr { return c.conn.RemoteAddr() }
+
+func (c *qmuxSendConn) ChangeRemoteAddr(net.Addr, packetInfo) {}
+
+func (c *qmuxSendConn) capabilities() connCapabilities { return connCapabilities{} }

--- a/qmux_sender.go
+++ b/qmux_sender.go
@@ -1,0 +1,133 @@
+package quic
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+type qmuxSender struct {
+	queue       chan qmuxOutboundRecord
+	closeCalled chan struct{}
+	runStopped  chan struct{}
+	available   chan struct{}
+	conn        sendConn
+	state       *qmuxState
+	mutex       sync.Mutex
+	stopped     bool
+}
+
+var _ sender = &qmuxSender{}
+
+func newQMuxSender(conn sendConn, state *qmuxState) sender {
+	return &qmuxSender{
+		conn:        conn,
+		state:       state,
+		runStopped:  make(chan struct{}),
+		closeCalled: make(chan struct{}),
+		available:   make(chan struct{}, 1),
+		queue:       make(chan qmuxOutboundRecord, sendQueueCapacity),
+	}
+}
+
+type qmuxOutboundRecord struct {
+	buf        *packetBuffer
+	gsoSize    uint16
+	ecn        protocol.ECN
+	completion qmuxWrittenFrameBatch
+}
+
+func (s *qmuxSender) Send(p *packetBuffer, gsoSize uint16, ecn protocol.ECN) {
+	s.send(qmuxOutboundRecord{buf: p, gsoSize: gsoSize, ecn: ecn})
+}
+
+func (s *qmuxSender) sendRecord(record qmuxOutboundRecord) {
+	s.send(record)
+}
+
+func (s *qmuxSender) send(record qmuxOutboundRecord) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.stopped {
+		record.buf.Release()
+		return
+	}
+	select {
+	case s.queue <- record:
+		if len(s.queue) == sendQueueCapacity {
+			select {
+			case <-s.available:
+			default:
+			}
+		}
+	default:
+		panic("qmuxSender.Send would have blocked")
+	}
+}
+
+func (s *qmuxSender) SendProbe(p *packetBuffer, _ net.Addr, _ packetInfo) {
+	p.Release()
+}
+
+func (s *qmuxSender) Run() error {
+	var shouldClose bool
+	for {
+		if shouldClose && s.stopIfDrained() {
+			return nil
+		}
+		select {
+		case <-s.closeCalled:
+			s.closeCalled = nil
+			shouldClose = true
+		case e := <-s.queue:
+			if err := s.conn.Write(e.buf.Data, e.gsoSize, e.ecn); err != nil {
+				e.buf.Release()
+				s.mutex.Lock()
+				s.stopped = true
+				close(s.runStopped)
+				for len(s.queue) > 0 {
+					(<-s.queue).buf.Release()
+				}
+				s.mutex.Unlock()
+				return err
+			}
+			s.state.queueWrittenFrameBatch(e.completion)
+			e.buf.Release()
+			select {
+			case s.available <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+func (s *qmuxSender) stopIfDrained() bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if len(s.queue) > 0 {
+		return false
+	}
+	s.stopped = true
+	close(s.runStopped)
+	return true
+}
+
+func (s *qmuxSender) WouldBlock() bool {
+	return len(s.queue) == sendQueueCapacity
+}
+
+func (s *qmuxSender) Available() <-chan struct{} {
+	return s.available
+}
+
+func (s *qmuxSender) Close() {
+	// Bound the writes of any remaining queued records: the peer may have stopped reading,
+	// and connection teardown must not block indefinitely on the underlying transport.
+	if conn, ok := s.conn.(*qmuxSendConn); ok {
+		_ = conn.setWriteDeadline(time.Now().Add(time.Second))
+	}
+	close(s.closeCalled)
+	<-s.runStopped
+}

--- a/qmux_state.go
+++ b/qmux_state.go
@@ -1,0 +1,134 @@
+package quic
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/qerr"
+	"github.com/quic-go/quic-go/internal/wire"
+)
+
+type qmuxState struct {
+	maxRecordSize protocol.ByteCount
+
+	// recordQueueSpace is signaled when the receive queue drains below its limit,
+	// allowing the read loop to resume reading records from the underlying transport.
+	recordQueueSpace chan struct{}
+
+	mutex                        sync.Mutex
+	writtenFrameBatchesAvailable chan struct{}
+	writtenFrameBatches          []qmuxWrittenFrameBatch
+	nextStreamOffsets            map[protocol.StreamID]protocol.ByteCount
+	nextPingSeq                  uint64
+	pendingPing                  bool
+	pingResponse                 *uint64
+}
+
+type qmuxWrittenFrameBatch struct {
+	frames       []ackhandler.Frame
+	streamFrames []ackhandler.StreamFrame
+}
+
+func (s *qmuxState) queueWrittenFrameBatch(p qmuxWrittenFrameBatch) {
+	s.mutex.Lock()
+	s.writtenFrameBatches = append(s.writtenFrameBatches, p)
+	s.mutex.Unlock()
+	select {
+	case s.writtenFrameBatchesAvailable <- struct{}{}:
+	default:
+	}
+}
+
+func (s *qmuxState) popWrittenFrameBatches() []qmuxWrittenFrameBatch {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if len(s.writtenFrameBatches) == 0 {
+		return nil
+	}
+	packets := s.writtenFrameBatches
+	s.writtenFrameBatches = nil
+	return packets
+}
+
+func acknowledgeWrittenFrames(p qmuxWrittenFrameBatch) {
+	for _, f := range p.frames {
+		if f.Handler != nil && f.Frame != nil {
+			f.Handler.OnAcked(f.Frame)
+		}
+	}
+	for _, f := range p.streamFrames {
+		if f.Handler != nil && f.Frame != nil {
+			f.Handler.OnAcked(f.Frame)
+		}
+	}
+}
+
+func (s *qmuxState) checkStreamFrameOrdering(f *wire.StreamFrame) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	expected := s.nextStreamOffsets[f.StreamID]
+	if f.Offset != expected {
+		return &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: fmt.Sprintf("non-contiguous QMux STREAM frame for stream %d: got offset %d, expected %d", f.StreamID, f.Offset, expected),
+		}
+	}
+	if s.nextStreamOffsets == nil {
+		s.nextStreamOffsets = make(map[protocol.StreamID]protocol.ByteCount)
+	}
+	s.nextStreamOffsets[f.StreamID] = expected + f.DataLen()
+	return nil
+}
+
+// removeStreamOffset drops the receive-side offset tracking for a stream once it has completed,
+// preventing unbounded growth of the map over the lifetime of a connection.
+func (s *qmuxState) removeStreamOffset(id protocol.StreamID) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	delete(s.nextStreamOffsets, id)
+}
+
+func (s *qmuxState) nextPingRequest() uint64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.nextPingSeq++
+	s.pendingPing = true
+	return s.nextPingSeq
+}
+
+func (s *qmuxState) queuePingResponse(seq uint64) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.pingResponse == nil || seq > *s.pingResponse {
+		s.pingResponse = &seq
+	}
+}
+
+func (s *qmuxState) popPingResponse() (uint64, bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.pingResponse == nil {
+		return 0, false
+	}
+	seq := *s.pingResponse
+	s.pingResponse = nil
+	return seq, true
+}
+
+func (s *qmuxState) receivedPingResponse(seq uint64) (bool, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if seq > s.nextPingSeq {
+		return false, &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: fmt.Sprintf("QX_PING response sequence %d exceeds greatest request sequence %d", seq, s.nextPingSeq),
+		}
+	}
+	if !s.pendingPing || seq < s.nextPingSeq {
+		return false, nil
+	}
+	s.pendingPing = false
+	return true, nil
+}

--- a/qmux_test.go
+++ b/qmux_test.go
@@ -1,0 +1,979 @@
+package quic
+
+import (
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"io"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/monotime"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/qerr"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/quicvarint"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func newQMuxConnPair(t *testing.T, conf *Config) (*Conn, *Conn) {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+	serverTLS, clientTLS := newQMuxTLSConfigs(t, "qmux-test")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	serverCh := make(chan struct {
+		conn *Conn
+		err  error
+	}, 1)
+	go func() {
+		conn, err := AcceptQMux(ctx, serverConn, serverTLS, conf)
+		serverCh <- struct {
+			conn *Conn
+			err  error
+		}{conn: conn, err: err}
+	}()
+	client, err := DialQMux(ctx, clientConn, clientTLS, conf)
+	require.NoError(t, err)
+	res := <-serverCh
+	require.NoError(t, res.err)
+	t.Cleanup(func() {
+		client.CloseWithError(0, "")
+		res.conn.CloseWithError(0, "")
+	})
+	return client, res.conn
+}
+
+func TestQMuxStreamRoundTrip(t *testing.T) {
+	client, server := newQMuxConnPair(t, nil)
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		str, err := server.AcceptStream(context.Background())
+		require.NoError(t, err)
+		data, err := io.ReadAll(str)
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello over qmux"), data)
+		_, err = str.Write([]byte("response over qmux"))
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+	}()
+
+	str, err := client.OpenStreamSync(context.Background())
+	require.NoError(t, err)
+	_, err = str.Write([]byte("hello over qmux"))
+	require.NoError(t, err)
+	require.NoError(t, str.Close())
+	data, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.Equal(t, []byte("response over qmux"), data)
+	<-serverDone
+}
+
+func TestQMuxLargeStreamTransfer(t *testing.T) {
+	client, server := newQMuxConnPair(t, nil)
+
+	// 128 KB in each direction: this spans many records (records are capped at
+	// max_record_size, 16382 bytes by default) and exceeds the initial stream and
+	// connection flow control windows, so window updates are exercised as well.
+	const transferSize = 128 * 1024
+	clientData := make([]byte, transferSize)
+	_, err := rand.Read(clientData)
+	require.NoError(t, err)
+	serverData := make([]byte, transferSize)
+	_, err = rand.Read(serverData)
+	require.NoError(t, err)
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		str, err := server.AcceptStream(context.Background())
+		require.NoError(t, err)
+		received, err := io.ReadAll(str)
+		require.NoError(t, err)
+		require.Equal(t, clientData, received)
+		_, err = str.Write(serverData)
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+	}()
+
+	str, err := client.OpenStreamSync(context.Background())
+	require.NoError(t, err)
+	n, err := str.Write(clientData)
+	require.NoError(t, err)
+	require.Equal(t, transferSize, n)
+	require.NoError(t, str.Close())
+	received, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.Equal(t, serverData, received)
+	<-serverDone
+}
+
+func TestQMuxDatagramRoundTrip(t *testing.T) {
+	client, server := newQMuxConnPair(t, &Config{EnableDatagrams: true})
+
+	require.NoError(t, client.SendDatagram([]byte("datagram over qmux")))
+	data, err := server.ReceiveDatagram(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []byte("datagram over qmux"), data)
+}
+
+func TestQMuxMaxSizeDatagram(t *testing.T) {
+	client, server := newQMuxConnPair(t, &Config{EnableDatagrams: true})
+
+	// determine the largest datagram SendDatagram accepts
+	var maxSize int
+	for size := 17000; size > 0; size-- {
+		err := client.SendDatagram(make([]byte, size))
+		if err == nil {
+			maxSize = size
+			break
+		}
+		var tooLarge *DatagramTooLargeError
+		require.ErrorAs(t, err, &tooLarge)
+	}
+	require.Greater(t, maxSize, 16000)
+
+	// QMux runs over a reliable transport: a datagram accepted by SendDatagram
+	// must fit into a record and actually be delivered.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	data, err := server.ReceiveDatagram(ctx)
+	require.NoError(t, err)
+	require.Len(t, data, maxSize)
+}
+
+func TestQMuxDialContextDoesNotBindConnectionLifetime(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	serverTLS, clientTLS := newQMuxTLSConfigs(t, "qmux-test")
+	dialCtx, dialCancel := context.WithCancel(context.Background())
+	defer dialCancel()
+
+	serverCh := make(chan *Conn, 1)
+	go func() {
+		conn, err := AcceptQMux(context.Background(), serverConn, serverTLS, nil)
+		if err != nil {
+			serverCh <- nil
+			return
+		}
+		serverCh <- conn
+	}()
+	client, err := DialQMux(dialCtx, clientConn, clientTLS, nil)
+	require.NoError(t, err)
+	server := <-serverCh
+	require.NotNil(t, server)
+	t.Cleanup(func() {
+		client.CloseWithError(0, "")
+		server.CloseWithError(0, "")
+	})
+
+	// canceling the dial context after the connection is established
+	// must not cancel the connection's context
+	dialCancel()
+	select {
+	case <-client.Context().Done():
+		t.Fatal("connection context was canceled when the dial context was canceled")
+	case <-time.After(scaleDuration(50 * time.Millisecond)):
+	}
+
+	// the connection is still usable
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		str, err := server.AcceptStream(context.Background())
+		require.NoError(t, err)
+		_, err = io.Copy(str, str)
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+	}()
+	str, err := client.OpenStreamSync(context.Background())
+	require.NoError(t, err)
+	_, err = str.Write([]byte("still alive"))
+	require.NoError(t, err)
+	require.NoError(t, str.Close())
+	data, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.Equal(t, []byte("still alive"), data)
+	<-serverDone
+}
+
+func TestQMuxRejectsPostSetupTransportParameters(t *testing.T) {
+	client, server := newQMuxConnPair(t, nil)
+
+	client.queueControlFrame(&wire.QXTransportParametersFrame{
+		TransportParameters: newQMuxTransportParameters(client.config).MarshalQMux(),
+	})
+
+	select {
+	case <-server.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for QMux server to close")
+	}
+	var transportErr *qerr.TransportError
+	require.True(t, errors.As(context.Cause(server.Context()), &transportErr))
+	require.Equal(t, qerr.TransportParameterError, transportErr.ErrorCode)
+}
+
+func TestQMuxPingResponseSequenceValidation(t *testing.T) {
+	newConn := func() *Conn {
+		return &Conn{
+			qmux:              &qmuxState{},
+			keepAlivePingSent: true,
+			logger:            utils.DefaultLogger,
+		}
+	}
+	handleResponse := func(c *Conn, seq uint64) error {
+		t.Helper()
+		_, err := c.handleFrame(
+			&wire.QXPingFrame{SequenceNumber: seq, IsResponse: true},
+			protocol.Encryption1RTT,
+			protocol.ConnectionID{},
+			monotime.Now(),
+		)
+		return err
+	}
+
+	t.Run("future sequence is a protocol violation", func(t *testing.T) {
+		c := newConn()
+		require.Equal(t, uint64(1), c.qmux.nextPingRequest())
+
+		err := handleResponse(c, 2)
+		var transportErr *qerr.TransportError
+		require.ErrorAs(t, err, &transportErr)
+		require.Equal(t, qerr.ProtocolViolation, transportErr.ErrorCode)
+		require.True(t, c.qmux.pendingPing)
+		require.True(t, c.keepAlivePingSent)
+	})
+
+	t.Run("exact sequence satisfies pending ping", func(t *testing.T) {
+		c := newConn()
+		require.Equal(t, uint64(1), c.qmux.nextPingRequest())
+
+		require.NoError(t, handleResponse(c, 1))
+		require.False(t, c.qmux.pendingPing)
+		require.False(t, c.keepAlivePingSent)
+	})
+
+	t.Run("stale sequence does not satisfy latest ping", func(t *testing.T) {
+		c := newConn()
+		require.Equal(t, uint64(1), c.qmux.nextPingRequest())
+		require.Equal(t, uint64(2), c.qmux.nextPingRequest())
+
+		require.NoError(t, handleResponse(c, 1))
+		require.True(t, c.qmux.pendingPing)
+		require.True(t, c.keepAlivePingSent)
+	})
+
+	t.Run("duplicate response with no pending ping is ignored", func(t *testing.T) {
+		c := newConn()
+		require.Equal(t, uint64(1), c.qmux.nextPingRequest())
+		require.NoError(t, handleResponse(c, 1))
+		require.False(t, c.qmux.pendingPing)
+
+		c.keepAlivePingSent = true
+		require.NoError(t, handleResponse(c, 1))
+		require.False(t, c.qmux.pendingPing)
+		require.True(t, c.keepAlivePingSent)
+	})
+}
+
+func TestQMuxRejectsNonContiguousStreamFrame(t *testing.T) {
+	client, server := newQMuxConnPair(t, nil)
+
+	client.queueControlFrame(&wire.StreamFrame{
+		StreamID:       protocol.StreamID(0),
+		Offset:         1,
+		Data:           []byte("out of order"),
+		DataLenPresent: true,
+	})
+
+	select {
+	case <-server.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for QMux server to close")
+	}
+	var transportErr *qerr.TransportError
+	require.True(t, errors.As(context.Cause(server.Context()), &transportErr))
+	require.Equal(t, qerr.ProtocolViolation, transportErr.ErrorCode)
+	require.Contains(t, transportErr.ErrorMessage, "non-contiguous QMux STREAM frame")
+}
+
+func TestQMuxExchangeTransportParametersContextTimeout(t *testing.T) {
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() { c1.Close(); c2.Close() })
+	local := newQMuxTransportParameters(populateConfig(nil))
+
+	// Consume our transport parameters, but never send the peer's response.
+	peerRead := make(chan struct{})
+	go func() {
+		_, _ = readQMuxRecord(c2, wire.DefaultMaxRecordSize, make([]byte, 0, int(wire.DefaultMaxRecordSize)))
+		close(peerRead)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, _, err := exchangeQMuxTransportParameters(ctx, c1, local)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(start), time.Second)
+	select {
+	case <-peerRead:
+	case <-time.After(time.Second):
+		t.Fatal("peer didn't receive local transport parameters")
+	}
+}
+
+func TestQMuxPackerPreservesConnectionCloseFrameType(t *testing.T) {
+	p := &qmuxPacker{state: &qmuxState{maxRecordSize: wire.DefaultMaxRecordSize}}
+	packet, err := p.PackConnectionClose(&qerr.TransportError{
+		ErrorCode:    qerr.FrameEncodingError,
+		FrameType:    uint64(wire.FrameTypeMaxData),
+		ErrorMessage: "bad MAX_DATA",
+	}, protocol.MaxByteCount, protocol.Version1)
+	require.NoError(t, err)
+	t.Cleanup(packet.buffer.Release)
+	require.Len(t, packet.shortHdrPacket.Frames, 1)
+	closeFrame, ok := packet.shortHdrPacket.Frames[0].Frame.(*wire.ConnectionCloseFrame)
+	require.True(t, ok)
+	require.Equal(t, uint64(wire.FrameTypeMaxData), closeFrame.FrameType)
+}
+
+func TestQMuxSendConnectionCloseReleasesBuffer(t *testing.T) {
+	local, peer := net.Pipe()
+	t.Cleanup(func() { local.Close(); peer.Close() })
+	mockCtrl := gomock.NewController(t)
+	packer := NewMockPacker(mockCtrl)
+	buf := getPacketWithContents([]byte("close"))
+	packer.EXPECT().PackConnectionClose(gomock.Any(), gomock.Any(), protocol.Version1).Return(&coalescedPacket{
+		buffer:         buf,
+		shortHdrPacket: &shortHeaderPacket{},
+	}, nil)
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		b := make([]byte, len(buf.Data))
+		_, _ = io.ReadFull(peer, b)
+	}()
+	c := &Conn{
+		conn:              &qmuxSendConn{conn: local},
+		packer:            packer,
+		qmux:              &qmuxState{maxRecordSize: wire.DefaultMaxRecordSize},
+		sentPacketHandler: &qmuxSentPacketHandler{},
+		logger:            utils.DefaultLogger,
+		version:           protocol.Version1,
+	}
+	closePacket, err := c.sendConnectionClose(&qerr.TransportError{ErrorCode: qerr.InternalError})
+	require.NoError(t, err)
+	require.Nil(t, closePacket)
+	require.Zero(t, buf.refCount)
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		t.Fatal("peer didn't receive CONNECTION_CLOSE")
+	}
+}
+
+type qmuxTestFrameHandler struct {
+	acked int
+}
+
+func (h *qmuxTestFrameHandler) OnAcked(wire.Frame) { h.acked++ }
+func (*qmuxTestFrameHandler) OnLost(wire.Frame)    {}
+
+func TestQMuxSenderQueuesCompletionExactlyOnce(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	conn := NewMockSendConn(mockCtrl)
+	state := &qmuxState{writtenFrameBatchesAvailable: make(chan struct{}, 1)}
+	sender := newQMuxSender(conn, state).(*qmuxSender)
+	buf := getPacketWithContents([]byte("record"))
+	handler := &qmuxTestFrameHandler{}
+	frame := &wire.PingFrame{}
+	conn.EXPECT().Write(buf.Data, uint16(0), protocol.ECNUnsupported).Return(nil)
+	sender.sendRecord(qmuxOutboundRecord{
+		buf:        buf,
+		ecn:        protocol.ECNUnsupported,
+		completion: qmuxWrittenFrameBatch{frames: []ackhandler.Frame{{Frame: frame, Handler: handler}}},
+	})
+	close(sender.closeCalled)
+
+	require.NoError(t, sender.Run())
+	require.Zero(t, buf.refCount)
+	require.Zero(t, handler.acked, "the sender goroutine must not run completion handlers")
+	c := &Conn{qmux: state}
+	require.True(t, c.handleQMuxWrittenFrameBatches())
+	require.Equal(t, 1, handler.acked)
+	require.False(t, c.handleQMuxWrittenFrameBatches())
+	require.Equal(t, 1, handler.acked)
+}
+
+func TestQMuxSenderDoesNotCompleteFailedOrAbandonedRecords(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	conn := NewMockSendConn(mockCtrl)
+	state := &qmuxState{writtenFrameBatchesAvailable: make(chan struct{}, 1)}
+	sender := newQMuxSender(conn, state).(*qmuxSender)
+	failedBuf := getPacketWithContents([]byte("failed"))
+	abandonedBuf := getPacketWithContents([]byte("abandoned"))
+	failedHandler := &qmuxTestFrameHandler{}
+	abandonedHandler := &qmuxTestFrameHandler{}
+	conn.EXPECT().Write(failedBuf.Data, uint16(0), protocol.ECNUnsupported).Return(assert.AnError)
+	sender.sendRecord(qmuxOutboundRecord{
+		buf:        failedBuf,
+		ecn:        protocol.ECNUnsupported,
+		completion: qmuxWrittenFrameBatch{frames: []ackhandler.Frame{{Frame: &wire.PingFrame{}, Handler: failedHandler}}},
+	})
+	sender.sendRecord(qmuxOutboundRecord{
+		buf:        abandonedBuf,
+		ecn:        protocol.ECNUnsupported,
+		completion: qmuxWrittenFrameBatch{frames: []ackhandler.Frame{{Frame: &wire.PingFrame{}, Handler: abandonedHandler}}},
+	})
+
+	require.ErrorIs(t, sender.Run(), assert.AnError)
+	require.Zero(t, failedBuf.refCount)
+	require.Zero(t, abandonedBuf.refCount)
+	require.Empty(t, state.popWrittenFrameBatches())
+	require.Zero(t, failedHandler.acked)
+	require.Zero(t, abandonedHandler.acked)
+}
+
+func TestQMuxOutboundRecordCompletionSurvivesBufferReuse(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	conn := NewMockSendConn(mockCtrl)
+	state := &qmuxState{writtenFrameBatchesAvailable: make(chan struct{}, 1)}
+	sender := newQMuxSender(conn, state).(*qmuxSender)
+	buf := getPacketWithContents([]byte("old"))
+	oldHandler := &qmuxTestFrameHandler{}
+	newHandler := &qmuxTestFrameHandler{}
+	conn.EXPECT().Write([]byte("old"), uint16(0), protocol.ECNUnsupported).Return(nil)
+	sender.sendRecord(qmuxOutboundRecord{
+		buf:        buf,
+		ecn:        protocol.ECNUnsupported,
+		completion: qmuxWrittenFrameBatch{frames: []ackhandler.Frame{{Frame: &wire.PingFrame{}, Handler: oldHandler}}},
+	})
+	close(sender.closeCalled)
+	require.NoError(t, sender.Run())
+
+	// Obtain the same packetBuffer object from the pool for a different record and
+	// completion batch. The old completion remains queued independently of it.
+	reusedBuf := getPacketBuffer()
+	require.Same(t, buf, reusedBuf)
+	reusedBuf.Data = append(reusedBuf.Data, "new"...)
+	sender = newQMuxSender(conn, state).(*qmuxSender)
+	conn.EXPECT().Write([]byte("new"), uint16(0), protocol.ECNUnsupported).Return(nil)
+	sender.sendRecord(qmuxOutboundRecord{
+		buf:        reusedBuf,
+		ecn:        protocol.ECNUnsupported,
+		completion: qmuxWrittenFrameBatch{frames: []ackhandler.Frame{{Frame: &wire.PingFrame{}, Handler: newHandler}}},
+	})
+	close(sender.closeCalled)
+	require.NoError(t, sender.Run())
+
+	c := &Conn{qmux: state}
+	require.True(t, c.handleQMuxWrittenFrameBatches())
+	require.Equal(t, 1, oldHandler.acked)
+	require.Equal(t, 1, newHandler.acked)
+	require.False(t, c.handleQMuxWrittenFrameBatches())
+}
+
+func TestQMuxSenderReleasesBuffersAfterWriteError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	conn := NewMockSendConn(mockCtrl)
+	sender := newQMuxSender(conn, &qmuxState{}).(*qmuxSender)
+	first := getPacketWithContents([]byte("first"))
+	second := getPacketWithContents([]byte("second"))
+	third := getPacketWithContents([]byte("third"))
+	conn.EXPECT().Write(first.Data, uint16(0), protocol.ECNUnsupported).Return(assert.AnError)
+	sender.Send(first, 0, protocol.ECNUnsupported)
+	sender.Send(second, 0, protocol.ECNUnsupported)
+	sender.Send(third, 0, protocol.ECNUnsupported)
+
+	err := sender.Run()
+	require.ErrorIs(t, err, assert.AnError)
+	require.Zero(t, first.refCount)
+	require.Zero(t, second.refCount)
+	require.Zero(t, third.refCount)
+}
+
+func TestQMuxExchangeRejectsNonTPFirstFrame(t *testing.T) {
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() { c1.Close(); c2.Close() })
+	local := newQMuxTransportParameters(populateConfig(nil))
+
+	closeFrameCh := make(chan *wire.ConnectionCloseFrame, 1)
+	go func() {
+		// Read (and discard) the local QX_TRANSPORT_PARAMETERS record.
+		_, _ = readQMuxRecord(c2, wire.DefaultMaxRecordSize, make([]byte, 0, int(wire.DefaultMaxRecordSize)))
+		// Send a first record whose first frame is a STREAM frame, not QX_TRANSPORT_PARAMETERS.
+		payload, _ := (&wire.StreamFrame{StreamID: 0, Data: []byte("x"), DataLenPresent: true}).Append(nil, protocol.Version1)
+		record, _ := appendQMuxRecord(nil, payload, wire.DefaultMaxRecordSize)
+		_, _ = c2.Write(record)
+		// The peer must respond with a CONNECTION_CLOSE frame.
+		ccRecord, err := readQMuxRecord(c2, wire.DefaultMaxRecordSize, make([]byte, 0, int(wire.DefaultMaxRecordSize)))
+		if err != nil {
+			closeFrameCh <- nil
+			return
+		}
+		parser := wire.NewFrameParser(false, false, false)
+		parser.SetSupportsQMux(true)
+		ft, l, err := parser.ParseType(ccRecord, protocol.Encryption1RTT)
+		if err != nil {
+			closeFrameCh <- nil
+			return
+		}
+		frame, _, err := parser.ParseLessCommonFrame(ft, ccRecord[l:], protocol.Version1)
+		if err != nil {
+			closeFrameCh <- nil
+			return
+		}
+		ccf, _ := frame.(*wire.ConnectionCloseFrame)
+		closeFrameCh <- ccf
+	}()
+
+	_, _, err := exchangeQMuxTransportParameters(context.Background(), c1, local)
+	require.Error(t, err)
+	var transportErr *qerr.TransportError
+	require.ErrorAs(t, err, &transportErr)
+	require.Equal(t, qerr.TransportParameterError, transportErr.ErrorCode)
+
+	select {
+	case ccf := <-closeFrameCh:
+		require.NotNil(t, ccf)
+		require.False(t, ccf.IsApplicationError)
+		require.Equal(t, uint64(qerr.TransportParameterError), ccf.ErrorCode)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for CONNECTION_CLOSE")
+	}
+}
+
+func TestQMuxALPNEnforcement(t *testing.T) {
+	// ALPN configured and negotiated: ok.
+	require.NoError(t, checkQMuxALPN(&tls.Config{NextProtos: []string{"h3"}}, tls.ConnectionState{NegotiatedProtocol: "h3"}))
+	// No ALPN configured: out-of-band agreement assumed, no enforcement.
+	require.NoError(t, checkQMuxALPN(&tls.Config{}, tls.ConnectionState{}))
+	// ALPN configured but not negotiated: must abort.
+	err := checkQMuxALPN(&tls.Config{NextProtos: []string{"h3"}}, tls.ConnectionState{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ALPN")
+}
+
+func TestQMuxClientRequiresNegotiatedALPN(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	serverTLS, clientTLS := newQMuxTLSConfigs(t, "qmux-test")
+	// The server doesn't configure ALPN, so the handshake succeeds without a negotiated protocol.
+	serverTLS.NextProtos = nil
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	go func() {
+		if conn, err := AcceptQMux(ctx, serverConn, serverTLS, nil); err == nil {
+			conn.CloseWithError(0, "")
+		}
+	}()
+	_, err := DialQMux(ctx, clientConn, clientTLS, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ALPN")
+}
+
+func TestQMuxExchangeTransportParametersCoalescedFrames(t *testing.T) {
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() { c1.Close(); c2.Close() })
+	local := newQMuxTransportParameters(populateConfig(nil))
+
+	go func() {
+		// Read (and discard) the local QX_TRANSPORT_PARAMETERS record.
+		_, _ = readQMuxRecord(c2, wire.DefaultMaxRecordSize, make([]byte, 0, int(wire.DefaultMaxRecordSize)))
+		// Reply with a record that coalesces a STREAM frame after QX_TRANSPORT_PARAMETERS.
+		peerParams := newQMuxTransportParameters(populateConfig(nil))
+		payload, _ := (&wire.QXTransportParametersFrame{TransportParameters: peerParams.MarshalQMux()}).Append(nil, protocol.Version1)
+		payload, _ = (&wire.StreamFrame{StreamID: 0, Data: []byte("coalesced"), DataLenPresent: true}).Append(payload, protocol.Version1)
+		record, _ := appendQMuxRecord(nil, payload, wire.DefaultMaxRecordSize)
+		_, _ = c2.Write(record)
+	}()
+
+	params, leftover, err := exchangeQMuxTransportParameters(context.Background(), c1, local)
+	require.NoError(t, err)
+	require.NotNil(t, params)
+	require.NotEmpty(t, leftover)
+
+	parser := wire.NewFrameParser(false, false, false)
+	parser.SetSupportsQMux(true)
+	frameType, l, err := parser.ParseType(leftover, protocol.Encryption1RTT)
+	require.NoError(t, err)
+	require.True(t, frameType.IsStreamFrameType())
+	frame, n, err := parser.ParseStreamFrame(frameType, leftover[l:], protocol.Version1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("coalesced"), frame.Data)
+	require.Equal(t, len(leftover)-l, n)
+}
+
+func TestEffectiveQMuxMaxRecordSizeCapsLargePeerValue(t *testing.T) {
+	require.Equal(t,
+		wire.DefaultMaxRecordSize,
+		effectiveQMuxMaxRecordSize(wire.DefaultMaxRecordSize),
+	)
+	// The peer's value is capped so that a full record (Size prefix + payload)
+	// still fits into a large packet buffer.
+	capped := effectiveQMuxMaxRecordSize(protocol.MaxLargePacketBufferSize + 1)
+	require.Equal(t,
+		protocol.ByteCount(protocol.MaxLargePacketBufferSize)-protocol.ByteCount(quicvarint.Len(protocol.MaxLargePacketBufferSize)),
+		capped,
+	)
+	require.LessOrEqual(t,
+		int(capped)+quicvarint.Len(uint64(capped)),
+		protocol.MaxLargePacketBufferSize,
+	)
+}
+
+func newQMuxTLSConfigs(t *testing.T, alpn string) (*tls.Config, *tls.Config) {
+	t.Helper()
+	ca, caPrivateKey := generateQMuxCA(t)
+	leafCert, leafPrivateKey := generateQMuxLeafCert(t, ca, caPrivateKey)
+	serverTLS := &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{leafCert.Raw},
+			PrivateKey:  leafPrivateKey,
+		}},
+		NextProtos: []string{alpn},
+	}
+	root := x509.NewCertPool()
+	root.AddCert(ca)
+	clientTLS := &tls.Config{
+		ServerName: "localhost",
+		RootCAs:    root,
+		NextProtos: []string{alpn},
+	}
+	return serverTLS, clientTLS
+}
+
+func generateQMuxCA(t *testing.T) (*x509.Certificate, crypto.PrivateKey) {
+	t.Helper()
+	certTempl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	caBytes, err := x509.CreateCertificate(rand.Reader, certTempl, certTempl, pub, priv)
+	require.NoError(t, err)
+	ca, err := x509.ParseCertificate(caBytes)
+	require.NoError(t, err)
+	return ca, priv
+}
+
+func generateQMuxLeafCert(t *testing.T, ca *x509.Certificate, caPriv crypto.PrivateKey) (*x509.Certificate, crypto.PrivateKey) {
+	t.Helper()
+	certTempl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	certBytes, err := x509.CreateCertificate(rand.Reader, certTempl, ca, pub, caPriv)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(certBytes)
+	require.NoError(t, err)
+	return cert, priv
+}
+
+type closeTrackingConn struct {
+	net.Conn
+	once   sync.Once
+	closed chan struct{}
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return c.Conn.Close()
+}
+
+func TestQMuxClosesUnderlyingConn(t *testing.T) {
+	clientRaw, serverRaw := net.Pipe()
+	clientTrack := &closeTrackingConn{Conn: clientRaw, closed: make(chan struct{})}
+	serverTrack := &closeTrackingConn{Conn: serverRaw, closed: make(chan struct{})}
+	serverTLS, clientTLS := newQMuxTLSConfigs(t, "qmux-test")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	serverCh := make(chan *Conn, 1)
+	go func() {
+		conn, err := AcceptQMux(ctx, serverTrack, serverTLS, nil)
+		if err != nil {
+			serverCh <- nil
+			return
+		}
+		serverCh <- conn
+	}()
+	client, err := DialQMux(ctx, clientTrack, clientTLS, nil)
+	require.NoError(t, err)
+	server := <-serverCh
+	require.NotNil(t, server)
+
+	require.NoError(t, client.CloseWithError(0, "bye"))
+
+	// The local transport must be closed once the connection is closed.
+	select {
+	case <-clientTrack.closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client underlying conn not closed after CloseWithError")
+	}
+	// The peer also tears down (and closes its transport) on receiving the CONNECTION_CLOSE.
+	select {
+	case <-serverTrack.closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server underlying conn not closed after peer close")
+	}
+}
+
+func TestQMuxPrunesStreamOffsets(t *testing.T) {
+	client, server := newQMuxConnPair(t, nil)
+
+	const numStreams = 5
+	for range numStreams {
+		serverDone := make(chan struct{})
+		go func() {
+			defer close(serverDone)
+			str, err := server.AcceptStream(context.Background())
+			require.NoError(t, err)
+			_, err = io.Copy(str, str) // echo back
+			require.NoError(t, err)
+			require.NoError(t, str.Close())
+		}()
+
+		str, err := client.OpenStreamSync(context.Background())
+		require.NoError(t, err)
+		_, err = str.Write([]byte("hello"))
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+		data, err := io.ReadAll(str)
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello"), data)
+		<-serverDone
+	}
+
+	// Once streams complete, their receive-side offset tracking must be pruned on both ends.
+	require.Eventually(t, func() bool {
+		return qmuxStreamOffsetCount(client.qmux) == 0 && qmuxStreamOffsetCount(server.qmux) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func qmuxStreamOffsetCount(s *qmuxState) int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return len(s.nextStreamOffsets)
+}
+
+// newQMuxServerWithRawClient establishes a QMux connection where the server side is a regular
+// *Conn, but the client side is a raw TLS connection that the test drives manually.
+func newQMuxServerWithRawClient(t *testing.T) (*Conn, *tls.Conn) {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+	serverTLS, clientTLS := newQMuxTLSConfigs(t, "qmux-test")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	serverCh := make(chan struct {
+		conn *Conn
+		err  error
+	}, 1)
+	go func() {
+		conn, err := AcceptQMux(ctx, serverConn, serverTLS, nil)
+		serverCh <- struct {
+			conn *Conn
+			err  error
+		}{conn: conn, err: err}
+	}()
+
+	tlsConn := tls.Client(clientConn, clientTLS)
+	require.NoError(t, tlsConn.HandshakeContext(ctx))
+	// exchange transport parameters with the server
+	params := newQMuxTransportParameters(populateConfig(nil))
+	payload, err := (&wire.QXTransportParametersFrame{TransportParameters: params.MarshalQMux()}).Append(nil, protocol.Version1)
+	require.NoError(t, err)
+	record, err := appendQMuxRecord(nil, payload, wire.DefaultMaxRecordSize)
+	require.NoError(t, err)
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := tlsConn.Write(record)
+		writeDone <- err
+	}()
+	_, err = readQMuxRecord(tlsConn, wire.DefaultMaxRecordSize, make([]byte, 0, int(wire.DefaultMaxRecordSize)))
+	require.NoError(t, err)
+	require.NoError(t, <-writeDone)
+
+	res := <-serverCh
+	require.NoError(t, res.err)
+	t.Cleanup(func() {
+		// Close the raw side first: the server's CONNECTION_CLOSE write would otherwise
+		// block forever on the pipe, as the raw client is no longer reading.
+		// Close the underlying pipe rather than the TLS layer: tlsConn.Close would block
+		// (up to crypto/tls's internal 5s deadline) trying to write a close_notify alert
+		// that no one reads.
+		tlsConn.NetConn().Close()
+		res.conn.CloseWithError(0, "")
+	})
+	return res.conn, tlsConn
+}
+
+func TestQMuxOversizedRecordClosesWithFrameEncodingError(t *testing.T) {
+	server, raw := newQMuxServerWithRawClient(t)
+
+	// announce a record larger than the server's max_record_size
+	_, err := raw.Write(quicvarint.Append(nil, uint64(wire.DefaultMaxRecordSize)+1))
+	require.NoError(t, err)
+
+	// Section 5.2: the server must close the connection with a FRAME_ENCODING_ERROR,
+	// conveyed to the peer in a CONNECTION_CLOSE frame.
+	record, err := readQMuxRecord(raw, wire.DefaultMaxRecordSize, make([]byte, 0, int(wire.DefaultMaxRecordSize)))
+	require.NoError(t, err)
+	parser := wire.NewFrameParser(false, false, false)
+	parser.SetSupportsQMux(true)
+	ft, l, err := parser.ParseType(record, protocol.Encryption1RTT)
+	require.NoError(t, err)
+	frame, _, err := parser.ParseLessCommonFrame(ft, record[l:], protocol.Version1)
+	require.NoError(t, err)
+	ccf, ok := frame.(*wire.ConnectionCloseFrame)
+	require.True(t, ok)
+	require.False(t, ccf.IsApplicationError)
+	require.Equal(t, uint64(qerr.FrameEncodingError), ccf.ErrorCode)
+
+	select {
+	case <-server.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for the server to close")
+	}
+	var transportErr *qerr.TransportError
+	require.ErrorAs(t, context.Cause(server.Context()), &transportErr)
+	require.Equal(t, qerr.FrameEncodingError, transportErr.ErrorCode)
+}
+
+func TestQMuxWritesLargeStreamFrames(t *testing.T) {
+	server, raw := newQMuxServerWithRawClient(t)
+
+	const transferSize = 64 * 1024
+	data := make([]byte, transferSize)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+
+	go func() {
+		str, err := server.OpenStreamSync(context.Background())
+		require.NoError(t, err)
+		_, err = str.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+	}()
+
+	// read the records and reassemble the STREAM frames
+	parser := wire.NewFrameParser(false, false, false)
+	parser.SetSupportsQMux(true)
+	buf := make([]byte, 0, int(wire.DefaultMaxRecordSize))
+	received := make([]byte, 0, transferSize)
+	var maxFrameDataLen protocol.ByteCount
+	var finReceived bool
+	for !finReceived {
+		record, err := readQMuxRecord(raw, wire.DefaultMaxRecordSize, buf)
+		require.NoError(t, err)
+		for len(record) > 0 {
+			ft, l, err := parser.ParseType(record, protocol.Encryption1RTT)
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			record = record[l:]
+			require.True(t, ft.IsStreamFrameType())
+			frame, n, err := parser.ParseStreamFrame(ft, record, protocol.Version1)
+			require.NoError(t, err)
+			record = record[n:]
+			require.Equal(t, protocol.ByteCount(len(received)), frame.Offset)
+			received = append(received, frame.Data...)
+			maxFrameDataLen = max(maxFrameDataLen, frame.DataLen())
+			if frame.Fin {
+				finReceived = true
+			}
+		}
+	}
+	require.Equal(t, data, received)
+	// STREAM frames are not limited to the size of a QUIC packet:
+	// a single frame carries (almost) an entire record.
+	require.Greater(t, maxFrameDataLen, protocol.ByteCount(protocol.MaxPacketBufferSize))
+}
+
+func TestQMuxReceiveQueueBackpressure(t *testing.T) {
+	server, raw := newQMuxServerWithRawClient(t)
+
+	// Flood the server with records containing QX_PING requests.
+	// The server's receive queue must stay bounded (the read loop pauses instead of
+	// queueing without limit), and the connection must stay functional.
+	const numPings = 1000
+	floodDone := make(chan error, 1)
+	go func() {
+		for i := 1; i <= numPings; i++ {
+			payload, err := (&wire.QXPingFrame{SequenceNumber: uint64(i)}).Append(nil, protocol.Version1)
+			if err != nil {
+				floodDone <- err
+				return
+			}
+			record, err := appendQMuxRecord(nil, payload, wire.DefaultMaxRecordSize)
+			if err != nil {
+				floodDone <- err
+				return
+			}
+			if _, err := raw.Write(record); err != nil {
+				floodDone <- err
+				return
+			}
+		}
+		floodDone <- nil
+	}()
+
+	// read the server's QX_PING responses until the final sequence number is echoed
+	parser := wire.NewFrameParser(false, false, false)
+	parser.SetSupportsQMux(true)
+	buf := make([]byte, 0, int(wire.DefaultMaxRecordSize))
+	var sawFinalResponse bool
+	for !sawFinalResponse {
+		require.LessOrEqual(t, server.queuedQMuxRecordCount(), protocol.MaxConnUnprocessedPackets)
+		record, err := readQMuxRecord(raw, wire.DefaultMaxRecordSize, buf)
+		require.NoError(t, err)
+		for len(record) > 0 {
+			ft, l, err := parser.ParseType(record, protocol.Encryption1RTT)
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			record = record[l:]
+			frame, n, err := parser.ParseLessCommonFrame(ft, record, protocol.Version1)
+			require.NoError(t, err)
+			record = record[n:]
+			if pf, ok := frame.(*wire.QXPingFrame); ok && pf.IsResponse && pf.SequenceNumber == numPings {
+				sawFinalResponse = true
+			}
+		}
+	}
+	require.NoError(t, <-floodDone)
+}

--- a/send_stream.go
+++ b/send_stream.go
@@ -154,7 +154,7 @@ func (s *SendStream) writeImmediately(p []byte) (bool /* is newly completed */, 
 	}
 
 	if s.nextFrame == nil {
-		s.nextFrame = wire.GetStreamFrame()
+		s.nextFrame = wire.GetStreamFrame(protocol.ByteCount(len(p)))
 		s.nextFrame.Offset = s.writeOffset
 		s.nextFrame.StreamID = s.streamID
 		s.nextFrame.DataLenPresent = true
@@ -219,7 +219,7 @@ func (s *SendStream) write(p []byte) (bool /* is newly completed */, int, error)
 		// allowing us to set the FIN bit on that frame (instead of sending an empty STREAM frame with FIN).
 		if s.canBufferStreamFrame() && len(s.dataForWriting) > 0 {
 			if s.nextFrame == nil {
-				f := wire.GetStreamFrame()
+				f := wire.GetStreamFrame(protocol.ByteCount(len(s.dataForWriting)))
 				f.Offset = s.writeOffset
 				f.StreamID = s.streamID
 				f.DataLenPresent = true
@@ -409,14 +409,8 @@ func (s *SendStream) popNewStreamFrame(maxDataLen protocol.ByteCount) (_ *wire.S
 		s.nextFrame = nil
 		s.nextFrameReserved = false
 		if nextFrame.DataLen() > maxDataLen {
-			if nextFrame.DataLen()-maxDataLen > protocol.MaxPacketBufferSize {
-				s.nextFrame = &wire.StreamFrame{
-					Data: make([]byte, nextFrame.DataLen()-maxDataLen),
-				}
-			} else {
-				s.nextFrame = wire.GetStreamFrame()
-				s.nextFrame.Data = s.nextFrame.Data[:nextFrame.DataLen()-maxDataLen]
-			}
+			s.nextFrame = wire.GetStreamFrame(nextFrame.DataLen() - maxDataLen)
+			s.nextFrame.Data = s.nextFrame.Data[:nextFrame.DataLen()-maxDataLen]
 			s.nextFrame.StreamID = s.streamID
 			s.nextFrame.Offset = s.writeOffset + maxDataLen
 			s.nextFrame.DataLenPresent = true
@@ -429,7 +423,7 @@ func (s *SendStream) popNewStreamFrame(maxDataLen protocol.ByteCount) (_ *wire.S
 		return nextFrame, s.nextFrame != nil || s.dataForWriting != nil
 	}
 
-	f := wire.GetStreamFrame()
+	f := wire.GetStreamFrame(maxDataLen)
 	f.Fin = false
 	f.StreamID = s.streamID
 	f.Offset = s.writeOffset


### PR DESCRIPTION
A prototype of the QMux draft (-01). The goal is to reuse the existing Conn struct so things like h3 just work, and to reuse as much existing code as possible. Thus there are a lot of stubbed interface implementations of things that QMux doesn't need (e.g. crypto)

The most important thing to review is likely connection.go and how qmux affects it.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add QMux transport to run QUIC connections over reliable stream transports
> - Introduces QMux, a multiplexing layer that lets existing `quic-go` `Conn` instances operate over a `net.Conn` stream (e.g. TLS) instead of UDP, using length-prefixed records in place of QUIC packets.
> - Adds `DialQMux` and `AcceptQMux` entrypoints in [qmux.go](https://github.com/quic-go/quic-go/pull/5755/files#diff-90a1b4c3cc90cfc05ff1a695d0994e2bfd462dc1fadef829a83738ca8e1ffa3b) that perform a TLS handshake and a custom transport parameter exchange (`QX_TRANSPORT_PARAMETERS`) before handing off to the standard connection run loop.
> - Adds QMux-specific implementations of the packer ([qmux_packer.go](https://github.com/quic-go/quic-go/pull/5755/files#diff-765d0c554554ff4ab5cf0b9332dcddbd899cc97d88f75d736982025d99db9918)), sender ([qmux_sender.go](https://github.com/quic-go/quic-go/pull/5755/files#diff-e923670ee093f1201e0f9a2561b4320dc2b704b7b2a76cdabfbb0fc748f488a6)), send-conn ([qmux_send_conn.go](https://github.com/quic-go/quic-go/pull/5755/files#diff-00d721efbb840490845f281f45e25988a988e5d746c2104a93e09d838371bf3f)), ACK handler ([qmux_ackhandler.go](https://github.com/quic-go/quic-go/pull/5755/files#diff-39aa795c496b98656ecb23b363aec53654f3cff1da89b2b9371b9fe7cea6537c)), and crypto handler ([qmux_crypto.go](https://github.com/quic-go/quic-go/pull/5755/files#diff-a62510caed057f0f6a9c338cb5354acba907a4af66303ebfcfb02189878701f0)) that bypass QUIC loss detection and ACK mechanics.
> - Extends `wire.FrameParser`, `wire.TransportParameters`, and `wire.StreamFrame` in [internal/wire](https://github.com/quic-go/quic-go/pull/5755/files#diff-fa3d74fef1a8ab7577be4de9b3051324aef611169bb8211aeef80f9a57b041c0) to support new QMux frame types (`QXPingFrame`, `QXTransportParametersFrame`) and large stream frames (up to `MaxLargePacketBufferSize`) needed for QMux records.
> - Risk: `wire.GetStreamFrame` signature now requires a `size` argument; callers not updated will fail to compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0bc911f. 17 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->