### PR TITLE
prioritize retransmissions over sending new stream data

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3006,6 +3006,11 @@ func (c *Conn) onHasStreamData(id protocol.StreamID, str *SendStream) {
 	c.scheduleSending()
 }
 
+func (c *Conn) onHasStreamRetransmission(id protocol.StreamID, str *SendStream) {
+	c.framer.AddStreamWithRetransmission(id, str)
+	c.scheduleSending()
+}
+
 func (c *Conn) onHasStreamControlFrame(id protocol.StreamID, str streamControlFrameGetter) {
 	c.framer.AddStreamWithControlFrames(id, str)
 	c.scheduleSending()

--- a/framer.go
+++ b/framer.go
@@ -23,6 +23,7 @@ const maxStreamControlFrameSize = 25
 
 type streamFrameGetter interface {
 	popStreamFrame(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool)
+	popRetransmissionFrame(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, bool)
 }
 
 type streamControlFrameGetter interface {
@@ -32,8 +33,15 @@ type streamControlFrameGetter interface {
 type framer struct {
 	mutex sync.Mutex
 
-	activeStreams            map[protocol.StreamID]streamFrameGetter
-	streamQueue              ringbuffer.RingBuffer[protocol.StreamID]
+	activeStreams map[protocol.StreamID]streamFrameGetter
+	// New stream data is sent incrementally. The ring buffer provides
+	// round-robin scheduling between active streams.
+	streamQueue           ringbuffer.RingBuffer[protocol.StreamID]
+	retransmissionStreams map[protocol.StreamID]streamFrameGetter
+	// Retransmissions are not incremental: repair all lost data for the first queued stream.
+	// New losses extend its batch, so A, B, A is repaired as A, A, B, delaying B.
+	// The ring buffer provides FIFO scheduling while reusing its storage.
+	retransmissionQueue      ringbuffer.RingBuffer[protocol.StreamID]
 	streamsWithControlFrames map[protocol.StreamID]streamControlFrameGetter
 
 	controlFrameMutex          sync.Mutex
@@ -46,6 +54,7 @@ type framer struct {
 func newFramer(connFlowController *connectionFlowController) *framer {
 	return &framer{
 		activeStreams:            make(map[protocol.StreamID]streamFrameGetter),
+		retransmissionStreams:    make(map[protocol.StreamID]streamFrameGetter),
 		streamsWithControlFrames: make(map[protocol.StreamID]streamControlFrameGetter),
 		connFlowController:       connFlowController,
 	}
@@ -53,7 +62,7 @@ func newFramer(connFlowController *connectionFlowController) *framer {
 
 func (f *framer) HasData() bool {
 	f.mutex.Lock()
-	hasData := !f.streamQueue.Empty()
+	hasData := !f.retransmissionQueue.Empty() || !f.streamQueue.Empty()
 	f.mutex.Unlock()
 	if hasData {
 		return true
@@ -99,6 +108,33 @@ func (f *framer) Append(
 	var lastFrame ackhandler.StreamFrame
 	var streamFrameLen protocol.ByteCount
 	f.mutex.Lock()
+	// retransmit all lost STREAM data before sending new STREAM data
+	for !f.retransmissionQueue.Empty() && protocol.MinStreamFrameSize <= maxLen {
+		id := f.retransmissionQueue.PeekFront()
+		str, ok := f.retransmissionStreams[id]
+		if !ok { // the stream was removed after being enqueued
+			f.retransmissionQueue.PopFront()
+			continue
+		}
+		// For the last STREAM frame, we'll remove the DataLen field later.
+		frameMaxLen := maxLen + protocol.ByteCount(quicvarint.Len(uint64(maxLen)))
+		sf, hasMoreRetransmissions := str.popRetransmissionFrame(frameMaxLen, v)
+		if !hasMoreRetransmissions {
+			f.retransmissionQueue.PopFront()
+			delete(f.retransmissionStreams, id)
+		}
+		if sf.Frame == nil {
+			// If the retransmission didn't fit, retry it in the next packet.
+			if hasMoreRetransmissions {
+				break
+			}
+			continue
+		}
+		streamFrames = append(streamFrames, sf)
+		maxLen -= sf.Frame.Length(v)
+		lastFrame = sf
+		streamFrameLen += sf.Frame.Length(v)
+	}
 	// pop STREAM frames, until less than 128 bytes are left in the packet
 	numActiveStreams := f.streamQueue.Len()
 	for range numActiveStreams {
@@ -226,6 +262,15 @@ func (f *framer) AddActiveStream(id protocol.StreamID, str streamFrameGetter) {
 	f.mutex.Unlock()
 }
 
+func (f *framer) AddStreamWithRetransmission(id protocol.StreamID, str streamFrameGetter) {
+	f.mutex.Lock()
+	if _, ok := f.retransmissionStreams[id]; !ok {
+		f.retransmissionQueue.PushBack(id)
+		f.retransmissionStreams[id] = str
+	}
+	f.mutex.Unlock()
+}
+
 func (f *framer) AddStreamWithControlFrames(id protocol.StreamID, str streamControlFrameGetter) {
 	f.controlFrameMutex.Lock()
 	if _, ok := f.streamsWithControlFrames[id]; !ok {
@@ -238,9 +283,9 @@ func (f *framer) AddStreamWithControlFrames(id protocol.StreamID, str streamCont
 func (f *framer) RemoveActiveStream(id protocol.StreamID) {
 	f.mutex.Lock()
 	delete(f.activeStreams, id)
-	// We don't delete the stream from the streamQueue,
-	// since we'd have to iterate over the ringbuffer.
-	// Instead, we check if the stream is still in activeStreams when appending STREAM frames.
+	delete(f.retransmissionStreams, id)
+	// We don't delete the stream from the queues, since we'd have to search them.
+	// Instead, we check if the stream is still in the corresponding map when appending STREAM frames.
 	f.mutex.Unlock()
 }
 
@@ -276,9 +321,9 @@ func (f *framer) Handle0RTTRejection() {
 	defer f.controlFrameMutex.Unlock()
 
 	f.streamQueue.Clear()
-	for id := range f.activeStreams {
-		delete(f.activeStreams, id)
-	}
+	clear(f.activeStreams)
+	f.retransmissionQueue.Clear()
+	clear(f.retransmissionStreams)
 	clear(f.streamsWithControlFrames)
 	var j int
 	for i, frame := range f.controlFrames {

--- a/framer_test.go
+++ b/framer_test.go
@@ -327,11 +327,47 @@ func TestFramerAppendStreamFrames(t *testing.T) {
 	require.False(t, framer.HasData())
 }
 
+func TestFramerPrioritizesStreamRetransmissions(t *testing.T) {
+	const (
+		newDataStreamID       = protocol.StreamID(1)
+		firstRetransStreamID  = protocol.StreamID(4)
+		secondRetransStreamID = protocol.StreamID(8)
+	)
+	newDataStream := NewMockStreamFrameGetter(gomock.NewController(t))
+	firstRetransStream := NewMockStreamFrameGetter(gomock.NewController(t))
+	secondRetransStream := NewMockStreamFrameGetter(gomock.NewController(t))
+	firstRetransmission := &wire.StreamFrame{StreamID: firstRetransStreamID, Data: []byte("first"), DataLenPresent: true}
+	secondRetransmission := &wire.StreamFrame{StreamID: secondRetransStreamID, Data: []byte("second"), DataLenPresent: true}
+	thirdRetransmission := &wire.StreamFrame{StreamID: secondRetransStreamID, Offset: 6, Data: []byte("third"), DataLenPresent: true}
+	newData := &wire.StreamFrame{StreamID: newDataStreamID, Data: []byte("new"), DataLenPresent: true}
+
+	firstRetransStream.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: firstRetransmission}, false)
+	secondRetransStream.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: secondRetransmission}, true)
+	secondRetransStream.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: thirdRetransmission}, false)
+	newDataStream.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: newData}, nil, false)
+
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddActiveStream(newDataStreamID, newDataStream)
+	framer.AddStreamWithRetransmission(secondRetransStreamID, secondRetransStream)
+	framer.AddStreamWithRetransmission(secondRetransStreamID, secondRetransStream) // duplicate calls are no-ops
+	framer.AddStreamWithRetransmission(firstRetransStreamID, firstRetransStream)
+
+	_, frames, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
+	require.Len(t, frames, 4)
+	require.Equal(t,
+		[]protocol.StreamID{secondRetransStreamID, secondRetransStreamID, firstRetransStreamID, newDataStreamID},
+		[]protocol.StreamID{frames[0].Frame.StreamID, frames[1].Frame.StreamID, frames[2].Frame.StreamID, frames[3].Frame.StreamID},
+	)
+	require.False(t, framer.HasData())
+}
+
 func TestFramerRemoveActiveStream(t *testing.T) {
 	const id = protocol.StreamID(42)
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 	require.False(t, framer.HasData())
-	framer.AddActiveStream(id, NewMockStreamFrameGetter(gomock.NewController(t)))
+	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	framer.AddActiveStream(id, str)
+	framer.AddStreamWithRetransmission(id, str)
 	require.True(t, framer.HasData())
 	framer.RemoveActiveStream(id) // no calls will be issued to the mock stream
 	// we can't assert on framer.HasData here, since it's not removed from the ringbuffer
@@ -463,7 +499,9 @@ func TestFramer0RTTRejection(t *testing.T) {
 	framer.QueueControlFrame(&wire.StreamsBlockedFrame{StreamLimit: 13})
 	framer.QueueControlFrame(pc)
 
-	framer.AddActiveStream(10, NewMockStreamFrameGetter(gomock.NewController(t)))
+	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	framer.AddActiveStream(10, str)
+	framer.AddStreamWithRetransmission(10, str)
 	framer.AddStreamWithControlFrames(10, NewMockStreamControlFrameGetter(gomock.NewController(t)))
 
 	framer.Handle0RTTRejection()

--- a/framer_test.go
+++ b/framer_test.go
@@ -333,31 +333,77 @@ func TestFramerPrioritizesStreamRetransmissions(t *testing.T) {
 		firstRetransStreamID  = protocol.StreamID(4)
 		secondRetransStreamID = protocol.StreamID(8)
 	)
-	newDataStream := NewMockStreamFrameGetter(gomock.NewController(t))
-	firstRetransStream := NewMockStreamFrameGetter(gomock.NewController(t))
-	secondRetransStream := NewMockStreamFrameGetter(gomock.NewController(t))
+	newDataStr := NewMockStreamFrameGetter(gomock.NewController(t))
+	str1 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str2 := NewMockStreamFrameGetter(gomock.NewController(t))
 	firstRetransmission := &wire.StreamFrame{StreamID: firstRetransStreamID, Data: []byte("first"), DataLenPresent: true}
 	secondRetransmission := &wire.StreamFrame{StreamID: secondRetransStreamID, Data: []byte("second"), DataLenPresent: true}
 	thirdRetransmission := &wire.StreamFrame{StreamID: secondRetransStreamID, Offset: 6, Data: []byte("third"), DataLenPresent: true}
 	newData := &wire.StreamFrame{StreamID: newDataStreamID, Data: []byte("new"), DataLenPresent: true}
 
-	firstRetransStream.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: firstRetransmission}, false)
-	secondRetransStream.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: secondRetransmission}, true)
-	secondRetransStream.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: thirdRetransmission}, false)
-	newDataStream.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: newData}, nil, false)
+	str1.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: firstRetransmission}, false)
+	str2.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: secondRetransmission}, true)
+	str2.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: thirdRetransmission}, false)
+	newDataStr.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: newData}, nil, false)
 
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
-	framer.AddActiveStream(newDataStreamID, newDataStream)
-	framer.AddStreamWithRetransmission(secondRetransStreamID, secondRetransStream)
-	framer.AddStreamWithRetransmission(secondRetransStreamID, secondRetransStream) // duplicate calls are no-ops
-	framer.AddStreamWithRetransmission(firstRetransStreamID, firstRetransStream)
+	require.False(t, framer.HasData())
+	framer.AddStreamWithRetransmission(secondRetransStreamID, str2)
+	require.True(t, framer.HasData())
+	framer.AddStreamWithRetransmission(secondRetransStreamID, str2) // duplicate calls are no-ops
+	framer.AddActiveStream(newDataStreamID, newDataStr)
+	framer.AddStreamWithRetransmission(firstRetransStreamID, str1)
 
-	_, frames, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
-	require.Len(t, frames, 4)
+	_, fs, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
+	require.Len(t, fs, 4)
 	require.Equal(t,
 		[]protocol.StreamID{secondRetransStreamID, secondRetransStreamID, firstRetransStreamID, newDataStreamID},
-		[]protocol.StreamID{frames[0].Frame.StreamID, frames[1].Frame.StreamID, frames[2].Frame.StreamID, frames[3].Frame.StreamID},
+		[]protocol.StreamID{fs[0].Frame.StreamID, fs[1].Frame.StreamID, fs[2].Frame.StreamID, fs[3].Frame.StreamID},
 	)
+	require.False(t, framer.HasData())
+}
+
+func TestFramerSplitsStreamRetransmissions(t *testing.T) {
+	const (
+		firstStreamID  = protocol.StreamID(4)
+		secondStreamID = protocol.StreamID(8)
+		maxLen         = protocol.ByteCount(1000)
+	)
+	str1 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str2 := NewMockStreamFrameGetter(gomock.NewController(t))
+	data1 := bytes.Repeat([]byte{1}, 500)
+	data2 := bytes.Repeat([]byte{2}, 1000)
+	retransmit1 := &wire.StreamFrame{StreamID: firstStreamID, Data: data1, DataLenPresent: true}
+	retransmit2 := &wire.StreamFrame{StreamID: secondStreamID, Data: data2, DataLenPresent: true}
+
+	str1.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: retransmit1}, false)
+	str2.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).DoAndReturn(func(maxSize protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, bool) {
+		f, split := retransmit2.MaybeSplitOffFrame(maxSize, v)
+		require.True(t, split)
+		return ackhandler.StreamFrame{Frame: f}, true
+	})
+	str2.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: retransmit2}, false)
+
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddStreamWithRetransmission(firstStreamID, str1)
+	framer.AddStreamWithRetransmission(secondStreamID, str2)
+
+	_, fs, length := framer.Append(nil, nil, maxLen, monotime.Now(), protocol.Version1)
+	require.Equal(t, maxLen, length)
+	require.Len(t, fs, 2)
+	require.Equal(t, firstStreamID, fs[0].Frame.StreamID)
+	require.Len(t, fs[0].Frame.Data, len(data1))
+	require.Equal(t, secondStreamID, fs[1].Frame.StreamID)
+	require.Equal(t, protocol.ByteCount(0), fs[1].Frame.Offset)
+	firstPartLen := len(fs[1].Frame.Data)
+	require.Less(t, firstPartLen, len(data2))
+	require.True(t, framer.HasData())
+
+	_, fs, _ = framer.Append(nil, nil, maxLen, monotime.Now(), protocol.Version1)
+	require.Len(t, fs, 1)
+	require.Equal(t, secondStreamID, fs[0].Frame.StreamID)
+	require.Equal(t, protocol.ByteCount(firstPartLen), fs[0].Frame.Offset)
+	require.Len(t, fs[0].Frame.Data, len(data2)-firstPartLen)
 	require.False(t, framer.HasData())
 }
 

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -523,7 +523,7 @@ func test0RTTRetransmitOnRetry(t *testing.T, useRetry bool) {
 
 		require.Len(t, connIDToCounter, 2)
 		require.InDelta(t, 5000+100 /* framing overhead */, int(connIDToCounter[0].bytes), 100) // the FIN bit might be sent extra
-		require.InDelta(t, int(connIDToCounter[0].bytes), int(connIDToCounter[1].bytes), 20)
+		require.InDelta(t, int(connIDToCounter[0].bytes), int(connIDToCounter[1].bytes), 30)
 		zeroRTTPackets := counter.getRcvd0RTTPacketNumbers()
 		require.GreaterOrEqual(t, len(zeroRTTPackets), 5)
 		require.GreaterOrEqual(t, zeroRTTPackets[0], protocol.PacketNumber(5))

--- a/mock_stream_frame_getter_test.go
+++ b/mock_stream_frame_getter_test.go
@@ -42,6 +42,45 @@ func (m *MockStreamFrameGetter) EXPECT() *MockStreamFrameGetterMockRecorder {
 	return m.recorder
 }
 
+// popRetransmissionFrame mocks base method.
+func (m *MockStreamFrameGetter) popRetransmissionFrame(arg0 protocol.ByteCount, arg1 protocol.Version) (ackhandler.StreamFrame, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "popRetransmissionFrame", arg0, arg1)
+	ret0, _ := ret[0].(ackhandler.StreamFrame)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// popRetransmissionFrame indicates an expected call of popRetransmissionFrame.
+func (mr *MockStreamFrameGetterMockRecorder) popRetransmissionFrame(arg0, arg1 any) *MockStreamFrameGetterpopRetransmissionFrameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popRetransmissionFrame", reflect.TypeOf((*MockStreamFrameGetter)(nil).popRetransmissionFrame), arg0, arg1)
+	return &MockStreamFrameGetterpopRetransmissionFrameCall{Call: call}
+}
+
+// MockStreamFrameGetterpopRetransmissionFrameCall wrap *gomock.Call
+type MockStreamFrameGetterpopRetransmissionFrameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStreamFrameGetterpopRetransmissionFrameCall) Return(arg0 ackhandler.StreamFrame, arg1 bool) *MockStreamFrameGetterpopRetransmissionFrameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStreamFrameGetterpopRetransmissionFrameCall) Do(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, bool)) *MockStreamFrameGetterpopRetransmissionFrameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStreamFrameGetterpopRetransmissionFrameCall) DoAndReturn(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, bool)) *MockStreamFrameGetterpopRetransmissionFrameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // popStreamFrame mocks base method.
 func (m *MockStreamFrameGetter) popStreamFrame(arg0 protocol.ByteCount, arg1 protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
 	m.ctrl.T.Helper()

--- a/mock_stream_sender_test.go
+++ b/mock_stream_sender_test.go
@@ -148,6 +148,42 @@ func (c *MockStreamSenderonHasStreamDataCall) DoAndReturn(f func(protocol.Stream
 	return c
 }
 
+// onHasStreamRetransmission mocks base method.
+func (m *MockStreamSender) onHasStreamRetransmission(arg0 protocol.StreamID, arg1 *SendStream) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "onHasStreamRetransmission", arg0, arg1)
+}
+
+// onHasStreamRetransmission indicates an expected call of onHasStreamRetransmission.
+func (mr *MockStreamSenderMockRecorder) onHasStreamRetransmission(arg0, arg1 any) *MockStreamSenderonHasStreamRetransmissionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "onHasStreamRetransmission", reflect.TypeOf((*MockStreamSender)(nil).onHasStreamRetransmission), arg0, arg1)
+	return &MockStreamSenderonHasStreamRetransmissionCall{Call: call}
+}
+
+// MockStreamSenderonHasStreamRetransmissionCall wrap *gomock.Call
+type MockStreamSenderonHasStreamRetransmissionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStreamSenderonHasStreamRetransmissionCall) Return() *MockStreamSenderonHasStreamRetransmissionCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStreamSenderonHasStreamRetransmissionCall) Do(f func(protocol.StreamID, *SendStream)) *MockStreamSenderonHasStreamRetransmissionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStreamSenderonHasStreamRetransmissionCall) DoAndReturn(f func(protocol.StreamID, *SendStream)) *MockStreamSenderonHasStreamRetransmissionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // onStreamCompleted mocks base method.
 func (m *MockStreamSender) onStreamCompleted(arg0 protocol.StreamID) {
 	m.ctrl.T.Helper()

--- a/send_stream.go
+++ b/send_stream.go
@@ -336,7 +336,7 @@ func (s *SendStream) canBufferStreamFrame() bool {
 // maxBytes is the maximum length this frame (including frame header) will have.
 func (s *SendStream) popStreamFrame(maxBytes protocol.ByteCount, v protocol.Version) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMore bool) {
 	s.mutex.Lock()
-	f, blocked, hasMoreData := s.popNewOrRetransmittedStreamFrame(maxBytes, v)
+	f, blocked, hasMoreData := s.popNewStreamFrameForPacket(maxBytes, v)
 	if f != nil {
 		s.numOutstandingFrames++
 	}
@@ -351,28 +351,17 @@ func (s *SendStream) popStreamFrame(maxBytes protocol.ByteCount, v protocol.Vers
 	}, blocked, hasMoreData
 }
 
-func (s *SendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCount, v protocol.Version) (_ *wire.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMoreData bool) {
+func (s *SendStream) popNewStreamFrameForPacket(maxBytes protocol.ByteCount, v protocol.Version) (_ *wire.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMoreData bool) {
 	if s.shutdownErr != nil {
 		return nil, nil, false
 	}
 	if s.resetErr != nil {
 		reliableOffset := s.reliableOffset()
-		if reliableOffset == 0 || (s.writeOffset >= reliableOffset && len(s.retransmissionQueue) == 0) {
+		if reliableOffset == 0 || s.writeOffset >= reliableOffset {
 			return nil, nil, false
 		}
 	}
 
-	if len(s.retransmissionQueue) > 0 {
-		f, hasMoreRetransmissions := s.maybeGetRetransmission(maxBytes, v)
-		if f != nil || hasMoreRetransmissions {
-			if f == nil {
-				return nil, nil, true
-			}
-			// We always claim that we have more data to send.
-			// This might be incorrect, in which case there'll be a spurious call to popStreamFrame in the future.
-			return f, nil, true
-		}
-	}
 	if s.writeLimited {
 		return nil, nil, false
 	}
@@ -491,14 +480,30 @@ func (s *SendStream) popNewStreamFrame(maxDataLen protocol.ByteCount) (_ *wire.S
 	return f, s.dataForWriting != nil || s.nextFrame != nil || s.finishedWriting
 }
 
-func (s *SendStream) maybeGetRetransmission(maxBytes protocol.ByteCount, v protocol.Version) (*wire.StreamFrame, bool /* has more retransmissions */) {
+func (s *SendStream) popRetransmissionFrame(maxBytes protocol.ByteCount, v protocol.Version) (_ ackhandler.StreamFrame, hasMore bool) {
+	s.mutex.Lock()
+	if s.shutdownErr != nil || len(s.retransmissionQueue) == 0 {
+		s.mutex.Unlock()
+		return ackhandler.StreamFrame{}, false
+	}
 	f := s.retransmissionQueue[0]
 	newFrame, needsSplit := f.MaybeSplitOffFrame(maxBytes, v)
 	if needsSplit {
-		return newFrame, true
+		f = newFrame
+		hasMore = true
+	} else {
+		s.retransmissionQueue = s.retransmissionQueue[1:]
+		hasMore = len(s.retransmissionQueue) > 0
 	}
-	s.retransmissionQueue = s.retransmissionQueue[1:]
-	return f, len(s.retransmissionQueue) > 0
+	if f != nil {
+		s.numOutstandingFrames++
+	}
+	s.mutex.Unlock()
+
+	if f == nil {
+		return ackhandler.StreamFrame{}, hasMore
+	}
+	return ackhandler.StreamFrame{Frame: f, Handler: (*sendStreamAckHandler)(s)}, hasMore
 }
 
 func (s *SendStream) getDataForWriting(f *wire.StreamFrame, maxBytes protocol.ByteCount) {
@@ -866,10 +871,13 @@ func (s *sendStreamAckHandler) OnLost(f wire.Frame) {
 	}
 
 	sf.DataLenPresent = true
+	wasEmpty := len(s.retransmissionQueue) == 0
 	s.retransmissionQueue = append(s.retransmissionQueue, sf)
 	s.mutex.Unlock()
 
-	s.sender.onHasStreamData(s.streamID, (*SendStream)(s))
+	if wasEmpty {
+		s.sender.onHasStreamRetransmission(s.streamID, (*SendStream)(s))
+	}
 }
 
 type sendStreamResetStreamHandler SendStream

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -1319,23 +1319,23 @@ func TestSendStreamRetransmissions(t *testing.T) {
 	f1.Handler.OnLost(f1.Frame)
 	require.True(t, mockCtrl.Satisfied())
 
-	// The retransmission queue returns the lost data.
-	f2, hasMoreRetransmissions := str.popRetransmissionFrame(protocol.MaxByteCount, protocol.Version1)
-	require.EqualExportedValues(t, &wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true}, f2.Frame)
-	require.False(t, hasMoreRetransmissions)
-	require.True(t, mockCtrl.Satisfied())
-
-	// We can then get the new data from the normal stream queue.
-	f3, _, hasMoreData := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
-	require.EqualExportedValues(t, &wire.StreamFrame{StreamID: streamID, Offset: 3, Fin: true, Data: []byte("bar"), DataLenPresent: true}, f3.Frame)
+	// popping new data doesn't take queued retransmissions into account
+	f2, _, hasMoreData := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	require.EqualExportedValues(t, &wire.StreamFrame{StreamID: streamID, Offset: 3, Fin: true, Data: []byte("bar"), DataLenPresent: true}, f2.Frame)
 	require.False(t, hasMoreData)
 	require.True(t, mockCtrl.Satisfied())
 
+	// the retransmission queue independently returns the lost data
+	f3, hasMoreRetransmissions := str.popRetransmissionFrame(protocol.MaxByteCount, protocol.Version1)
+	require.EqualExportedValues(t, &wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true}, f3.Frame)
+	require.False(t, hasMoreRetransmissions)
+	require.True(t, mockCtrl.Satisfied())
+
 	// acknowledge the retransmission...
-	f2.Handler.OnAcked(f2.Frame)
+	f3.Handler.OnAcked(f3.Frame)
 	// ... and the last frame, which concludes this stream
 	mockSender.EXPECT().onStreamCompleted(streamID)
-	f3.Handler.OnAcked(f3.Frame)
+	f2.Handler.OnAcked(f2.Frame)
 }
 
 func TestSendStreamRetransmissionFraming(t *testing.T) {

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -1315,17 +1315,17 @@ func TestSendStreamRetransmissions(t *testing.T) {
 	require.True(t, mockCtrl.Satisfied())
 
 	// lose the frame
-	mockSender.EXPECT().onHasStreamData(streamID, str)
+	mockSender.EXPECT().onHasStreamRetransmission(streamID, str)
 	f1.Handler.OnLost(f1.Frame)
 	require.True(t, mockCtrl.Satisfied())
 
-	// when popping a new frame, we first get the retransmission...
-	f2, _, hasMoreData := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	// The retransmission queue returns the lost data.
+	f2, hasMoreRetransmissions := str.popRetransmissionFrame(protocol.MaxByteCount, protocol.Version1)
 	require.EqualExportedValues(t, &wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true}, f2.Frame)
-	require.True(t, hasMoreData)
+	require.False(t, hasMoreRetransmissions)
 	require.True(t, mockCtrl.Satisfied())
 
-	// ... then we get the new data
+	// We can then get the new data from the normal stream queue.
 	f3, _, hasMoreData := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 	require.EqualExportedValues(t, &wire.StreamFrame{StreamID: streamID, Offset: 3, Fin: true, Data: []byte("bar"), DataLenPresent: true}, f3.Frame)
 	require.False(t, hasMoreData)
@@ -1353,31 +1353,28 @@ func TestSendStreamRetransmissionFraming(t *testing.T) {
 	require.NotNil(t, f.Frame)
 
 	// lose the frame
-	mockSender.EXPECT().onHasStreamData(streamID, str)
+	mockSender.EXPECT().onHasStreamRetransmission(streamID, str)
 	f.Handler.OnLost(f.Frame)
 
 	// retransmission doesn't fit
-	f, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, 0), protocol.Version1)
+	f, hasMore := str.popRetransmissionFrame(expectedFrameHeaderLen(streamID, 0), protocol.Version1)
 	require.Nil(t, f.Frame)
 	require.True(t, hasMore)
 
 	// split the retransmission
-	r1, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, 0)+3, protocol.Version1)
+	r1, hasMore := str.popRetransmissionFrame(expectedFrameHeaderLen(streamID, 0)+3, protocol.Version1)
 	require.True(t, hasMore)
 	require.EqualExportedValues(t,
 		&wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true},
 		r1.Frame,
 	)
-	r2, _, hasMore := str.popStreamFrame(expectedFrameHeaderLen(streamID, 3)+3, protocol.Version1)
-	require.True(t, hasMore)
-	// When popping a retransmission, we always claim that there's more data to send.
-	// We accept that this might be incorrect.
-	require.True(t, hasMore)
+	r2, hasMore := str.popRetransmissionFrame(expectedFrameHeaderLen(streamID, 3)+3, protocol.Version1)
+	require.False(t, hasMore)
 	require.EqualExportedValues(t,
 		&wire.StreamFrame{StreamID: streamID, Offset: 3, Data: []byte("bar"), DataLenPresent: true},
 		r2.Frame,
 	)
-	_, _, hasMore = str.popStreamFrame(expectedFrameHeaderLen(streamID, 3)+3, protocol.Version1)
+	_, hasMore = str.popRetransmissionFrame(expectedFrameHeaderLen(streamID, 3)+3, protocol.Version1)
 	require.False(t, hasMore)
 }
 
@@ -1394,6 +1391,7 @@ func TestSendStreamRetransmitDataUntilAcknowledged(t *testing.T) {
 	str := newSendStream(context.Background(), streamID, mockSender, mockFC, false)
 
 	mockSender.EXPECT().onHasStreamData(streamID, str).AnyTimes()
+	mockSender.EXPECT().onHasStreamRetransmission(streamID, str).AnyTimes()
 
 	data := make([]byte, dataLen)
 	_, err := rand.Read(data)
@@ -1417,7 +1415,11 @@ func TestSendStreamRetransmitDataUntilAcknowledged(t *testing.T) {
 		if counter > 1e6 {
 			t.Fatal("stream should have completed")
 		}
-		f, _, _ := str.popStreamFrame(protocol.ByteCount(mrand.IntN(300)+100), protocol.Version1)
+		maxSize := protocol.ByteCount(mrand.IntN(300) + 100)
+		f, hasMoreRetransmissions := str.popRetransmissionFrame(maxSize, protocol.Version1)
+		if f.Frame == nil && !hasMoreRetransmissions {
+			f, _, _ = str.popStreamFrame(maxSize, protocol.Version1)
+		}
 		var dequeuedFrame bool
 		if f.Frame != nil {
 			frameQueue = append(frameQueue, f)
@@ -1475,16 +1477,16 @@ func TestSendStreamResetStreamAtCancelBeforeSend(t *testing.T) {
 
 	// Lose the frame.
 	// Since it's before the reliable size, we should get a retransmission.
-	mockSender.EXPECT().onHasStreamData(protocol.StreamID(1337), str)
+	mockSender.EXPECT().onHasStreamRetransmission(protocol.StreamID(1337), str)
 	f.Handler.OnLost(f.Frame)
 	require.True(t, mockCtrl.Satisfied())
 
-	retransmission, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	retransmission, hasMore := str.popRetransmissionFrame(protocol.MaxByteCount, protocol.Version1)
 	require.EqualExportedValues(t,
 		&wire.StreamFrame{StreamID: 1337, Data: []byte("foobar"), DataLenPresent: true},
 		retransmission.Frame,
 	)
-	require.True(t, hasMore) // hasMore is always true when dequeuing a retransmission
+	require.False(t, hasMore)
 	require.True(t, mockCtrl.Satisfied())
 	f, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 	require.Nil(t, f.Frame)
@@ -1528,15 +1530,15 @@ func TestSendStreamResetStreamAtCancelAfterSend(t *testing.T) {
 
 	cf.Handler.OnAcked(cf.Frame)
 	// lose the STREAM frame
-	mockSender.EXPECT().onHasStreamData(protocol.StreamID(1337), str)
+	mockSender.EXPECT().onHasStreamRetransmission(protocol.StreamID(1337), str)
 	f.Handler.OnLost(f.Frame)
 	// only the first 6 bytes need to be retransmitted
-	retransmission1, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	retransmission1, hasMore := str.popRetransmissionFrame(protocol.MaxByteCount, protocol.Version1)
 	require.EqualExportedValues(t,
 		&wire.StreamFrame{StreamID: 1337, Data: []byte("foobar"), DataLenPresent: true},
 		retransmission1.Frame,
 	)
-	require.True(t, hasMore) // hasMore is always true when dequeuing a retransmission
+	require.False(t, hasMore)
 	require.True(t, mockCtrl.Satisfied())
 	f, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 	require.Nil(t, f.Frame)
@@ -1544,14 +1546,14 @@ func TestSendStreamResetStreamAtCancelAfterSend(t *testing.T) {
 	require.True(t, mockCtrl.Satisfied())
 
 	// lose the retransmission as well
-	mockSender.EXPECT().onHasStreamData(protocol.StreamID(1337), str)
+	mockSender.EXPECT().onHasStreamRetransmission(protocol.StreamID(1337), str)
 	retransmission1.Handler.OnLost(retransmission1.Frame)
-	retransmission2, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	retransmission2, hasMore := str.popRetransmissionFrame(protocol.MaxByteCount, protocol.Version1)
 	require.EqualExportedValues(t,
 		&wire.StreamFrame{StreamID: 1337, Data: []byte("foobar"), DataLenPresent: true},
 		retransmission2.Frame,
 	)
-	require.True(t, hasMore) // hasMore is always true when dequeuing a retransmission
+	require.False(t, hasMore)
 	require.True(t, mockCtrl.Satisfied())
 	f, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 	require.Nil(t, f.Frame)
@@ -1575,6 +1577,7 @@ func TestSendStreamResetStreamAtRetransmissions(t *testing.T) {
 	// f4: amet
 	// sitting in the write buffer: consectetur (but not popped)
 	mockSender.EXPECT().onHasStreamData(protocol.StreamID(1337), str).AnyTimes()
+	mockSender.EXPECT().onHasStreamRetransmission(protocol.StreamID(1337), str)
 	_, err := str.Write([]byte("lorem"))
 	require.NoError(t, err)
 	f1, _, _ := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
@@ -1628,20 +1631,20 @@ func TestSendStreamResetStreamAtRetransmissions(t *testing.T) {
 	cf.Handler.OnAcked(cf.Frame)
 
 	// // the retransmission of f1 should be truncated to 6 bytes
-	r1, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	r1, hasMore := str.popRetransmissionFrame(protocol.MaxByteCount, protocol.Version1)
 	require.EqualExportedValues(t,
 		&wire.StreamFrame{StreamID: 1337, Offset: 5, Data: []byte("ipsum"), DataLenPresent: true},
 		r1.Frame,
 	)
 	require.True(t, hasMore)
-	r2, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	r2, hasMore := str.popRetransmissionFrame(protocol.MaxByteCount, protocol.Version1)
 	require.EqualExportedValues(t,
 		&wire.StreamFrame{StreamID: 1337, Data: []byte("lorem"), DataLenPresent: true},
 		r2.Frame,
 	)
-	require.True(t, hasMore) // hasMore is always true when dequeuing a retransmission
+	require.False(t, hasMore)
 	require.True(t, mockCtrl.Satisfied())
-	r3, _, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	r3, hasMore := str.popRetransmissionFrame(protocol.MaxByteCount, protocol.Version1)
 	require.Nil(t, r3.Frame)
 	require.False(t, hasMore)
 	require.True(t, mockCtrl.Satisfied())
@@ -1773,6 +1776,7 @@ func TestSendStreamResetStreamAtRandomized(t *testing.T) {
 	str := newSendStream(context.Background(), streamID, mockSender, mockFC, true)
 
 	mockSender.EXPECT().onHasStreamData(streamID, str).AnyTimes()
+	mockSender.EXPECT().onHasStreamRetransmission(streamID, str).AnyTimes()
 	mockSender.EXPECT().onHasStreamControlFrame(streamID, str).AnyTimes()
 
 	data := make([]byte, dataLen)
@@ -1823,7 +1827,11 @@ func TestSendStreamResetStreamAtRandomized(t *testing.T) {
 			receivedResetStreamAt = true
 			require.Equal(t, protocol.ByteCount(reliableOffset), cf.Frame.(*wire.ResetStreamFrame).ReliableSize)
 		} else {
-			f, _, _ := str.popStreamFrame(protocol.ByteCount(mrand.IntN(300)+100), protocol.Version1)
+			maxSize := protocol.ByteCount(mrand.IntN(300) + 100)
+			f, hasMoreRetransmissions := str.popRetransmissionFrame(maxSize, protocol.Version1)
+			if f.Frame == nil && !hasMoreRetransmissions {
+				f, _, _ = str.popStreamFrame(maxSize, protocol.Version1)
+			}
 			if f.Frame != nil {
 				// make sure that only retransmissions are sent once the RESET_STREAM_AT frame is sent
 				if receivedResetStreamAt {

--- a/stream.go
+++ b/stream.go
@@ -26,6 +26,7 @@ var errDeadline net.Error = &deadlineError{}
 type streamSender interface {
 	onHasConnectionData()
 	onHasStreamData(protocol.StreamID, *SendStream)
+	onHasStreamRetransmission(protocol.StreamID, *SendStream)
 	onHasStreamControlFrame(protocol.StreamID, streamControlFrameGetter)
 	// must be called without holding the mutex that is acquired by closeForShutdown
 	onStreamCompleted(protocol.StreamID)
@@ -206,6 +207,10 @@ func (s *Stream) enableResetStreamAt() {
 
 func (s *Stream) popStreamFrame(maxBytes protocol.ByteCount, v protocol.Version) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMore bool) {
 	return s.sendStr.popStreamFrame(maxBytes, v)
+}
+
+func (s *Stream) popRetransmissionFrame(maxBytes protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, bool) {
+	return s.sendStr.popRetransmissionFrame(maxBytes, v)
 }
 
 func (s *Stream) getControlFrame(now monotime.Time) (_ ackhandler.Frame, ok, hasMore bool) {


### PR DESCRIPTION
Retransmissions were prioritized within one stream, but not globally. Globally streams were scheduled on a round robin basis. Prioritizing loss over sending new data globally makes it possible to recover from that loss quicker.

This change will also make implementing stream priorities (#437) a lot easier.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prioritize STREAM retransmissions over new stream data in packet framing
> - Adds `SendStream.popRetransmissionFrame` to produce retransmission frames independently of new data, with frame splitting and accurate reporting of remaining retransmissions.
> - Adds `framer.AddStreamWithRetransmission` and a `retransmissionQueue` ringbuffer so retransmission frames are dequeued and framed before any new STREAM data in each packet.
> - Loss events now notify via a dedicated `onHasStreamRetransmission` callback (instead of `onHasStreamData`), and only fire when the retransmission queue transitions from empty to non-empty.
> - `Handle0RTTRejection` is extended to clear the retransmission queue and map alongside existing state.
> - Behavioral Change: `popStreamFrame` no longer considers retransmissions; callers must use `popRetransmissionFrame` separately to retrieve lost data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3993dbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery of lost stream data by prioritizing retransmissions ahead of new data.
  * Improved retransmission scheduling and ordering across streams.
  * Enhanced handling of stream removal and 0-RTT rejection when retransmissions are pending.
  * Improved retransmission handling when data exceeds available packet capacity.

* **Tests**
  * Added coverage for retransmission priority, ordering, splitting, truncation, and repeated loss scenarios.
  * Expanded validation of retransmission scheduling and stream state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->