### PR TITLE
http3: expose TryWriteAll method on Stream and RequestStream

### DIFF
--- a/http3/mock_datagram_stream_test.go
+++ b/http3/mock_datagram_stream_test.go
@@ -496,6 +496,44 @@ func (c *MockDatagramStreamStreamIDCall) DoAndReturn(f func() quic.StreamID) *Mo
 	return c
 }
 
+// TryWriteAll mocks base method.
+func (m *MockDatagramStream) TryWriteAll(arg0 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TryWriteAll", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TryWriteAll indicates an expected call of TryWriteAll.
+func (mr *MockDatagramStreamMockRecorder) TryWriteAll(arg0 any) *MockDatagramStreamTryWriteAllCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryWriteAll", reflect.TypeOf((*MockDatagramStream)(nil).TryWriteAll), arg0)
+	return &MockDatagramStreamTryWriteAllCall{Call: call}
+}
+
+// MockDatagramStreamTryWriteAllCall wrap *gomock.Call
+type MockDatagramStreamTryWriteAllCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDatagramStreamTryWriteAllCall) Return(arg0 error) *MockDatagramStreamTryWriteAllCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDatagramStreamTryWriteAllCall) Do(f func([]byte) error) *MockDatagramStreamTryWriteAllCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDatagramStreamTryWriteAllCall) DoAndReturn(f func([]byte) error) *MockDatagramStreamTryWriteAllCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Write mocks base method.
 func (m *MockDatagramStream) Write(p []byte) (int, error) {
 	m.ctrl.T.Helper()

--- a/http3/state_tracking_stream.go
+++ b/http3/state_tracking_stream.go
@@ -100,6 +100,14 @@ func (s *stateTrackingStream) Write(b []byte) (int, error) {
 	return n, err
 }
 
+func (s *stateTrackingStream) TryWriteAll(b []byte) error {
+	err := s.Stream.TryWriteAll(b)
+	if err != nil && !errors.Is(err, quic.ErrWouldBlock) {
+		s.closeSend(err)
+	}
+	return err
+}
+
 func (s *stateTrackingStream) CancelRead(e quic.StreamErrorCode) {
 	s.closeReceive(&quic.StreamError{StreamID: s.StreamID(), ErrorCode: e})
 	s.Stream.CancelRead(e)

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -25,6 +25,7 @@ type datagramStream interface {
 	SetDeadline(time.Time) error
 	SetReadDeadline(time.Time) error
 	SetWriteDeadline(time.Time) error
+	TryWriteAll([]byte) error
 	SendDatagram(b []byte) error
 	ReceiveDatagram(ctx context.Context) ([]byte, error)
 
@@ -135,6 +136,28 @@ func (s *Stream) Write(b []byte) (int, error) {
 	return s.datagramStream.Write(b)
 }
 
+// TryWriteAll writes b in a DATA frame if the entire frame can be queued immediately.
+// It returns [quic.ErrWouldBlock] without queueing anything otherwise.
+func (s *Stream) TryWriteAll(b []byte) error {
+	data := make([]byte, 0, frameHeaderLen+len(b))
+	data = (&dataFrame{Length: uint64(len(b))}).Append(data)
+	data = append(data, b...)
+	if err := s.datagramStream.TryWriteAll(data); err != nil {
+		return err
+	}
+	if s.qlogger != nil {
+		s.qlogger.RecordEvent(qlog.FrameCreated{
+			StreamID: s.StreamID(),
+			Raw: qlog.RawInfo{
+				Length:        len(data),
+				PayloadLength: len(b),
+			},
+			Frame: qlog.Frame{Frame: qlog.DataFrame{}},
+		})
+	}
+	return nil
+}
+
 func (s *Stream) writeUnframed(b []byte) (int, error) {
 	return s.datagramStream.Write(b)
 }
@@ -221,6 +244,15 @@ func (s *RequestStream) Write(b []byte) (int, error) {
 		return 0, errors.New("http3: invalid use of RequestStream.Write before SendRequestHeader")
 	}
 	return s.str.Write(b)
+}
+
+// TryWriteAll writes b if the entire DATA frame can be queued immediately.
+// It can only be used after the request has been sent (using SendRequestHeader).
+func (s *RequestStream) TryWriteAll(b []byte) error {
+	if !s.sentRequest {
+		return errors.New("http3: invalid use of RequestStream.TryWriteAll before SendRequestHeader")
+	}
+	return s.str.TryWriteAll(b)
 }
 
 // Close closes the send-direction of the stream.

--- a/http3/stream_test.go
+++ b/http3/stream_test.go
@@ -175,6 +175,31 @@ func TestStreamWrite(t *testing.T) {
 	)
 }
 
+func TestStreamTryWriteAll(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	qstr := NewMockDatagramStream(mockCtrl)
+	qstr.EXPECT().StreamID().Return(quic.StreamID(42)).AnyTimes()
+	qstr.EXPECT().TryWriteAll(getDataFrame([]byte("foobar"))).Return(nil)
+	qstr.EXPECT().TryWriteAll(getDataFrame([]byte("blocked"))).Return(quic.ErrWouldBlock)
+
+	var eventRecorder events.Recorder
+	str := newStream(qstr, nil, nil, func(io.Reader, *headersFrame) error { return nil }, &eventRecorder)
+	require.NoError(t, str.TryWriteAll([]byte("foobar")))
+	require.ErrorIs(t, str.TryWriteAll([]byte("blocked")), quic.ErrWouldBlock)
+
+	frameLen, payloadLen := expectedFrameLength(t, &dataFrame{Length: 6})
+	require.Equal(t,
+		[]qlogwriter.Event{
+			qlog.FrameCreated{
+				StreamID: 42,
+				Raw:      qlog.RawInfo{Length: frameLen, PayloadLength: payloadLen},
+				Frame:    qlog.Frame{Frame: qlog.DataFrame{}},
+			},
+		},
+		eventRecorder.Events(qlog.FrameCreated{}),
+	)
+}
+
 func TestRequestStream(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	qstr := NewMockDatagramStream(mockCtrl)
@@ -201,6 +226,10 @@ func TestRequestStream(t *testing.T) {
 	require.EqualError(t, err, "http3: invalid use of RequestStream.Read before ReadResponse")
 	_, err = str.Write([]byte{0})
 	require.EqualError(t, err, "http3: invalid use of RequestStream.Write before SendRequestHeader")
+	require.EqualError(t,
+		str.TryWriteAll([]byte{0}),
+		"http3: invalid use of RequestStream.TryWriteAll before SendRequestHeader",
+	)
 
 	// calling ReadResponse before SendRequestHeader is not valid
 	_, err = str.ReadResponse()
@@ -218,6 +247,8 @@ func TestRequestStream(t *testing.T) {
 	require.NoError(t, str.SendRequestHeader(req))
 	// duplicate calls are not allowed
 	require.EqualError(t, str.SendRequestHeader(req), "http3: invalid duplicate use of RequestStream.SendRequestHeader")
+	qstr.EXPECT().TryWriteAll(getDataFrame([]byte("request body"))).Return(nil)
+	require.NoError(t, str.TryWriteAll([]byte("request body")))
 
 	buf := bytes.NewBuffer(encodeResponse(t, http.StatusOK))
 	buf.Write((&dataFrame{Length: 6}).Append(nil))


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Expose `TryWriteAll` method on `http3.Stream` and `RequestStream`
- Adds `TryWriteAll([]byte) error` to the `datagramStream` interface, `http3.Stream`, and `http3.RequestStream` in [http3/stream.go](https://github.com/quic-go/quic-go/pull/5765/files#diff-78b9dd15996d79e5718e0b1a031fd73b67983fceb406305fb50ec797dbb558de), mirroring the non-blocking semantics of the underlying QUIC stream.
- `Stream.TryWriteAll` wraps the payload in a DATA frame and calls through to `datagramStream.TryWriteAll`, returning `quic.ErrWouldBlock` if the full frame cannot be queued; on success it records a qlog `FrameCreated` event.
- `RequestStream.TryWriteAll` guards against calls made before `SendRequestHeader`, returning an error in that case.
- `stateTrackingStream.TryWriteAll` in [http3/state_tracking_stream.go](https://github.com/quic-go/quic-go/pull/5765/files#diff-14cc91b13b7fcb317551c2b1586fd8e4e385047c80397768068218cc64766c4f) delegates to the embedded stream and calls `closeSend` on any non-`ErrWouldBlock` error.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47961f3.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added non-blocking `TryWriteAll` support for HTTP/3 request and stream data.
  * Added validation to ensure request headers are sent before writing request data.
  * Added qlog tracking for successfully created DATA frames.

* **Bug Fixes**
  * Preserved and propagated write errors, including backpressure notifications, while recording relevant send-side failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->