### PR TITLE
add Config.MaxPacketSize to limit the packet size used by Path MTU Discovery

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,6 +45,12 @@ func validateConfig(config *Config) error {
 	if config.InitialPacketSize > protocol.MaxPacketBufferSize {
 		config.InitialPacketSize = protocol.MaxPacketBufferSize
 	}
+	if config.MaxPacketSize > 0 && config.MaxPacketSize < protocol.MinInitialPacketSize {
+		config.MaxPacketSize = protocol.MinInitialPacketSize
+	}
+	if config.MaxPacketSize > protocol.MaxPacketBufferSize {
+		config.MaxPacketSize = protocol.MaxPacketBufferSize
+	}
 	// check that all QUIC versions are actually supported
 	for _, v := range config.Versions {
 		if !protocol.IsValidVersion(v) {
@@ -104,6 +110,10 @@ func populateConfig(config *Config) *Config {
 	if initialPacketSize == 0 {
 		initialPacketSize = protocol.InitialPacketSize
 	}
+	maxPacketSize := config.MaxPacketSize
+	if maxPacketSize == 0 {
+		maxPacketSize = protocol.DefaultMaxPacketSize
+	}
 
 	return &Config{
 		GetConfigForClient:               config.GetConfigForClient,
@@ -121,6 +131,7 @@ func populateConfig(config *Config) *Config {
 		TokenStore:                       config.TokenStore,
 		EnableDatagrams:                  config.EnableDatagrams,
 		InitialPacketSize:                initialPacketSize,
+		MaxPacketSize:                    maxPacketSize,
 		DisablePathMTUDiscovery:          config.DisablePathMTUDiscovery,
 		EnableStreamResetPartialDelivery: config.EnableStreamResetPartialDelivery,
 		Allow0RTT:                        config.Allow0RTT,

--- a/config_test.go
+++ b/config_test.go
@@ -65,6 +65,23 @@ func TestConfigValidation(t *testing.T) {
 		require.NoError(t, validateConfig(conf))
 		require.Equal(t, uint16(protocol.MaxPacketBufferSize), conf.InitialPacketSize)
 	})
+
+	t.Run("max packet size", func(t *testing.T) {
+		// not set
+		conf := &Config{MaxPacketSize: 0}
+		require.NoError(t, validateConfig(conf))
+		require.Zero(t, conf.MaxPacketSize)
+
+		// too small
+		conf = &Config{MaxPacketSize: 10}
+		require.NoError(t, validateConfig(conf))
+		require.Equal(t, uint16(1200), conf.MaxPacketSize)
+
+		// too large
+		conf = &Config{MaxPacketSize: protocol.MaxPacketBufferSize + 1}
+		require.NoError(t, validateConfig(conf))
+		require.Equal(t, uint16(protocol.MaxPacketBufferSize), conf.MaxPacketSize)
+	})
 }
 
 func TestConfigHandshakeIdleTimeout(t *testing.T) {
@@ -122,6 +139,8 @@ func configWithNonZeroNonFunctionFields(t *testing.T) *Config {
 			f.Set(reflect.ValueOf(true))
 		case "InitialPacketSize":
 			f.Set(reflect.ValueOf(uint16(1350)))
+		case "MaxPacketSize":
+			f.Set(reflect.ValueOf(uint16(1390)))
 		case "DisablePathMTUDiscovery":
 			f.Set(reflect.ValueOf(true))
 		case "Allow0RTT":
@@ -184,6 +203,7 @@ func TestConfigDefaultValues(t *testing.T) {
 	require.EqualValues(t, protocol.DefaultMaxReceiveConnectionFlowControlWindow, c.MaxConnectionReceiveWindow)
 	require.EqualValues(t, protocol.DefaultMaxIncomingStreams, c.MaxIncomingStreams)
 	require.EqualValues(t, protocol.DefaultMaxIncomingUniStreams, c.MaxIncomingUniStreams)
+	require.EqualValues(t, protocol.DefaultMaxPacketSize, c.MaxPacketSize)
 	require.False(t, c.DisablePathMTUDiscovery)
 	require.Nil(t, c.GetConfigForClient)
 }

--- a/connection.go
+++ b/connection.go
@@ -917,7 +917,7 @@ func (c *Conn) switchToNewPath(tr *Transport, now monotime.Time) {
 	if c.peerParams.MaxUDPPayloadSize > 0 && c.peerParams.MaxUDPPayloadSize < maxPacketSize {
 		maxPacketSize = c.peerParams.MaxUDPPayloadSize
 	}
-	c.mtuDiscoverer.Reset(now, initialPacketSize, maxPacketSize)
+	c.mtuDiscoverer.Reset(now, initialPacketSize, c.cappedMaxPacketSize(maxPacketSize))
 	c.conn = newSendConn(tr.conn, c.conn.RemoteAddr(), packetInfo{}, utils.DefaultLogger) // TODO: find a better way
 	c.sendQueue.Close()
 	c.sendQueue = newSendQueue(c.conn)
@@ -1300,7 +1300,7 @@ func (c *Conn) handleShortHeaderPacket(
 	c.mtuDiscoverer.Reset(
 		p.rcvTime,
 		protocol.ByteCount(c.config.InitialPacketSize),
-		maxPacketSize,
+		c.cappedMaxPacketSize(maxPacketSize),
 	)
 	c.conn.ChangeRemoteAddr(p.remoteAddr, p.info)
 	return true, nil
@@ -2442,9 +2442,22 @@ func (c *Conn) applyTransportParameters() {
 	c.mtuDiscoverer = newMTUDiscoverer(
 		c.rttStats,
 		protocol.ByteCount(c.config.InitialPacketSize),
-		maxPacketSize,
+		c.cappedMaxPacketSize(maxPacketSize),
 		c.qlogger,
 	)
+}
+
+// cappedMaxPacketSize caps a Path MTU Discovery upper limit to the configured MaxPacketSize.
+// The result is never smaller than the configured InitialPacketSize: a MaxPacketSize below the
+// initial packet size disables upward probing rather than producing an invalid probing range.
+func (c *Conn) cappedMaxPacketSize(maxPacketSize protocol.ByteCount) protocol.ByteCount {
+	if limit := protocol.ByteCount(c.config.MaxPacketSize); limit < maxPacketSize {
+		maxPacketSize = limit
+	}
+	if initialPacketSize := protocol.ByteCount(c.config.InitialPacketSize); maxPacketSize < initialPacketSize {
+		maxPacketSize = initialPacketSize
+	}
+	return maxPacketSize
 }
 
 func (c *Conn) triggerSending(now monotime.Time) error {

--- a/connection_test.go
+++ b/connection_test.go
@@ -3482,3 +3482,23 @@ func testConnectionDatagrams(t *testing.T, enabled bool) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("bar"), d)
 }
+
+func TestConnectionCappedMaxPacketSize(t *testing.T) {
+	newConn := func(maxPacketSize, initialPacketSize uint16) *Conn {
+		return &Conn{config: &Config{MaxPacketSize: maxPacketSize, InitialPacketSize: initialPacketSize}}
+	}
+	const maxBuf = protocol.ByteCount(protocol.MaxPacketBufferSize) // 1452
+
+	// the default caps discovery at 1352 bytes
+	c := newConn(protocol.DefaultMaxPacketSize, protocol.InitialPacketSize)
+	require.Equal(t, protocol.ByteCount(protocol.DefaultMaxPacketSize), c.cappedMaxPacketSize(maxBuf))
+	// setting MaxPacketSize to the buffer size imposes no additional limit
+	c = newConn(protocol.MaxPacketBufferSize, protocol.InitialPacketSize)
+	require.Equal(t, maxBuf, c.cappedMaxPacketSize(maxBuf))
+	// a smaller limit (e.g. the peer's max_udp_payload_size) is preserved
+	c = newConn(protocol.MaxPacketBufferSize, protocol.InitialPacketSize)
+	require.Equal(t, protocol.ByteCount(1300), c.cappedMaxPacketSize(1300))
+	// the limit never drops below the initial packet size, disabling upward probing instead
+	c = newConn(1200, 1400)
+	require.Equal(t, protocol.ByteCount(1400), c.cappedMaxPacketSize(maxBuf))
+}

--- a/integrationtests/self/mtu_test.go
+++ b/integrationtests/self/mtu_test.go
@@ -116,6 +116,7 @@ func TestPathMTUDiscovery(t *testing.T) {
 		getTLSClientConfig(),
 		getQuicConfig(&quic.Config{
 			InitialPacketSize: protocol.MinInitialPacketSize,
+			MaxPacketSize:     protocol.MaxPacketBufferSize,
 			EnableDatagrams:   true,
 			Tracer:            newTracer(&eventRecorder),
 		}),

--- a/interface.go
+++ b/interface.go
@@ -169,6 +169,16 @@ type Config struct {
 	// If set too high, the path might not support packets of that size, leading to a timeout of the QUIC handshake.
 	// Values below 1200 are invalid.
 	InitialPacketSize uint16
+	// MaxPacketSize is the upper limit for packets sent, and thereby for Path MTU Discovery.
+	// If unset, it defaults to 1352 bytes, i.e. a 1400-byte IPv6 packet (1380 bytes on IPv4).
+	// Some paths transparently fragment or intermittently lose packets above a certain size
+	// instead of dropping them outright; DPLPMTUD (RFC 8899) cannot detect this, since probe
+	// packets are delivered and acknowledged. On such paths the residual loss degrades
+	// throughput, and capping the packet size is the only remedy.
+	// Set this to 1452 to probe up to the maximum packet size supported on 1500-byte MTU paths.
+	// Values below 1200 are invalid, values above 1452 are clipped to 1452,
+	// and values below InitialPacketSize disable upward probing altogether.
+	MaxPacketSize uint16
 	// DisablePathMTUDiscovery disables Path MTU Discovery (RFC 8899).
 	// This allows the sending of QUIC packets that fully utilize the available MTU of the path.
 	// Path MTU discovery is only available on systems that allow setting of the Don't Fragment (DF) bit.

--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -11,6 +11,13 @@ const DesiredSendBufferSize = (1 << 20) * 7 // 7 MB
 // InitialPacketSize is the initial (before Path MTU discovery) maximum packet size used.
 const InitialPacketSize = 1280
 
+// DefaultMaxPacketSize is the default upper limit for Path MTU Discovery: a 1352-byte UDP
+// payload produces a 1400-byte IPv6 packet (1380 bytes on IPv4). Tunnels (PPPoE, GTP, VXLAN,
+// DS-Lite, IPsec) commonly reduce the path MTU below Ethernet's 1500, and some of them
+// fragment or lose larger packets in ways DPLPMTUD cannot detect. This size matches the
+// 1350/1370-byte payloads Chrome established from large-scale reachability measurements.
+const DefaultMaxPacketSize = 1352
+
 // MaxCongestionWindowPackets is the maximum congestion window in packet.
 const MaxCongestionWindowPackets = 10000
 


### PR DESCRIPTION

## The problem

Some paths deliver packets above a certain size *imperfectly* instead of dropping them. In the case I debugged, a mobile carrier's GTP tunnel transparently fragments large packets, and a small fraction of them (~1%) is lost. DPLPMTUD (RFC 8899) cannot detect this, structurally: probe packets are delivered and acknowledged, so discovery validates the larger size, and re-validation probes keep succeeding. The residual loss is then misread by loss-based congestion control as congestion, and throughput collapses.

Field measurements (server: quic-go behind Traefik on a 1500-MTU link; client: Vodafone Italy mobile, IPv4):

| Server sends | Loss (per ~50-packet window) | Download throughput |
|---|---|---|
| ≤ 1440-byte IP packets | 0% | ~5 MiB/s (sustained) |
| 1469-byte IP packets (discovered: 1441-byte payload) | ~1–1.5% | ~500 KiB/s |

Same path, minutes apart; the only changed variable is packet size. Notably:

- `ping -4 -M do` on the same path passes at 1450 and gets a hard drop at 1451 — yet QUIC capped at 1450 still collapsed; 1440 was needed. The fragmentation/loss threshold is not even observable with DF probing.
- I prototyped the "reduce" half of DPLPMTUD (periodic re-validation, ceiling ratchet, loss-rate detector): it never triggered, because the probes are always acknowledged and per-window loss stays below any sane black-hole threshold. HTTP/2 over TCP on the same path runs at full speed (TCP's MSS keeps packets below the threshold).

Since no probing scheme can see this failure mode, an operator-supplied ceiling is the only effective remedy — and quic-go currently has no way to express one. `InitialPacketSize` raises the *lower* end of the probing range (#3385 / #4503), and `DisablePathMTUDiscovery` pins packets all the way down at 1252/1232. There is nothing in between.

## What this PR does

1. **Adds `Config.MaxPacketSize`** — the upper limit (in bytes) for sent packets and thereby for Path MTU Discovery, mirroring `Config.InitialPacketSize` at the other end of the range. Validation clamps it to [1200, 1452]; values below `InitialPacketSize` disable upward probing rather than producing an invalid range.

2. **Lowers the default ceiling from 1452 to 1352 bytes** — i.e. a 1400-byte IPv6 packet (1380 bytes on IPv4). For comparison, what the major implementations ship:

   | Implementation | Default max packet size | PMTUD | Upper limit | Source |
   |---|---|---|---|---|
   | Google (Chromium / quiche) | 1250-byte payload (`kDefaultMaxPacketSize`); 1350 for tunnel scenarios (`kDefaultMaxPacketSizeForTunnels`) | not enabled by default | 1452-byte payload (`kMaxOutgoingPacketSize`) | [quic_constants.h](https://github.com/google/quiche/blob/main/quiche/quic/core/quic_constants.h) |
   | Mozilla (Firefox / neqo) | 1252 / 1232-byte payload (1280-byte IP packet) before probing | probes a fixed table of IP MTUs: 1280, 1380, 1420, 1470/1472, 1500, then jumbo sizes — steps chosen from path-MTU measurements (Custura et al., "Exploring Usable Path MTU in the Internet", TMA 2018 — cited in the source) | search table | [pmtud.rs](https://github.com/mozilla/neqo/blob/main/neqo-transport/src/pmtud.rs) |
   | Microsoft (msquic) | starts at `MinimumMtu` = 1288-byte IP packet | enabled by default | `MaximumMtu` = 1500-byte IP packet | [Settings.md](https://github.com/microsoft/msquic/blob/main/docs/Settings.md) |
   | Cloudflare (quiche) | 1200-byte payload ("default and minimum") | disabled by default (`discover_pmtu`) | 1200-byte payload unless configured | [Config docs](https://docs.rs/quiche/latest/quiche/struct.Config.html#method.set_max_send_udp_payload_size) |
   | quic-go today | starts at 1280-byte payload | enabled by default | 1452-byte payload = 1480-byte IPv4 / 1500-byte IPv6 packet | [protocol.go](https://github.com/quic-go/quic-go/blob/master/internal/protocol/protocol.go) |
   | **this PR** | starts at 1280-byte payload | enabled by default | **1352-byte payload = 1380-byte IPv4 / 1400-byte IPv6 packet** | — |

   Every implementation that ships a *fixed* size chose 1200–1350 bytes — reachability over efficiency (Google's measurements found UDP delivery failures rising "a bit above 1350" bytes, [proto-quic discussion](https://groups.google.com/a/chromium.org/g/proto-quic/c/yLGEMYvcESc)). The implementations that probe to ~1500 by default (msquic, quic-go) are exposed to the undetectable-degradation problem described above. 1352 splits the difference: above every fixed default, clear of common tunnel overheads (PPPoE 1492, 6in4 1480, DS-Lite 1460, VXLAN 1450, the GTP case above ≤1440), and sitting between Firefox's 1380 and 1420 probe steps. The cost on clean 1500-MTU paths is ~7% more packets at line rate, fully recoverable by setting `MaxPacketSize: 1452`.

   The default change is separable from the knob itself — if you'd rather keep 1452 as the default, that's a one-line change and the PR still solves the problem for deployments that can set the field.

## Testing

- Unit tests for config validation/defaults and the capping logic; `TestPathMTUDiscovery` self-test updated to opt into the full probing range.
- The capping approach has been running in production for a month (quic-go behind Traefik, Nextcloud workload, mixed mobile/fixed clients): full HTTP/3 throughput restored on the affected mobile paths, no regressions observed on clean paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum packet size for Path MTU Discovery.
  * Added a default maximum packet size when no value is configured.
  * Packet-size limits are automatically constrained to supported bounds and remain compatible with the configured initial packet size.
* **Bug Fixes**
  * Improved MTU discovery behavior during connection setup, migration, and path updates by respecting configured packet-size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Config.MaxPacketSize` to cap the upper bound used by Path MTU Discovery
> - Adds a `MaxPacketSize` field to [`Config`](https://github.com/quic-go/quic-go/pull/5767/files#diff-189ad68e1729b49c973b8a4baa0ac4a7058d274d5b52abe852ac21a28accf8cf) that limits the maximum packet size sent and the ceiling used by Path MTU Discovery (PMTUD). Defaults to `protocol.DefaultMaxPacketSize` (1352) and is clamped to `[1200, 1452]` during validation.
> - Introduces `Conn.cappedMaxPacketSize` in [`connection.go`](https://github.com/quic-go/quic-go/pull/5767/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7) to enforce the cap, ensuring the limit never falls below `InitialPacketSize` to avoid an invalid probing range.
> - All `mtuDiscoverer.Reset` call sites (path switch, short-header migration, transport parameter application) now pass the capped value.
> - Behavioral Change: existing code that left `MaxPacketSize` unset will now default to 1352 instead of deriving the ceiling purely from peer transport parameters.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3ca6a7a. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->