### PR TITLE
guard qlogger when dropping malformed short-header packets

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1182,15 +1182,17 @@ func (c *Conn) handleShortHeaderPacket(
 
 	destConnID, err := wire.ParseConnectionID(p.data, c.srcConnIDLen)
 	if err != nil {
-		c.qlogger.RecordEvent(qlog.PacketDropped{
-			Header: qlog.PacketHeader{
-				PacketType:   qlog.PacketType1RTT,
-				PacketNumber: protocol.InvalidPacketNumber,
-			},
-			Raw:                     qlog.RawInfo{Length: len(p.data)},
-			DatagramPayloadChecksum: datagramPayloadChecksum,
-			Trigger:                 qlog.PacketDropHeaderParseError,
-		})
+		if c.qlogger != nil {
+			c.qlogger.RecordEvent(qlog.PacketDropped{
+				Header: qlog.PacketHeader{
+					PacketType:   qlog.PacketType1RTT,
+					PacketNumber: protocol.InvalidPacketNumber,
+				},
+				Raw:                     qlog.RawInfo{Length: len(p.data)},
+				DatagramPayloadChecksum: datagramPayloadChecksum,
+				Trigger:                 qlog.PacketDropHeaderParseError,
+			})
+		}
 		return false, nil
 	}
 	pn, pnLen, keyPhase, data, err := c.unpacker.UnpackShortHeader(p.rcvTime, p.data)


### PR DESCRIPTION
This is not a vulnerability: A malformed short-header packet is rejected by `Transport` using the same connection-ID length before it can reach the connection-level parser.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nil panic in `Conn.handleShortHeaderPacket` when qlogger is not set
> Adds a nil-check on `c.qlogger` before calling `RecordEvent` in [connection.go](https://github.com/quic-go/quic-go/pull/5759/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7). Previously, a failure to parse the destination connection ID from a short-header packet would unconditionally call `c.qlogger.RecordEvent`, panicking if qlogger was nil.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33ec3bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a connection error when malformed packet headers are received while event logging is disabled.
  * Improved handling of dropped packets during connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->