### PR TITLE
http3: make server reject 0-RTT when settings are incompatible

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -1,6 +1,7 @@
 package http3
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -45,21 +46,58 @@ var _ QUICListener = &quic.EarlyListener{}
 // ConfigureTLSConfig creates a new tls.Config which can be used
 // to create a quic.Listener meant for serving HTTP/3.
 func ConfigureTLSConfig(tlsConf *tls.Config) *tls.Config {
+	return configureTLSConfig(tlsConf, nil)
+}
+
+func configureTLSConfig(tlsConf *tls.Config, configure func(*tls.Config)) *tls.Config {
 	// Workaround for https://github.com/golang/go/issues/60506.
 	// This initializes the session tickets _before_ cloning the config.
 	_, _ = tlsConf.DecryptTicket(nil, tls.ConnectionState{})
 	config := tlsConf.Clone()
 	config.NextProtos = []string{NextProtoH3}
+	if configure != nil {
+		configure(config)
+	}
 	if gfc := config.GetConfigForClient; gfc != nil {
 		config.GetConfigForClient = func(ch *tls.ClientHelloInfo) (*tls.Config, error) {
 			conf, err := gfc(ch)
 			if conf == nil || err != nil {
 				return conf, err
 			}
-			return ConfigureTLSConfig(conf), nil
+			return configureTLSConfig(conf, configure), nil
 		}
 	}
 	return config
+}
+
+func (s *Server) configureTLSConfig(tlsConf *tls.Config) *tls.Config {
+	settings := s.settings()
+	settingsExtra := settingsForSessionTicket(settings)
+	return configureTLSConfig(tlsConf, func(config *tls.Config) {
+		wrapSession := config.WrapSession
+		if wrapSession == nil {
+			wrapSession = config.EncryptTicket
+		}
+		config.WrapSession = func(cs tls.ConnectionState, ss *tls.SessionState) ([]byte, error) {
+			ss.Extra = append(ss.Extra, bytes.Clone(settingsExtra))
+			return wrapSession(cs, ss)
+		}
+		unwrapSession := config.UnwrapSession
+		if unwrapSession == nil {
+			unwrapSession = config.DecryptTicket
+		}
+		config.UnwrapSession = func(identity []byte, cs tls.ConnectionState) (*tls.SessionState, error) {
+			ss, err := unwrapSession(identity, cs)
+			if err != nil || ss == nil || !ss.EarlyData {
+				return ss, err
+			}
+			settingsData, ok := settingsDataFromSessionTicket(ss.Extra)
+			if !ok || !settingsCompatibleFor0RTT(settingsData, settings) {
+				ss.EarlyData = false
+			}
+			return ss, nil
+		}
+	})
 }
 
 // contextKey is a value for use with context.WithValue. It's used as
@@ -297,7 +335,7 @@ func (s *Server) setupListenerForConn(tlsConf *tls.Config, conn net.PacketConn) 
 		return nil, errServerWithoutTLSConfig
 	}
 
-	baseConf := ConfigureTLSConfig(tlsConf)
+	baseConf := s.configureTLSConfig(tlsConf)
 	quicConf := s.QUICConfig
 	if quicConf == nil {
 		quicConf = &quic.Config{Allow0RTT: true}
@@ -453,16 +491,20 @@ func (s *Server) newRawServerConn(conn *quic.Conn) (*RawServerConn, *quic.SendSt
 
 	// open the control stream and send a SETTINGS frame, it's also used to send a GOAWAY frame later
 	// when the server is gracefully closed
-	ctrlStr, err := hconn.openControlStream(&settingsFrame{
-		MaxFieldSectionSize: int64(s.maxHeaderBytes()),
-		Datagram:            s.EnableDatagrams,
-		ExtendedConnect:     true,
-		Other:               s.AdditionalSettings,
-	})
+	ctrlStr, err := hconn.openControlStream(s.settings())
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("opening the control stream failed: %w", err)
 	}
 	return hconn, ctrlStr, qlogger, nil
+}
+
+func (s *Server) settings() *settings {
+	return &settings{
+		MaxFieldSectionSize: int64(s.maxHeaderBytes()),
+		Datagram:            s.EnableDatagrams,
+		ExtendedConnect:     true,
+		Other:               s.AdditionalSettings,
+	}
 }
 
 // handleConn handles the HTTP/3 exchange on a QUIC connection.

--- a/http3/settings_0rtt.go
+++ b/http3/settings_0rtt.go
@@ -1,0 +1,56 @@
+package http3
+
+import (
+	"bytes"
+
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+const serverSettingsSessionTicketPrefix = "quic-go h3 settings v1"
+
+type settings = settingsFrame
+
+func settingsForSessionTicket(current *settings) []byte {
+	return current.Append([]byte(serverSettingsSessionTicketPrefix))
+}
+
+func settingsDataFromSessionTicket(extras [][]byte) ([]byte, bool) {
+	prefix := []byte(serverSettingsSessionTicketPrefix)
+	for _, extra := range extras {
+		if data, ok := bytes.CutPrefix(extra, prefix); ok {
+			return data, true
+		}
+	}
+	return nil, false
+}
+
+func settingsCompatibleFor0RTT(data []byte, current *settings) bool {
+	r := bytes.NewReader(data)
+	frameType, err := quicvarint.Read(r)
+	if err != nil || frameType != 0x4 {
+		return false
+	}
+	length, err := quicvarint.Read(r)
+	if err != nil || uint64(r.Len()) != length {
+		return false
+	}
+	old, err := parseSettingsFrame(&countingByteReader{Reader: r}, length, 0, nil)
+	if err != nil {
+		return false
+	}
+	// An unknown setting might belong to an extension that this version no longer supports.
+	if len(old.Other) > 0 {
+		return false
+	}
+
+	if current.MaxFieldSectionSize >= 0 && (old.MaxFieldSectionSize < 0 || old.MaxFieldSectionSize > current.MaxFieldSectionSize) {
+		return false
+	}
+	if old.Datagram && !current.Datagram {
+		return false
+	}
+	if old.ExtendedConnect && !current.ExtendedConnect {
+		return false
+	}
+	return true
+}

--- a/http3/settings_0rtt_test.go
+++ b/http3/settings_0rtt_test.go
@@ -1,0 +1,62 @@
+package http3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingsCompatibleFor0RTT(t *testing.T) {
+	ticket := func(saved *settings) [][]byte {
+		return [][]byte{settingsForSessionTicket(saved)}
+	}
+
+	for _, tc := range []struct {
+		name       string
+		current    *settings
+		extra      [][]byte
+		compatible bool
+	}{
+		{
+			name:       "max field section size increased",
+			current:    &settings{MaxFieldSectionSize: 101},
+			extra:      ticket(&settings{MaxFieldSectionSize: 100}),
+			compatible: true,
+		},
+		{
+			name:    "missing settings",
+			current: &settings{},
+		},
+		{
+			name:    "malformed settings",
+			current: &settings{},
+			extra:   [][]byte{append([]byte(serverSettingsSessionTicketPrefix), 0xff)},
+		},
+		{
+			name:    "max field section size reduced",
+			current: &settings{MaxFieldSectionSize: 100},
+			extra:   ticket(&settings{MaxFieldSectionSize: 101}),
+		},
+		{
+			name:    "datagrams disabled",
+			current: &settings{MaxFieldSectionSize: 100},
+			extra: ticket(&settings{
+				MaxFieldSectionSize: 100,
+				Datagram:            true,
+			}),
+		},
+		{
+			name:    "unknown setting",
+			current: &settings{MaxFieldSectionSize: 100},
+			extra: ticket(&settings{
+				MaxFieldSectionSize: 100,
+				Other:               map[uint64]uint64{13: 37},
+			}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data, ok := settingsDataFromSessionTicket(tc.extra)
+			require.Equal(t, tc.compatible, ok && settingsCompatibleFor0RTT(data, tc.current))
+		})
+	}
+}

--- a/integrationtests/self/http_0rtt_test.go
+++ b/integrationtests/self/http_0rtt_test.go
@@ -1,0 +1,158 @@
+package self_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
+	"github.com/quic-go/quic-go/internal/protocol"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTP0RTT(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/0rtt", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, strconv.FormatBool(!r.TLS.HandshakeComplete))
+	})
+	port := startHTTPServer(t, mux)
+
+	var num0RTTPackets atomic.Uint32
+	proxy := quicproxy.Proxy{
+		Conn:       newUDPConnLocalhost(t),
+		ServerAddr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
+		DelayPacket: func(_ quicproxy.Direction, _, _ net.Addr, data []byte) time.Duration {
+			if containsPacketType(data, protocol.PacketType0RTT) {
+				num0RTTPackets.Add(1)
+			}
+			return scaleDuration(25 * time.Millisecond)
+		},
+	}
+	require.NoError(t, proxy.Start())
+	defer proxy.Close()
+
+	tlsConf := getTLSClientConfigWithoutServerName()
+	puts := make(chan string, 10)
+	tlsConf.ClientSessionCache = newClientSessionCache(tls.NewLRUClientSessionCache(10), nil, puts)
+	tr := &http3.Transport{
+		TLSClientConfig:    tlsConf,
+		QUICConfig:         getQuicConfig(&quic.Config{MaxIdleTimeout: 10 * time.Second}),
+		DisableCompression: true,
+	}
+	defer tr.Close()
+	addDialCallback(t, tr)
+
+	proxyPort := proxy.LocalAddr().(*net.UDPAddr).Port
+	req, err := http.NewRequest(http3.MethodGet0RTT, fmt.Sprintf("https://localhost:%d/0rtt", proxyPort), nil)
+	require.NoError(t, err)
+	rsp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+	data, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "false", string(data))
+	require.Zero(t, num0RTTPackets.Load())
+
+	select {
+	case <-puts:
+	case <-time.After(time.Second):
+		t.Fatal("did not receive session ticket")
+	}
+
+	tr2 := &http3.Transport{
+		TLSClientConfig:    tr.TLSClientConfig,
+		QUICConfig:         tr.QUICConfig,
+		DisableCompression: true,
+	}
+	defer tr2.Close()
+	addDialCallback(t, tr2)
+	rsp, err = tr2.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+	data, err = io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "true", string(data))
+	require.NotZero(t, num0RTTPackets.Load())
+}
+
+func TestHTTP0RTTWithChangedServerSettings(t *testing.T) {
+	const originalMaxHeaderBytes = 1024
+
+	for _, tc := range []struct {
+		name              string
+		newMaxHeaderBytes int
+		expect0RTT        bool
+	}{
+		{name: "increased", newMaxHeaderBytes: 1025, expect0RTT: true},
+		{name: "decreased", newMaxHeaderBytes: 1023, expect0RTT: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/0rtt", func(w http.ResponseWriter, r *http.Request) {
+				io.WriteString(w, strconv.FormatBool(!r.TLS.HandshakeComplete))
+			})
+			serverTLSConf := getTLSConfig()
+			port := startHTTPServer(t, mux, func(s *http3.Server) {
+				s.TLSConfig = serverTLSConf
+				s.MaxHeaderBytes = originalMaxHeaderBytes
+			})
+
+			puts := make(chan string, 1)
+			clientTLSConf := getTLSClientConfigWithoutServerName()
+			clientTLSConf.ClientSessionCache = newClientSessionCache(tls.NewLRUClientSessionCache(1), nil, puts)
+			doRequest := func(port int) (string, error) {
+				cl := newHTTP3Client(t, func(tr *http3.Transport) { tr.TLSClientConfig = clientTLSConf })
+				req, err := http.NewRequest(http3.MethodGet0RTT, fmt.Sprintf("https://localhost:%d/0rtt", port), nil)
+				require.NoError(t, err)
+				rsp, err := cl.Do(req)
+				if err != nil {
+					return "", err
+				}
+				defer rsp.Body.Close()
+				body, err := io.ReadAll(rsp.Body)
+				return string(body), err
+			}
+
+			body, err := doRequest(port)
+			require.NoError(t, err)
+			require.Equal(t, "false", body)
+			select {
+			case <-puts:
+			case <-time.After(time.Second):
+				t.Fatal("did not receive session ticket")
+			}
+
+			port = startHTTPServer(t, mux, func(s *http3.Server) {
+				s.TLSConfig = serverTLSConf
+				s.MaxHeaderBytes = tc.newMaxHeaderBytes
+			})
+			proxy := quicproxy.Proxy{
+				Conn:       newUDPConnLocalhost(t),
+				ServerAddr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
+				DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration {
+					return scaleDuration(25 * time.Millisecond)
+				},
+			}
+			require.NoError(t, proxy.Start())
+			defer proxy.Close()
+
+			proxyPort := proxy.LocalAddr().(*net.UDPAddr).Port
+			body, err = doRequest(proxyPort)
+			if tc.expect0RTT {
+				require.NoError(t, err)
+				require.Equal(t, "true", body)
+			} else {
+				require.ErrorIs(t, err, quic.Err0RTTRejected)
+			}
+		})
+	}
+}

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -16,7 +16,6 @@ import (
 	"net/http/httptrace"
 	"net/textproto"
 	"os"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -28,7 +27,6 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/http3/qlog"
 	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
-	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/testutils/events"
 
 	"github.com/stretchr/testify/assert"
@@ -1069,71 +1067,6 @@ func TestHTTP1xxTerminalResponse(t *testing.T) {
 	require.Zero(t, status)
 	require.Zero(t, cnt)
 	require.NoError(t, resp.Body.Close())
-}
-
-func TestHTTP0RTT(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/0rtt", func(w http.ResponseWriter, r *http.Request) {
-		io.WriteString(w, strconv.FormatBool(!r.TLS.HandshakeComplete))
-	})
-	port := startHTTPServer(t, mux)
-
-	var num0RTTPackets atomic.Uint32
-	proxy := quicproxy.Proxy{
-		Conn:       newUDPConnLocalhost(t),
-		ServerAddr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
-		DelayPacket: func(_ quicproxy.Direction, _, _ net.Addr, data []byte) time.Duration {
-			if containsPacketType(data, protocol.PacketType0RTT) {
-				num0RTTPackets.Add(1)
-			}
-			return scaleDuration(25 * time.Millisecond)
-		},
-	}
-	require.NoError(t, proxy.Start())
-	defer proxy.Close()
-
-	tlsConf := getTLSClientConfigWithoutServerName()
-	puts := make(chan string, 10)
-	tlsConf.ClientSessionCache = newClientSessionCache(tls.NewLRUClientSessionCache(10), nil, puts)
-	tr := &http3.Transport{
-		TLSClientConfig:    tlsConf,
-		QUICConfig:         getQuicConfig(&quic.Config{MaxIdleTimeout: 10 * time.Second}),
-		DisableCompression: true,
-	}
-	defer tr.Close()
-	addDialCallback(t, tr)
-
-	proxyPort := proxy.LocalAddr().(*net.UDPAddr).Port
-	req, err := http.NewRequest(http3.MethodGet0RTT, fmt.Sprintf("https://localhost:%d/0rtt", proxyPort), nil)
-	require.NoError(t, err)
-	rsp, err := tr.RoundTrip(req)
-	require.NoError(t, err)
-	require.Equal(t, 200, rsp.StatusCode)
-	data, err := io.ReadAll(rsp.Body)
-	require.NoError(t, err)
-	require.Equal(t, "false", string(data))
-	require.Zero(t, num0RTTPackets.Load())
-
-	select {
-	case <-puts:
-	case <-time.After(time.Second):
-		t.Fatal("did not receive session ticket")
-	}
-
-	tr2 := &http3.Transport{
-		TLSClientConfig:    tr.TLSClientConfig,
-		QUICConfig:         tr.QUICConfig,
-		DisableCompression: true,
-	}
-	defer tr2.Close()
-	addDialCallback(t, tr2)
-	rsp, err = tr2.RoundTrip(req)
-	require.NoError(t, err)
-	require.Equal(t, 200, rsp.StatusCode)
-	data, err = io.ReadAll(rsp.Body)
-	require.NoError(t, err)
-	require.Equal(t, "true", string(data))
-	require.NotZero(t, num0RTTPackets.Load())
 }
 
 func TestHTTPStreamer(t *testing.T) {


### PR DESCRIPTION
Fixes #5705.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject HTTP/3 0-RTT when server settings are incompatible with stored session ticket settings
> - Adds [settings_0rtt.go](https://github.com/quic-go/quic-go/pull/5771/files#diff-4174c0c246509d8e8e74c1cd06dd16c02f64dd6859f4d4e138159c18b042a2d5) with helpers to serialize HTTP/3 settings into TLS session ticket extras and check saved vs. current settings compatibility for 0-RTT.
> - Adds `Server.configureTLSConfig` which wraps `WrapSession`/`UnwrapSession` to embed settings in tickets and disable early data on resumption when saved settings are incompatible (e.g. reduced `MaxFieldSectionSize`, disabled datagrams or extended connect, or unknown settings present).
> - Moves the `TestHTTP0RTT` integration test to a dedicated file and adds `TestHTTP0RTTWithChangedServerSettings` to verify that increasing `MaxHeaderBytes` permits 0-RTT while decreasing it causes `quic.Err0RTTRejected`.
> - Behavioral Change: servers now embed settings in every session ticket; 0-RTT is rejected on resumption whenever the current settings are stricter than what was negotiated in the original session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77ea70a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/3 0-RTT session resumption by preserving and validating server settings.
  * Automatically disables 0-RTT when previously stored settings are invalid or no longer compatible.
  * Prevents 0-RTT when server limits are reduced or previously supported features are unavailable.

* **Tests**
  * Added coverage for successful 0-RTT reuse and compatibility changes.
  * Added validation for malformed, unknown, or incompatible session settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->