### PR TITLE
qlog: replace datagram IDs with CRC32c payload checksums

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -56,9 +56,9 @@ type receivedPacket struct {
 	info packetInfo // only valid if the contained IP address is valid
 }
 
-type receivedPacketWithDatagramID struct {
+type receivedPacketWithChecksum struct {
 	receivedPacket
-	datagramID qlog.DatagramID
+	checksum qlog.DatagramPayloadChecksum
 }
 
 func (p *receivedPacket) Size() protocol.ByteCount { return protocol.ByteCount(len(p.data)) }
@@ -184,8 +184,8 @@ type Conn struct {
 	ctxCancel             context.CancelCauseFunc
 	handshakeCompleteChan chan struct{}
 
-	undecryptablePackets          []receivedPacketWithDatagramID // undecryptable packets, waiting for a change in encryption level
-	undecryptablePacketsToProcess []receivedPacketWithDatagramID
+	undecryptablePackets          []receivedPacketWithChecksum // undecryptable packets, waiting for a change in encryption level
+	undecryptablePacketsToProcess []receivedPacketWithChecksum
 
 	earlyConnReadyChan chan struct{}
 	sentFirstPacket    bool
@@ -620,7 +620,7 @@ runLoop:
 			queue := c.undecryptablePacketsToProcess
 			c.undecryptablePacketsToProcess = nil
 			for _, p := range queue {
-				processed, err := c.handleOnePacket(p.receivedPacket, p.datagramID)
+				processed, err := c.handleOnePacket(p.receivedPacket, p.checksum)
 				if err != nil {
 					c.setCloseError(&closeError{err: err})
 					break runLoop
@@ -1015,11 +1015,11 @@ func (c *Conn) handlePackets() (wasProcessed bool, _ error) {
 		p := c.receivedPackets.PopFront()
 		c.receivedPacketMx.Unlock()
 
-		var datagramID qlog.DatagramID
+		var datagramPayloadChecksum qlog.DatagramPayloadChecksum
 		if c.qlogger != nil && wire.IsLongHeaderPacket(p.data[0]) {
-			datagramID = qlog.CalculateDatagramID(p.data)
+			datagramPayloadChecksum = qlog.CalculateDatagramPayloadChecksum(p.data)
 		}
-		processed, err := c.handleOnePacket(p, datagramID)
+		processed, err := c.handleOnePacket(p, datagramPayloadChecksum)
 		if err != nil {
 			return false, err
 		}
@@ -1048,7 +1048,7 @@ func (c *Conn) handlePackets() (wasProcessed bool, _ error) {
 	return wasProcessed, nil
 }
 
-func (c *Conn) handleOnePacket(rp receivedPacket, datagramID qlog.DatagramID) (wasProcessed bool, _ error) {
+func (c *Conn) handleOnePacket(rp receivedPacket, datagramPayloadChecksum qlog.DatagramPayloadChecksum) (wasProcessed bool, _ error) {
 	c.sentPacketHandler.ReceivedBytes(rp.Size(), rp.rcvTime)
 
 	if wire.IsVersionNegotiationPacket(rp.data) {
@@ -1068,9 +1068,9 @@ func (c *Conn) handleOnePacket(rp receivedPacket, datagramID qlog.DatagramID) (w
 			if err != nil {
 				if c.qlogger != nil {
 					c.qlogger.RecordEvent(qlog.PacketDropped{
-						Raw:        qlog.RawInfo{Length: len(data)},
-						DatagramID: datagramID,
-						Trigger:    qlog.PacketDropHeaderParseError,
+						Raw:                     qlog.RawInfo{Length: len(data)},
+						DatagramPayloadChecksum: datagramPayloadChecksum,
+						Trigger:                 qlog.PacketDropHeaderParseError,
 					})
 				}
 				c.logger.Debugf("error parsing packet, couldn't parse connection ID: %s", err)
@@ -1079,10 +1079,10 @@ func (c *Conn) handleOnePacket(rp receivedPacket, datagramID qlog.DatagramID) (w
 			if destConnID != lastConnID {
 				if c.qlogger != nil {
 					c.qlogger.RecordEvent(qlog.PacketDropped{
-						Header:     qlog.PacketHeader{DestConnectionID: destConnID},
-						Raw:        qlog.RawInfo{Length: len(data)},
-						DatagramID: datagramID,
-						Trigger:    qlog.PacketDropUnknownConnectionID,
+						Header:                  qlog.PacketHeader{DestConnectionID: destConnID},
+						Raw:                     qlog.RawInfo{Length: len(data)},
+						DatagramPayloadChecksum: datagramPayloadChecksum,
+						Trigger:                 qlog.PacketDropUnknownConnectionID,
 					})
 				}
 				c.logger.Debugf("coalesced packet has different destination connection ID: %s, expected %s", destConnID, lastConnID)
@@ -1096,16 +1096,16 @@ func (c *Conn) handleOnePacket(rp receivedPacket, datagramID qlog.DatagramID) (w
 				if c.qlogger != nil {
 					if err == wire.ErrUnsupportedVersion {
 						c.qlogger.RecordEvent(qlog.PacketDropped{
-							Header:     qlog.PacketHeader{Version: hdr.Version},
-							Raw:        qlog.RawInfo{Length: len(data)},
-							DatagramID: datagramID,
-							Trigger:    qlog.PacketDropUnsupportedVersion,
+							Header:                  qlog.PacketHeader{Version: hdr.Version},
+							Raw:                     qlog.RawInfo{Length: len(data)},
+							DatagramPayloadChecksum: datagramPayloadChecksum,
+							Trigger:                 qlog.PacketDropUnsupportedVersion,
 						})
 					} else {
 						c.qlogger.RecordEvent(qlog.PacketDropped{
-							Raw:        qlog.RawInfo{Length: len(data)},
-							DatagramID: datagramID,
-							Trigger:    qlog.PacketDropHeaderParseError,
+							Raw:                     qlog.RawInfo{Length: len(data)},
+							DatagramPayloadChecksum: datagramPayloadChecksum,
+							Trigger:                 qlog.PacketDropHeaderParseError,
 						})
 					}
 				}
@@ -1117,9 +1117,9 @@ func (c *Conn) handleOnePacket(rp receivedPacket, datagramID qlog.DatagramID) (w
 			if hdr.Version != c.version {
 				if c.qlogger != nil {
 					c.qlogger.RecordEvent(qlog.PacketDropped{
-						Raw:        qlog.RawInfo{Length: len(data)},
-						DatagramID: datagramID,
-						Trigger:    qlog.PacketDropUnexpectedVersion,
+						Raw:                     qlog.RawInfo{Length: len(data)},
+						DatagramPayloadChecksum: datagramPayloadChecksum,
+						Trigger:                 qlog.PacketDropUnexpectedVersion,
 					})
 				}
 				c.logger.Debugf("Dropping packet with version %x. Expected %x.", hdr.Version, c.version)
@@ -1138,7 +1138,7 @@ func (c *Conn) handleOnePacket(rp receivedPacket, datagramID qlog.DatagramID) (w
 
 			p.data = packetData
 
-			processed, err := c.handleLongHeaderPacket(p, hdr, datagramID)
+			processed, err := c.handleLongHeaderPacket(p, hdr, datagramPayloadChecksum)
 			if err != nil {
 				return false, err
 			}
@@ -1150,7 +1150,7 @@ func (c *Conn) handleOnePacket(rp receivedPacket, datagramID qlog.DatagramID) (w
 			if counter > 0 {
 				p.buffer.Split()
 			}
-			processed, err := c.handleShortHeaderPacket(p, counter > 0, datagramID)
+			processed, err := c.handleShortHeaderPacket(p, counter > 0, datagramPayloadChecksum)
 			if err != nil {
 				return false, err
 			}
@@ -1169,7 +1169,7 @@ func (c *Conn) handleOnePacket(rp receivedPacket, datagramID qlog.DatagramID) (w
 func (c *Conn) handleShortHeaderPacket(
 	p receivedPacket,
 	isCoalesced bool,
-	datagramID qlog.DatagramID, // only for logging
+	datagramPayloadChecksum qlog.DatagramPayloadChecksum, // only for logging
 ) (wasProcessed bool, _ error) {
 	var wasQueued bool
 
@@ -1187,9 +1187,9 @@ func (c *Conn) handleShortHeaderPacket(
 				PacketType:   qlog.PacketType1RTT,
 				PacketNumber: protocol.InvalidPacketNumber,
 			},
-			Raw:        qlog.RawInfo{Length: len(p.data)},
-			DatagramID: datagramID,
-			Trigger:    qlog.PacketDropHeaderParseError,
+			Raw:                     qlog.RawInfo{Length: len(p.data)},
+			DatagramPayloadChecksum: datagramPayloadChecksum,
+			Trigger:                 qlog.PacketDropHeaderParseError,
 		})
 		return false, nil
 	}
@@ -1206,7 +1206,7 @@ func (c *Conn) handleShortHeaderPacket(
 				return false, &StatelessResetError{}
 			}
 		}
-		wasQueued, err = c.handleUnpackError(err, p, qlog.PacketType1RTT, datagramID)
+		wasQueued, err = c.handleUnpackError(err, p, qlog.PacketType1RTT, datagramPayloadChecksum)
 		return false, err
 	}
 	c.largestRcvdAppData = max(c.largestRcvdAppData, pn)
@@ -1224,9 +1224,9 @@ func (c *Conn) handleShortHeaderPacket(
 					PacketType:   qlog.PacketType1RTT,
 					PacketNumber: pn,
 				},
-				Raw:        qlog.RawInfo{Length: int(p.Size())},
-				DatagramID: datagramID,
-				Trigger:    qlog.PacketDropDuplicate,
+				Raw:                     qlog.RawInfo{Length: int(p.Size())},
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Trigger:                 qlog.PacketDropDuplicate,
 			})
 		}
 		return false, nil
@@ -1246,9 +1246,9 @@ func (c *Conn) handleShortHeaderPacket(
 					Length:        int(p.Size()),
 					PayloadLength: int(p.Size() - wire.ShortHeaderLen(destConnID, pnLen)),
 				},
-				DatagramID: datagramID,
-				Frames:     frames,
-				ECN:        toQlogECN(p.ecn),
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Frames:                  frames,
+				ECN:                     toQlogECN(p.ecn),
 			})
 		}
 	}
@@ -1280,7 +1280,7 @@ func (c *Conn) handleShortHeaderPacket(
 			return true, err
 		}
 		c.logger.Debugf("sending path probe packet to %s", p.remoteAddr)
-		c.logShortHeaderPacketWithDatagramID(probe, protocol.ECNNon, buf.Len(), false, datagramID)
+		c.logShortHeaderPacketWithDatagramPayloadChecksum(probe, protocol.ECNNon, buf.Len(), false, datagramPayloadChecksum)
 		c.registerPackedShortHeaderPacket(probe, protocol.ECNNon, p.rcvTime)
 		c.sendQueue.SendProbe(buf, p.remoteAddr, p.info)
 	}
@@ -1304,7 +1304,7 @@ func (c *Conn) handleShortHeaderPacket(
 	return true, nil
 }
 
-func (c *Conn) handleLongHeaderPacket(p receivedPacket, hdr *wire.Header, datagramID qlog.DatagramID) (wasProcessed bool, _ error) {
+func (c *Conn) handleLongHeaderPacket(p receivedPacket, hdr *wire.Header, datagramPayloadChecksum qlog.DatagramPayloadChecksum) (wasProcessed bool, _ error) {
 	var wasQueued bool
 
 	defer func() {
@@ -1327,9 +1327,9 @@ func (c *Conn) handleLongHeaderPacket(p receivedPacket, hdr *wire.Header, datagr
 					PacketType:   qlog.PacketTypeInitial,
 					PacketNumber: protocol.InvalidPacketNumber,
 				},
-				Raw:        qlog.RawInfo{Length: int(p.Size())},
-				DatagramID: datagramID,
-				Trigger:    qlog.PacketDropUnknownConnectionID,
+				Raw:                     qlog.RawInfo{Length: int(p.Size())},
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Trigger:                 qlog.PacketDropUnknownConnectionID,
 			})
 		}
 		c.logger.Debugf("Dropping Initial packet (%d bytes) with unexpected source connection ID: %s (expected %s)", p.Size(), hdr.SrcConnectionID, c.handshakeDestConnID)
@@ -1343,9 +1343,9 @@ func (c *Conn) handleLongHeaderPacket(p receivedPacket, hdr *wire.Header, datagr
 					PacketType:   qlog.PacketType0RTT,
 					PacketNumber: protocol.InvalidPacketNumber,
 				},
-				Raw:        qlog.RawInfo{Length: int(p.Size())},
-				DatagramID: datagramID,
-				Trigger:    qlog.PacketDropUnexpectedPacket,
+				Raw:                     qlog.RawInfo{Length: int(p.Size())},
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Trigger:                 qlog.PacketDropUnexpectedPacket,
 			})
 		}
 		return false, nil
@@ -1353,7 +1353,7 @@ func (c *Conn) handleLongHeaderPacket(p receivedPacket, hdr *wire.Header, datagr
 
 	packet, err := c.unpacker.UnpackLongHeader(hdr, p.data)
 	if err != nil {
-		wasQueued, err = c.handleUnpackError(err, p, toQlogPacketType(hdr.Type), datagramID)
+		wasQueued, err = c.handleUnpackError(err, p, toQlogPacketType(hdr.Type), datagramPayloadChecksum)
 		return false, err
 	}
 
@@ -1373,21 +1373,21 @@ func (c *Conn) handleLongHeaderPacket(p receivedPacket, hdr *wire.Header, datagr
 					PacketNumber:     pn,
 					Version:          packet.hdr.Version,
 				},
-				Raw:        qlog.RawInfo{Length: int(p.Size()), PayloadLength: int(packet.hdr.Length)},
-				DatagramID: datagramID,
-				Trigger:    qlog.PacketDropDuplicate,
+				Raw:                     qlog.RawInfo{Length: int(p.Size()), PayloadLength: int(packet.hdr.Length)},
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Trigger:                 qlog.PacketDropDuplicate,
 			})
 		}
 		return false, nil
 	}
 
-	if err := c.handleUnpackedLongHeaderPacket(packet, p.ecn, p.rcvTime, datagramID, p.Size()); err != nil {
+	if err := c.handleUnpackedLongHeaderPacket(packet, p.ecn, p.rcvTime, datagramPayloadChecksum, p.Size()); err != nil {
 		return false, err
 	}
 	return true, nil
 }
 
-func (c *Conn) handleUnpackError(err error, p receivedPacket, pt qlog.PacketType, datagramID qlog.DatagramID) (wasQueued bool, _ error) {
+func (c *Conn) handleUnpackError(err error, p receivedPacket, pt qlog.PacketType, datagramPayloadChecksum qlog.DatagramPayloadChecksum) (wasQueued bool, _ error) {
 	switch err {
 	case handshake.ErrKeysDropped:
 		if c.qlogger != nil {
@@ -1398,9 +1398,9 @@ func (c *Conn) handleUnpackError(err error, p receivedPacket, pt qlog.PacketType
 					DestConnectionID: connID,
 					PacketNumber:     protocol.InvalidPacketNumber,
 				},
-				Raw:        qlog.RawInfo{Length: int(p.Size())},
-				DatagramID: datagramID,
-				Trigger:    qlog.PacketDropKeyUnavailable,
+				Raw:                     qlog.RawInfo{Length: int(p.Size())},
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Trigger:                 qlog.PacketDropKeyUnavailable,
 			})
 		}
 		c.logger.Debugf("Dropping %s packet (%d bytes) because we already dropped the keys.", pt, p.Size())
@@ -1408,7 +1408,7 @@ func (c *Conn) handleUnpackError(err error, p receivedPacket, pt qlog.PacketType
 	case handshake.ErrKeysNotYetAvailable:
 		// Sealer for this encryption level not yet available.
 		// Try again later.
-		c.tryQueueingUndecryptablePacket(p, pt, datagramID)
+		c.tryQueueingUndecryptablePacket(p, pt, datagramPayloadChecksum)
 		return true, nil
 	case wire.ErrInvalidReservedBits:
 		return false, &qerr.TransportError{
@@ -1425,9 +1425,9 @@ func (c *Conn) handleUnpackError(err error, p receivedPacket, pt qlog.PacketType
 					DestConnectionID: connID,
 					PacketNumber:     protocol.InvalidPacketNumber,
 				},
-				Raw:        qlog.RawInfo{Length: int(p.Size())},
-				DatagramID: datagramID,
-				Trigger:    qlog.PacketDropPayloadDecryptError,
+				Raw:                     qlog.RawInfo{Length: int(p.Size())},
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Trigger:                 qlog.PacketDropPayloadDecryptError,
 			})
 		}
 		c.logger.Debugf("Dropping %s packet (%d bytes) that could not be unpacked. Error: %s", pt, p.Size(), err)
@@ -1444,9 +1444,9 @@ func (c *Conn) handleUnpackError(err error, p receivedPacket, pt qlog.PacketType
 						DestConnectionID: connID,
 						PacketNumber:     protocol.InvalidPacketNumber,
 					},
-					Raw:        qlog.RawInfo{Length: int(p.Size())},
-					DatagramID: datagramID,
-					Trigger:    qlog.PacketDropHeaderParseError,
+					Raw:                     qlog.RawInfo{Length: int(p.Size())},
+					DatagramPayloadChecksum: datagramPayloadChecksum,
+					Trigger:                 qlog.PacketDropHeaderParseError,
 				})
 			}
 			c.logger.Debugf("Dropping %s packet (%d bytes) for which we couldn't unpack the header. Error: %s", pt, p.Size(), err)
@@ -1642,7 +1642,7 @@ func (c *Conn) handleUnpackedLongHeaderPacket(
 	packet *unpackedPacket,
 	ecn protocol.ECN,
 	rcvTime monotime.Time,
-	datagramID qlog.DatagramID, // only for logging
+	datagramPayloadChecksum qlog.DatagramPayloadChecksum, // only for logging
 	packetSize protocol.ByteCount, // only for logging
 ) error {
 	if !c.receivedFirstPacket {
@@ -1728,9 +1728,9 @@ func (c *Conn) handleUnpackedLongHeaderPacket(
 					Length:        int(packetSize),
 					PayloadLength: int(packet.hdr.Length),
 				},
-				DatagramID: datagramID,
-				Frames:     frames,
-				ECN:        toQlogECN(ecn),
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Frames:                  frames,
+				ECN:                     toQlogECN(ecn),
 			})
 		}
 	}
@@ -1955,14 +1955,14 @@ func (c *Conn) handlePacket(p receivedPacket) {
 	// the channel size, protocol.MaxConnUnprocessedPackets
 	if c.receivedPackets.Len() >= protocol.MaxConnUnprocessedPackets {
 		if c.qlogger != nil {
-			var datagramID qlog.DatagramID
+			var datagramPayloadChecksum qlog.DatagramPayloadChecksum
 			if wire.IsLongHeaderPacket(p.data[0]) {
-				datagramID = qlog.CalculateDatagramID(p.data)
+				datagramPayloadChecksum = qlog.CalculateDatagramPayloadChecksum(p.data)
 			}
 			c.qlogger.RecordEvent(qlog.PacketDropped{
-				Raw:        qlog.RawInfo{Length: int(p.Size())},
-				DatagramID: datagramID,
-				Trigger:    qlog.PacketDropDOSPrevention,
+				Raw:                     qlog.RawInfo{Length: int(p.Size())},
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Trigger:                 qlog.PacketDropDOSPrevention,
 			})
 		}
 		c.receivedPacketMx.Unlock()
@@ -2959,7 +2959,7 @@ func (c *Conn) scheduleSending() {
 
 // tryQueueingUndecryptablePacket queues a packet for which we're missing the decryption keys.
 // The qlogevents.PacketType is only used for logging purposes.
-func (c *Conn) tryQueueingUndecryptablePacket(p receivedPacket, pt qlog.PacketType, datagramID qlog.DatagramID) {
+func (c *Conn) tryQueueingUndecryptablePacket(p receivedPacket, pt qlog.PacketType, datagramPayloadChecksum qlog.DatagramPayloadChecksum) {
 	if c.handshakeComplete {
 		panic("shouldn't queue undecryptable packets after handshake completion")
 	}
@@ -2970,9 +2970,9 @@ func (c *Conn) tryQueueingUndecryptablePacket(p receivedPacket, pt qlog.PacketTy
 					PacketType:   pt,
 					PacketNumber: protocol.InvalidPacketNumber,
 				},
-				Raw:        qlog.RawInfo{Length: int(p.Size())},
-				DatagramID: datagramID,
-				Trigger:    qlog.PacketDropDOSPrevention,
+				Raw:                     qlog.RawInfo{Length: int(p.Size())},
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Trigger:                 qlog.PacketDropDOSPrevention,
 			})
 		}
 		c.logger.Infof("Dropping undecryptable packet (%d bytes). Undecryptable packet queue full.", p.Size())
@@ -2985,11 +2985,11 @@ func (c *Conn) tryQueueingUndecryptablePacket(p receivedPacket, pt qlog.PacketTy
 				PacketType:   pt,
 				PacketNumber: protocol.InvalidPacketNumber,
 			},
-			Raw:        qlog.RawInfo{Length: int(p.Size())},
-			DatagramID: datagramID,
+			Raw:                     qlog.RawInfo{Length: int(p.Size())},
+			DatagramPayloadChecksum: datagramPayloadChecksum,
 		})
 	}
-	c.undecryptablePackets = append(c.undecryptablePackets, receivedPacketWithDatagramID{receivedPacket: p, datagramID: datagramID})
+	c.undecryptablePackets = append(c.undecryptablePackets, receivedPacketWithChecksum{receivedPacket: p, checksum: datagramPayloadChecksum})
 }
 
 func (c *Conn) queueControlFrame(f wire.Frame) {

--- a/connection_logging.go
+++ b/connection_logging.go
@@ -57,7 +57,7 @@ func toQlogAckFrame(f *wire.AckFrame) *qlog.AckFrame {
 	return ack
 }
 
-func (c *Conn) logLongHeaderPacket(p *longHeaderPacket, ecn protocol.ECN, datagramID qlog.DatagramID) {
+func (c *Conn) logLongHeaderPacket(p *longHeaderPacket, ecn protocol.ECN, datagramPayloadChecksum qlog.DatagramPayloadChecksum) {
 	// quic-go logging
 	if c.logger.Debug() {
 		p.header.Log(c.logger)
@@ -101,18 +101,18 @@ func (c *Conn) logLongHeaderPacket(p *longHeaderPacket, ecn protocol.ECN, datagr
 				Length:        int(p.length),
 				PayloadLength: int(p.header.Length),
 			},
-			DatagramID: datagramID,
-			Frames:     frames,
-			ECN:        toQlogECN(ecn),
+			DatagramPayloadChecksum: datagramPayloadChecksum,
+			Frames:                  frames,
+			ECN:                     toQlogECN(ecn),
 		})
 	}
 }
 
 func (c *Conn) logShortHeaderPacket(p shortHeaderPacket, ecn protocol.ECN, size protocol.ByteCount) {
-	c.logShortHeaderPacketWithDatagramID(p, ecn, size, false, 0)
+	c.logShortHeaderPacketWithDatagramPayloadChecksum(p, ecn, size, false, 0)
 }
 
-func (c *Conn) logShortHeaderPacketWithDatagramID(p shortHeaderPacket, ecn protocol.ECN, size protocol.ByteCount, isCoalesced bool, datagramID qlog.DatagramID) {
+func (c *Conn) logShortHeaderPacketWithDatagramPayloadChecksum(p shortHeaderPacket, ecn protocol.ECN, size protocol.ByteCount, isCoalesced bool, datagramPayloadChecksum qlog.DatagramPayloadChecksum) {
 	if c.logger.Debug() && !isCoalesced {
 		c.logger.Debugf("-> Sending packet %d (%d bytes) for connection %s, 1-RTT (ECN: %s)", p.PacketNumber, size, c.logID, ecn)
 	}
@@ -158,28 +158,28 @@ func (c *Conn) logShortHeaderPacketWithDatagramID(p shortHeaderPacket, ecn proto
 				Length:        int(size),
 				PayloadLength: int(size - wire.ShortHeaderLen(p.DestConnID, p.PacketNumberLen)),
 			},
-			DatagramID: datagramID,
-			Frames:     fs,
-			ECN:        toQlogECN(ecn),
+			DatagramPayloadChecksum: datagramPayloadChecksum,
+			Frames:                  fs,
+			ECN:                     toQlogECN(ecn),
 		})
 	}
 }
 
 func (c *Conn) logCoalescedPacket(packet *coalescedPacket, ecn protocol.ECN) {
-	var datagramID qlog.DatagramID
+	var datagramPayloadChecksum qlog.DatagramPayloadChecksum
 	if c.qlogger != nil {
-		datagramID = qlog.CalculateDatagramID(packet.buffer.Data)
+		datagramPayloadChecksum = qlog.CalculateDatagramPayloadChecksum(packet.buffer.Data)
 	}
 	if c.logger.Debug() {
 		// There's a short period between dropping both Initial and Handshake keys and completion of the handshake,
 		// during which we might call PackCoalescedPacket but just pack a short header packet.
 		if len(packet.longHdrPackets) == 0 && packet.shortHdrPacket != nil {
-			c.logShortHeaderPacketWithDatagramID(
+			c.logShortHeaderPacketWithDatagramPayloadChecksum(
 				*packet.shortHdrPacket,
 				ecn,
 				packet.shortHdrPacket.Length,
 				false,
-				datagramID,
+				datagramPayloadChecksum,
 			)
 			return
 		}
@@ -190,10 +190,10 @@ func (c *Conn) logCoalescedPacket(packet *coalescedPacket, ecn protocol.ECN) {
 		}
 	}
 	for _, p := range packet.longHdrPackets {
-		c.logLongHeaderPacket(p, ecn, datagramID)
+		c.logLongHeaderPacket(p, ecn, datagramPayloadChecksum)
 	}
 	if p := packet.shortHdrPacket; p != nil {
-		c.logShortHeaderPacketWithDatagramID(*p, ecn, p.Length, true, datagramID)
+		c.logShortHeaderPacketWithDatagramPayloadChecksum(*p, ecn, p.Length, true, datagramPayloadChecksum)
 	}
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -472,10 +472,10 @@ func TestConnectionServerInvalidPackets(t *testing.T) {
 		require.Equal(t,
 			[]qlogwriter.Event{
 				qlog.PacketDropped{
-					Header:     qlog.PacketHeader{Version: 1234},
-					Raw:        qlog.RawInfo{Length: int(p.Size())},
-					DatagramID: 42,
-					Trigger:    qlog.PacketDropUnsupportedVersion,
+					Header:                  qlog.PacketHeader{Version: 1234},
+					Raw:                     qlog.RawInfo{Length: int(p.Size())},
+					DatagramPayloadChecksum: 42,
+					Trigger:                 qlog.PacketDropUnsupportedVersion,
 				},
 			},
 			eventRecorder.Events(qlog.PacketDropped{}),
@@ -502,10 +502,10 @@ func TestConnectionServerInvalidPackets(t *testing.T) {
 		require.Equal(t,
 			[]qlogwriter.Event{
 				qlog.PacketDropped{
-					Header:     qlog.PacketHeader{},
-					Raw:        qlog.RawInfo{Length: int(p.Size())},
-					DatagramID: 42,
-					Trigger:    qlog.PacketDropHeaderParseError,
+					Header:                  qlog.PacketHeader{},
+					Raw:                     qlog.RawInfo{Length: int(p.Size())},
+					DatagramPayloadChecksum: 42,
+					Trigger:                 qlog.PacketDropHeaderParseError,
 				},
 			},
 			eventRecorder.Events(qlog.PacketDropped{}),
@@ -536,9 +536,9 @@ func TestConnectionClientDrop0RTT(t *testing.T) {
 					PacketType:   qlog.PacketType0RTT,
 					PacketNumber: protocol.InvalidPacketNumber,
 				},
-				Raw:        qlog.RawInfo{Length: int(p.Size())},
-				DatagramID: 1234,
-				Trigger:    qlog.PacketDropUnexpectedPacket,
+				Raw:                     qlog.RawInfo{Length: int(p.Size())},
+				DatagramPayloadChecksum: 1234,
+				Trigger:                 qlog.PacketDropUnexpectedPacket,
 			},
 		},
 		eventRecorder.Events(qlog.PacketDropped{}),
@@ -592,10 +592,10 @@ func TestConnectionUnpacking(t *testing.T) {
 					PacketNumber:     protocol.PacketNumber(0x1337),
 					Version:          protocol.Version1,
 				},
-				Frames:     []qlog.Frame{},
-				ECN:        qlog.ECNCE,
-				Raw:        qlog.RawInfo{Length: int(packet.Size()), PayloadLength: 1},
-				DatagramID: 42,
+				Frames:                  []qlog.Frame{},
+				ECN:                     qlog.ECNCE,
+				Raw:                     qlog.RawInfo{Length: int(packet.Size()), PayloadLength: 1},
+				DatagramPayloadChecksum: 42,
 			},
 		},
 		eventRecorder.Events(qlog.PacketReceived{}, qlog.PacketDropped{}),
@@ -621,9 +621,9 @@ func TestConnectionUnpacking(t *testing.T) {
 					PacketNumber:     protocol.PacketNumber(0x1337),
 					Version:          protocol.Version1,
 				},
-				Raw:        qlog.RawInfo{Length: int(packet.Size()), PayloadLength: 1},
-				DatagramID: 43,
-				Trigger:    qlog.PacketDropDuplicate,
+				Raw:                     qlog.RawInfo{Length: int(packet.Size()), PayloadLength: 1},
+				DatagramPayloadChecksum: 43,
+				Trigger:                 qlog.PacketDropDuplicate,
 			},
 		},
 		eventRecorder.Events(qlog.PacketReceived{}, qlog.PacketDropped{}),
@@ -739,10 +739,10 @@ func TestConnectionUnpackCoalescedPacket(t *testing.T) {
 					PacketNumber:     protocol.PacketNumber(1337),
 					Version:          protocol.Version1,
 				},
-				Raw:        qlog.RawInfo{Length: int(firstPacketLen), PayloadLength: 1},
-				DatagramID: 42,
-				Frames:     []qlog.Frame{},
-				ECN:        qlog.ECT1,
+				Raw:                     qlog.RawInfo{Length: int(firstPacketLen), PayloadLength: 1},
+				DatagramPayloadChecksum: 42,
+				Frames:                  []qlog.Frame{},
+				ECN:                     qlog.ECT1,
 			},
 			qlog.PacketReceived{
 				Header: qlog.PacketHeader{
@@ -751,16 +751,16 @@ func TestConnectionUnpackCoalescedPacket(t *testing.T) {
 					PacketNumber:     protocol.PacketNumber(1338),
 					Version:          protocol.Version1,
 				},
-				Raw:        qlog.RawInfo{Length: int(packet2.Size()), PayloadLength: 1},
-				DatagramID: 42,
-				Frames:     []qlog.Frame{{Frame: &wire.PingFrame{}}},
-				ECN:        qlog.ECT1,
+				Raw:                     qlog.RawInfo{Length: int(packet2.Size()), PayloadLength: 1},
+				DatagramPayloadChecksum: 42,
+				Frames:                  []qlog.Frame{{Frame: &wire.PingFrame{}}},
+				ECN:                     qlog.ECT1,
 			},
 			qlog.PacketDropped{
-				Header:     qlog.PacketHeader{DestConnectionID: incorrectSrcConnID},
-				Raw:        qlog.RawInfo{Length: int(packet3.Size())},
-				DatagramID: 42,
-				Trigger:    qlog.PacketDropUnknownConnectionID,
+				Header:                  qlog.PacketHeader{DestConnectionID: incorrectSrcConnID},
+				Raw:                     qlog.RawInfo{Length: int(packet3.Size())},
+				DatagramPayloadChecksum: 42,
+				Trigger:                 qlog.PacketDropUnknownConnectionID,
 			},
 		},
 		eventRecorder.Events(qlog.PacketReceived{}, qlog.PacketDropped{}),
@@ -1641,11 +1641,11 @@ func TestConnectionPacketBuffering(t *testing.T) {
 		hdrs := make(map[string]*wire.ExtendedHeader)
 
 		packet1 := getLongHeaderPacket(t, tc.remoteAddr, &hdr1, []byte("packet1"))
-		datagramID1 := qlog.CalculateDatagramID(packet1.data)
+		datagramPayloadChecksum1 := qlog.CalculateDatagramPayloadChecksum(packet1.data)
 		hdrs["packet1"] = &hdr1
 		tc.conn.handlePacket(packet1)
 		packet2 := getLongHeaderPacket(t, tc.remoteAddr, &hdr2, []byte("packet2"))
-		datagramID2 := qlog.CalculateDatagramID(packet2.data)
+		datagramPayloadChecksum2 := qlog.CalculateDatagramPayloadChecksum(packet2.data)
 		hdrs["packet2"] = &hdr2
 		tc.conn.handlePacket(packet2)
 		synctest.Wait()
@@ -1657,16 +1657,16 @@ func TestConnectionPacketBuffering(t *testing.T) {
 						PacketType:   qlog.PacketTypeHandshake,
 						PacketNumber: protocol.InvalidPacketNumber,
 					},
-					Raw:        qlog.RawInfo{Length: int(packet1.Size())},
-					DatagramID: datagramID1,
+					Raw:                     qlog.RawInfo{Length: int(packet1.Size())},
+					DatagramPayloadChecksum: datagramPayloadChecksum1,
 				},
 				qlog.PacketBuffered{
 					Header: qlog.PacketHeader{
 						PacketType:   qlog.PacketTypeHandshake,
 						PacketNumber: protocol.InvalidPacketNumber,
 					},
-					Raw:        qlog.RawInfo{Length: int(packet2.Size())},
-					DatagramID: datagramID2,
+					Raw:                     qlog.RawInfo{Length: int(packet2.Size())},
+					DatagramPayloadChecksum: datagramPayloadChecksum2,
 				},
 			},
 			eventRecorder.Events(qlog.PacketBuffered{}),
@@ -1715,7 +1715,7 @@ func TestConnectionPacketBuffering(t *testing.T) {
 		)
 
 		packet3 := getLongHeaderPacket(t, tc.remoteAddr, &hdr3, []byte("packet3"))
-		datagramID3 := qlog.CalculateDatagramID(packet3.data)
+		datagramPayloadChecksum3 := qlog.CalculateDatagramPayloadChecksum(packet3.data)
 		tc.conn.handlePacket(packet3)
 
 		synctest.Wait()
@@ -1734,9 +1734,9 @@ func TestConnectionPacketBuffering(t *testing.T) {
 						PacketNumber:     3,
 						Version:          protocol.Version1,
 					},
-					Raw:        qlog.RawInfo{Length: int(packet3.Size()), PayloadLength: 8},
-					DatagramID: datagramID3,
-					Frames:     []qlog.Frame{{Frame: &qlog.CryptoFrame{Length: 6}}},
+					Raw:                     qlog.RawInfo{Length: int(packet3.Size()), PayloadLength: 8},
+					DatagramPayloadChecksum: datagramPayloadChecksum3,
+					Frames:                  []qlog.Frame{{Frame: &qlog.CryptoFrame{Length: 6}}},
 				},
 				qlog.PacketReceived{
 					Header: qlog.PacketHeader{
@@ -1746,9 +1746,9 @@ func TestConnectionPacketBuffering(t *testing.T) {
 						PacketNumber:     1,
 						Version:          protocol.Version1,
 					},
-					Raw:        qlog.RawInfo{Length: int(packet1.Size()), PayloadLength: 8},
-					DatagramID: datagramID1,
-					Frames:     []qlog.Frame{},
+					Raw:                     qlog.RawInfo{Length: int(packet1.Size()), PayloadLength: 8},
+					DatagramPayloadChecksum: datagramPayloadChecksum1,
+					Frames:                  []qlog.Frame{},
 				},
 				qlog.PacketReceived{
 					Header: qlog.PacketHeader{
@@ -1758,9 +1758,9 @@ func TestConnectionPacketBuffering(t *testing.T) {
 						PacketNumber:     2,
 						Version:          protocol.Version1,
 					},
-					Raw:        qlog.RawInfo{Length: int(packet1.Size()), PayloadLength: 8},
-					DatagramID: datagramID2,
-					Frames:     []qlog.Frame{},
+					Raw:                     qlog.RawInfo{Length: int(packet1.Size()), PayloadLength: 8},
+					DatagramPayloadChecksum: datagramPayloadChecksum2,
+					Frames:                  []qlog.Frame{},
 				},
 			},
 			eventRecorder.Events(qlog.PacketReceived{}, qlog.PacketBuffered{}),
@@ -3101,9 +3101,9 @@ func testConnectionConnectionIDChanges(t *testing.T, sendRetry bool) {
 						PacketNumber:     1,
 						Version:          protocol.Version1,
 					},
-					Raw:        qlog.RawInfo{Length: int(packet1.Size()), PayloadLength: int(hdr1.Length)},
-					DatagramID: qlog.CalculateDatagramID(packet1.data),
-					Frames:     []qlog.Frame{},
+					Raw:                     qlog.RawInfo{Length: int(packet1.Size()), PayloadLength: int(hdr1.Length)},
+					DatagramPayloadChecksum: qlog.CalculateDatagramPayloadChecksum(packet1.data),
+					Frames:                  []qlog.Frame{},
 				},
 			},
 			eventRecorder.Events(qlog.PacketReceived{}, qlog.PacketDropped{}),
@@ -3123,9 +3123,9 @@ func testConnectionConnectionIDChanges(t *testing.T, sendRetry bool) {
 						PacketType:   qlog.PacketTypeInitial,
 						PacketNumber: protocol.InvalidPacketNumber,
 					},
-					Raw:        qlog.RawInfo{Length: int(packet2.Size())},
-					DatagramID: qlog.CalculateDatagramID(packet2.data),
-					Trigger:    qlog.PacketDropUnknownConnectionID,
+					Raw:                     qlog.RawInfo{Length: int(packet2.Size())},
+					DatagramPayloadChecksum: qlog.CalculateDatagramPayloadChecksum(packet2.data),
+					Trigger:                 qlog.PacketDropUnknownConnectionID,
 				},
 			},
 			eventRecorder.Events(qlog.PacketDropped{}, qlog.PacketReceived{}),

--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -387,15 +387,15 @@ func TestHandshakePacketBuffering(t *testing.T) {
 		buffered := clientEventRecorder.Events(qlog.PacketBuffered{})
 		t.Logf("buffered packets: %d", len(buffered))
 		require.NotEmpty(t, buffered)
-		receivedPackets := make(map[qlog.DatagramID][]qlog.PacketType)
+		receivedPackets := make(map[qlog.DatagramPayloadChecksum][]qlog.PacketType)
 		for _, ev := range clientEventRecorder.Events(qlog.PacketReceived{}) {
-			id := ev.(qlog.PacketReceived).DatagramID
-			receivedPackets[id] = append(receivedPackets[id], ev.(qlog.PacketReceived).Header.PacketType)
+			checksum := ev.(qlog.PacketReceived).DatagramPayloadChecksum
+			receivedPackets[checksum] = append(receivedPackets[checksum], ev.(qlog.PacketReceived).Header.PacketType)
 		}
 		for _, ev := range buffered {
-			id := ev.(qlog.PacketBuffered).DatagramID
-			require.Contains(t, receivedPackets, id)
-			require.Contains(t, receivedPackets[id], qlog.PacketTypeHandshake)
+			checksum := ev.(qlog.PacketBuffered).DatagramPayloadChecksum
+			require.Contains(t, receivedPackets, checksum)
+			require.Contains(t, receivedPackets[checksum], qlog.PacketTypeHandshake)
 		}
 
 		sconn, err := ln.Accept(context.Background())

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -212,14 +212,14 @@ func (e ConnectionClosed) Encode(enc *jsontext.Encoder, _ time.Time) error {
 }
 
 type PacketSent struct {
-	Header            PacketHeader
-	Raw               RawInfo
-	DatagramID        DatagramID
-	Frames            []Frame
-	ECN               ECN
-	IsCoalesced       bool
-	Trigger           string
-	SupportedVersions []Version
+	Header                  PacketHeader
+	Raw                     RawInfo
+	DatagramPayloadChecksum DatagramPayloadChecksum
+	Frames                  []Frame
+	ECN                     ECN
+	IsCoalesced             bool
+	Trigger                 string
+	SupportedVersions       []Version
 }
 
 func (e PacketSent) Name() string { return "transport:packet_sent" }
@@ -235,9 +235,9 @@ func (e PacketSent) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	if err := e.Raw.encode(enc); err != nil {
 		return err
 	}
-	if e.DatagramID != 0 {
-		h.WriteToken(jsontext.String("datagram_id"))
-		h.WriteToken(jsontext.Uint(uint64(e.DatagramID)))
+	if e.DatagramPayloadChecksum != 0 {
+		h.WriteToken(jsontext.String("datagram_payload_checksum"))
+		h.WriteToken(jsontext.Uint(uint64(e.DatagramPayloadChecksum)))
 	}
 	if len(e.Frames) > 0 {
 		h.WriteToken(jsontext.String("frames"))
@@ -262,13 +262,13 @@ func (e PacketSent) Encode(enc *jsontext.Encoder, _ time.Time) error {
 }
 
 type PacketReceived struct {
-	Header      PacketHeader
-	Raw         RawInfo
-	DatagramID  DatagramID
-	Frames      []Frame
-	ECN         ECN
-	IsCoalesced bool
-	Trigger     string
+	Header                  PacketHeader
+	Raw                     RawInfo
+	DatagramPayloadChecksum DatagramPayloadChecksum
+	Frames                  []Frame
+	ECN                     ECN
+	IsCoalesced             bool
+	Trigger                 string
 }
 
 func (e PacketReceived) Name() string { return "transport:packet_received" }
@@ -284,9 +284,9 @@ func (e PacketReceived) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	if err := e.Raw.encode(enc); err != nil {
 		return err
 	}
-	if e.DatagramID != 0 {
-		h.WriteToken(jsontext.String("datagram_id"))
-		h.WriteToken(jsontext.Uint(uint64(e.DatagramID)))
+	if e.DatagramPayloadChecksum != 0 {
+		h.WriteToken(jsontext.String("datagram_payload_checksum"))
+		h.WriteToken(jsontext.Uint(uint64(e.DatagramPayloadChecksum)))
 	}
 	if len(e.Frames) > 0 {
 		h.WriteToken(jsontext.String("frames"))
@@ -355,9 +355,9 @@ func (e VersionNegotiationSent) Encode(enc *jsontext.Encoder, _ time.Time) error
 }
 
 type PacketBuffered struct {
-	Header     PacketHeader
-	Raw        RawInfo
-	DatagramID DatagramID
+	Header                  PacketHeader
+	Raw                     RawInfo
+	DatagramPayloadChecksum DatagramPayloadChecksum
 }
 
 func (e PacketBuffered) Name() string { return "transport:packet_buffered" }
@@ -373,9 +373,9 @@ func (e PacketBuffered) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	if err := e.Raw.encode(enc); err != nil {
 		return err
 	}
-	if e.DatagramID != 0 {
-		h.WriteToken(jsontext.String("datagram_id"))
-		h.WriteToken(jsontext.Uint(uint64(e.DatagramID)))
+	if e.DatagramPayloadChecksum != 0 {
+		h.WriteToken(jsontext.String("datagram_payload_checksum"))
+		h.WriteToken(jsontext.Uint(uint64(e.DatagramPayloadChecksum)))
 	}
 	h.WriteToken(jsontext.String("trigger"))
 	h.WriteToken(jsontext.String("keys_unavailable"))
@@ -385,10 +385,10 @@ func (e PacketBuffered) Encode(enc *jsontext.Encoder, _ time.Time) error {
 
 // PacketDropped is the transport:packet_dropped event.
 type PacketDropped struct {
-	Header     PacketHeader
-	Raw        RawInfo
-	DatagramID DatagramID
-	Trigger    PacketDropReason
+	Header                  PacketHeader
+	Raw                     RawInfo
+	DatagramPayloadChecksum DatagramPayloadChecksum
+	Trigger                 PacketDropReason
 }
 
 func (e PacketDropped) Name() string { return "transport:packet_dropped" }
@@ -404,9 +404,9 @@ func (e PacketDropped) Encode(enc *jsontext.Encoder, _ time.Time) error {
 	if err := e.Raw.encode(enc); err != nil {
 		return err
 	}
-	if e.DatagramID != 0 {
-		h.WriteToken(jsontext.String("datagram_id"))
-		h.WriteToken(jsontext.Uint(uint64(e.DatagramID)))
+	if e.DatagramPayloadChecksum != 0 {
+		h.WriteToken(jsontext.String("datagram_payload_checksum"))
+		h.WriteToken(jsontext.Uint(uint64(e.DatagramPayloadChecksum)))
 	}
 	h.WriteToken(jsontext.String("trigger"))
 	h.WriteToken(jsontext.String(string(e.Trigger)))

--- a/qlog/event_test.go
+++ b/qlog/event_test.go
@@ -399,7 +399,7 @@ func TestPacketSent(t *testing.T) {
 	require.Equal(t, "transport:packet_sent", name)
 	require.Contains(t, ev, "raw")
 	raw := ev["raw"].(map[string]any)
-	require.NotContains(t, ev, "datagram_id")
+	require.NotContains(t, ev, "datagram_payload_checksum")
 	require.Equal(t, float64(987), raw["length"])
 	require.Equal(t, float64(1337), raw["payload_length"])
 	require.Contains(t, ev, "header")
@@ -416,16 +416,16 @@ func TestPacketSent(t *testing.T) {
 }
 
 func TestPacketSent1RTT(t *testing.T) {
-	t.Run("with datagram ID", func(t *testing.T) {
+	t.Run("with datagram payload checksum", func(t *testing.T) {
 		testPacketSent1RTT(t, 1337)
 	})
 
-	t.Run("without datagram ID", func(t *testing.T) {
+	t.Run("without datagram payload checksum", func(t *testing.T) {
 		testPacketSent1RTT(t, 0)
 	})
 }
 
-func testPacketSent1RTT(t *testing.T, datagramID DatagramID) {
+func testPacketSent1RTT(t *testing.T, datagramPayloadChecksum DatagramPayloadChecksum) {
 	name, ev := testEventEncoding(t, &PacketSent{
 		Header: PacketHeader{
 			PacketType:       PacketType1RTT,
@@ -438,8 +438,8 @@ func testPacketSent1RTT(t *testing.T, datagramID DatagramID) {
 			{Frame: &AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 10}}}},
 			{Frame: &MaxDataFrame{MaximumData: 987}},
 		},
-		ECN:        ECNUnsupported,
-		DatagramID: datagramID,
+		ECN:                     ECNUnsupported,
+		DatagramPayloadChecksum: datagramPayloadChecksum,
 	})
 
 	require.Equal(t, "transport:packet_sent", name)
@@ -456,11 +456,11 @@ func testPacketSent1RTT(t *testing.T, datagramID DatagramID) {
 	require.Len(t, frames, 2)
 	require.Equal(t, "ack", frames[0].(map[string]any)["frame_type"])
 	require.Equal(t, "max_data", frames[1].(map[string]any)["frame_type"])
-	if datagramID != 0 {
-		require.Contains(t, ev, "datagram_id")
-		require.Equal(t, float64(datagramID), ev["datagram_id"])
+	if datagramPayloadChecksum != 0 {
+		require.Contains(t, ev, "datagram_payload_checksum")
+		require.Equal(t, float64(datagramPayloadChecksum), ev["datagram_payload_checksum"])
 	} else {
-		require.NotContains(t, ev, "datagram_id")
+		require.NotContains(t, ev, "datagram_payload_checksum")
 	}
 }
 
@@ -482,8 +482,8 @@ func TestPacketReceived(t *testing.T) {
 			{Frame: &MaxStreamDataFrame{StreamID: 42, MaximumStreamData: 987}},
 			{Frame: &StreamFrame{StreamID: 123, Offset: 1234, Length: 6, Fin: true}},
 		},
-		ECN:        ECT0,
-		DatagramID: 42,
+		ECN:                     ECT0,
+		DatagramPayloadChecksum: 42,
 	})
 
 	require.Equal(t, "transport:packet_received", name)
@@ -502,21 +502,21 @@ func TestPacketReceived(t *testing.T) {
 	require.Equal(t, "deadbeef", token["data"])
 	require.Contains(t, ev, "frames")
 	require.Len(t, ev["frames"].([]any), 2)
-	require.Contains(t, ev, "datagram_id")
-	require.Equal(t, float64(42), ev["datagram_id"])
+	require.Contains(t, ev, "datagram_payload_checksum")
+	require.Equal(t, float64(42), ev["datagram_payload_checksum"])
 }
 
 func TestPacketReceived1RTT(t *testing.T) {
-	t.Run("with datagram ID", func(t *testing.T) {
+	t.Run("with datagram payload checksum", func(t *testing.T) {
 		testPacketReceived1RTT(t, 1337)
 	})
 
-	t.Run("without datagram ID", func(t *testing.T) {
+	t.Run("without datagram payload checksum", func(t *testing.T) {
 		testPacketReceived1RTT(t, 0)
 	})
 }
 
-func testPacketReceived1RTT(t *testing.T, datagramID DatagramID) {
+func testPacketReceived1RTT(t *testing.T, datagramPayloadChecksum DatagramPayloadChecksum) {
 	name, ev := testEventEncoding(t, &PacketReceived{
 		Header: PacketHeader{
 			PacketType:       PacketType1RTT,
@@ -529,8 +529,8 @@ func testPacketReceived1RTT(t *testing.T, datagramID DatagramID) {
 			{Frame: &MaxStreamDataFrame{StreamID: 42, MaximumStreamData: 987}},
 			{Frame: &StreamFrame{StreamID: 123, Offset: 1234, Length: 6, Fin: true}},
 		},
-		ECN:        ECT1,
-		DatagramID: datagramID,
+		ECN:                     ECT1,
+		DatagramPayloadChecksum: datagramPayloadChecksum,
 	})
 
 	require.Equal(t, "transport:packet_received", name)
@@ -545,11 +545,11 @@ func testPacketReceived1RTT(t *testing.T, datagramID DatagramID) {
 	require.Equal(t, float64(1337), hdr["packet_number"])
 	require.Contains(t, ev, "frames")
 	require.Len(t, ev["frames"].([]any), 2)
-	if datagramID != 0 {
-		require.Contains(t, ev, "datagram_id")
-		require.Equal(t, float64(datagramID), ev["datagram_id"])
+	if datagramPayloadChecksum != 0 {
+		require.Contains(t, ev, "datagram_payload_checksum")
+		require.Equal(t, float64(datagramPayloadChecksum), ev["datagram_payload_checksum"])
 	} else {
-		require.NotContains(t, ev, "datagram_id")
+		require.NotContains(t, ev, "datagram_payload_checksum")
 	}
 }
 
@@ -613,27 +613,31 @@ func TestPacketBuffered(t *testing.T) {
 			DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
 			SrcConnectionID:  protocol.ParseConnectionID([]byte{4, 3, 2, 1}),
 		},
-		Raw: RawInfo{Length: 1337},
+		Raw:                     RawInfo{Length: 1337},
+		DatagramPayloadChecksum: 42,
 	})
 
 	require.Equal(t, "transport:packet_buffered", name)
 	require.Contains(t, ev, "header")
 	require.Contains(t, ev, "raw")
 	require.Equal(t, float64(1337), ev["raw"].(map[string]any)["length"])
+	require.Equal(t, float64(42), ev["datagram_payload_checksum"])
 	require.Contains(t, ev, "trigger")
 	require.Equal(t, "keys_unavailable", ev["trigger"])
 }
 
 func TestPacketDropped(t *testing.T) {
 	name, ev := testEventEncoding(t, &PacketDropped{
-		Header:  PacketHeader{PacketType: PacketTypeRetry},
-		Raw:     RawInfo{Length: 1337},
-		Trigger: PacketDropPayloadDecryptError,
+		Header:                  PacketHeader{PacketType: PacketTypeRetry},
+		Raw:                     RawInfo{Length: 1337},
+		DatagramPayloadChecksum: 42,
+		Trigger:                 PacketDropPayloadDecryptError,
 	})
 
 	require.Equal(t, "transport:packet_dropped", name)
 	require.Contains(t, ev, "raw")
 	require.Equal(t, float64(1337), ev["raw"].(map[string]any)["length"])
+	require.Equal(t, float64(42), ev["datagram_payload_checksum"])
 	require.Contains(t, ev, "header")
 	require.Equal(t, "payload_decrypt_error", ev["trigger"])
 }

--- a/qlog/types.go
+++ b/qlog/types.go
@@ -295,10 +295,11 @@ const (
 	ConnectionCloseTriggerStatelessReset ConnectionCloseTrigger = "stateless_reset"
 )
 
-// DatagramID is a unique identifier for a datagram
-type DatagramID uint32
+// DatagramPayloadChecksum is the CRC32c checksum of a UDP datagram payload.
+// ponytail: zero means absent; use an optional value if zero-valued checksums need to be logged.
+type DatagramPayloadChecksum uint32
 
-// CalculateDatagramID computes a DatagramID for a given packet
-func CalculateDatagramID(packet []byte) DatagramID {
-	return DatagramID(crc32.ChecksumIEEE(packet))
+// CalculateDatagramPayloadChecksum computes the checksum of a UDP datagram payload.
+func CalculateDatagramPayloadChecksum(payload []byte) DatagramPayloadChecksum {
+	return DatagramPayloadChecksum(crc32.Checksum(payload, crc32.MakeTable(crc32.Castagnoli)))
 }

--- a/qlog/types_test.go
+++ b/qlog/types_test.go
@@ -15,6 +15,6 @@ func TestEncryptionLevelToPacketType(t *testing.T) {
 	require.Equal(t, "1RTT", string(EncryptionLevelToPacketType(protocol.Encryption1RTT)))
 }
 
-func TestCalculateDatagramID(t *testing.T) {
-	require.Equal(t, DatagramID(0xcbf43926), CalculateDatagramID([]byte("123456789")))
+func TestCalculateDatagramPayloadChecksum(t *testing.T) {
+	require.Equal(t, DatagramPayloadChecksum(0xe3069283), CalculateDatagramPayloadChecksum([]byte("123456789")))
 }


### PR DESCRIPTION
This was recently changed in the qlog draft: https://github.com/quicwg/qlog/pull/520

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace datagram IDs with CRC32c payload checksums in qlog events
> - Replaces the `DatagramID` field with `DatagramPayloadChecksum` across all qlog event types (`PacketSent`, `PacketReceived`, `PacketBuffered`, `PacketDropped`) in [qlog/types.go](https://github.com/quic-go/quic-go/pull/5758/files#diff-0640cb20e7513924809ffe721e92a9e2d485b88cdc96b43cecdcf01767629e9c) and [qlog/event.go](https://github.com/quic-go/quic-go/pull/5758/files#diff-53fd9fb730363f0167210bd063270f6e81f4b279b2ae02609e283073bff3cbe2).
> - Checksum is computed using CRC32 Castagnoli (CRC32c) via `qlog.CalculateDatagramPayloadChecksum` over the UDP payload, replacing the previous CRC32 IEEE datagram ID.
> - All send and receive paths in [connection.go](https://github.com/quic-go/quic-go/pull/5758/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7) and [connection_logging.go](https://github.com/quic-go/quic-go/pull/5758/files#diff-d002296ec0d92d036409a635f28c187c30bcf05c292aa2cc2a38f851b4772569) propagate the checksum instead of the ID through packet handling and logging helpers.
> - Behavioral Change: JSON qlog output now emits `datagram_payload_checksum` instead of `datagram_id`; tools consuming qlog output must be updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized abe84e5. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * qlog packet events now record datagram payload checksums instead of datagram IDs.
  * Added support for calculating and reporting payload checksums for relevant packets.
  * Updated packet buffering, receiving, sending, and drop events to use the new checksum field.
* **Bug Fixes**
  * Improved correlation of buffered and received handshake packets in qlog output.
* **Documentation**
  * Clarified checksum behavior, including when values are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->