### PR TITLE
return error from Conn.NextConnection when the connection is closed

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3136,10 +3136,11 @@ func (c *Conn) NextConnection(ctx context.Context) (*Conn, error) {
 	case <-ctx.Done():
 		return nil, context.Cause(ctx)
 	case <-c.Context().Done():
+		return nil, context.Cause(c.Context())
 	case <-c.HandshakeComplete():
 		c.streamsMap.UseResetMaps()
+		return c, nil
 	}
-	return c, nil
 }
 
 // estimateMaxPayloadSize estimates the maximum payload size for short header packets.


### PR DESCRIPTION
Fixes #5763.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Conn.NextConnection` to return the context error when the connection context is cancelled
> Previously, `NextConnection` in [connection.go](https://github.com/quic-go/quic-go/pull/5764/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7) could return a usable connection even when the connection's context was cancelled. The fix moves the success return into the `HandshakeComplete` case and adds an explicit `context.Cause(c.Context())` error return when `c.Context().Done()` fires. Risk: callers that previously received a connection on context cancellation will now receive an error instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a79c1d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown handling so operations stop promptly when the connection context is canceled.
  * Ensured connection state is updated immediately after the handshake completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->